### PR TITLE
Retire a fence tracker before delivering, and run the swarm suite with OOB threads

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -885,6 +885,41 @@ foreground under `docker exec -d` (see §5).
 
 ---
 
+### The suite runs the OOB with worker threads
+
+`prte_oob_base.num_progress_threads` defaults to **0** in the library: every
+peer's socket send/recv events are serviced on the main progress thread, so
+the OOB is effectively single-threaded. With workers configured, each peer is
+assigned to a worker base and its handlers run on that thread, posting
+completions back to `prte_event_base` — and that is the arrangement in which a
+missing lock, a peer touched from two threads, or a completion that assumes it
+runs on the main thread has any consequence at all.
+
+At the library default this suite could never reach that path: not one case
+would exercise it, and a race introduced there would ship. So `run-tests.sh`
+opts in, exporting `PRTE_MCA_oob_progress_threads` into every tool it runs —
+and thereby into every daemon, since `prte_plm_base_setup_virtual_machine`
+harvests `PRTE_MCA_*` from the launcher's environment onto the daemon command
+line.
+
+**The default here is 2**, the smallest genuinely multi-threaded setting: one
+worker plus the main thread is already two threads touching the OOB, and two
+workers means two peers can be serviced at once. The preflight prints the
+number it used, so a suite log always says which mode produced it.
+
+Override with `PRTE_SWARM_OOB_THREADS`:
+
+```sh
+PRTE_SWARM_OOB_THREADS=0 ./run-tests.sh linux   # library default, single-threaded
+PRTE_SWARM_OOB_THREADS=8 ./run-tests.sh linux   # push the threading harder
+```
+
+**If a case fails, re-run it at 0 before reading the failure as a bug in what
+you just changed.** A failure that reproduces only with workers is a genuine
+threading defect worth chasing; one that reproduces at 0 as well has nothing
+to do with the OOB threading. Keeping that distinction cheap is the reason the
+knob exists rather than the number being hard-coded.
+
 ## 7. Cleanup hygiene
 
 `run-tests.sh` cleans every node before its first case and between phases.

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -76,15 +76,41 @@ bounded() {
 # Linux: the full 10-node swarm
 ########################################################################
 
+# THE SUITE RUNS WITH OOB PROGRESS THREADS ON, AND THAT IS DELIBERATE.
+#
+# prte_oob_base.num_progress_threads defaults to 0 in the library: every
+# peer's socket send/recv events are serviced on the main progress thread, so
+# the OOB is effectively single-threaded and the ordering between a send
+# completing and anything else the daemon does is fixed. With workers, each
+# peer is assigned to a worker base and its handlers run on that thread,
+# posting completions back to prte_event_base -- which is the arrangement
+# where a missing lock, a peer touched from two threads, or a completion that
+# assumes it runs on the main thread actually has consequences.
+#
+# At the default of 0 this suite could never reach any of that: not one case
+# would exercise the threaded path, and a race introduced there would ship.
+# So the suite opts in, for every tool and (via the PRTE_MCA_ forwarding in
+# prte_plm_base_setup_virtual_machine) every daemon it launches.
+#
+# Two is the smallest number that is genuinely multi-threaded -- one worker
+# plus the main thread is already two threads touching the OOB, and two
+# workers means two peers can be serviced concurrently. Override with
+# PRTE_SWARM_OOB_THREADS to sweep it, or set it to 0 to reproduce the old
+# single-threaded behavior when bisecting a failure.
+OOB_THREADS="${PRTE_SWARM_OOB_THREADS:-2}"
+OOBENV=(-e "PRTE_MCA_oob_progress_threads=$OOB_THREADS")
+
 # run a command on the head node (login env so PATH/LD_LIBRARY_PATH are set)
 RUN() { docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+            "${OOBENV[@]}" \
             "${NODE}1" bash -lc ". /opt/prte/env.sh; $*"; }
-ON()  { docker exec "$NODE$1" bash -lc ". /opt/prte/env.sh 2>/dev/null; ${*:2}"; }
+ON()  { docker exec "${OOBENV[@]}" "$NODE$1" bash -lc ". /opt/prte/env.sh 2>/dev/null; ${*:2}"; }
 # ...and the same for a case that drives a TOOL from a node other than the
 # head. ON alone is enough for shell housekeeping, but every PRRTE tool
 # refuses to run as root without these two, and the refusal text is long
 # enough to bury whatever the case was actually asserting.
 ONT() { docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+            "${OOBENV[@]}" \
             "$NODE$1" bash -lc ". /opt/prte/env.sh; ${*:2}"; }
 
 # What must not survive into the next test, on one node.  Each tool has its
@@ -4699,6 +4725,16 @@ test_linux() {
     stamp=$(RUN 'cat /opt/prte/.build-stamp 2>/dev/null' | tr -d '\r')
     if [ -n "$stamp" ]; then
         ok "install built $stamp"
+        # Say which OOB threading the whole run used. The library defaults to
+        # 0 (everything on the main progress thread); this suite opts in to
+        # workers so the threaded send/recv path is covered at all. A failure
+        # that only appears here is the first thing to re-check with
+        # PRTE_SWARM_OOB_THREADS=0, which is why the number is in the log.
+        if [ "$OOB_THREADS" = 0 ]; then
+            ok "...running with OOB progress threads OFF (single-threaded OOB)"
+        else
+            ok "...running with $OOB_THREADS OOB progress threads (library default is 0)"
+        fi
     else
         bad "no build stamp in the volume -- the last ./build.sh did not complete."
         echo "     Re-run ./build.sh and check its exit status; the install now" >&2

--- a/src/grpcomm/AGENTS.md
+++ b/src/grpcomm/AGENTS.md
@@ -147,7 +147,7 @@ always one thing.
 | `output` | Verbosity stream. `-1` until the `grpcomm_base_verbose` MCA parameter opens it. The parameter deliberately **keeps its old framework spelling**, because it is in every debugging recipe and in the guides. |
 | `context_id` | The group context-id pool. A construct asking for `PMIX_GROUP_ASSIGN_CONTEXT_ID` gets this value, and it **decrements** — it counts *down* from `UINT32_MAX` so DVM-assigned ids cannot collide with ids assigned from the bottom of the range elsewhere. |
 | `xcast_ops` | In-flight broadcasts, the `pending_completions` FIFO, and the three op-id sequence counters. |
-| `fence_ops` | List of `prte_grpcomm_fence_t`. |
+| `fence_ops` | List of `prte_grpcomm_fence_t`. A tracker is found here by its signature alone, so it must come **off** this list before its result is delivered — see *Retire before you deliver* below. |
 | `group_ops` | List of `prte_grpcomm_group_t`. |
 | `completed_group_ops` | Bounded memo of already-released group ops (see below). |
 | `recovery_epoch` | The collective recovery epoch, shared by fence and group: one failure, one restart, one epoch. |
@@ -156,6 +156,33 @@ Note the verbosity variable that backs the MCA parameter is at **file
 scope** in `grpcomm.c`, not a local: the MCA layer keeps the pointer it is
 handed and writes through it whenever the variable is set, so a stack slot
 would be a dangling write the moment registration returns.
+
+### Retire before you deliver
+
+**A fence tracker comes off `fence_ops` before its completion callback runs,
+not after.** The fence is over the moment its result is in hand; everything
+after that is delivery, and delivery is precisely when the next fence can
+start.
+
+The reason is that a fence signature is *only its participant list*. It
+carries nothing to distinguish one fence over a set of procs from the next
+fence over that same set. So when `fence_release()` runs the callback, the
+local clients' `PMIx_Fence` completes, and any of them may call `PMIx_Fence`
+again over the same participants immediately — and that lookup would find the
+tracker that has just been answered and is about to be released, joining a
+collective that is already finished.
+
+Both completion paths honor this, by different means:
+
+- `fence_release()` unlinks the tracker first, then delivers. It still holds
+  the reference that keeps the object alive across the callback.
+- the entry point's failure path leaves the tracker in place deliberately (a
+  later release from the controller still has to find it) and instead clears
+  `cbfunc`/`cbdata` so the participants cannot be completed twice.
+
+Do not "tidy" the unlink back down next to `PMIX_RELEASE(coll)`. It reads like
+teardown belonging together and it is not: one of those two is the end of the
+collective and the other is just freeing memory.
 
 ---
 

--- a/src/grpcomm/grpcomm_fence.c
+++ b/src/grpcomm/grpcomm_fence.c
@@ -893,6 +893,21 @@ void prte_grpcomm_fence_release(int status, pmix_proc_t *sender,
         ret = rc;
     }
 
+    /* Retire the tracker BEFORE delivering, not after. This fence is over the
+     * moment we have its result; everything below is delivery, and delivery is
+     * exactly when the next fence can start. The callback completes the local
+     * clients' PMIx_Fence, and a client is free to fence again over the same
+     * participants as soon as it returns - a signature is only its participant
+     * list, so that next fence looks up the very tracker we are about to free
+     * and would join a collective that has already been answered.
+     *
+     * Taking it off the list first costs nothing: we still hold the reference
+     * that keeps `coll` alive for the callback below, and nothing between here
+     * and the release needs to find it by lookup. The abort path above does
+     * the same thing for the same reason, by clearing cbfunc rather than by
+     * unlinking. */
+    pmix_list_remove_item(&prte_grpcomm_globals.fence_ops, &coll->super);
+
     /* execute the callback */
     if (NULL != coll->cbfunc) {
         coll->cbfunc(ret, bo.bytes, bo.size, coll->cbdata, relcb, bo.bytes);
@@ -904,7 +919,6 @@ void prte_grpcomm_fence_release(int status, pmix_proc_t *sender,
          * callback above was handed it. */
         PMIX_BYTE_OBJECT_DESTRUCT(&bo);
     }
-    pmix_list_remove_item(&prte_grpcomm_globals.fence_ops, &coll->super);
     PMIX_RELEASE(coll);
     PMIX_RELEASE(sig);
 }


### PR DESCRIPTION
Two small, independent changes that came out of re-testing the fence work.

### Retire a fence tracker before delivering its result

`fence_release()` ran the completion callback and only then unlinked the
tracker from `fence_ops`. Those two are not both teardown — the first is
delivery, the second is the end of the collective — and in that order the
tracker stays findable across exactly the window where something is most
likely to look for it.

A fence signature is only its participant list; nothing in it separates one
fence over a set of procs from the next fence over that same set. The callback
completes the local clients' `PMIx_Fence`, and a client may fence again over
the same participants the instant it returns, finding the tracker that has
just been answered and is about to be released.

Unlinking first costs nothing — the reference we hold keeps the object alive
across the callback, and nothing between the unlink and the release finds a
tracker by lookup. The entry point's failure path already reasons this way
from the other side: it clears `cbfunc`/`cbdata` so a later release cannot
complete the participants twice, while deliberately leaving the tracker in
place for that release to find.

**This is ordering hygiene, not a fix for an observed failure, and the guide
says so.** The window may be unreachable as the code stands: the callback
hands off to PMIx, and the client's next fence arrives as a fresh event on
`prte_event_base`, which is not serviced until the current handler — including
the unlink — has run to completion. It is one line either way, and the version
that doesn't rest on that argument is the one worth having.

The rule is recorded in `src/grpcomm/AGENTS.md` beside the `fence_ops` entry,
because what makes it easy to undo is that the unlink *looks* like it belongs
next to `PMIX_RELEASE(coll)`.

### Run the swarm suite with OOB progress threads

`prte_oob_base.num_progress_threads` defaults to 0 — every peer's socket
events serviced on the main progress thread. No case in `run-tests.sh` has
ever set it, so the threaded path (each peer on a worker base, handlers on
that thread, completions posted back to `prte_event_base`) has never been
exercised by this suite at all. That is the wrong default for a test suite:
the reason the worker bases are interesting is that they add concurrency to
the OOB, and a missing lock or a peer touched from two threads has no
consequence at zero workers, so such a race would pass every case here and
ship.

The suite now exports `PRTE_MCA_oob_progress_threads`, which reaches the
daemons too — `prte_plm_base_setup_virtual_machine` harvests `PRTE_MCA_*` onto
the daemon command line. Verified end to end: a `prted` on another node comes
up carrying `--prtemca oob_progress_threads 2`.

Default 2 (one worker plus the main thread is already two threads in the OOB;
two workers means two peers serviced at once). `PRTE_SWARM_OOB_THREADS`
overrides it, and `=0` restores the library default — the first thing to try
when a case fails, since a failure that survives at 0 has nothing to do with
threading. The preflight prints the number used.

### Testing

- `make check`: **21/21 pass**, including `test_grpcomm`.
- dockerswarm collectives, fault-tolerance, and the two PMIx-churn regression
  phases: **49 passed, 0 failed**, all with OOB workers on.
- Clean build, no new warnings.

### Context

This started as a port of the fence *generation* work from the withdrawn
`topic/lateral-modex`. I dropped that deliberately: its rationale was
specifically that a release travels down the tree while `rd_allgather`'s
blocks go straight across to Bruck partners, and `75fb61a2ba` ("move every
collective on the tree, and only on the tree") removed that lateral exchange.
On the 32-container scale swarm I could not reproduce the hang on current
master in 16 runs across four configurations — 16 and 32 nodes, up to 64
ranks, radix 2, ~1000 consecutive fences — against a historical repro of
"within one or two attempts at 16, first fence at 32". Porting a wire field
and a per-signature memo to close a race nothing can currently demonstrate
did not seem like a good trade; the one piece of it that is still literally
present on master is the ordering above.