### PR TITLE
Cover PMIx client churn in the swarm, and fix the node size it turned up

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -63,6 +63,7 @@ It is **not** a Docker Swarm in the orchestration sense — just ten plain
 | `scaletest.c` | A PMIx client that **times** a full-data fence and a bare barrier over the whole job (`scaletest` in the install). Not a pass/fail case — a measurement. See §18. |
 | `mpinoop.c` | `MPI_Init` and `MPI_Finalize` and nothing else, so the only thing timed is the modex fence and the barrier behind it. Built only when `OMPI_SRC` is set — see §19. |
 | `scaletest.sh` | The measurement driver: stands up a swarm of arbitrary size (default 40), sweeps DVM size × procs-per-node × routing radix × payload, and writes a CSV. See §18. |
+| `pmixloop.c` | The client-churn probe (`pmixloop` in the install): cycles `PMIx_Init` / collecting fence / bare fence / `PMIx_Finalize` with a per-rank skew, so one rank opens its next cycle while its peers are still finalizing the last. The reproducer from openpmix#4113 and #4112, and the only client here that connects to its server more than once. See §21. |
 
 ## 2. How it works
 
@@ -825,6 +826,47 @@ every build-tree directory that holds a `Makefile` against the source tree,
 reconfigures when one of them is gone, and removes the orphan as part of the
 same step (`orphan_dirs`/`drop_orphans`) — dropping it matters, or the next run
 finds an orphan again and reconfigures forever.
+
+### Swapping `PMIX_SRC` between two trees rebuilds nothing
+
+The nastiest member of this family, because every guard above is working as
+designed and none of them applies. Both trees are bind-mounted at the **same**
+container path, `/pmix-src`, so switching `PMIX_SRC` from one host checkout to
+another changes the configure arguments not at all — `reconfigure_needed` has
+nothing to see. What is left is an ordinary incremental `make`, which decides
+by timestamp. So if the tree you switch **to** has older mtimes than the
+objects built from the tree you switched **from**, make declares every object
+up to date and the volume keeps serving the *other* tree's library.
+
+This is exactly the shape an A/B against a `git worktree` produces. A fresh
+worktree is stamped today; a long-lived clone is stamped whenever its files
+were last written. Going clone → worktree rebuilds (the worktree is newer) and
+looks fine. Going worktree → clone recompiles **zero** files, prints
+`Linux build complete`, rewrites `.build-stamp` — the build really did succeed,
+it just did nothing — and the next suite silently measures the library you were
+trying to get away from. That was first hit while A/B-ing openpmix
+[#4113](https://github.com/openpmix/openpmix/issues/4113): the "back to master"
+build reported success and the reproducer went on failing, which reads as a
+fix that does not work.
+
+So when a run is meant to turn on a specific source change, **verify the object
+carrying it was compiled**, rather than trusting the build to have noticed:
+
+```sh
+grep -cE "server/pmix_server_(fence|group)\.lo" build.log   # must be non-zero
+```
+
+To force it, wipe the PMIx build dir and install — a `touch` over the source
+tree also works, but it mutates a clone other worktrees and sessions may share:
+
+```sh
+docker run --rm -v prte-build:/opt/prte prte-swarm:latest \
+    rm -rf /opt/prte/vpath-linux-pmix /opt/prte/pmix /opt/prte/.build-stamp
+PMIX_SRC=/path/to/openpmix ./build.sh
+```
+
+The same reasoning applies to `OMPI_SRC`, and to `PRTE_SRC` if you ever point
+the builder at a second PRRTE tree.
 
 ### Writing a case that asserts on an error message
 
@@ -1767,3 +1809,74 @@ mean the caching is not working; a count of zero means the path did not
 run and everything above it proved nothing. `--leave-session-attached` is
 required, and for the same reason it is in §19: a daemonized `prted` has no
 stderr to read, so without it only the master's traces come back.
+
+## 21. Client churn against the PMIx server (`pmixloop`, `test_pmix_cycling`, `test_pmix_server_teardown`)
+
+Every other client here connects to its PMIx server once. `pmixloop` cycles
+**`PMIx_Init` → collecting fence → bare fence → `PMIx_Finalize`**, hundreds of
+times, with a per-rank sleep before the first fence so the ranks are
+deliberately skewed — one rank opens cycle N+1 while its peers are still
+finalizing cycle N. That is what an MPI Sessions application does, one cycle
+per `MPI_Session_init`, and it is the shape that found two distinct bugs:
+
+- **openpmix#4113** — a rank that dropped its socket through `PMIx_Finalize`
+  was recorded on the fence tracker's `departed` list even though it had not
+  left the accounting, so the next cycle's fence completed without it. The
+  ranks drift apart by whole cycles: fences return `PMIX_ERR_PARTIAL_SUCCESS`
+  / `LOST_CONNECTION` / `INVALID_ARG`, and eventually a run hangs.
+- **openpmix#4112** — a strictly local fence's completion, which only
+  thread-shifts, leaves the tracker on `pmix_server_globals.collectives` still
+  looking complete and unclaimed, so a second driver completes it again. Two
+  handlers release the same tracker and unlink through freed links; the
+  corrupted list outlives the event and the abort lands far away, typically as
+  an invalid free in `PMIx_server_finalize`.
+
+The two phases assert opposite ends of that: `test_pmix_cycling` reads the
+**clients'** tallies, `test_pmix_server_teardown` reads the **server's** exit
+status and stderr (under `prterun` the HNP hosts these ranks itself, so it is
+the process that aborts).
+
+### Three constraints, each of which silently empties a case
+
+**The machine must be loaded.** This is not a way to make the test faster or
+more likely — it is the experiment. Measured against a library with both
+fixes removed:
+
+| | 100 iters | 400 iters | 800 iters |
+|---|---|---|---|
+| idle | passes | passes | passes |
+| 3× oversubscribed | **aborts** | aborts | aborts |
+
+Iterations cannot substitute for load. `load_on()` raises `3 × nproc` burners
+on node1 — every container shares the one host kernel, so that loads the whole
+swarm — and `SWARM_CLEAN` reaps them as a backstop. Delete them to speed the
+suite up and both phases keep passing while testing nothing.
+
+**At least two ranks must share a daemon** (`test_pmix_cycling`). The #4113
+defect is in one server's own tracker accounting: it takes *two* ranks
+finalizing cycle N to satisfy, between them, the expected count of a fence a
+faster peer already opened for N+1. At one rank per node there is no such
+pair, and the unfixed library passes 5 runs out of 5. Do not rewrite these as
+`--map-by node` one-per-host — that is why the second case is 8 ranks over
+*two* nodes rather than eight.
+
+**The job must NOT be spread** (`test_pmix_server_teardown`). The #4112 window
+exists only for a collective the host never sees — a strictly local fence, the
+ordinary case under `fence_localonly_opt`. Give that job a second node and the
+fence goes up to PRRTE, `host_called` is set, and the case tests nothing. Note
+this is the opposite of the constraint above, which is why the two live in
+separate phases rather than sharing a job.
+
+### Confirming they still bite
+
+Both phases were verified by removing the fixes and re-running, which is the
+only way to know a passing case is a passing case. Build a PMIx worktree with
+the two `if (peer->finalized) return;` guards deleted from
+`pmix_server_trk_peer_lost` / `pmix_server_grp_peer_lost` **and** the three
+`tracker->completion_fired = true;` assignments deleted from
+`pmix_server_op_replies.c`, then `PMIX_SRC=<that tree> ./build.sh`. All six
+assertions go red. Both fixes have to come out together: #4124's guard removes
+the lost-connection sweep for finalized peers, and that sweep is #4127's second
+driver, so with #4124 in place this workload cannot reach #4112 at all.
+
+Mind the `PMIX_SRC` staleness trap when doing that A/B — see §2.

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -490,6 +490,20 @@ build_linux() {
                 /prrte-src/contrib/dockerswarm/fencer.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
+            # pmixloop: the reproducer from openpmix issue #4113 -- ranks
+            # cycling Init / collecting fence / bare fence / Finalize with a
+            # per-rank skew, so one rank opens the next cycle while its peers
+            # are still finalizing the last one.  The issue drives it under
+            # PMIx simptest, where every rank is local to one server and the
+            # fence never reaches the host; run here across nodes it is a
+            # real PRRTE collective, which is the half a single host cannot
+            # test.
+            # (No apostrophes here: see the note further down.)
+            echo ">>>> pmixloop (init/fence/finalize cycling) test client"
+            gcc -O0 -g -o /opt/prte/prte/bin/pmixloop \
+                /prrte-src/contrib/dockerswarm/pmixloop.c \
+                -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
+
             # faulty: a PMIx client that fails on purpose, once per way the
             # errmgr has a policy branch for (abort, non-zero exit, signal,
             # exit without finalize).  Both errmgr components are involved in

--- a/contrib/dockerswarm/pmixloop.c
+++ b/contrib/dockerswarm/pmixloop.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * pmixloop -- the reproducer from openpmix issue #4113, "Fence semantics
+ * when clients rapidly cycle PMIx_Init/PMIx_Finalize".
+ *
+ * Each rank cycles Init -> collecting fence -> bare fence -> Finalize, with
+ * a per-rank sleep before the first fence so the ranks are deliberately
+ * skewed: rank 0 reaches cycle N+1 while its peers are still finalizing
+ * cycle N.  That skew is the whole experiment.  The defect (openpmix
+ * PR #4124) recorded a rank that had left through PMIx_Finalize on the
+ * fence tracker's departed list even though the rank had not left the
+ * accounting -- so a later cycle's fence completed one contribution short
+ * with LOST_CONNECTION, the ranks drifted a cycle apart, and a collecting
+ * fence merged with a non-collecting one to produce INVALID_ARG.
+ *
+ * The issue's own harness runs this under PMIx's simptest, where all four
+ * ranks are local to one server and the fence never reaches the host.  Run
+ * here under prun with the ranks spread over several nodes, the fence is
+ * a real PRRTE collective across daemons instead -- which is the half a
+ * single host cannot test.
+ *
+ * The body of the loop is the issue's program unchanged.  What is added is
+ * a tally at the end, so a run can be judged by counting rather than by
+ * grepping for the absence of something:
+ *
+ *   PMIXLOOP <rank> ALLDONE iters=<n> fence1_bad=<n> fence2_bad=<n> \
+ *            init_bad=<n> fini_bad=<n>
+ *
+ * Every _bad count must be zero, and every rank must print the line.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <pmix.h>
+
+int main(int argc, char *argv[])
+{
+    int iters = (argc > 1) ? atoi(argv[1]) : 100;
+    pmix_proc_t myproc, wildcard;
+    pmix_status_t rc;
+    pmix_info_t info;
+    uint32_t rank = UINT32_MAX;
+    int fence1_bad = 0, fence2_bad = 0, init_bad = 0, fini_bad = 0;
+    bool collect;
+    int i;
+
+    for (i = 0; i < iters; i++) {
+        rc = PMIx_Init(&myproc, NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            /* an Init that fails leaves us with no library to continue
+             * against, so this one is still fatal -- but say which cycle */
+            fprintf(stderr, "PMIXLOOP %u iter %d: PMIx_Init failed: %s\n",
+                    rank, i, PMIx_Error_string(rc));
+            ++init_bad;
+            exit(1);
+        }
+        rank = myproc.rank;
+        PMIX_PROC_CONSTRUCT(&wildcard);
+        PMIX_LOAD_PROCID(&wildcard, myproc.nspace, PMIX_RANK_WILDCARD);
+
+        usleep(1000 * (rank + 1)); /* per-rank jitter */
+
+        collect = true;
+        PMIX_INFO_LOAD(&info, PMIX_COLLECT_DATA, &collect, PMIX_BOOL);
+        rc = PMIx_Fence(&wildcard, 1, &info, 1);
+        PMIX_INFO_DESTRUCT(&info);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "PMIXLOOP %u iter %d: fence1 rc=%d (%s)\n",
+                    rank, i, rc, PMIx_Error_string(rc));
+            ++fence1_bad;
+        }
+
+        rc = PMIx_Fence(&wildcard, 1, NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "PMIXLOOP %u iter %d: fence2 rc=%d (%s)\n",
+                    rank, i, rc, PMIx_Error_string(rc));
+            ++fence2_bad;
+        }
+
+        rc = PMIx_Finalize(NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "PMIXLOOP %u iter %d: PMIx_Finalize rc=%d (%s)\n",
+                    rank, i, rc, PMIx_Error_string(rc));
+            ++fini_bad;
+        }
+    }
+
+    fprintf(stderr,
+            "PMIXLOOP %u ALLDONE iters=%d fence1_bad=%d fence2_bad=%d "
+            "init_bad=%d fini_bad=%d\n",
+            rank, iters, fence1_bad, fence2_bad, init_bad, fini_bad);
+    return 0;
+}

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -103,6 +103,9 @@ ONT() { docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIR
 # rendezvous file of its own, and killing it is the point of a teardown.
 SWARM_CLEAN='
     for t in prted prte prterun prun pterm; do pkill -9 -x $t 2>/dev/null; done
+    # the CPU burners the PMIx-churn phases raise (see load_on): harmless if
+    # none are running, and leaving one behind would slow every later phase
+    pkill -9 -x yes 2>/dev/null
     rm -rf /tmp/prte.* /tmp/prted.* /tmp/prtrn.* /tmp/prun.* /tmp/ompi.* \
            /tmp/pmix.* 2>/dev/null
     find /tmp -maxdepth 2 -name "pmix.*" -prune -exec rm -rf {} + 2>/dev/null
@@ -3371,6 +3374,157 @@ FLT=/opt/prte/prte/bin/faulty
 # nothing ess-specific left to assert here.
 ########################################################################
 
+PMIXLOOP=/opt/prte/prte/bin/pmixloop
+
+# LOAD IS NOT AN OPTIMIZATION FOR THE TWO PHASES BELOW, IT IS THE EXPERIMENT.
+# Both of them chase a race between one rank opening its next collective and
+# its peers finalizing the last one, and on an idle machine that race simply
+# does not run: measured against a library with BOTH fixes removed, an idle
+# host is clean at 100, 400 and even 800 iterations -- 4 of 4 ranks done, not
+# one bad return, no abort -- while the same library under 3x oversubscription
+# aborts at 100. So iterations cannot substitute for load, and a phase that
+# quietly lost these burners would keep passing while testing nothing.
+#
+# 3x the core count is what the macOS investigation needed too. The burners
+# live on node1 but every container shares the one host kernel, so this loads
+# the whole swarm; SWARM_CLEAN reaps them as a backstop if a phase dies early.
+load_on()  { docker exec -d "${NODE}1" sh -c \
+                 'n=$(nproc); i=0; while [ "$i" -lt $((n*3)) ]; do yes > /dev/null & i=$((i+1)); done'; }
+load_off() { docker exec "${NODE}1" sh -c 'pkill -9 -x yes; true' >/dev/null 2>&1; }
+
+test_pmix_cycling() {
+    local out n bad_n
+
+    banner "PMIx cycling: repeated Init/fence/Finalize stays in step (openpmix#4113)"
+    # A client that cycles PMIx_Init / fence / PMIx_Finalize -- which is what
+    # an MPI Sessions application does, one cycle per MPI_Session_init -- used
+    # to drift apart by whole cycles and eventually wedge.  A rank that
+    # dropped its socket through PMIx_Finalize was recorded on the fence
+    # tracker's "departed" list even though it had NOT left the accounting
+    # (nlocalprocs is deliberately not decremented for it and its peer object
+    # is tombstoned, precisely so it can Init again and contribute).  Counting
+    # it twice let the NEXT cycle's fence complete without it, and from there
+    # the ranks are out of step: mid-run fences return PMIX_ERR_PARTIAL_SUCCESS
+    # / PMIX_ERR_LOST_CONNECTION / PMIX_ERR_INVALID_ARG and the run eventually
+    # hangs outright.  openpmix#4113, fixed by openpmix PR #4124.
+    #
+    # TWO THINGS DECIDE WHETHER THIS CASE HAS TEETH, and both are easy to
+    # "simplify" away:
+    #
+    #  - AT LEAST TWO RANKS MUST SHARE A DAEMON.  The defect is in one PMIx
+    #    server's own tracker accounting: it takes two ranks finalizing cycle N
+    #    to satisfy, between them, the expected count of a fence that a faster
+    #    peer has already opened for cycle N+1.  At one rank per node there is
+    #    no such pair, and the unfixed library passes this case 5 times out of
+    #    5 -- measured, not assumed.  So do NOT rewrite these as --map-by node
+    #    one-per-host.
+    #  - THE MACHINE MUST BE LOADED.  See load_on(): idle, the unfixed library
+    #    passes this at 100, 400 and 800 iterations alike.  Under load it
+    #    fails at 100.  Dropping the burners to speed the suite up would leave
+    #    both phases passing and testing nothing.
+    #
+    # Against the unfixed library and under load, the first shape aborts or
+    # hangs every time, with hundreds of non-success returns -- so this is a
+    # real regression guard rather than a smoke test.
+    cleanup_swarm
+    if ! RUN "test -x $PMIXLOOP"; then
+        skp "pmixloop client not installed -- re-run ./build.sh"
+        return
+    fi
+    load_on
+
+    # 4 ranks on ONE node: every rank is local to one PMIx server, which is
+    # the arrangement the issue was reported against (its own harness runs
+    # under simptest, where that is the only arrangement there is).
+    out=$(RUN "timeout -k 10 240 prterun --host node1:4 -n 4 $PMIXLOOP 100" 2>&1)
+    n=$(echo "$out" | grep -c ALLDONE)
+    [ "$n" = 4 ] \
+        && ok "4 ranks on one node each completed 100 Init/fence/Finalize cycles" \
+        || bad "$n of 4 ranks finished cycling (a hang is the classic symptom): $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    # Assert on the tally rather than on the absence of an error line: a run
+    # that hung produces no error lines either, and would otherwise pass.
+    bad_n=$(echo "$out" | grep -oE '(fence1_bad|fence2_bad|init_bad|fini_bad)=[0-9]+' \
+            | cut -d= -f2 | awk '{s+=$1} END {print s+0}')
+    [ "$bad_n" = 0 ] \
+        && ok "...with no fence returning a non-success status" \
+        || bad "$bad_n non-success returns from the fences: $(echo "$out" | grep -m3 'rc=-' | tr '\n' ' ')"
+
+    # 8 ranks over two nodes, 4 per node: still two ranks per server, so the
+    # local accounting is exercised exactly as above, but now the fence is a
+    # real PRRTE collective between daemons rather than one PMIx server
+    # talking to itself.  That combination is what no single host can test.
+    out=$(RUN "timeout -k 10 240 prterun --host node1:4,node2:4 -n 8 --map-by node $PMIXLOOP 100" 2>&1)
+    n=$(echo "$out" | grep -c ALLDONE)
+    [ "$n" = 8 ] \
+        && ok "8 ranks over 2 nodes completed cycling with a host-mediated fence" \
+        || bad "$n of 8 ranks finished cycling across nodes: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    bad_n=$(echo "$out" | grep -oE '(fence1_bad|fence2_bad|init_bad|fini_bad)=[0-9]+' \
+            | cut -d= -f2 | awk '{s+=$1} END {print s+0}')
+    [ "$bad_n" = 0 ] \
+        && ok "...with no fence returning a non-success status" \
+        || bad "$bad_n non-success returns from the fences: $(echo "$out" | grep -m3 'rc=-' | tr '\n' ' ')"
+    load_off
+    cleanup_swarm
+}
+
+test_pmix_server_teardown() {
+    local out rc
+
+    banner "PMIx server teardown: heavy client churn leaves a sane heap (openpmix#4112)"
+    # The subject here is the SERVER, not the client.  A collective the host
+    # never sees is finished by calling the tracker's own completion function,
+    # which only thread-shifts -- so on return the tracker is still on
+    # pmix_server_globals.collectives and still satisfies trk_complete(), and
+    # for that window anything walking the list sees a collective that looks
+    # complete and unclaimed.  A second driver (in practice the
+    # lost-connection sweep, firing as ranks finalize right after a fence)
+    # completes it again: two handlers unlink and release the same tracker,
+    # the second reading and re-releasing what the first freed.  The corrupted
+    # list outlives the event, so the abort surfaces far away -- typically as
+    # an invalid free inside PMIX_LIST_DESTRUCT(&collectives) in
+    # PMIx_server_finalize, which is why openpmix#4112 reads as a teardown bug
+    # and only reproduces after heavy connect/disconnect churn.  Fixed by
+    # openpmix PR #4127.
+    #
+    # THE JOB MUST NOT BE SPREAD ACROSS NODES.  The window exists only for a
+    # collective the host never sees -- a strictly local fence, the ordinary
+    # case under fence_localonly_opt.  Give the job two nodes and the fence
+    # goes up to PRRTE, host_called is set, and the case tests nothing.  That
+    # is the opposite constraint from most of this file, so it is stated here
+    # rather than left to be rediscovered.
+    #
+    # AND THE MACHINE MUST BE LOADED, for the same reason as the phase above
+    # and to the same degree -- see load_on().  Idle, the unfixed library is
+    # clean here however many iterations it is given.
+    #
+    # What is asserted is prterun's own exit and output: the HNP hosts these
+    # ranks itself and finalizes its PMIx server on the way out, so it is the
+    # process that aborts.  Measured against a library with the fix removed
+    # (and under load): 10 of 10 runs abort with "malloc(): unsorted double
+    # linked list corrupted", and under valgrind the invalid free lands in
+    # PMIx_server_finalize at an address inside pmix_server_globals.
+    cleanup_swarm
+    if ! RUN "test -x $PMIXLOOP"; then
+        skp "pmixloop client not installed -- re-run ./build.sh"
+        return
+    fi
+    load_on
+
+    out=$(RUN "timeout -k 10 300 prterun --host node1:4 -n 4 $PMIXLOOP 200" 2>&1)
+    rc=$?
+    [ "$rc" = 0 ] \
+        && ok "prterun survived 800 client connect/disconnect cycles and exited 0" \
+        || bad "prterun exited $rc after heavy client churn (134 = SIGABRT): $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    # The heap diagnostic is worth asserting separately: glibc aborts only
+    # when its own heuristics happen to catch the bad free, so a corrupted
+    # heap can also surface as a message without a non-zero exit.
+    echo "$out" | grep -qiE 'pointer being freed|free\(\): |double free|corrupted|malloc\(\): ' \
+        && bad "the heap complained during teardown: $(echo "$out" | grep -iEm2 'pointer being freed|free\(\): |double free|corrupted|malloc\(\): ' | tr '\n' ' ')" \
+        || ok "...with no invalid-free or heap-corruption diagnostic"
+    load_off
+    cleanup_swarm
+}
+
 test_ess() {
     local out rc n
 
@@ -5759,6 +5913,10 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     test_odls
 
     test_grpcomm
+
+    test_pmix_cycling
+
+    test_pmix_server_teardown
 
 
 

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -257,6 +257,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
     prte_pmix_server_pset_t *pset;
     pmix_cpuset_t cpuset;
     uint32_t ui32, *ui32_ptr;
+    uint32_t nodesize;
     prte_job_t *parent = NULL;
     pmix_device_distance_t *distances;
     size_t ndist;
@@ -385,8 +386,15 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
             }
             /* pass the node ID */
             PMIX_INFO_LIST_ADD(ret, iarray, PMIX_NODEID, &node->index, PMIX_UINT32);
-            /* add node size */
-            PMIX_INFO_LIST_ADD(ret, iarray, PMIX_NODE_SIZE, &node->num_procs, PMIX_UINT32);
+            /* Add node size. Widen it first: node->num_procs is a
+             * prte_node_rank_t (uint16_t), so handing its address over as
+             * PMIX_UINT32 makes PMIx read four bytes out of a two-byte
+             * field. The extra two are the padding before node->procs -
+             * PMIX_NEW does not zero its allocation - so the value the
+             * client is told is num_procs with heap garbage in its upper
+             * half. */
+            nodesize = node->num_procs;
+            PMIX_INFO_LIST_ADD(ret, iarray, PMIX_NODE_SIZE, &nodesize, PMIX_UINT32);
             /* add local size for this job */
             PMIX_INFO_LIST_ADD(ret, iarray, PMIX_LOCAL_SIZE, &ui32, PMIX_UINT32);
             /* pass the local ldr */


### PR DESCRIPTION
Nothing in the dockerswarm harness had a client that connects to its PMIx
server more than once. That is an ordinary thing for an application to do —
an MPI Sessions program runs a cycle per `MPI_Session_init` — and it is the
shape that produced openpmix#4113 and openpmix#4112. Neither issue could
have been caught by anything in this suite, and after both were fixed there
was still nothing standing between them and a regression.

### The coverage

`pmixloop` cycles `PMIx_Init` → collecting fence → bare fence →
`PMIx_Finalize` with a per-rank skew, so one rank opens its next cycle while
its peers are still finalizing the last. Two phases assert opposite ends of
it:

- **`test_pmix_cycling`** reads the *clients'* tallies. #4113 counted a rank
  that departed through `PMIx_Finalize` as lost, so the next cycle's fence
  completed without it and the ranks drifted apart by whole cycles.
- **`test_pmix_server_teardown`** reads the *server's* exit status and
  stderr, because #4112 is a crash in the server: a strictly local fence's
  completion only thread-shifts, the tracker stays on the collectives list
  looking complete and unclaimed, a second driver completes it again, and
  the corrupted list surfaces later as an invalid free in
  `PMIx_server_finalize`.

### Three things decide whether these test anything

All three are documented in the phases and in `AGENTS.md` §21, because each
one silently empties a case rather than failing it.

**The machine has to be loaded** — this is the experiment, not a tuning
knob. Against a PMIx with both fixes removed:

| | 100 iters | 400 iters | 800 iters |
|---|---|---|---|
| idle | passes | passes | passes |
| 3× oversubscribed | **aborts** | aborts | aborts |

Iterations cannot substitute for load. The phases raise their own burners
and `SWARM_CLEAN` reaps strays.

**Two ranks must share a daemon** (cycling): the defect is in one server's
own tracker accounting, and it takes two ranks finalizing together to
satisfy a third's next fence. One rank per node passes 5 runs out of 5
against the unfixed library.

**The job must not be spread at all** (teardown): that window exists only
for a fence the host never sees. These two requirements contradict each
other, which is why they are separate phases rather than one job.

### Verified in both directions

6 assertions pass against master; **all 6 fail** against a PMIx with the two
`peer->finalized` guards and the three `completion_fired` marks removed —
where the teardown case reproduces #4112 exactly, `malloc(): unsorted double
linked list corrupted`, with valgrind putting the invalid free in
`PMIx_server_finalize` at an address inside `pmix_server_globals`.

Both fixes have to come out together: #4124's guard skips the
lost-connection sweep for finalized peers, and that sweep is what drives
#4112's second completion — so with #4124 in place this workload cannot
reach #4112 at all.

### The bug it turned up

Running the new phase under valgrind reported a conditional jump on an
uninitialised value in `encode_int` beneath `server_register_new_job_info`.
`--track-origins` traced it to `node->num_procs`, a `uint16_t` being handed
to `PMIX_INFO_LIST_ADD` as `PMIX_UINT32`: PMIx read four bytes from a
two-byte field, taking the padding before `node->procs`, which `PMIX_NEW`
does not zero. So the `PMIX_NODE_SIZE` published to clients was `num_procs`
with heap garbage in its upper half. Usually that padding is zero; nothing
makes it so. Fixed in its own commit, and every other field-address entry in
that function was checked against its member's width at the same time — it
was the only one that disagreed.