### PR TITLE
Regenerate the build system when any m4 changed, not just configure.ac

### DIFF
--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -214,7 +214,28 @@ prep_srcdir() {
         exit 2
     fi
 
-    if [ ! -x "$root/configure" ] || [ "$root/configure.ac" -nt "$root/configure" ]; then
+    # configure.ac is not the only input.  Every config/*.m4 is one too, and so
+    # is config/oac -- a submodule, so an ordinary `git submodule update` (or a
+    # merge that moves the pointer) rewrites m4 files with no other trace.  A
+    # source tree stale that way is not a slow build, it is a dead one: PRRTE
+    # builds in maintainer mode, so `make` inside the container tries to
+    # regenerate aclocal.m4 itself and dies on
+    #
+    #     config/missing: line 85: aclocal-1.18: command not found
+    #
+    # because the container does not have the exact autotools the host used.
+    # build.sh then stops with the previous install still in the volume, and
+    # nothing in that message mentions a submodule.  Regenerate on the host,
+    # where the right autotools are, whenever any input is newer.
+    autogen_needed() {
+        [ -x "$root/configure" ] || return 0
+        [ "$root/configure.ac" -nt "$root/configure" ] && return 0
+        [ -n "$(find "$root/config" -name '*.m4' -newer "$root/configure" \
+                     -print -quit 2>/dev/null)" ] && return 0
+        return 1
+    }
+
+    if autogen_needed; then
         echo ">>> autogen.pl"
         ( cd "$root" && ./autogen.pl )
     fi

--- a/contrib/slurmswarm/build.sh
+++ b/contrib/slurmswarm/build.sh
@@ -173,7 +173,28 @@ prep_srcdir() {
         exit 2
     fi
 
-    if [ ! -x "$root/configure" ] || [ "$root/configure.ac" -nt "$root/configure" ]; then
+    # configure.ac is not the only input.  Every config/*.m4 is one too, and so
+    # is config/oac -- a submodule, so an ordinary `git submodule update` (or a
+    # merge that moves the pointer) rewrites m4 files with no other trace.  A
+    # source tree stale that way is not a slow build, it is a dead one: PRRTE
+    # builds in maintainer mode, so `make` inside the container tries to
+    # regenerate aclocal.m4 itself and dies on
+    #
+    #     config/missing: line 85: aclocal-1.18: command not found
+    #
+    # because the container does not have the exact autotools the host used.
+    # build.sh then stops with the previous install still in the volume, and
+    # nothing in that message mentions a submodule.  Regenerate on the host,
+    # where the right autotools are, whenever any input is newer.
+    autogen_needed() {
+        [ -x "$root/configure" ] || return 0
+        [ "$root/configure.ac" -nt "$root/configure" ] && return 0
+        [ -n "$(find "$root/config" -name '*.m4' -newer "$root/configure" \
+                     -print -quit 2>/dev/null)" ] && return 0
+        return 1
+    }
+
+    if autogen_needed; then
         echo ">>> autogen.pl"
         ( cd "$root" && ./autogen.pl )
     fi


### PR DESCRIPTION
## Problem

Both container harnesses (`contrib/dockerswarm`, `contrib/slurmswarm`) decide whether to run `autogen.pl` by comparing `configure.ac` against `configure`. Every `config/*.m4` is an input too — and `config/oac` is a **submodule**, so a `git submodule update`, or a merge that moves the pointer, rewrites m4 files and leaves no trace either test can see.

A source tree stale that way does not build slowly, it does not build at all. PRRTE builds in maintainer mode, so `make` inside the builder tries to regenerate `aclocal.m4` itself, and the container does not carry the exact autotools the host used:

```
config/missing: line 85: aclocal-1.18: command not found
make: *** [Makefile:715: /prrte-src/aclocal.m4] Error 127
```

`build.sh` then stops with the previous install still standing in the volume, and nothing in that message names a submodule — or suggests running `autogen.pl` on the host, which is the fix.

This is reachable from an ordinary update: pull master, `git submodule update`, rebuild the swarm.

## Fix

Widen the test to any m4 under `config/` being newer than `configure`. That covers the submodule, an edited macro, and a merge, and it costs one `find(1)` over a directory of a few dozen files. Applied identically to both harnesses, which carried the same condition.

## Testing

Reproduced the failure, applied the fix, and rebuilt both harnesses from a tree in exactly that state — each ran `autogen.pl` on its own and completed. Suites on the resulting installs:

- `contrib/dockerswarm`: 530 passed, 0 failed, 0 skipped
- `contrib/slurmswarm`: 97 passed, 0 failed, 0 skipped