### PR TITLE
Fix the two HNP leaks from #2649 that are still live

### DIFF
--- a/src/grpcomm/grpcomm_classes.c
+++ b/src/grpcomm/grpcomm_classes.c
@@ -242,6 +242,16 @@ static void mddes(prte_pmix_fence_caddy_t *p)
     if (NULL != p->buf) {
         PMIX_DATA_BUFFER_RELEASE(p->buf);
     }
+    /* The modex bucket PMIx handed up with the fence.  Ownership transfers on
+     * that call and cannot not: PMIx unloads the buffer into a bare pointer
+     * and returns, while we park it here and read it later from another
+     * thread, so PMIx has nothing left it could free it from.  Nothing copies
+     * it out on our side either - PMIx_Data_embed() copies the bytes into the
+     * relay and says in its own comment that it deliberately does not free
+     * the source - so this is the only place it can go. */
+    if (NULL != p->data) {
+        free(p->data);
+    }
 }
 PMIX_CLASS_INSTANCE(prte_pmix_fence_caddy_t,
                     pmix_object_t,

--- a/src/mca/iof/base/iof_base_frame.c
+++ b/src/mca/iof/base/iof_base_frame.c
@@ -240,7 +240,14 @@ static void prte_iof_base_write_event_destruct(prte_iof_write_event_t *wev)
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), wev->fd));
         close(wev->fd);
     }
-    PMIX_DESTRUCT(&wev->outputs);
+    /* Anything still queued here was never written - the sink closed with a
+     * backlog, or carried the zero-byte marker that only asks for the fd to
+     * be closed.  It has to be RELEASED, not merely destructed:
+     * pmix_list_destruct() re-initializes the list and frees nothing on it,
+     * so the plain PMIX_DESTRUCT this used to do looked like a drain and was
+     * not one.  Each chunk carries its buffer inline, so a release of the
+     * item is the whole of it. */
+    PMIX_LIST_DESTRUCT(&wev->outputs);
 }
 PMIX_CLASS_INSTANCE(prte_iof_write_event_t, pmix_list_item_t,
                     prte_iof_base_write_event_construct,


### PR DESCRIPTION
Fixes items 3 and 4 of #2649.

## Items 1 and 2 are already fixed — no change needed

That issue was measured at `22ed5f9d83` and cites `src/mca/grpcomm/direct/*`, which the de-framework'ing has since moved to `src/grpcomm/`. Re-checking each item against current master:

- **1, the `reply` buffer handed to xcast** — already fixed. All four sites (two in `grpcomm_fence.c`, two in `grpcomm_group.c`) now release it after the broadcast, with the comment *"xcast copies the payload, so the buffer is still ours to free"*.
- **2, the fence signature's proc array** — already fixed. `fence()` now funnels every exit through a single `done:` label that does `PMIX_DESTRUCT(&sig)`.

## 4. The fence modex bucket (`96c552c634`)

The report is exactly right, including that it reads as a PMIx leak and is not one. Ownership of the bucket transfers on the `fence_nb` upcall and cannot not: PMIx unloads the buffer into a bare pointer and returns, while the host parks it and reads it later from another thread. Nothing on our side copies it out either — `PMIx_Data_embed()` copies into the relay and says in its own comment that it deliberately does not free the source. So the caddy is the last owner, and `mddes()` freed `sig` and `buf` and walked past `data`.

**Reproduced and confirmed.** Note the issue's own reproducer (`group_leave`) does *not* reproduce it — I measured 0 definitely lost on the unfixed build with it, at both 8 ranks over 4 nodes and 2 ranks on 1 node. What reaches it is a **multi-node collecting fence**; single-node has no rollup:

```sh
echo hi | valgrind --leak-check=full --show-leak-kinds=definite,indirect \
    --trace-children=no --num-callers=40 --child-silent-after-fork=yes \
    prterun --host node1:2,node2:2,node3:2,node4:2 -np 8 --map-by node \
    /opt/prte/prte/bin/fencer collect
```

**128 bytes definitely lost** at `pmix_server_collect_data` before, **0 after**, same command.

The matching PMIx documentation half is openpmix/openpmix#4132 — the header never said the host owns this buffer, and PMIx's own reference host was leaking it for the same reason.

## 3. The IOF write outputs (`c43c984e48`)

Real, but the mechanism is not what the issue says. It reports that nothing drains the list at teardown; something does — `prte_iof_base_write_event_destruct()` ends with `PMIX_DESTRUCT(&wev->outputs)`. That call is a **no-op**:

```c
static void pmix_list_destruct(pmix_list_t *list)
{
    pmix_list_construct(list);
}
```

It re-initializes the list and releases none of the items on it, so a sink torn down with anything queued leaks every chunk — each a fixed 8192-byte buffer. `PMIX_LIST_DESTRUCT` is the macro that removes and releases first. A chunk the write handler is currently working on is already off the list, so nothing here can double-free one.

**Scope of the evidence:** unlike item 4, this one is fixed by inspection. I could not construct a case that leaves a chunk queued at teardown, so there is no before/after measurement for it. The no-op is a fact about `pmix_list_destruct`, not an inference.

It is worth knowing when reading the rest of that report, and anywhere else in the tree: seeing a `PMIX_DESTRUCT` of a list is not evidence its contents were freed.

## Testing

- macOS `--enable-debug` build warning-free; `make check` passes
- `contrib/dockerswarm` full suite: **530 passed, 0 failed, 0 skipped**
- valgrind before/after as above for item 4