### PR TITLE
Hand the connect blob to the fence rather than lending it

### DIFF
--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -1315,6 +1315,7 @@ pmix_status_t pmix_server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
                                      pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     prte_pmix_server_req_t *cd;
+    pmix_byte_object_t bo;
     size_t n;
     pmix_status_t rc;
 
@@ -1345,10 +1346,31 @@ pmix_status_t pmix_server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
     cd->opcbfunc = cbfunc;
     cd->cbdata = cbdata;
 
+    /* prte_grpcomm_fence() takes OWNERSHIP of the blob it is handed - the
+     * fence caddy's destructor frees it, which is right for its other
+     * caller, where the blob is the modex bucket PMIx transferred to us on
+     * the fence_nb up-call. So this one must hand its bytes over rather
+     * than lend them: passing cd->msg's own pointer left the buffer still
+     * owning them, and rqdes destructed it after the fence caddy had
+     * already freed it. Unloading empties the buffer, so the destruct
+     * becomes the no-op it needs to be. An empty buffer unloads to
+     * (NULL, 0), which is what a connect carrying no endpoint data
+     * passed before. */
+    PMIX_BYTE_OBJECT_CONSTRUCT(&bo);
+    rc = PMIx_Data_unload(&cd->msg, &bo);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(cd);
+        return rc;
+    }
+
     rc = prte_grpcomm_fence(procs, nprocs, info, ninfo,
-                            cd->msg.unpack_ptr, cd->msg.bytes_used,
+                            bo.bytes, bo.size,
                             connect_release, cd);
     if (PRTE_SUCCESS != rc) {
+        /* it refused before taking the blob, so it is still ours */
+        if (NULL != bo.bytes) {
+            free(bo.bytes);
+        }
         /* the release callback will never fire */
         PMIX_RELEASE(cd);
         /* grpcomm answers in PRTE codes, our caller reads PMIx ones */


### PR DESCRIPTION
A cross-namespace `PMIx_Connect` aborts the HNP with `double free or
corruption (out)` as the collective completes, leaving a stray `prted`
behind.

## Two owners, one blob

`prte_grpcomm_fence()` takes **ownership** of the blob it is handed.
`mddes()` frees `cd->data`, and the comment there says why it has to: for
the other caller — `pmix_server_fencenb_fn()` — that blob is the modex
bucket PMIx transferred to us on the `fence_nb` up-call, and PMIx has
nothing left it could free it from.

`pmix_server_connect_fn()` did not hand its bytes over. It packs the
participants' endpoint arrays into `cd->msg`, a `pmix_data_buffer_t` the
`prte_pmix_server_req_t` owns, and passed `cd->msg.unpack_ptr` to the
fence. So:

1. the fence caddy's destructor frees that block when the collective
   completes, then
2. `connect_release()` releases the request, and `rqdes()` destructs
   `cd->msg` — freeing the same block a second time.

## The fix

Unload the buffer before handing the pointer over. That empties
`cd->msg`, so the request's destruct becomes the no-op it needs to be,
and the fence gets a block that really is its own. An empty buffer
unloads to `(NULL, 0)`, which is exactly what a connect carrying no
endpoint data passed before. The error path frees the blob itself, since
`prte_grpcomm_fence()` refuses before it takes it.

## How it was found, and how it was checked

valgrind against a **prted** running `examples/dynamic.c` and
`examples/resolve.c` from openpmix's `contrib/dockerswarm` suite — both
call `PMIx_Spawn` and then connect across namespaces, and both aborted.
Neither the application ranks nor the remote daemons were at fault; they
came back clean, which is what pointed at the HNP.

`run-server-tests.sh` reported **12 passed / 4 failed** before this
(`dynamic` and `resolve`, each with the abort plus a stray `prted`) and
reports **14 passed / 0 failed** after. The same valgrind run reports
`0 errors from 0 contexts`, where it previously reported the invalid
free.
