### PR TITLE
rml/oob: try the remaining addresses when a connection fails

### DIFF
--- a/src/rml/oob/oob_tcp_component.c
+++ b/src/rml/oob/oob_tcp_component.c
@@ -181,6 +181,7 @@ static void peer_cons(prte_oob_tcp_peer_t *peer)
     PMIX_CONSTRUCT(&peer->addrs, pmix_list_t);
     peer->active_addr = NULL;
     peer->state = MCA_OOB_TCP_UNCONNECTED;
+    peer->established = false;
     peer->num_retries = 0;
     peer->first_attempt = 0;
     PMIX_CONSTRUCT(&peer->send_queue, pmix_list_t);

--- a/src/rml/oob/oob_tcp_connection.c
+++ b/src/rml/oob/oob_tcp_connection.c
@@ -1212,6 +1212,7 @@ static void tcp_peer_connected(prte_oob_tcp_peer_t *peer)
     pmix_mutex_lock(&peer->lock);
     tcp_peer_rebind_events(peer);
     peer->state = MCA_OOB_TCP_CONNECTED;
+    peer->established = true;
 
     /* initiate send of first message on queue */
     if (NULL == peer->send_msg) {
@@ -1253,13 +1254,55 @@ void prte_oob_tcp_peer_close(prte_oob_tcp_peer_t *peer)
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&(peer->name)),
                         peer->sd, prte_oob_tcp_state_print(peer->state));
 
-    /* if we were CONNECTING, then we need to mark the address as
-     * failed and cycle back to try the next address */
-    if (MCA_OOB_TCP_CONNECTING == peer->state) {
+    /* If this connection was still being established, mark the address as
+     * failed and cycle back to try the next one.  A peer is handed a list of
+     * addresses so that a bad one is not fatal, and an attempt can die three
+     * ways before the connection is usable: connect() itself failed
+     * (CONNECTING), something answered but the IDENT handshake did not
+     * complete (CONNECT_ACK), or a caller set FAILED on the way in.  Only
+     * CONNECTING used to rotate, so a peer that failed the handshake was
+     * closed with its remaining addresses untried and its queued messages
+     * dropped, reporting nothing to anyone.  With no follow-up traffic to
+     * trigger a fresh connect, as with a daemon's first report to the HNP,
+     * the DVM never finished coming up and the job hung.
+     *
+     * Rotating above the queued-send flush below is deliberate: the messages
+     * waiting on this peer must survive to go out over the next address.  The
+     * established flag keeps the paths that close a *working* connection out
+     * of this branch, so those still report a lost connection instead of
+     * silently reconnecting.  It also guarantees the socket events are still
+     * on prte_event_base, since they move to peer->evbase only at CONNECTED,
+     * so deleting them here cannot block on a worker's callback. */
+    if (!peer->established
+        && (MCA_OOB_TCP_CONNECTING == peer->state || MCA_OOB_TCP_CONNECT_ACK == peer->state
+            || MCA_OOB_TCP_FAILED == peer->state)) {
+        /* try_connect never sets the peer state; every caller does it first,
+         * so leaving CLOSED here would advertise a dead peer while a
+         * connection attempt was in flight */
+        peer->state = MCA_OOB_TCP_CONNECTING;
         pmix_mutex_unlock(&peer->lock);
+        /* drop any registration on the socket we are about to discard:
+         * tcp_peer_event_init asserts that neither event is active, and
+         * try_connect always reaches it once peer->sd is reset below */
+        if (peer->recv_ev_active) {
+            prte_event_del(&peer->recv_event);
+            peer->recv_ev_active = false;
+        }
+        if (peer->send_ev_active) {
+            prte_event_del(&peer->send_event);
+            peer->send_ev_active = false;
+        }
+        if (peer->timer_ev_active) {
+            prte_event_del(&peer->timer_event);
+            peer->timer_ev_active = false;
+        }
         close(peer->sd);
         peer->sd = -1;
         if (NULL != peer->active_addr) {
+            /* FAILED stops try_connect from picking this address again, so
+             * the candidate set shrinks and the rotation terminates.  With
+             * nothing untried left, try_connect reports the failure and
+             * activates failed_to_connect, so we never give up silently. */
             peer->active_addr->state = MCA_OOB_TCP_FAILED;
         }
         PRTE_ACTIVATE_TCP_CONN_STATE(peer, prte_oob_tcp_peer_try_connect);
@@ -1268,6 +1311,7 @@ void prte_oob_tcp_peer_close(prte_oob_tcp_peer_t *peer)
 
     old_state = peer->state;
     peer->state = MCA_OOB_TCP_CLOSED;
+    peer->established = false;
     pmix_mutex_unlock(&peer->lock);
 
     if (NULL != peer->active_addr) {

--- a/src/rml/oob/oob_tcp_peer.h
+++ b/src/rml/oob/oob_tcp_peer.h
@@ -57,6 +57,11 @@ typedef struct {
     pmix_list_t addrs;
     prte_oob_tcp_addr_t *active_addr;
     prte_oob_tcp_state_t state;
+    bool established;          /**< did the connection currently held ever reach CONNECTED?
+                                    Cleared by prte_oob_tcp_peer_close, so it always describes
+                                    the connection being closed.  Separates a connection that
+                                    died while still being established, whose untried addresses
+                                    must still be tried, from the loss of a working one. */
     int num_retries;
     time_t first_attempt; /**< wall-clock time of the first connection attempt in the current
                                retry sequence; 0 until the first retry is scheduled.  Used to


### PR DESCRIPTION
A peer is handed a list of addresses so that a bad one need not be fatal, but only one of the three ways an attempt can die before the connection is usable caused us to move on to the next address. peer_close rotated when the peer was CONNECTING, meaning connect() itself had failed. It did not rotate when the peer was CONNECT_ACK, meaning something answered and the IDENT handshake then failed, nor when a caller had set FAILED on the way in, which is the idiom used throughout this file. In those two cases the peer was closed with its untried addresses still untried and its queued messages discarded, and nothing was reported to anyone.

That is reachable whenever a listener that is not a PRRTE daemon happens to hold the port we dialed, since such a peer completes connect() and then fails the handshake. Where the peer has no follow-up traffic to trigger a fresh connection attempt the failure is permanent: a daemon's first report to the HNP is exactly that, so the DVM never finished coming up and the job hung until something killed it, having produced no output.

Extend the rotation to cover all three states. Rotating above the queued-send flush is deliberate, as the messages waiting on the peer must survive to go out over the next address. Several callers set FAILED on a connection that is working, an oversized header being one example, so the state alone cannot distinguish the two cases, and nothing already recorded whether the connection in hand had ever been usable: the peer state is overwritten by those callers, and a live address still reads UNCONNECTED. Hence the new established flag, which keeps those callers on the existing path so they continue to report a lost connection. It also guarantees the socket events are still on prte_event_base, since they move to peer->evbase only at CONNECTED, so deleting them here cannot block on a worker's callback.

The rotation terminates because each pass marks its own address FAILED before retrying, so the candidate set strictly shrinks; when nothing untried remains, try_connect reports the failure and activates failed_to_connect, replacing a silent hang with a prompt error.