### PR TITLE
Extend the underlining in a subtitle

### DIFF
--- a/src/mca/schizo/ompi/schizo-ompi-cli.rstxt
+++ b/src/mca/schizo/ompi/schizo-ompi-cli.rstxt
@@ -549,7 +549,7 @@ The ``--report-bindings`` option
 .. include:: /prrte-rst-content/deprecated-report-bindings.rst
 
 The ``--report-child-jobs-separately`` option
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. include:: /prrte-rst-content/deprecated-report-child-jobs-separately.rst
 


### PR DESCRIPTION
Silence a silly Sphinx complaint by adding one
'~' to an underline