### PR TITLE
ras/slurm: don't log the missing-extensions diagnostic on every init

### DIFF
--- a/src/mca/ras/slurm/ras_slurm.h
+++ b/src/mca/ras/slurm/ras_slurm.h
@@ -49,9 +49,11 @@ BEGIN_C_DECLS
 /* To check if Jansson is available in compilation */
 bool prte_ras_slurm_have_jansson(void);
 
-/* Whether this build can serve the elastic modify surface at all, reporting
- * why not when it cannot.  Every entry point of that surface asks first. */
-bool prte_ras_slurm_have_extensions(void);
+/* Whether this build can serve the elastic modify surface at all.  Every
+ * entry point of that surface asks first, with quiet=false, so the refusal
+ * is reported.  Callers that just need the answer (e.g. deciding whether to
+ * set up bookkeeping at init time) pass quiet=true to suppress that. */
+bool prte_ras_slurm_have_extensions(bool quiet);
 
 /* Features requiring JSON parser */
 int prte_ras_slurm_extract_job_fields(pmix_hash_table_t *values_table);

--- a/src/mca/ras/slurm/ras_slurm_modify_cancel.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_cancel.c
@@ -43,7 +43,7 @@ static void prte_ras_slurm_cancel_req_at(int idx);
  */
 int prte_ras_slurm_serve_cancel_req(prte_pmix_server_req_t *req)
 {
-    if (!prte_ras_slurm_have_extensions()) {
+    if (!prte_ras_slurm_have_extensions(false)) {
         return PRTE_ERR_NOT_AVAILABLE;
     }
 
@@ -283,7 +283,7 @@ static int prte_ras_slurm_find_pending_req(const char *request_id, int *idx)
  */
 int prte_ras_slurm_modify_cancel_init(void)
 {
-    if(initialized || !prte_ras_slurm_have_jansson()) {
+    if(initialized || !prte_ras_slurm_have_extensions(true)) {
         return PRTE_SUCCESS;
     }
 

--- a/src/mca/ras/slurm/ras_slurm_modify_common.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_common.c
@@ -39,17 +39,22 @@
  * jansson and a Slurm too old to emit the schema the parser reads -- and
  * that machine is every stock Ubuntu 24.04, so it is not a corner case.
  *
- * @return true when the request can be served, false (having said why) when
- *         it cannot.
+ * @param[in] quiet  Suppress the diagnostic on refusal (e.g. when the caller
+ *                   just wants the answer, not a report to the user).
+ *
+ * @return true when the request can be served, false (having said why,
+ *         unless quiet) when it cannot.
  */
-bool prte_ras_slurm_have_extensions(void)
+bool prte_ras_slurm_have_extensions(bool quiet)
 {
     const prte_common_slurm_version_t *slurm;
 
 #if PRTE_HAVE_SLURM_EXTENSIONS
     if (!prte_ras_slurm_have_jansson()) {
-        pmix_output(0, "ras:slurm:modify: "
-                    "Jansson support is required but not enabled in this build");
+        if (!quiet) {
+            pmix_output(0, "ras:slurm:modify: "
+                        "Jansson support is required but not enabled in this build");
+        }
         return false;
     }
 
@@ -59,11 +64,13 @@ bool prte_ras_slurm_have_extensions(void)
      * failed popen would turn a transient into a policy. */
     slurm = prte_common_slurm_version();
     if (slurm->available && !slurm->extended) {
-        pmix_output(0, "ras:slurm:modify: this Slurm (%s) is older than %s, "
-                    "whose JSON schema the allocation extensions read. The "
-                    "request cannot be served; extend/release/cancel need a "
-                    "newer Slurm.",
-                    slurm->version, PRTE_SLURM_MIN_EXT_VERSION);
+        if (!quiet) {
+            pmix_output(0, "ras:slurm:modify: this Slurm (%s) is older than %s, "
+                        "whose JSON schema the allocation extensions read. The "
+                        "request cannot be served; extend/release/cancel need a "
+                        "newer Slurm.",
+                        slurm->version, PRTE_SLURM_MIN_EXT_VERSION);
+        }
         return false;
     }
     return true;
@@ -74,14 +81,16 @@ bool prte_ras_slurm_have_extensions(void)
      * or by --disable-slurm-extensions, and configure folds all three into
      * one flag. */
     slurm = prte_common_slurm_version();
-    pmix_output(0, "ras:slurm:modify: the Slurm elastic allocation extensions "
-                "were not built into this PRRTE. They need jansson and Slurm "
-                "%s or later; this tree was configured against Slurm %s, and "
-                "is running under Slurm %s. Rebuild with "
-                "--enable-slurm-extensions (and --with-jansson) to enable "
-                "them.",
-                PRTE_SLURM_MIN_EXT_VERSION, PRTE_SLURM_VERSION_STRING,
-                slurm->version);
+    if (!quiet) {
+        pmix_output(0, "ras:slurm:modify: the Slurm elastic allocation extensions "
+                    "were not built into this PRRTE. They need jansson and Slurm "
+                    "%s or later; this tree was configured against Slurm %s, and "
+                    "is running under Slurm %s. Rebuild with "
+                    "--enable-slurm-extensions (and --with-jansson) to enable "
+                    "them.",
+                    PRTE_SLURM_MIN_EXT_VERSION, PRTE_SLURM_VERSION_STRING,
+                    slurm->version);
+    }
     return false;
 #endif
 }

--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -224,7 +224,7 @@ static void ssc_des(prte_slurm_salloc_child_t *p)
  */
 int prte_ras_slurm_modify_extend_init(void)
 {
-    if (extend_initialized || !prte_ras_slurm_have_extensions()) {
+    if (extend_initialized || !prte_ras_slurm_have_extensions(true)) {
         return PRTE_SUCCESS;
     }
 
@@ -1473,7 +1473,7 @@ void prte_ras_slurm_extend_abort_request(const char *request_id)
  */
 int prte_ras_slurm_serve_extend_req(prte_pmix_server_req_t *req)
 {
-    if (!prte_ras_slurm_have_extensions()) {
+    if (!prte_ras_slurm_have_extensions(false)) {
         return PRTE_ERR_NOT_AVAILABLE;
     }
 

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -621,7 +621,7 @@ void prte_ras_slurm_shrink_complete(prte_shrink_campaign_t *campaign)
  */
 int prte_ras_slurm_serve_release_req(prte_pmix_server_req_t *req)
 {
-    if (!prte_ras_slurm_have_extensions()) {
+    if (!prte_ras_slurm_have_extensions(false)) {
         return PRTE_ERR_NOT_AVAILABLE;
     }
 

--- a/src/mca/ras/slurm/ras_slurm_modify_release_tracker.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release_tracker.c
@@ -65,8 +65,17 @@ static void shrink_tracker_des(prte_ras_slurm_shrink_tracker_t *p)
     PMIX_DESTRUCT(&p->actions);
 }
 
+/*
+ * Only needed when extensions are built: nothing populates this list
+ * otherwise, since serve_release_req refuses before ever attaching a
+ * tracker.
+ */
 int prte_ras_slurm_modify_release_init(void)
 {
+    if (!prte_ras_slurm_have_extensions(true)) {
+        return PRTE_SUCCESS;
+    }
+
     prte_slurm_shrink_trackers = PMIX_NEW(pmix_list_t);
     if (NULL == prte_slurm_shrink_trackers) {
         return PRTE_ERR_OUT_OF_RESOURCE;


### PR DESCRIPTION
modify_extend_init, modify_cancel_init and modify_release_init all ran on every component init, and the first two gated on have_extensions(), which logs unconditionally on refusal, so a build without the extensions printed the diagnostic on every DVM startup regardless of whether anything had asked for extend/release/cancel; give have_extensions() a quiet mode and use it from the three init functions so they can size their bookkeeping to what the build supports without reporting anything, while the serve_*_req entry points, where a request is genuinely refused, keep reporting.

Credits: AccelCom @ Barcelona Supercomputing Center