### PR TITLE
Route a job's output to every daemon that has someone watching it

### DIFF
--- a/src/mca/iof/hnp/iof_hnp_receive.c
+++ b/src/mca/iof/hnp/iof_hnp_receive.c
@@ -75,6 +75,7 @@ void prte_iof_hnp_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buff
     unsigned char *stdindata = NULL;
     pmix_iof_channel_t pchan;
     prte_iof_deliver_t *p;
+    prte_job_t *jdata;
     pmix_status_t prc;
     PRTE_HIDE_UNUSED_PARAMS(status, tag, cbdata);
 
@@ -144,6 +145,32 @@ void prte_iof_hnp_recv(int status, pmix_proc_t *sender, pmix_data_buffer_t *buff
     PMIX_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
                          "%s received IOF cmd for source %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                          PRTE_NAME_PRINT(&origin)));
+
+    /* A daemon telling us that somebody attached to IT wants this job's
+     * output. That tool's IOF subscription is held by that daemon's PMIx
+     * server and only that server can deliver to it, so we have to relay
+     * a copy of this job's output there - which we will not do unless the
+     * daemon is in the job's interested set. Record it and we are done;
+     * the message carries no payload. Sent by record_interest() in
+     * src/prted/pmix/pmix_server_gen.c, on PRTE_RML_TAG_IOF_HNP - the
+     * upstream tag this handler is registered on. */
+    if (PRTE_IOF_PULL & stream) {
+        jdata = prte_get_job_data_object(origin.nspace);
+        if (NULL == jdata) {
+            /* a job we have never heard of, or one already gone */
+            PMIX_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
+                                 "%s iof:hnp interest from daemon %s in unknown job %s",
+                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                 PRTE_NAME_PRINT(sender), origin.nspace));
+            goto CLEAN_RETURN;
+        }
+        PMIX_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
+                             "%s iof:hnp daemon %s is interested in job %s output",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                             PRTE_NAME_PRINT(sender), origin.nspace));
+        pmix_bitmap_set_bit(&jdata->iof_daemons, (int) sender->rank);
+        goto CLEAN_RETURN;
+    }
 
     /* a daemon that is hosting a tool cannot route the tool's stdin - only
      * we know which daemon hosts the target proc - so it relays the push to

--- a/src/mca/iof/hnp/iof_hnp_send.c
+++ b/src/mca/iof/hnp/iof_hnp_send.c
@@ -161,6 +161,37 @@ int prte_iof_hnp_send_data_to_endpoint(const pmix_proc_t *host,
  *     duplicate it. Same for output from our own children when the tool is
  *     attached to us.
  */
+#if PRTE_PMIX_IOF_DELIVER_LOCAL
+/* Relay one job's output to one daemon, skipping the two destinations
+ * that would duplicate what has already been written: ourselves, and
+ * whichever daemon the caller says already delivered it. */
+static void relay_one(pmix_rank_t dmn,
+                      const pmix_proc_t *source,
+                      prte_iof_tag_t stream,
+                      unsigned char *data, int numbytes,
+                      pmix_rank_t already_delivered)
+{
+    pmix_proc_t host;
+    int rc;
+
+    if (dmn == PRTE_PROC_MY_NAME->rank || dmn == already_delivered ||
+        PMIX_RANK_INVALID == dmn) {
+        return;
+    }
+
+    PMIX_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
+                         "%s iof:hnp relaying %d bytes of %s output to the tool on daemon %s",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), numbytes,
+                         PRTE_NAME_PRINT(source), PMIX_RANK_PRINT(dmn)));
+
+    PMIX_LOAD_PROCID(&host, PRTE_PROC_MY_NAME->nspace, dmn);
+    rc = prte_iof_hnp_send_data_to_endpoint(&host, source, stream, data, numbytes);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+    }
+}
+#endif
+
 void prte_iof_hnp_relay_to_tool(const pmix_proc_t *source,
                                 prte_iof_tag_t stream,
                                 unsigned char *data, int numbytes,
@@ -168,32 +199,44 @@ void prte_iof_hnp_relay_to_tool(const pmix_proc_t *source,
 {
 #if PRTE_PMIX_IOF_DELIVER_LOCAL
     prte_job_t *jdata;
-    pmix_proc_t host;
-    int rc;
+    pmix_rank_t dmn;
+    int n, last;
 
     jdata = prte_get_job_data_object(source->nspace);
-    if (NULL == jdata || PMIX_NSPACE_INVALID(jdata->originator.nspace)) {
-        return;
-    }
-    /* an originator outside the daemon namespace is a tool attached to us */
-    if (!PMIX_CHECK_NSPACE(jdata->originator.nspace, PRTE_PROC_MY_NAME->nspace)) {
-        return;
-    }
-    if (jdata->originator.rank == PRTE_PROC_MY_NAME->rank ||
-        jdata->originator.rank == already_delivered) {
+    if (NULL == jdata) {
         return;
     }
 
-    PMIX_OUTPUT_VERBOSE((1, prte_iof_base_framework.framework_output,
-                         "%s iof:hnp relaying %d bytes of %s output to the tool on daemon %s",
-                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), numbytes,
-                         PRTE_NAME_PRINT(source),
-                         PMIX_RANK_PRINT(jdata->originator.rank)));
+    /* The daemon hosting the tool that LAUNCHED this job, which is what
+     * jdata->originator names once the HNP has resolved it. Kept as the
+     * seed of the set below rather than as a second mechanism: a job that
+     * nobody has since subscribed to has exactly this one destination,
+     * which is the behavior this function has always had. */
+    if (!PMIX_NSPACE_INVALID(jdata->originator.nspace) &&
+        /* an originator outside the daemon namespace is a tool attached
+         * to us, so there is nothing to relay anywhere */
+        PMIX_CHECK_NSPACE(jdata->originator.nspace, PRTE_PROC_MY_NAME->nspace)) {
+        relay_one(jdata->originator.rank, source, stream, data, numbytes,
+                  already_delivered);
+    }
 
-    PMIX_LOAD_PROCID(&host, PRTE_PROC_MY_NAME->nspace, jdata->originator.rank);
-    rc = prte_iof_hnp_send_data_to_endpoint(&host, source, stream, data, numbytes);
-    if (PRTE_SUCCESS != rc) {
-        PRTE_ERROR_LOG(rc);
+    /* ...and every daemon that has since acquired an interest in this
+     * job's output: a tool that attached to it and called PMIx_IOF_pull,
+     * or - for a spawned job - whatever its parent had. Relaying to a
+     * daemon is what puts the bytes in front of the PMIx server that
+     * holds that tool's subscription; no other server can deliver to it. */
+    last = pmix_bitmap_size(&jdata->iof_daemons);
+    for (n = 0; n < last; n++) {
+        if (!pmix_bitmap_is_set_bit(&jdata->iof_daemons, n)) {
+            continue;
+        }
+        dmn = (pmix_rank_t) n;
+        if (!PMIX_NSPACE_INVALID(jdata->originator.nspace) &&
+            PMIX_CHECK_NSPACE(jdata->originator.nspace, PRTE_PROC_MY_NAME->nspace) &&
+            dmn == jdata->originator.rank) {
+            continue;   // already served as the seed above
+        }
+        relay_one(dmn, source, stream, data, numbytes, already_delivered);
     }
 #else
     /* without a PMIx that can be told not to emit a delivery, relaying would

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -553,6 +553,8 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     bool bind_inherited = false;
     prte_rmaps_base_selected_module_t *mod;
     prte_job_t *parent = NULL;
+    prte_job_t *iof_parent = NULL;
+    bool iof_declined = false;
     prte_app_context_t *app;
     bool inherit = false;
     pmix_proc_t *nptr = NULL, *target_proc;
@@ -755,6 +757,22 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
             /* we do allow inheritance of the defaults */
             inherit = true;
         } else if (NULL != (parent = prte_get_job_data_object(nptr->nspace))) {
+            /* Output forwarding asks the same question with a DIFFERENT
+             * default, so it cannot key off the `inherit` the arms below
+             * resolve. prte_rmaps_base.inherit is false unless the user
+             * says otherwise - a spawned job does not pick up mapping,
+             * ranking and binding unless asked - whereas output
+             * forwarding inherits unless it is REFUSED, on both sides of
+             * the PMIx interface. Keying off the resolved value silenced
+             * every spawned job.
+             *
+             * So capture the explicit refusal, and the parent, here:
+             * two of the arms below null the parent out. */
+            iof_parent = parent;
+            iof_declined = prte_get_attribute(&jdata->attributes, PRTE_JOB_NOINHERIT,
+                                              NULL, PMIX_BOOL) ||
+                           prte_get_attribute(&parent->attributes, PRTE_JOB_NOINHERIT,
+                                              NULL, PMIX_BOOL);
             if (PRTE_FLAG_TEST(parent, PRTE_JOB_FLAG_TOOL)) {
                 // we don't inherit anything from tools as they were not
                 // mapped by us
@@ -779,6 +797,34 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
                                 "mca:rmaps: dynamic job %s %s inherit launch directives - parent %s",
                                 PRTE_JOBID_PRINT(jdata->nspace), inherit ? "will" : "will not",
                                 (NULL == parent) ? "N/A" : PRTE_JOBID_PRINT((parent->nspace)));
+
+            /* Who receives this job's output. A spawned job is treated
+             * the way its parent is being treated, so the daemons
+             * interested in the parent's output are interested in this
+             * one's - unless inheritance was explicitly refused.
+             *
+             * This is the routing half of that behavior; PMIx supplies
+             * the matching half, deciding that a subscription covering
+             * the parent job also covers its children. Both are needed:
+             * this puts the bytes in front of the right PMIx server, and
+             * that gets them from there to the tool. */
+            if (iof_declined) {
+                /* PMIx asks this again on the server the child's output
+                 * ARRIVES at, which need not be this one, and it cannot
+                 * reach the answer itself - so record it where the job's
+                 * PMIx information is built and can carry it there. Set
+                 * only to say NO: absence of the attribute, like absence
+                 * of PMIX_IOF_INHERIT, means the job inherits. */
+                prte_set_attribute(&jdata->attributes, PRTE_JOB_NO_IOF_INHERIT,
+                                   PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+            } else if (NULL != iof_parent) {
+                rc = pmix_bitmap_copy(&jdata->iof_daemons, &iof_parent->iof_daemons);
+                if (PMIX_SUCCESS != rc) {
+                    /* not fatal to the launch - the job simply starts with
+                     * no inherited watchers, which is what it had before */
+                    PMIX_ERROR_LOG(rc);
+                }
+            }
         } else {
             inherit = true;
         }

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -1015,6 +1015,64 @@ pmix_status_t pmix_server_log2_fn(const pmix_proc_t *client, const pmix_info_t d
 }
 #endif
 
+/* Tell the HNP that somebody attached to US wants this job's output.
+ *
+ * A tool's IOF subscription is held by the PMIx server of the daemon it
+ * attached to, and only that server can deliver to it - so for output
+ * produced anywhere else to reach that tool, the HNP has to relay a copy
+ * here. It cannot know to do that unless we say so: this up-call is the
+ * only notice anyone gets, and it arrives HERE, at the daemon the tool
+ * attached to, which is precisely the daemon that needs recording. The
+ * requesting tool's own identity is not needed and is not supplied.
+ *
+ * The counterpart is the PRTE_IOF_PULL arm of prte_iof_hnp_recv().
+ */
+static void record_interest(const pmix_proc_t *proc)
+{
+    prte_job_t *jdata;
+    pmix_data_buffer_t *buf;
+    prte_iof_tag_t stream = PRTE_IOF_PULL;
+    pmix_proc_t job;
+    int rc;
+
+    /* name the job, not the rank: what gets relayed is a job's output */
+    PMIX_LOAD_PROCID(&job, proc->nspace, PMIX_RANK_WILDCARD);
+
+    if (PRTE_PROC_IS_MASTER) {
+        /* we are the HNP - record it directly */
+        jdata = prte_get_job_data_object(job.nspace);
+        if (NULL != jdata) {
+            pmix_bitmap_set_bit(&jdata->iof_daemons, (int) PRTE_PROC_MY_NAME->rank);
+        }
+        return;
+    }
+
+    PMIX_DATA_BUFFER_CREATE(buf);
+    rc = PMIx_Data_pack(NULL, buf, &stream, 1, PMIX_UINT16);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        return;
+    }
+    rc = PMIx_Data_pack(NULL, buf, &job, 1, PMIX_PROC);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        return;
+    }
+    /* PRTE_RML_TAG_IOF_HNP is the UPSTREAM tag - the one prte_iof_hnp_recv
+     * is registered on, and the one a prted forwards its own output to the
+     * HNP with. PRTE_RML_TAG_IOF_PROXY is the other direction: the HNP
+     * relaying down to a daemon. Sending this upstream on the downstream
+     * tag delivers it to the HNP and then drops it, with the reliable send
+     * still reporting success. */
+    PRTE_RML_RELIABLE_SEND(rc, PRTE_PROC_MY_HNP->rank, buf, PRTE_RML_TAG_IOF_HNP);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+    }
+}
+
 static void _iof_pull(int sd, short args, void *cbdata)
 {
     prte_pmix_server_op_caddy_t *cd = (prte_pmix_server_op_caddy_t *) cbdata;
@@ -1027,6 +1085,12 @@ static void _iof_pull(int sd, short args, void *cbdata)
     /* Set up I/O forwarding sinks and handlers for stdout and stderr for each proc
      * requesting I/O forwarding */
     for (i = 0; i < cd->nprocs; i++) {
+        /* whoever asked is attached to us, so record us as interested in
+         * this job before setting the sinks up - a stop request is the
+         * one case that must not, since it is asking for the opposite */
+        if (!cd->flag) {
+            record_interest(&cd->procs[i]);
+        }
         if (cd->channels & PMIX_FWD_STDOUT_CHANNEL) {
             if (cd->flag) {
                 /* ask the IOF to stop forwarding this channel */

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -545,6 +545,21 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_XML_OUTPUT, (void**)&fptr, PMIX_BOOL)) {
         PMIX_INFO_LIST_ADD(ret, info, PMIX_IOF_XML_OUTPUT, &flag, PMIX_BOOL);
     }
+#ifdef PMIX_IOF_INHERIT
+    /* Whether this job is to inherit the output forwarding of the job that
+     * spawned it. PMIx asks this on the server the child's output ARRIVES
+     * at, which need not be the one that processed the spawn, so the answer
+     * has to travel with the job rather than with the spawn request - and
+     * this is what carries it there. The mapper resolved it, subject to the
+     * same inherit rule that governs mapping, ranking and binding.
+     *
+     * Sent only to say NO: absence means inherit, on both sides of the
+     * interface, so a job with no opinion adds nothing to the wire. */
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_NO_IOF_INHERIT, NULL, PMIX_BOOL)) {
+        bool noinherit = false;
+        PMIX_INFO_LIST_ADD(ret, info, PMIX_IOF_INHERIT, &noinherit, PMIX_BOOL);
+    }
+#endif
     tmp = NULL;
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_OUTPUT_TO_FILE, (void **) &tmp, PMIX_STRING)
         && NULL != tmp) {

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -705,6 +705,10 @@ static void prte_job_construct(prte_job_t *job)
     job->num_ready_for_debug = 0;
 
     PMIX_LOAD_PROCID(&job->originator, NULL, PMIX_RANK_INVALID);
+    /* Left unsized: the constructor uncaps max_size and set_bit grows the
+     * map from nothing, so a job with no interested daemon - which is
+     * most of them - carries no allocation at all. */
+    PMIX_CONSTRUCT(&job->iof_daemons, pmix_bitmap_t);
     job->num_local_procs = 0;
 
     job->flags = 0;
@@ -739,6 +743,8 @@ static void prte_job_destruct(prte_job_t *job)
     if (NULL != job->personality) {
         PMIx_Argv_free(job->personality);
     }
+
+    PMIX_DESTRUCT(&job->iof_daemons);
 
     for (n = 0; n < job->apps->size; n++) {
         if (NULL == (app = (prte_app_context_t *) pmix_pointer_array_get_item(job->apps, n))) {

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -446,6 +446,21 @@ typedef struct prte_job_t {
     pmix_rank_t num_ready_for_debug;
     /* originator of a dynamic spawn */
     pmix_proc_t originator;
+    /* Daemons that have someone interested in this job's output, by rank
+     * within our own namespace. A tool's IOF subscription is held by the
+     * PMIx server of the daemon that tool attached to, and only that
+     * server can deliver to it - so the HNP has to relay a copy of this
+     * job's output to every daemon in this set.
+     *
+     * It is a SET rather than the single "originator" it replaces because
+     * there can legitimately be several: the daemon hosting the tool that
+     * launched the job, plus any daemon whose tool later asked for this
+     * job's output through PMIx_IOF_pull, plus - for a spawned job - the
+     * ones its parent had.
+     *
+     * HNP-local; never packed. Nothing below the HNP relays, so no other
+     * daemon has any use for it. */
+    pmix_bitmap_t iof_daemons;
     /* number of local procs */
     pmix_rank_t num_local_procs;
     /* flags */

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -524,6 +524,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "DO-NOT-AGGREGATE-HELP";
         case PRTE_JOB_REPORT_CHILD_SEP:
             return "REPORT-CHILD-JOBS-SEPARATELY";
+        case PRTE_JOB_NO_IOF_INHERIT:
+            return "JOB-DOES-NOT-INHERIT-OUTPUT-FORWARDING";
         case PRTE_JOB_COLOCATE_PROCS:
             return "COLOCATE PROCS";
         case PRTE_JOB_COLOCATE_NPERPROC:

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -279,6 +279,14 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_REPORT_CHILD_SEP           (PRTE_JOB_START_KEY + 126) // bool - report the exit status of child jobs separately: return the
                                                                        // primary job's status only, rather than the first non-zero status
                                                                        // returned by the primary job or any job it spawned
+#define PRTE_JOB_NO_IOF_INHERIT             (PRTE_JOB_START_KEY + 127) // bool - this job is NOT to inherit the output forwarding of the job
+                                                                       // that spawned it. Recorded by the mapper, which is where the
+                                                                       // inherit question is resolved, and read where the job's PMIx
+                                                                       // information is built, which is where it has to be told to PMIx.
+                                                                       // Deliberately NOT PRTE_JOB_NOINHERIT: that one is consulted when
+                                                                       // this job later becomes a parent itself, so reusing it would make
+                                                                       // a non-inheriting child silently refuse to pass mapping,
+                                                                       // ranking and binding on to a grandchild
 
 #define PRTE_JOB_MAX_KEY (PRTE_JOB_START_KEY + 200)
 


### PR DESCRIPTION
The PRRTE half of output forwarding for spawned and watched jobs. The
PMIx half is openpmix/openpmix#4133 (merged); the whole design is in
[`docs/how-things-work/iof_inheritance.rst`](https://github.com/openpmix/openpmix/blob/master/docs/how-things-work/iof_inheritance.rst)
over there.

## The shape of the problem

A tool's IOF subscription is held by the PMIx server of the daemon that
tool attached to, and **only that server can deliver to it**. So for
output produced anywhere else to reach that tool, the HNP has to relay a
copy to that daemon. `prte_iof_hnp_relay_to_tool()` relayed to exactly
one, derived from `jdata->originator` — right for the tool that launched
the job, and the only destination PRRTE could name.

Two things fall outside that: a tool that attaches to a running DVM and
asks for a job's output with `PMIx_IOF_pull`, which was recorded
nowhere; and a spawned job, whose output went toward the *spawner's*
daemon rather than toward whoever was watching its parent.

## The three commits

**1. Give a job a set of interested daemons.** A bitmap of ranks,
HNP-local and never packed — nothing below the HNP relays, so no other
daemon has a use for it — and left unsized, since `set_bit` grows it from
nothing and most jobs never acquire a member. The relay fans out across
it. `originator` stays the *seed* rather than becoming a second
mechanism, so a job nobody has subscribed to takes exactly the path it
always has. Nothing sets a bit yet: this commit changes no behavior.

**2. Record the daemon a tool pulled a job's output through.** The
`iof_pull` upcall is the only notice anyone gets, and it arrives at the
daemon the tool attached to — precisely the daemon that needs recording.
Note what is *not* needed: the requesting tool's identity, which the
upcall does not carry. The question is which daemons need a copy, and
the answer is "this one".

The message reuses `PRTE_IOF_PULL`, one of three tags in `iof_types.h`
defined and unused since the tree was imported and whose name already
means this, and is recognized in `prte_iof_hnp_recv()` the way XON/XOFF
already are — no new RML tag, no new receive. It travels on
`PRTE_RML_TAG_IOF_HNP`, the **upstream** tag; `PRTE_RML_TAG_IOF_PROXY`
is the other direction. That distinction is worth the comment at the
send site: the HNP registers a receive on *both*, so sending upstream on
the downstream tag delivers the message to the HNP and then drops it,
with the reliable send still reporting success because delivery is all
it promises. This cost an afternoon.

**3. Inherit onto a spawned job, unless refused.** The child's set is
seeded from the parent's where the mapper has already resolved both.

The trap here is that output forwarding takes the **opposite default**
from the launch directives. `prte_rmaps_base.inherit` is false unless
the user says otherwise — a spawned job does not pick up mapping,
ranking and binding unless asked — whereas output forwarding inherits
unless it is *refused*, which is also what PMIx assumes from its side.
Keying off the `inherit` the mapper resolves therefore silences every
spawned job; the gate has to be the explicit refusal, which is what
`PRTE_JOB_NOINHERIT` records.

A refusal is carried to PMIx as `PMIX_IOF_INHERIT=false` in the job
information, because PMIx asks the same question again on the server the
child's output *arrives* at — which on a multi-node DVM is not the one
that processed the spawn — and cannot reach our answer by itself. Sent
only to say no: absence means inherit on both sides.

`PRTE_JOB_NO_IOF_INHERIT` is a new attribute rather than a reuse of
`PRTE_JOB_NOINHERIT`, which is consulted when this job later becomes a
parent itself: reusing it would make a non-inheriting child silently
refuse to pass mapping, ranking and binding to a *grandchild*, which is
a different question from who reads its output. The `PMIX_IOF_INHERIT`
emission is `#ifdef`-guarded, so this still builds against a PMIx that
predates the attribute.

## Testing

Ten-node swarm, driven by openpmix's `contrib/dockerswarm`:

* `run-spawn-iof.sh` **8/8** — including a tool, a spawning rank and a
  child job on three different daemons, and (openpmix/openpmix#4135) a
  tool on a **non-HNP** daemon that pulls a job already running and then
  sees the job it spawns. That last case is what caught the RML tag bug
  in commit 2; the other four passed straight through it.
* `--map-by :noinherit` verified in the other direction: the child still
  runs — a marker file it writes out of band says where — and none of its
  output comes back, while the parent's still does.
* `run-server-tests.sh` **14/14**, `run-tool-tests.sh` **10/10**.
