### PR TITLE
Scatter the launch message's per-proc cpusets

### DIFF
--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -1477,6 +1477,15 @@ PI=/opt/prte/prte/bin/peerinfo
 # assertion is a string compare: what rank r was told about rank p must be
 # what rank p says about itself.  Prints nothing when the run is consistent,
 # and one line per disagreement otherwise.
+#
+# The last two fields - the cpuset and the locality string - are the ones
+# with two different ways of being answered now.  A daemon holds them only
+# for the procs it forks (the launch message sends each daemon its own
+# bindings and broadcasts nobody's, see src/mca/odls/AGENTS.md), so for an
+# off-node peer they come back from a direct modex to the daemon that does
+# hold them.  They still have to agree, and that is the point: this compare
+# is what says the referral produced the same answer the local derivation
+# used to, rather than nothing or somebody else's binding.
 peerinfo_mismatches() {
     echo "$1" | tr -d '\r' | awk '
         $1 == "SELF" { r = $2; s = ""; for (i = 3; i <= NF; i++) { s = s " " $i }
@@ -1753,6 +1762,15 @@ test_pmix() {
         [ -z "$mism" ] \
             && ok "...and every rank's account of a peer matches that peer's own" \
             || bad "peer descriptions disagree: $(echo "$mism" | head -3 | tr '\n' ' ' | tail -c 500)"
+        # The binding is the one field a daemon no longer holds for a proc it
+        # does not fork, so for an off-node peer the comparison above is
+        # covering a direct modex to the hosting daemon rather than a local
+        # derivation. Assert the bindings are actually populated, or that
+        # half of the compare passes on two empty strings.
+        n=$(echo "$lazyout" | tr -d '\r' | awk '$1 == "PEER" && $NF != "-" {c++} END {print c+0}')
+        [ "$n" = 56 ] \
+            && ok "...including every peer's binding, which off-node had to be fetched" \
+            || bad "$n of 56 peer lookups came back with a binding"
 
         # Note what that comparison already is: a SELF line is what the
         # proc's OWN daemon published about it -- which a daemon does for
@@ -4177,6 +4195,77 @@ test_odls() {
             fi
             RUN "timeout -k 5 30 pterm --dvm-uri file:/tmp/dvm.uri" >/dev/null 2>&1
         fi
+    fi
+    cleanup_swarm
+
+    banner "odls: the launch message's cpuset slice reaches the daemon that forks"
+    # The launch message no longer carries anybody's binding: it is packed
+    # PRTE_JOB_PACK_NO_CPUSETS and each daemon is sent the bindings of the
+    # procs it will fork, point to point, arriving in either order relative
+    # to the broadcast (prte_odls_base_send_cpuset_slices).
+    #
+    # This has to be read from the PROCESS, not from "--display map": the map
+    # is rendered on the master, which holds every proc's cpuset either way,
+    # so it would show a correct binding for a slice that never arrived.
+    # /proc/self/status is what the daemon actually applied.
+    cleanup_swarm
+    out=$(RUN 'timeout 90 prterun --host node2:8,node3:8,node4:8 -n 12 \
+                   --map-by ppr:4:node --bind-to core --output tag \
+                   grep Cpus_allowed_list /proc/self/status' 2>&1)
+    rc=$?
+    if [ "$rc" != 0 ]; then
+        bad "the bound multi-node launch failed (rc=$rc): $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    else
+        n=$(echo "$out" | grep -ac 'Cpus_allowed_list:[[:space:]]*[0-9]*$')
+        [ "$n" = 12 ] \
+            && ok "all 12 procs on three remote nodes were bound to a single cpu" \
+            || bad "$n/12 procs came back bound to one cpu -- a slice that never arrived leaves the proc unbound, i.e. allowed every cpu: $(echo "$out" | grep -a Cpus_allowed | tr '\n' ' ' | tail -c 300)"
+        # ...and to the RIGHT cpu.  ppr:4:node over 8 cores puts local ranks
+        # 0-3 on cpus 0-3 of each node, so each node's four procs must hold
+        # four DIFFERENT cpus.  A slice applied to the wrong ranks - the
+        # failure that carrying the rank explicitly is there to prevent -
+        # keeps the count above and fails here.
+        c=$(echo "$out" | sed -n 's/.*Cpus_allowed_list:[[:space:]]*\([0-9]*\)$/\1/p' | sort | uniq -c \
+            | awk '$1 != 3 {n++} END {print n+0}')
+        [ "$c" = 0 ] \
+            && ok "each of cpus 0-3 was used by exactly one proc per node" \
+            || bad "the bindings are not one proc per cpu per node: $(echo "$out" | grep -a Cpus_allowed | tr '\n' ' ' | tail -c 300)"
+    fi
+
+    # The same run with the scatter turned off must give the same answer -
+    # that is the A/B, and it is also what keeps the off switch honest.
+    out=$(RUN 'timeout 90 prterun --prtemca odls_base_scatter_cpusets 0 \
+                   --host node2:8,node3:8,node4:8 -n 12 \
+                   --map-by ppr:4:node --bind-to core --output tag \
+                   grep Cpus_allowed_list /proc/self/status' 2>&1)
+    n=$(echo "$out" | grep -ac 'Cpus_allowed_list:[[:space:]]*[0-9]*$')
+    [ "$n" = 12 ] \
+        && ok "broadcasting the bindings instead gives the same 12" \
+        || bad "$n/12 procs bound with odls_base_scatter_cpusets 0: $(echo "$out" | grep -a Cpus_allowed | tr '\n' ' ' | tail -c 300)"
+    cleanup_swarm
+
+    banner "odls: a daemon hosting none of a job's procs does not wait for a slice"
+    # The launch message goes to EVERY daemon; the slices go only to the
+    # daemons in the job's map.  A daemon with no procs of the job must
+    # therefore not park waiting for one - if it does, the launch never
+    # completes on it and the job hangs with nothing logged.
+    cleanup_swarm
+    if ! prted_dvm_start "node1:8,node2:8,node3:8,node4:8"; then
+        bad "could not start a DVM for the empty-slice test"
+    else
+        out=$(PRUN "--host node2:4 -n 4 --bind-to core --output tag \
+                    grep Cpus_allowed_list /proc/self/status" 2>&1)
+        rc=$?
+        n=$(echo "$out" | grep -ac 'Cpus_allowed_list:[[:space:]]*[0-9]*$')
+        [ "$rc" = 0 ] && [ "$n" = 4 ] \
+            && ok "a job on one node of a four-node DVM launched and bound" \
+            || bad "the job did not complete on a DVM with idle daemons (rc=$rc, $n/4 bound): $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        # and the DVM is still usable afterwards - a daemon that parked a
+        # launch would still be holding it
+        out=$(PRUN "--host node3:2 -n 2 hostname" 2>&1)
+        [ $? = 0 ] && ok "a second job onto a different node still runs" \
+                   || bad "the DVM was left wedged: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        RUN "timeout -k 5 30 pterm --dvm-uri file:$PRTED_URI" >/dev/null 2>&1
     fi
     cleanup_swarm
 }

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -106,32 +106,51 @@ goes through the same parser and is not separately covered.
 Performance work not landed
 ---------------------------
 
-**Lazy proc-data registration.**
-``prte_pmix_server_register_nspace`` publishes a PMIx proc-data entry for
-*every* proc in the job on *every* daemon — a table that grows with the whole
-job on a node running a fixed slice of it.  An experimental branch registers
-only the procs a daemon hosts and derives the rest on demand in
-``dmodex_req``.  It is **written but unproven**, and it is stacked on the
-xcast-shared-payload work rather than on a clean master, so it needs a rebase
-before it can even be measured.  The rule it must keep to: switch on what
-PRRTE is the *authority* for (the placement and binding it decided, a closed
-set), never on what an application is expected to ask for.
+**Lazy proc-data registration is only half landed.**  The *deriving* half is
+in: ``dmodex_req`` answers a request for one of the placement keys out of
+``jdata->procs[rank]`` rather than going to the hosting daemon
+(``prte_pmix_lazy_procdata``, on by default).  The *withholding* half is not.
+``prte_pmix_server_register_nspace`` still publishes a PMIx proc-data entry
+for **every** proc in the job on **every** daemon — a table that grows with
+the whole job on a node running a fixed slice of it, and
+``prte_hostname_cutoff`` is the record of that wall having been met once
+already.  Only the two location keys are now withheld, and for a different
+reason (see below).  Narrowing the rest is what the commit message claims
+and the code does not do.
 
-**Scatter the launch message's per-proc cpuset.**  Placement already travels
-as a node map plus a proc map per app, and lazy proc-data registration has
-landed, so what still goes to every daemon is a per-proc record of what the
-maps cannot say: node rank, state and the cpuset.  The remaining idea is to
-send that residual only to the daemon that will fork the proc — common part
-broadcast as now, per-destination slice routed point to point.  It needs no
-new broadcast movement: ``prte_rml_get_route`` aggregates N routed sends in
-the tree, so the bytes leaving the controller are the sum of the slices
-rather than the sum replicated.
+The rule it must keep to: switch on what PRRTE is the *authority* for (the
+placement and binding it decided, a closed set), never on what an
+application is expected to ask for.  And the thing to measure first is
+whether a **partial** entry is even usable — whether a get for a key absent
+from a published proc-data array still reaches the host, or whether PMIx
+treats the array as the complete answer for that rank.  Nothing here
+currently depends on that (the two location keys are withheld from *remote*
+procs only, and a remote proc's locality is a question almost nobody asks),
+but withholding the rest would.  ``contrib/dockerswarm/peerinfo.c`` is the
+probe: every rank asks every other rank in its job where it is.
 
-**Judge it on wire bytes, not on the raw message size.**  That distinction is
-the whole reason this entry is worth reading.  ``--rtos donotlaunch`` reports
-the *raw* buffer, and the xcast compresses before it forwards, so a raw
-figure can overstate the prize by a factor of three — and a field that holds
-the same value in every record can compress away to nothing while looking
+**Aggregate the launch-message cpuset slices per next hop.**  The scatter
+itself has landed: the launch message is packed ``PRTE_JOB_PACK_NO_CPUSETS``
+and each daemon is sent the bindings of the procs it will fork, point to
+point (``prte_odls_base_send_cpuset_slices``).  Measured with ``--rtos
+donotlaunch`` at 1000 x 128 on a 176-core, 5-NUMA topology, that takes the
+raw launch message from **1,622,647 to 602,647 bytes** — 8 B/proc, 63% of
+what was left after the maps and the empty attribute list came out.
+
+What is left to do is how those slices leave the master.  Today it is one
+routed send per daemon: the *bytes* aggregate, because
+``prte_rml_get_route`` sends each toward its target and the tree carries a
+subtree's slices over one link, but the *messages* do not — a 1000-node job
+posts 1000 sends from the master on the launch path.  Sending one message
+per next hop, each carrying the slices for that child's whole subtree, and
+having the relay split it, makes that O(radix) per daemon instead.  It needs
+a relay step the point-to-point form does not.
+
+**Judge this kind of change on wire bytes, not on the raw message size.**
+The figures above are raw, which is the right unit for "how much buffer does
+the master build and deflate" and the wrong one for "how much crosses the
+network": the xcast compresses before it forwards, and a field holding the
+same value in every record can compress away to nothing while looking
 enormous raw.  Measured on a live 32-node broadcast at 8 ppn
 (``grpcomm_base_verbose 1``, tag 18 is the launch message):
 
@@ -146,16 +165,10 @@ cpuset (core vs none)  2.0 B/proc   0.77 B/proc   0.40
 **The cpuset does not compress away, and more repetition does not help it.**
 Its marginal wire cost held flat — 0.766, 0.742, 0.797 B/proc — across 8, 16
 and 32 nodes, i.e. a fourfold increase in how often the same handful of
-cpuset strings recur.  The overall ratio improves with scale (0.42 → 0.34)
-only because the fixed job-level part amortizes.  So the marginal ratio of
-~0.4 is the number to extrapolate with, and at 1000 x 128 — where the cpuset
-is 5.97 B/proc raw on a 176-core, 5-NUMA node — that is roughly 2.3 B/proc,
-or **~295 KB of an estimated ~535 KB wire launch message.**  About half.
-That is what makes the change worth its cost, and the cost is real: the
-message stops being one payload delivered identically, the receiver handles
-two pieces with an ordering constraint, an elastic grow needs the joining
-daemon's slice, and ``prte_job_pack``/``_unpack`` are hand-written mirrors
-with no version and nothing that catches a half-done edit.
+cpuset strings recur.  The overall ratio improves with scale (0.42 -> 0.34)
+only because the fixed job-level part amortizes.  So ~0.4 is the marginal
+ratio to extrapolate with, and it is what said the scatter was worth
+building before it was built.
 
 **Do not model this instead of measuring it.**  A synthetic model of the
 per-proc region — the right fields, the right varint encoding, a faithful
@@ -176,14 +189,17 @@ per-proc region does not exist in isolation on the wire.
   ``RESTART`` identically, so the wire never needs to tell them apart.  It is
   ~2 B/proc raw and varint-squashed, and it genuinely varies for the *job
   catchup* caller, which packs already-running jobs whose proc states feed
-  ``PMIX_QUERY_PROC_TABLE``.  Leave it alone.
+  ``PMIX_QUERY_PROC_TABLE``.  Leave it alone.  The **node rank** is likewise
+  staying in the broadcast: a remote node-rank get that falls through to
+  PMIx's one-job-per-node assumption returns a *wrong* value rather than
+  nothing.
 * *An optional trailing field per proc does not work.*  ``prte_proc_pack``
   runs in a loop and more job fields follow the array, so an absent flag is
   ambiguous both against the next proc's first field and against
   ``stdin_target``; ``PMIX_ERR_UNPACK_PAST_END`` never fires because there is
   always more buffer.  Any conditional field needs a discriminator the
-  decoder has already read — the job flags are packed first and are the
-  obvious candidate.
+  decoder has already read — which is why the shape is now declared by a
+  mode byte at the head of the buffer.
 
 **Measuring the launch message at all takes three settings**, and each one
 silently gives a wrong answer if omitted: ``--prtemca hwloc_use_topo_file``

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -117,6 +117,83 @@ before it can even be measured.  The rule it must keep to: switch on what
 PRRTE is the *authority* for (the placement and binding it decided, a closed
 set), never on what an application is expected to ask for.
 
+**Scatter the launch message's per-proc cpuset.**  Placement already travels
+as a node map plus a proc map per app, and lazy proc-data registration has
+landed, so what still goes to every daemon is a per-proc record of what the
+maps cannot say: node rank, state and the cpuset.  The remaining idea is to
+send that residual only to the daemon that will fork the proc — common part
+broadcast as now, per-destination slice routed point to point.  It needs no
+new broadcast movement: ``prte_rml_get_route`` aggregates N routed sends in
+the tree, so the bytes leaving the controller are the sum of the slices
+rather than the sum replicated.
+
+**Judge it on wire bytes, not on the raw message size.**  That distinction is
+the whole reason this entry is worth reading.  ``--rtos donotlaunch`` reports
+the *raw* buffer, and the xcast compresses before it forwards, so a raw
+figure can overstate the prize by a factor of three — and a field that holds
+the same value in every record can compress away to nothing while looking
+enormous raw.  Measured on a live 32-node broadcast at 8 ppn
+(``grpcomm_base_verbose 1``, tag 18 is the launch message):
+
+=====================  ===========  ============  =====
+what                   raw          wire          ratio
+=====================  ===========  ============  =====
+whole message          3,790 B      1,280 B       0.34
+per proc (slope)       13.0 B       --            --
+cpuset (core vs none)  2.0 B/proc   0.77 B/proc   0.40
+=====================  ===========  ============  =====
+
+**The cpuset does not compress away, and more repetition does not help it.**
+Its marginal wire cost held flat — 0.766, 0.742, 0.797 B/proc — across 8, 16
+and 32 nodes, i.e. a fourfold increase in how often the same handful of
+cpuset strings recur.  The overall ratio improves with scale (0.42 → 0.34)
+only because the fixed job-level part amortizes.  So the marginal ratio of
+~0.4 is the number to extrapolate with, and at 1000 x 128 — where the cpuset
+is 5.97 B/proc raw on a 176-core, 5-NUMA node — that is roughly 2.3 B/proc,
+or **~295 KB of an estimated ~535 KB wire launch message.**  About half.
+That is what makes the change worth its cost, and the cost is real: the
+message stops being one payload delivered identically, the receiver handles
+two pieces with an ordering constraint, an elastic grow needs the joining
+daemon's slice, and ``prte_job_pack``/``_unpack`` are hand-written mirrors
+with no version and nothing that catches a half-done edit.
+
+**Do not model this instead of measuring it.**  A synthetic model of the
+per-proc region — the right fields, the right varint encoding, a faithful
+cpuset distribution — predicted the region would deflate ~180:1 and the
+cpuset would cost 0.05 B/proc on the wire.  The real answer is 0.77, a factor
+of fifteen out, and the conclusion drawn from the model ("the compressor
+already solves this, drop the idea") was the opposite of the one the
+measurement supports.  The model is not salvageable by refining it; the
+per-proc region does not exist in isolation on the wire.
+
+**Two things settled along the way, so they need not be re-derived:**
+
+* *The state is not worth scattering.*  Nothing in the tree ever sets a proc
+  state to ``PRTE_PROC_STATE_RESTART`` — the only occurrence is
+  ``prte_pmix_convert_pstate()`` translating an incoming PMIx state — and
+  nothing sets ``PRTE_JOB_FLAG_RESTARTED`` either.  Both consumers
+  (``odls_base_default_fns.c`` and ``filem_raw_module.c``) treat ``INIT`` and
+  ``RESTART`` identically, so the wire never needs to tell them apart.  It is
+  ~2 B/proc raw and varint-squashed, and it genuinely varies for the *job
+  catchup* caller, which packs already-running jobs whose proc states feed
+  ``PMIX_QUERY_PROC_TABLE``.  Leave it alone.
+* *An optional trailing field per proc does not work.*  ``prte_proc_pack``
+  runs in a loop and more job fields follow the array, so an absent flag is
+  ambiguous both against the next proc's first field and against
+  ``stdin_target``; ``PMIX_ERR_UNPACK_PAST_END`` never fires because there is
+  always more buffer.  Any conditional field needs a discriminator the
+  decoder has already read — the job flags are packed first and are the
+  obvious candidate.
+
+**Measuring the launch message at all takes three settings**, and each one
+silently gives a wrong answer if omitted: ``--prtemca hwloc_use_topo_file``
+with a NUMA-bearing topology (a dev box and the swarm containers have no NUMA
+node, so the default ``NUMA:IF-SUPPORTED`` binds nothing and you measure the
+unbound shape while believing otherwise); a PMIx built *without* debug (see
+below); and, for a wire number, a payload above the compressor's
+``pcompress_base_limit`` — below it ``wire`` simply equals ``raw`` and the
+census tells you nothing about the ratio.
+
 **Small effects cannot be measured end-to-end on the container swarm.**  At
 40 nodes the collect fence's wall clock has a run-to-run coefficient of
 variation of 35–50%, so anything under about a third is not resolvable there

--- a/src/mca/odls/AGENTS.md
+++ b/src/mca/odls/AGENTS.md
@@ -245,6 +245,8 @@ message cost per proc before any of this. `plm_base_verbose 2` prints the
 size; `--rtos donotlaunch` will size a job of any shape without launching
 it.
 
+**And the cpuset does not go in this message at all** — see 2a below.
+
 It then calls `PMIx_server_setup_application()` **asynchronously and does
 not wait**. It returns `PRTE_SUCCESS` immediately, having handed a
 `prte_odls_jcaddy_t` to PMIx; the completion callback `setup_cbfunc()`
@@ -255,6 +257,68 @@ activates `PRTE_JOB_STATE_SEND_LAUNCH_MSG` — which is what actually
 continues the launch. **Nothing blocks**: a `PRTE_SUCCESS` return here
 means "the callback will fire", and an error return means it never will
 (the caddy is released on the spot).
+
+### 2a. The half addressed to one daemon — `prte_odls_base_send_cpuset_slices()`
+
+A proc's binding is read by exactly one daemon, the one that forks it, and
+it is the largest of the three things a proc still costs the launch message
+(~6 B/proc raw on a 176-core node, ~40% of the message). Broadcasting it
+put every daemon's bindings on every link of the tree. So the launch message
+is packed `PRTE_JOB_PACK_NO_CPUSETS` and each daemon is sent its own
+bindings point to point, from `prte_plm_base_send_launch_msg()` immediately
+before the broadcast. No new data movement was needed: `prte_rml_get_route()`
+sends each one toward its target, so the bytes leaving the master are the
+*sum* of the slices rather than the sum replicated per daemon.
+
+The slice is `nspace`, a count, and then `(rank, cpuset)` per proc. **The
+rank is carried, not implied by position** — the receiver would otherwise
+have to reproduce the order the sender's loop happened to walk in, and
+getting that wrong binds processes to each other's cpus without failing
+anywhere.
+
+**The two halves are independent messages and arrive in either order.**
+Neither order is the rare one — the broadcast takes more hops, the slices
+are sent one at a time — so both are handled the same way, by a rendezvous
+on `prte_odls_globals.pending_slices`: whichever arrives first parks, and
+whichever arrives second finds it and completes the launch.
+`construct_child_list` therefore does **not** always register the nspace
+before it returns; when it parks, `prte_odls_base_recv_cpuset_slice()` is
+what calls `start_registration()` later. Both run on `prte_event_base`, so
+the list needs no lock.
+
+Three cases that must not wait, and each is a hang if you get it wrong:
+
+- **the master**, which keeps its own fully populated job object and is
+  never sent a slice;
+- **a daemon hosting none of the job's procs** — the broadcast reaches every
+  daemon, the slices only the ones in the map. It has nothing to bind, so
+  it waits for nothing (and discards anything parked for that job);
+- **`PRTE_JOB_PACK_ALL`**, the shape a spawn request and the job catchup
+  use, where the cpusets were in the buffer all along. The receiver keys off
+  the mode byte it unpacked, not off its own MCA parameter, so a daemon can
+  never wait for a slice the master did not send.
+
+`--prtemca odls_base_scatter_cpusets 0` turns it off and broadcasts the
+bindings as before; it is an A/B switch, not a supported difference in
+behavior.
+
+**What this costs:** a daemon no longer *holds* the binding of a proc it
+does not host, so a `PMIx_Get` for a remote proc's `PMIX_CPUSET` or
+`PMIX_LOCALITY_STRING` becomes a direct modex to the daemon that does -
+which answers it out of its own job object without waiting on the process.
+The value is unchanged; what it costs is one round trip, once, since PMIx
+caches the reply. Nothing else on a proc is affected, and a proc on the
+asker's own node - the only place a locality string means anything - is
+held locally as before.
+
+**Three states that had to be told apart** to make that referral safe, and
+the whole of [`src/prted/pmix/AGENTS.md`](../../prted/pmix/AGENTS.md)'s
+dmodex section is about them. The hosting daemon may not have the answer
+*yet* (its own slice is still in flight - `prte_odls_base_awaiting_cpusets()`
+says so, and the request waits); it may never have it *again* (its share of
+the job finished and it released the job object - it answers NOT_FOUND);
+or it may simply not have been reached by the launch message yet (it waits).
+Confusing the second with the third is a hang with nothing logged.
 
 ### 3. Parsing the message and wiring up — `prte_odls_base_default_construct_child_list()`
 

--- a/src/mca/odls/base/base.h
+++ b/src/mca/odls/base/base.h
@@ -65,6 +65,11 @@ typedef struct {
     int next_base;                // counter to load-level thread use
     bool signal_direct_children_only;
     char *exec_agent;
+    /* send each daemon its own procs' bindings instead of broadcasting
+     * everybody's to everybody */
+    bool scatter_cpusets;
+    /* launches and cpuset slices that are waiting for each other */
+    pmix_list_t pending_slices;
 } prte_odls_globals_t;
 
 PRTE_EXPORT extern prte_odls_globals_t prte_odls_globals;
@@ -92,6 +97,24 @@ PRTE_EXPORT int prte_odls_base_default_get_add_procs_data(pmix_data_buffer_t *da
 PRTE_EXPORT int prte_odls_base_default_construct_child_list(pmix_data_buffer_t *data,
                                                             pmix_nspace_t *job,
                                                             prte_odls_base_fork_local_proc_fn_t fork_local);
+
+/* Send each daemon in the job's map the bindings of the procs it is about
+ * to fork - the part of the launch message that is of no use to anybody
+ * else.  Called on the master, immediately before the launch message is
+ * broadcast; the two arrive in either order and the receiver waits for
+ * whichever is second. */
+PRTE_EXPORT int prte_odls_base_send_cpuset_slices(prte_job_t *jdata);
+
+/* True while this daemon holds the job but has not yet been sent the
+ * bindings of the procs it will fork.  A binding question about one of them
+ * has no answer yet - and "no cpuset" would be the wrong one. */
+PRTE_EXPORT bool prte_odls_base_awaiting_cpusets(const pmix_nspace_t nspace);
+
+/* Receive one - registered on PRTE_RML_TAG_LAUNCH_SLICE by every daemon,
+ * including the master (which never receives one). */
+PRTE_EXPORT void prte_odls_base_recv_cpuset_slice(int status, pmix_proc_t *sender,
+                                                  pmix_data_buffer_t *buffer,
+                                                  prte_rml_tag_t tag, void *cbdata);
 
 PRTE_EXPORT void prte_odls_base_spawn_proc(int fd, short sd, void *cbdata);
 

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -242,8 +242,15 @@ int prte_odls_base_default_get_add_procs_data(pmix_data_buffer_t *buffer, pmix_n
      * message the master sends at VM_READY - see prte_util_pack_job_catchup.
      */
 
-    /* pack the job struct */
-    rc = prte_job_pack(buffer, jdata);
+    /* Pack the job struct.
+     *
+     * Without the cpusets, if we are scattering them: this buffer is
+     * broadcast to every daemon, and a proc's binding is read only by the
+     * daemon that forks it.  Each daemon's own bindings follow separately
+     * from prte_odls_base_send_cpuset_slices() below. */
+    rc = prte_job_pack(buffer, jdata,
+                       prte_odls_globals.scatter_cpusets ? PRTE_JOB_PACK_NO_CPUSETS
+                                                         : PRTE_JOB_PACK_ALL);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         return rc;
@@ -495,6 +502,350 @@ static void _job_reg_complete(pmix_status_t status, void *cbdata)
     job_reg_join(cd);
 }
 
+/* Register the nspace and start the launch.  Reached either straight from
+ * construct_child_list or, when this daemon's cpuset slice had not arrived
+ * by then, from the receiver that completes it. */
+static void start_registration(prte_odls_jcaddy_t *cd)
+{
+    int rc;
+
+    /* register this job with the PMIx server. We have to wait until
+     * after we computed the #local_procs before registering it. The
+     * registration completes asynchronously, and the launch proceeds
+     * once it has reported. Hold a sentinel on the join so it cannot
+     * fire before we finish initiating the registration */
+    cd->pending = 1;
+    rc = prte_pmix_server_register_nspace(cd->jdata, _job_reg_complete, cd);
+    if (PRTE_SUCCESS == rc) {
+        cd->pending++;
+    } else {
+        PRTE_ERROR_LOG(rc);
+        cd->rstatus = PMIX_ERROR;
+    }
+    /* release our sentinel - if everything already reported,
+     * this progresses the launch */
+    job_reg_join(cd);
+}
+
+/*
+ * The launch message's cpuset slice.
+ *
+ * A proc's binding is read by exactly one daemon - the one that forks it -
+ * and it is the largest of the three things a proc costs the launch
+ * message.  Broadcasting it put every daemon's bindings on every link of
+ * the tree; sending each daemon its own costs the tree the sum of the
+ * slices instead of the sum times the number of daemons they pass.
+ *
+ * The two halves are independent messages, so they arrive in either order,
+ * and neither order is the rare one: the broadcast has more hops but the
+ * slices are sent one at a time from the master.  Whichever comes second
+ * finds the other waiting on this list and completes the launch.  A daemon
+ * that hosts none of the job's procs is sent no slice and waits for none.
+ */
+typedef struct {
+    pmix_list_item_t super;
+    pmix_nspace_t nspace;
+    /* exactly one of these is set: the slice arrived first, or the
+     * launch did */
+    pmix_data_buffer_t *slice;
+    prte_odls_jcaddy_t *cd;
+} prte_odls_slice_t;
+static void slcon(prte_odls_slice_t *p)
+{
+    PMIX_LOAD_NSPACE(p->nspace, NULL);
+    p->slice = NULL;
+    p->cd = NULL;
+}
+static void sldes(prte_odls_slice_t *p)
+{
+    if (NULL != p->slice) {
+        PMIX_DATA_BUFFER_RELEASE(p->slice);
+    }
+}
+static PMIX_CLASS_INSTANCE(prte_odls_slice_t, pmix_list_item_t, slcon, sldes);
+
+static prte_odls_slice_t *slice_find(const pmix_nspace_t nspace)
+{
+    prte_odls_slice_t *sl;
+
+    PMIX_LIST_FOREACH(sl, &prte_odls_globals.pending_slices, prte_odls_slice_t)
+    {
+        if (PMIX_CHECK_NSPACE(sl->nspace, nspace)) {
+            return sl;
+        }
+    }
+    return NULL;
+}
+
+/* drop anything parked for a job we are not going to launch after all */
+static void slice_discard(const pmix_nspace_t nspace)
+{
+    prte_odls_slice_t *sl;
+
+    sl = slice_find(nspace);
+    if (NULL != sl) {
+        pmix_list_remove_item(&prte_odls_globals.pending_slices, &sl->super);
+        PMIX_RELEASE(sl);
+    }
+}
+
+/* read one slice into the job's procs */
+static int apply_cpuset_slice(prte_job_t *jdata, pmix_data_buffer_t *buffer)
+{
+    pmix_status_t rc;
+    int32_t cnt, n, nprocs;
+    pmix_rank_t rank;
+    char *cpuset;
+    prte_proc_t *proc;
+
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &nprocs, &cnt, PMIX_INT32);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return prte_pmix_convert_status(rc);
+    }
+
+    for (n = 0; n < nprocs; n++) {
+        cnt = 1;
+        rc = PMIx_Data_unpack(NULL, buffer, &rank, &cnt, PMIX_PROC_RANK);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            return prte_pmix_convert_status(rc);
+        }
+        cpuset = NULL;
+        cnt = 1;
+        rc = PMIx_Data_unpack(NULL, buffer, &cpuset, &cnt, PMIX_STRING);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            return prte_pmix_convert_status(rc);
+        }
+        proc = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, (int) rank);
+        if (NULL == proc) {
+            /* the slice and the job it belongs to disagree about which
+             * procs exist - the two are packed from the same job object on
+             * the same daemon, so this cannot be a routine race */
+            PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+            if (NULL != cpuset) {
+                free(cpuset);
+            }
+            return PRTE_ERR_NOT_FOUND;
+        }
+        if (NULL != proc->cpuset) {
+            free(proc->cpuset);
+        }
+        proc->cpuset = cpuset; // the proc owns it now
+    }
+
+    return PRTE_SUCCESS;
+}
+
+int prte_odls_base_send_cpuset_slices(prte_job_t *jdata)
+{
+    prte_node_t *node;
+    prte_proc_t *pptr;
+    pmix_data_buffer_t *buf;
+    pmix_status_t rc;
+    int i, k;
+    int32_t nprocs;
+
+    if (NULL == jdata->map) {
+        return PRTE_SUCCESS;
+    }
+
+    for (i = 0; i < jdata->map->nodes->size; i++) {
+        node = (prte_node_t *) pmix_pointer_array_get_item(jdata->map->nodes, i);
+        if (NULL == node) {
+            continue;
+        }
+        if (NULL == node->daemon) {
+            PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+            return PRTE_ERR_NOT_FOUND;
+        }
+        if (node->daemon->name.rank == PRTE_PROC_MY_NAME->rank) {
+            /* our own procs are already bound in our own job object -
+             * construct_child_list keeps that copy and discards the
+             * unpacked one */
+            continue;
+        }
+
+        /* count first: the receiver reads a count rather than unpacking
+         * until the buffer runs out, because it has no way to tell the end
+         * of the slice from a short read */
+        nprocs = 0;
+        for (k = 0; k < node->procs->size; k++) {
+            pptr = (prte_proc_t *) pmix_pointer_array_get_item(node->procs, k);
+            if (NULL == pptr || !PMIX_CHECK_NSPACE(jdata->nspace, pptr->name.nspace)) {
+                continue;
+            }
+            ++nprocs;
+        }
+
+        PMIX_DATA_BUFFER_CREATE(buf);
+        rc = PMIx_Data_pack(NULL, buf, &jdata->nspace, 1, PMIX_PROC_NSPACE);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(buf);
+            return prte_pmix_convert_status(rc);
+        }
+        rc = PMIx_Data_pack(NULL, buf, &nprocs, 1, PMIX_INT32);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(buf);
+            return prte_pmix_convert_status(rc);
+        }
+        for (k = 0; k < node->procs->size; k++) {
+            pptr = (prte_proc_t *) pmix_pointer_array_get_item(node->procs, k);
+            if (NULL == pptr || !PMIX_CHECK_NSPACE(jdata->nspace, pptr->name.nspace)) {
+                continue;
+            }
+            /* the rank is carried rather than implied by position: the
+             * receiver would otherwise have to reproduce the order this
+             * loop happens to walk in, and getting that wrong would bind
+             * procs to each other's cpus without failing anywhere */
+            rc = PMIx_Data_pack(NULL, buf, &pptr->name.rank, 1, PMIX_PROC_RANK);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_DATA_BUFFER_RELEASE(buf);
+                return prte_pmix_convert_status(rc);
+            }
+            rc = PMIx_Data_pack(NULL, buf, &pptr->cpuset, 1, PMIX_STRING);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_DATA_BUFFER_RELEASE(buf);
+                return prte_pmix_convert_status(rc);
+            }
+        }
+
+        PMIX_OUTPUT_VERBOSE((2, prte_odls_base_framework.framework_output,
+                             "%s odls:launch_msg slice %lu bytes (%d procs) to %s",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                             (unsigned long) buf->bytes_used, nprocs,
+                             PRTE_NAME_PRINT(&node->daemon->name)));
+
+        PRTE_RML_SEND(rc, node->daemon->name.rank, buf, PRTE_RML_TAG_LAUNCH_SLICE);
+        if (PRTE_SUCCESS != rc) {
+            PRTE_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(buf);
+            return rc;
+        }
+    }
+
+    return PRTE_SUCCESS;
+}
+
+void prte_odls_base_recv_cpuset_slice(int status, pmix_proc_t *sender,
+                                      pmix_data_buffer_t *buffer,
+                                      prte_rml_tag_t tag, void *cbdata)
+{
+    pmix_nspace_t nspace;
+    pmix_status_t rc;
+    int32_t cnt;
+    prte_odls_slice_t *sl;
+    prte_odls_jcaddy_t *cd;
+    PRTE_HIDE_UNUSED_PARAMS(status, sender, tag, cbdata);
+
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &nspace, &cnt, PMIX_PROC_NSPACE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return;
+    }
+
+    sl = slice_find(nspace);
+    if (NULL == sl || NULL == sl->cd) {
+        /* we are first - park the payload for the launch to collect.
+         * PMIx_Data_copy_payload takes what has not been unpacked yet,
+         * which is the slice proper */
+        if (NULL == sl) {
+            sl = PMIX_NEW(prte_odls_slice_t);
+            PMIX_LOAD_NSPACE(sl->nspace, nspace);
+            pmix_list_append(&prte_odls_globals.pending_slices, &sl->super);
+        } else {
+            /* a second slice for a job whose first is still parked - the
+             * master sends one per daemon per job, so this is a bug
+             * somewhere, not a race.  Keep the first. */
+            PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+            return;
+        }
+        PMIX_DATA_BUFFER_CREATE(sl->slice);
+        rc = PMIx_Data_copy_payload(sl->slice, buffer);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            pmix_list_remove_item(&prte_odls_globals.pending_slices, &sl->super);
+            PMIX_RELEASE(sl);
+        }
+        return;
+    }
+
+    /* the launch got here first and is parked on this entry */
+    cd = sl->cd;
+    pmix_list_remove_item(&prte_odls_globals.pending_slices, &sl->super);
+    PMIX_RELEASE(sl);
+
+    rc = apply_cpuset_slice(cd->jdata, buffer);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        /* the procs would launch unbound, or bound to somebody else's
+         * cpus - report rather than proceed */
+        PRTE_ACTIVATE_JOB_STATE(cd->jdata, PRTE_JOB_STATE_NEVER_LAUNCHED);
+        PMIX_RELEASE(cd);
+        return;
+    }
+    start_registration(cd);
+}
+
+bool prte_odls_base_awaiting_cpusets(const pmix_nspace_t nspace)
+{
+    prte_odls_slice_t *sl;
+
+    sl = slice_find(nspace);
+    /* an entry holding a parked launch is one waiting for its slice; an
+     * entry holding a slice is the other way round, and that daemon has no
+     * job object yet, so nobody can be asking it anything */
+    return (NULL != sl && NULL != sl->cd);
+}
+
+/* Returns true if this daemon's bindings are in hand and the launch can go
+ * on, false if the caddy has been parked to await them. */
+static bool slice_rendezvous(prte_odls_jcaddy_t *cd)
+{
+    prte_odls_slice_t *sl;
+    int rc;
+
+    sl = slice_find(cd->jdata->nspace);
+    if (NULL == sl) {
+        /* we are first */
+        sl = PMIX_NEW(prte_odls_slice_t);
+        PMIX_LOAD_NSPACE(sl->nspace, cd->jdata->nspace);
+        sl->cd = cd;
+        pmix_list_append(&prte_odls_globals.pending_slices, &sl->super);
+        PMIX_OUTPUT_VERBOSE((5, prte_odls_base_framework.framework_output,
+                             "%s odls:construct_child_list awaiting cpuset slice for %s",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                             PRTE_JOBID_PRINT(cd->jdata->nspace)));
+        return false;
+    }
+
+    /* the slice beat us here - unless what is parked is another launch of
+     * this same job, which the master does not do and which would leave us
+     * dereferencing a slice that was never stored */
+    pmix_list_remove_item(&prte_odls_globals.pending_slices, &sl->super);
+    if (NULL == sl->slice) {
+        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+        rc = PRTE_ERR_BAD_PARAM;
+    } else {
+        rc = apply_cpuset_slice(cd->jdata, sl->slice);
+    }
+    PMIX_RELEASE(sl);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PRTE_ACTIVATE_JOB_STATE(cd->jdata, PRTE_JOB_STATE_NEVER_LAUNCHED);
+        PMIX_RELEASE(cd);
+        return false;
+    }
+    return true;
+}
+
 int prte_odls_base_default_construct_child_list(pmix_data_buffer_t *buffer, pmix_nspace_t *job,
                                                 prte_odls_base_fork_local_proc_fn_t fork_local)
 {
@@ -514,6 +865,7 @@ int prte_odls_base_default_construct_child_list(pmix_data_buffer_t *buffer, pmix
     size_t m;
     pmix_envar_t envt;
     char *tmp;
+    prte_job_pack_mode_t mode = PRTE_JOB_PACK_ALL;
 
     PMIX_OUTPUT_VERBOSE((5, prte_odls_base_framework.framework_output,
                          "%s odls:constructing child list", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
@@ -531,7 +883,7 @@ int prte_odls_base_default_construct_child_list(pmix_data_buffer_t *buffer, pmix
      * prte_util_decode_job_catchup. */
 
     /* unpack the job we are to launch */
-    rc = prte_job_unpack(buffer, &jdata);
+    rc = prte_job_unpack(buffer, &jdata, &mode);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         goto REPORT_ERROR;
@@ -768,27 +1120,35 @@ int prte_odls_base_default_construct_child_list(pmix_data_buffer_t *buffer, pmix
     cd->fork_local = fork_local;
     info = NULL; // the caddy now owns the info array
 
-    /* register this job with the PMIx server. We have to wait until
-     * after we computed the #local_procs before registering it. The
-     * registration completes asynchronously, and the launch proceeds
-     * once it has reported. Hold a sentinel on the join so it cannot
-     * fire before we finish initiating the registration */
-    cd->pending = 1;
-    rc = prte_pmix_server_register_nspace(jdata, _job_reg_complete, cd);
-    if (PRTE_SUCCESS == rc) {
-        cd->pending++;
-    } else {
-        PRTE_ERROR_LOG(rc);
-        cd->rstatus = PMIX_ERROR;
+    /* Our procs' bindings came separately, and may not be here yet.
+     *
+     * The master is never sent one - it kept its own fully-populated job
+     * object above - and neither is a daemon hosting none of this job's
+     * procs, which has nothing to bind and nothing to wait for.  Anything
+     * parked for such a daemon is a slice for a job it will not launch;
+     * drop it rather than leave it on the list. */
+    if (PRTE_JOB_PACK_NO_CPUSETS == mode && !PRTE_PROC_IS_MASTER) {
+        if (0 < jdata->num_local_procs) {
+            if (!slice_rendezvous(cd)) {
+                /* parked - the slice's receiver takes it from here, and
+                 * has released the caddy if it failed */
+                return PRTE_SUCCESS;
+            }
+        } else {
+            slice_discard(jdata->nspace);
+        }
     }
-    /* release our sentinel - if everything already reported,
-     * this progresses the launch */
-    job_reg_join(cd);
+
+    start_registration(cd);
     return PRTE_SUCCESS;
 
 REPORT_ERROR:
     if (NULL != info) {
         PMIX_INFO_FREE(info, ninfo);
+    }
+    if (NULL != jdata) {
+        /* nobody is going to collect a slice for a job we are failing */
+        slice_discard(jdata->nspace);
     }
     /* NB: "jdata" is either NULL (we failed before unpacking the job we
      * were told to launch) or that job - never one of the prior jobs

--- a/src/mca/odls/base/odls_base_frame.c
+++ b/src/mca/odls/base/odls_base_frame.c
@@ -80,7 +80,9 @@ prte_odls_globals_t prte_odls_globals = {
     .ev_threads = NULL,
     .next_base = 0,
     .signal_direct_children_only = false,
-    .exec_agent = NULL
+    .exec_agent = NULL,
+    .scatter_cpusets = true,
+    .pending_slices = PMIX_LIST_STATIC_INIT
 };
 
 static prte_event_base_t **prte_event_base_ptr = NULL;
@@ -121,6 +123,13 @@ static int prte_odls_base_register(pmix_mca_base_register_flag_t flags)
                                       "Command used to exec application processes [default: NULL]",
                                       PMIX_MCA_BASE_VAR_TYPE_STRING,
                                       &prte_odls_globals.exec_agent);
+
+    prte_odls_globals.scatter_cpusets = true;
+    (void) pmix_mca_base_var_register("prte", "odls", "base", "scatter_cpusets",
+                                      "Send each daemon the bindings of the procs it will launch, "
+                                      "rather than broadcasting every proc's binding to every daemon",
+                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                                      &prte_odls_globals.scatter_cpusets);
 
     return PRTE_SUCCESS;
 }
@@ -242,6 +251,10 @@ static int prte_odls_base_close(void)
     }
     PMIX_DESTRUCT(&prte_odls_globals.xterm_ranks);
 
+    /* anything still here is a launch that never completed, or a slice for
+     * one - PMIX_DESTRUCT would leave the items themselves behind */
+    PMIX_LIST_DESTRUCT(&prte_odls_globals.pending_slices);
+
     /* cleanup the global list of local children and job data */
     for (i = 0; i < prte_local_children->size; i++) {
         if (NULL != (proc = (prte_proc_t *) pmix_pointer_array_get_item(prte_local_children, i))) {
@@ -277,6 +290,7 @@ static int prte_odls_base_open(pmix_mca_base_open_flag_t flags)
 
     /* initialize ODLS globals */
     PMIX_CONSTRUCT(&prte_odls_globals.xterm_ranks, pmix_list_t);
+    PMIX_CONSTRUCT(&prte_odls_globals.pending_slices, pmix_list_t);
     prte_odls_globals.xtermcmd = NULL;
 
     /* ensure that SIGCHLD is unblocked as we need to capture it */

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -990,6 +990,21 @@ void prte_plm_base_send_launch_msg(int fd, short args, void *cbdata)
         return;
     }
 
+    /* Send each daemon the part of the message addressed to it alone - the
+     * bindings of the procs it will fork.  Ahead of the broadcast, but only
+     * for tidiness: the two are independent messages on independent paths,
+     * the receiving daemon waits for whichever arrives second, and nothing
+     * here depends on which that is. */
+    if (prte_odls_globals.scatter_cpusets) {
+        rc = prte_odls_base_send_cpuset_slices(jdata);
+        if (PRTE_SUCCESS != rc) {
+            PRTE_ERROR_LOG(rc);
+            PRTE_ACTIVATE_JOB_STATE(caddy->jdata, PRTE_JOB_STATE_NEVER_LAUNCHED);
+            PMIX_RELEASE(caddy);
+            return;
+        }
+    }
+
     /* Goes to all daemons, on the launch message's own tag rather than the
      * general daemon-command tag. This is the one large broadcast PRRTE makes
      * on a regular basis, and naming it is what lets grpcomm move it by what

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -523,7 +523,7 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
 
         /* unpack the job object */
         count = 1;
-        rc = prte_job_unpack(buffer, &jdata);
+        rc = prte_job_unpack(buffer, &jdata, NULL);
         if (PRTE_SUCCESS != rc) {
             PRTE_ERROR_LOG(rc);
             goto ANSWER_LAUNCH;

--- a/src/mca/state/prted/state_prted.c
+++ b/src/mca/state/prted/state_prted.c
@@ -37,6 +37,7 @@
 #include "src/util/session_dir.h"
 
 #include "src/mca/state/base/base.h"
+#include "src/prted/pmix/pmix_server.h"
 #include "state_prted.h"
 
 /*
@@ -656,6 +657,14 @@ static void job_teardown(int fd, short argc, void *cbdata)
         PMIX_LOAD_PROCID(&target, jdata->nspace, PMIX_RANK_WILDCARD);
         prte_state_base_notify_data_server(&target);
     }
+
+    /* Remember that this job was here and has gone.  We are dropping the only
+     * copy of what we knew about it, while the job itself goes on running on
+     * other daemons - so a peer can still ask us about one of the procs we
+     * hosted.  Without this record that request cannot be told apart from one
+     * that arrived before the launch message did, and the two want opposite
+     * answers: wait for the one, refuse the other. */
+    prte_pmix_server_job_departed(jdata->nspace);
 
     /* cleanup the job info.  The caddy still holds a reference of its own,
      * so the object survives until it is released below. */

--- a/src/mca/state/prted/state_prted.c
+++ b/src/mca/state/prted/state_prted.c
@@ -658,19 +658,19 @@ static void job_teardown(int fd, short argc, void *cbdata)
         prte_state_base_notify_data_server(&target);
     }
 
-    /* Remember that this job was here and has gone.  We are dropping the only
-     * copy of what we knew about it, while the job itself goes on running on
-     * other daemons - so a peer can still ask us about one of the procs we
-     * hosted.  Without this record that request cannot be told apart from one
-     * that arrived before the launch message did, and the two want opposite
-     * answers: wait for the one, refuse the other. */
-    prte_pmix_server_job_departed(jdata->nspace);
-
-    /* cleanup the job info.  The caddy still holds a reference of its own,
-     * so the object survives until it is released below. */
-    pmix_pointer_array_set_item(prte_job_data, jdata->index, NULL);
-    PMIX_RELEASE(jdata);
-
+    /* The resources are back, but the JOB OBJECT STAYS until the DVM says
+     * the job is over everywhere - prted_comm.c's DVM_CLEANUP_JOB.
+     *
+     * What we hold about a proc we hosted is the only copy of it: its
+     * placement and, since the launch message started scattering them, its
+     * binding.  This daemon finishing its own share says nothing about the
+     * rest of the job, and a peer still running on another node can ask us
+     * about one of these procs at any time until it does.  Releasing here
+     * answered those questions with silence - measured on peerinfo, 50 of
+     * 56 peer bindings when two daemons happened to finish early.
+     *
+     * Only the caddy's reference is dropped here; the one the job array
+     * holds is what keeps the object alive. */
     PMIX_RELEASE(caddy);
 }
 

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -156,6 +156,22 @@ asked us to service. `prte_pmix_server_clear()` sweeps only
 `remote_reqs`, because the local ones belong to callbacks that will still
 fire.
 
+Two things about that sweep, both of which it got wrong:
+
+- **Discarding a request is not answering it.** Every entry it drops is a
+  peer daemon waiting for a reply, and dropping it in silence leaves that
+  peer waiting for the life of the DVM. The sweep runs when a job is done,
+  so the honest reply is `PRTE_ERR_NOT_FOUND` — the proc it asked about is
+  gone and its data with it, which is a question that no longer has an
+  answer rather than a failure. Only for requests not marked `inprogress`:
+  those are held by somebody who will answer them.
+- **It has to skip the entries that name no target.** The match is on
+  `req->tproc`, and a *monitor* request never sets one — so its nspace is
+  empty, which is PMIx's wildcard and matches every job. Every job that
+  ended was quietly taking the outstanding monitor requests with it. Guard
+  with `PMIX_NSPACE_INVALID()` first; this is the same trap described above
+  for `tproc` versus `target`, in a second place.
+
 ---
 
 ## The relay pattern

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -232,6 +232,60 @@ bearing:
   the caller saying our copy may be stale, which is exactly when we must
   go and ask.
 
+### A binding we were not sent is not a binding of "none"
+
+`prte_proc_t.cpuset` is NULL in two completely different situations, and
+since the launch message started **scattering** the cpusets — each daemon
+is sent only the bindings of the procs it will fork, see
+[`src/mca/odls/AGENTS.md`](../../mca/odls/AGENTS.md) — both are ordinary:
+
+| NULL cpuset on | means |
+|----------------|-------|
+| a proc we host | the mapper bound nothing (`--bind-to none`, or it could not) |
+| any other proc | we were never told, and are not the authority |
+
+Everything that reads a cpuset therefore has to ask *whose proc it is*
+first, because the answer to "where is it bound" differs and neither
+answer is an error:
+
+- **`register_nspace()`** publishes `PMIX_CPUSET` and the locality string
+  when it has a cpuset, publishes a **NULL** `PMIX_LOCALITY_STRING` — which
+  positively asserts "unbound" — only for a proc *it hosts*, and publishes
+  nothing at all for any other. Silence is what makes a get fall through to
+  somebody who knows; a NULL locality is an answer, and the wrong one.
+- **`derive_proc_data()`** does the same, and `dmodex_req()` goes further:
+  when the key asked for is `PMIX_CPUSET` or `PMIX_LOCALITY_STRING` and we
+  hold neither the cpuset nor the proc, it declines to derive at all and
+  sends the request to the daemon that forks the proc.
+
+The failure this prevents is silent — a peer told that a bound process is
+unbound, on a path where nothing returns an error.
+
+### The hosting daemon answers a placement key from the job, not from the process
+
+That referral only works because of the other half, in
+`pmix_server_dmdx_recv()` (`pmix_server.c`): a direct modex whose
+`PMIX_REQUIRED_KEY` is one of the `derivable_key()` set is answered
+**straight out of `jdata->procs[rank]`**, by the same
+`prte_pmix_server_derive_proc_data()`, before the handler goes anywhere near
+its own PMIx server.
+
+That ordering is load bearing, and getting it wrong is a hang rather than a
+wrong answer. The ordinary path below it asks the local server for the key
+and, not finding it, parks the request on a two-second retry until the
+process publishes something. For application data that is exactly right —
+the asker wants a value the process has not produced yet. For **PRRTE's own**
+placement and binding it is a deadlock: those keys have never required a
+`PMIx_Put` from the proc being asked about, and a process that only ever
+*gets* never commits anything, so the request is never satisfied. Seen
+outright with `contrib/dockerswarm/peerinfo.c`, which does nothing but get:
+every rank hung.
+
+So the rule for anything added to `derivable_key()`: **this daemon must be
+able to answer it from what PRRTE knows, on both sides.** The asking daemon
+derives it when it holds the facts; the hosting daemon derives it when asked;
+neither waits on the process.
+
 **This depends on a PMIx that surfaces the request at all**, which is why
 it could not have been written earlier: a client's get for a reserved key
 its server did not hold used to have `PMIX_IMMEDIATE` forced onto it,

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -569,6 +569,14 @@ void prte_pmix_server_clear(pmix_proc_t *pname)
     for (n = 0; n < prte_pmix_server_globals.remote_reqs.size; n++) {
         req = (prte_pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.remote_reqs, n);
         if (NULL != req) {
+            /* Only requests that name a target proc are ours to clear.
+             * A monitor request does not set tproc at all, and an empty
+             * nspace is PMIx's wildcard - it matches everything - so
+             * without this guard every job that ended took the outstanding
+             * monitor requests with it. */
+            if (PMIX_NSPACE_INVALID(req->tproc.nspace)) {
+                continue;
+            }
             if (!PMIX_CHECK_NSPACE(req->tproc.nspace, pname->nspace) ||
                 !PMIX_CHECK_RANK(req->tproc.rank, pname->rank)) {
                 continue;
@@ -583,6 +591,14 @@ void prte_pmix_server_clear(pmix_proc_t *pname)
             }
             pmix_pointer_array_set_item(&prte_pmix_server_globals.remote_reqs, n, NULL);
             if (!req->inprogress) {
+                /* Somebody is still waiting on the other end of this, and
+                 * dropping it in silence leaves them waiting forever.  The
+                 * proc it asked about is gone and its data with it, which is
+                 * not an error - it is a question that no longer has an
+                 * answer, so say exactly that.  A request that IS in progress
+                 * is answered by whoever holds it. */
+                send_error(PRTE_ERR_NOT_FOUND, &req->tproc, &req->proxy,
+                           req->remote_index);
                 /* if the request is in progress, then someone (host or PMIx server
                  * library) has the req object - so we cannot release it yet.
                  * We'll take care of it once the current holder returns.

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -787,6 +787,7 @@ int pmix_server_init(void)
 
     /* setup the server's state variables */
     PMIX_CONSTRUCT(&prte_pmix_server_globals.psets, pmix_list_t);
+    PMIX_CONSTRUCT(&prte_pmix_server_globals.departed_jobs, pmix_list_t);
     PMIX_CONSTRUCT(&prte_pmix_server_globals.groups, pmix_list_t);
     PMIX_CONSTRUCT(&prte_pmix_server_globals.local_reqs, pmix_pointer_array_t);
     pmix_pointer_array_init(&prte_pmix_server_globals.local_reqs, 128, INT_MAX, 2);
@@ -1283,6 +1284,7 @@ void pmix_server_finalize(void)
     PMIX_DESTRUCT(&prte_pmix_server_globals.local_reqs);
     PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.notifications);
     PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.psets);
+    PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.departed_jobs);
     PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.groups);
 
     /* shutdown the local server */
@@ -1321,6 +1323,46 @@ static void send_error(int status, pmix_proc_t *idreq, pmix_proc_t *remote, int 
     if (PRTE_SUCCESS != prc) {
         PRTE_ERROR_LOG(prc);
         PMIX_DATA_BUFFER_RELEASE(reply);
+    }
+}
+
+
+void prte_pmix_server_job_departed(const pmix_nspace_t nspace)
+{
+    prte_namelist_t *nm;
+
+    if (prte_pmix_server_job_has_departed(nspace)) {
+        return;
+    }
+    nm = PMIX_NEW(prte_namelist_t);
+    PMIX_LOAD_PROCID(&nm->name, nspace, PMIX_RANK_WILDCARD);
+    pmix_list_append(&prte_pmix_server_globals.departed_jobs, &nm->super);
+}
+
+bool prte_pmix_server_job_has_departed(const pmix_nspace_t nspace)
+{
+    prte_namelist_t *nm;
+
+    PMIX_LIST_FOREACH(nm, &prte_pmix_server_globals.departed_jobs, prte_namelist_t)
+    {
+        if (PMIX_CHECK_NSPACE(nm->name.nspace, nspace)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void prte_pmix_server_forget_departed(const pmix_nspace_t nspace)
+{
+    prte_namelist_t *nm;
+
+    PMIX_LIST_FOREACH(nm, &prte_pmix_server_globals.departed_jobs, prte_namelist_t)
+    {
+        if (PMIX_CHECK_NSPACE(nm->name.nspace, nspace)) {
+            pmix_list_remove_item(&prte_pmix_server_globals.departed_jobs, &nm->super);
+            PMIX_RELEASE(nm);
+            return;
+        }
     }
 }
 
@@ -1478,6 +1520,57 @@ static void modex_resp(pmix_status_t status, char *data, size_t sz, void *cbdata
     prte_event_active(&(cd->ev), PRTE_EV_WRITE, 1);
 }
 
+/* Answer a direct modex out of the job object.
+ *
+ * The keys this covers are the ones the DVM itself decided when it mapped
+ * the job - see prte_pmix_server_derivable_key() - and none of them is data
+ * the process publishes.  Asking our own PMIx server for them instead is
+ * what used to hang the requester: that path parks the request until the
+ * proc commits something, and a proc that only ever calls PMIx_Get commits
+ * nothing, ever.  Both entry points into this file's dmodex service - the
+ * receive and the retry it can defer to - therefore try this first.
+ *
+ * Returns true if the request has been answered and disposed of. */
+static bool answer_from_job(prte_job_t *jdata, prte_proc_t *proc,
+                            pmix_proc_t *pproc, const char *key,
+                            pmix_proc_t *sender, int remote_index)
+{
+    prte_pmix_server_req_t *rq;
+    pmix_data_buffer_t dbuf;
+    pmix_byte_object_t bo;
+    pmix_status_t prc;
+
+    if (NULL == key || !prte_pmix_server_derivable_key(key)) {
+        return false;
+    }
+    PMIX_DATA_BUFFER_CONSTRUCT(&dbuf);
+    prc = prte_pmix_server_derive_proc_data(jdata, proc, &dbuf);
+    if (PMIX_SUCCESS != prc) {
+        /* we could not build it - let the caller do this the ordinary way,
+         * which at worst leaves the asker where it was before */
+        PMIX_DATA_BUFFER_DESTRUCT(&dbuf);
+        return false;
+    }
+    PMIX_DATA_BUFFER_UNLOAD(&dbuf, bo.bytes, bo.size);
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s dmdx: key %s for %s:%u ANSWERED FROM THE JOB (%lu bytes)",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), key,
+                        pproc->nspace, pproc->rank, (unsigned long) bo.size);
+
+    rq = PMIX_NEW(prte_pmix_server_req_t);
+    pmix_asprintf(&rq->operation, "DMDX: %s:%d", __FILE__, __LINE__);
+    rq->proxy = *sender;
+    memcpy(&rq->tproc, pproc, sizeof(pmix_proc_t));
+    rq->remote_index = remote_index;
+    rq->pstatus = PMIX_SUCCESS;
+    rq->data = (char *) bo.bytes;
+    rq->sz = bo.size;
+    /* _mdxresp clears our slot as it sends, so we must occupy one */
+    rq->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.remote_reqs, rq);
+    _mdxresp(0, 0, rq);
+    return true;
+}
+
 static void dmdx_check(int sd, short args, void *cbdata)
 {
     prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
@@ -1491,6 +1584,18 @@ static void dmdx_check(int sd, short args, void *cbdata)
     /* do we know about this job? */
     jdata = prte_get_job_data_object(req->tproc.nspace);
     if (NULL == jdata) {
+        /* it may have arrived and departed while we were waiting for it -
+         * see the same test in dmdx_recv */
+        if (prte_pmix_server_job_has_departed(req->tproc.nspace)) {
+            send_error(PRTE_ERR_NOT_FOUND, &req->tproc, &req->proxy, req->remote_index);
+            if (req->event_active) {
+                prte_event_del(&req->ev);
+            }
+            pmix_pointer_array_set_item(&prte_pmix_server_globals.remote_reqs,
+                                        req->local_index, NULL);
+            PMIX_RELEASE(req);
+            return;
+        }
         /* wait some more */
         pmix_output_verbose(2, prte_pmix_server_globals.output,
                             "%s dmdx:recv dmdx_check cannot find job object - delaying",
@@ -1521,6 +1626,19 @@ static void dmdx_check(int sd, short args, void *cbdata)
             prte_event_del(&req->ev);
         }
         pmix_pointer_array_set_item(&prte_pmix_server_globals.remote_reqs, req->local_index, NULL);
+        PMIX_RELEASE(req);
+        return;
+    }
+
+    /* a placement key is ours to answer, and nothing about the process will
+     * ever make the check below succeed for one - see answer_from_job() */
+    if (answer_from_job(jdata, proc, &req->tproc, req->key,
+                        &req->proxy, req->remote_index)) {
+        if (req->event_active) {
+            prte_event_del(&req->ev);
+        }
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.remote_reqs,
+                                    req->local_index, NULL);
         PMIX_RELEASE(req);
         return;
     }
@@ -1668,6 +1786,23 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
     /* do we know about this job? */
     jdata = prte_get_job_data_object(pproc.nspace);
     if (NULL == jdata) {
+        /* Two things look like this, and they want opposite answers.  If the
+         * job has already been and gone from here - our share of it finished
+         * and we released it - then nothing will ever make this answerable,
+         * and waiting means the asker waits forever. */
+        if (prte_pmix_server_job_has_departed(pproc.nspace)) {
+            pmix_output_verbose(2, prte_pmix_server_globals.output,
+                                "%s dmdx:recv request for departed job %s - not found",
+                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), pproc.nspace);
+            send_error(PRTE_ERR_NOT_FOUND, &pproc, sender, index);
+            if (NULL != info) {
+                PMIX_INFO_FREE(info, ninfo);
+            }
+            if (NULL != key) {
+                free(key);
+            }
+            return;
+        }
         /* not having the jdata means that we haven't unpacked the
          * the launch message for this job yet - this is a race
          * condition, so just log the request and we will fill
@@ -1729,6 +1864,19 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
         if (NULL != key) {
           free(key);
         }
+        return;
+    }
+
+    /* If what they are asking for is something this DVM decided when it
+     * mapped the job, answer it out of the job object and do not go near our
+     * PMIx server.  We host this proc - the check above says so - so we hold
+     * the placement and the binding, and neither of them is data the process
+     * publishes. */
+    if (answer_from_job(jdata, proc, &pproc, key, sender, index)) {
+        if (NULL != info) {
+            PMIX_INFO_FREE(info, ninfo);
+        }
+        free(key);
         return;
     }
 

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -1344,12 +1344,22 @@ static void send_error(int status, pmix_proc_t *idreq, pmix_proc_t *remote, int 
 }
 
 
+/* How many departed jobs to remember.  A request can only arrive for one of
+ * these if it was already in flight when the job ended, so the window is
+ * short; the bound is here because a persistent DVM runs jobs without end
+ * and this list would otherwise grow with all of them. */
+#define PRTE_MAX_DEPARTED_JOBS 32
+
 void prte_pmix_server_job_departed(const pmix_nspace_t nspace)
 {
     prte_namelist_t *nm;
 
     if (prte_pmix_server_job_has_departed(nspace)) {
         return;
+    }
+    while (PRTE_MAX_DEPARTED_JOBS <= pmix_list_get_size(&prte_pmix_server_globals.departed_jobs)) {
+        nm = (prte_namelist_t *) pmix_list_remove_first(&prte_pmix_server_globals.departed_jobs);
+        PMIX_RELEASE(nm);
     }
     nm = PMIX_NEW(prte_namelist_t);
     PMIX_LOAD_PROCID(&nm->name, nspace, PMIX_RANK_WILDCARD);
@@ -1367,20 +1377,6 @@ bool prte_pmix_server_job_has_departed(const pmix_nspace_t nspace)
         }
     }
     return false;
-}
-
-void prte_pmix_server_forget_departed(const pmix_nspace_t nspace)
-{
-    prte_namelist_t *nm;
-
-    PMIX_LIST_FOREACH(nm, &prte_pmix_server_globals.departed_jobs, prte_namelist_t)
-    {
-        if (PMIX_CHECK_NSPACE(nm->name.nspace, nspace)) {
-            pmix_list_remove_item(&prte_pmix_server_globals.departed_jobs, &nm->super);
-            PMIX_RELEASE(nm);
-            return;
-        }
-    }
 }
 
 static void _mdxresp(int sd, short args, void *cbdata)

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -65,6 +65,7 @@
 #include "src/util/prte_show_help.h"
 
 #include "src/mca/errmgr/errmgr.h"
+#include "src/mca/odls/base/base.h"
 #include "src/grpcomm/grpcomm.h"
 #include "src/mca/ras/base/base.h"
 #include "src/mca/state/state.h"
@@ -1541,6 +1542,15 @@ static bool answer_from_job(prte_job_t *jdata, prte_proc_t *proc,
     pmix_status_t prc;
 
     if (NULL == key || !prte_pmix_server_derivable_key(key)) {
+        return false;
+    }
+    /* The bindings arrive separately from the rest of the launch message,
+     * and until ours land we cannot say where our own procs are bound -
+     * deriving now would answer "nowhere", which is a different thing.
+     * Returning false parks the request on the retry cycle, which comes
+     * back through here once the slice has been applied. */
+    if ((PMIx_Check_key(key, PMIX_CPUSET) || PMIx_Check_key(key, PMIX_LOCALITY_STRING)) &&
+        NULL == proc->cpuset && prte_odls_base_awaiting_cpusets(jdata->nspace)) {
         return false;
     }
     PMIX_DATA_BUFFER_CONSTRUCT(&dbuf);

--- a/src/prted/pmix/pmix_server.h
+++ b/src/prted/pmix/pmix_server.h
@@ -44,15 +44,14 @@ PRTE_EXPORT void prte_pmix_server_clear(pmix_proc_t *pname);
 /* Record that every local proc of this job has gone and its job object has
  * been released here, and ask whether that has happened.
  *
- * A daemon retires a job as soon as its own share of it finishes, while the
- * job goes on running elsewhere - so "I have no job object for this" has two
- * meanings, and a direct modex has to tell them apart. Not yet arrived means
- * wait; already gone means answer NOT_FOUND, because nothing will ever make
- * it answerable again. The record is dropped when the DVM declares the job
+ * A daemon holds a job object from the launch message until the DVM declares
+ * the job complete - so "I have no job object for this" has two meanings, and
+ * a direct modex has to tell them apart. Not yet arrived means wait; already
+ * gone means answer NOT_FOUND, because nothing will ever make it answerable
+ * again. The record is dropped when the DVM declares the job
  * complete, so the list holds at most the jobs currently running. */
 PRTE_EXPORT void prte_pmix_server_job_departed(const pmix_nspace_t nspace);
 PRTE_EXPORT bool prte_pmix_server_job_has_departed(const pmix_nspace_t nspace);
-PRTE_EXPORT void prte_pmix_server_forget_departed(const pmix_nspace_t nspace);
 
 PRTE_EXPORT void pmix_server_notify_spawn(pmix_nspace_t jobid, int room, pmix_status_t ret);
 

--- a/src/prted/pmix/pmix_server.h
+++ b/src/prted/pmix/pmix_server.h
@@ -41,6 +41,19 @@ PRTE_EXPORT int prte_pmix_server_register_nspace(prte_job_t *jdata,
 
 PRTE_EXPORT void prte_pmix_server_clear(pmix_proc_t *pname);
 
+/* Record that every local proc of this job has gone and its job object has
+ * been released here, and ask whether that has happened.
+ *
+ * A daemon retires a job as soon as its own share of it finishes, while the
+ * job goes on running elsewhere - so "I have no job object for this" has two
+ * meanings, and a direct modex has to tell them apart. Not yet arrived means
+ * wait; already gone means answer NOT_FOUND, because nothing will ever make
+ * it answerable again. The record is dropped when the DVM declares the job
+ * complete, so the list holds at most the jobs currently running. */
+PRTE_EXPORT void prte_pmix_server_job_departed(const pmix_nspace_t nspace);
+PRTE_EXPORT bool prte_pmix_server_job_has_departed(const pmix_nspace_t nspace);
+PRTE_EXPORT void prte_pmix_server_forget_departed(const pmix_nspace_t nspace);
+
 PRTE_EXPORT void pmix_server_notify_spawn(pmix_nspace_t jobid, int room, pmix_status_t ret);
 
 END_C_DECLS

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -168,7 +168,7 @@ static void spawn(int sd, short args, void *cbdata)
     }
 
     /* pack the jdata object */
-    rc = prte_job_pack(buf, req->jdata);
+    rc = prte_job_pack(buf, req->jdata, PRTE_JOB_PACK_ALL);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);

--- a/src/prted/pmix/pmix_server_fence.c
+++ b/src/prted/pmix/pmix_server_fence.c
@@ -89,11 +89,6 @@ static void wildcard_reg_complete(pmix_status_t status, void *cbdata)
     PMIX_RELEASE(req);
 }
 
-/* answering a dmodex from the job object rather than from the hosting
- * daemon - defined below, next to the key set they cover */
-static bool derivable_key(const char *key);
-static pmix_status_t derive_proc_data(prte_job_t *jdata, prte_proc_t *proct,
-                                      pmix_data_buffer_t *buf);
 static void derived_relfn(void *cbdata);
 
 static void dmodex_req(int sd, short args, void *cbdata)
@@ -233,12 +228,22 @@ static void dmodex_req(int sd, short args, void *cbdata)
      * that is an answer eager publication would have had in hand.  Requiring
      * a live daemon here would turn it into a failure. */
     if (prte_pmix_server_globals.lazy_procdata && !refresh_cache &&
-        derivable_key(req->key)) {
+        prte_pmix_server_derivable_key(req->key) &&
+        /* ...but not a binding we do not hold.  The launch message scatters
+         * the cpusets, so a NULL one on a proc we do not host means "never
+         * sent", not "not bound", and answering either way would be a
+         * guess.  Send it to the daemon that forks the proc, which answers
+         * this same closed set of keys straight out of its job object
+         * (pmix_server_dmdx_recv) rather than out of anything the process
+         * has to have published. */
+        (NULL != proct->cpuset || proct->parent == PRTE_PROC_MY_NAME->rank ||
+         (!PMIx_Check_key(req->key, PMIX_CPUSET) &&
+          !PMIx_Check_key(req->key, PMIX_LOCALITY_STRING)))) {
         pmix_data_buffer_t dbuf;
         pmix_byte_object_t bo;
 
         PMIX_DATA_BUFFER_CONSTRUCT(&dbuf);
-        prc = derive_proc_data(jdata, proct, &dbuf);
+        prc = prte_pmix_server_derive_proc_data(jdata, proct, &dbuf);
         if (PMIX_SUCCESS == prc) {
             PMIX_DATA_BUFFER_UNLOAD(&dbuf, bo.bytes, bo.size);
             PMIX_DATA_BUFFER_DESTRUCT(&dbuf);
@@ -365,7 +370,7 @@ callback:
  * the values ourselves with PMIx_Data_store_internal would put them in the
  * INTERNAL scope, which that lookup does not reach.
  */
-static bool derivable_key(const char *key)
+bool prte_pmix_server_derivable_key(const char *key)
 {
     if (NULL == key) {
         /* no key named means "everything you have", and we do not have the
@@ -413,8 +418,8 @@ static pmix_status_t pack_derived(pmix_data_buffer_t *buf, const char *key,
 /* Build the blob describing one proc.  Mirrors the per-proc section of
  * prte_pmix_server_register_nspace() - if a key is added there and a peer can
  * ask for it, it belongs here too, or that key becomes a wire round trip. */
-static pmix_status_t derive_proc_data(prte_job_t *jdata, prte_proc_t *proct,
-                                      pmix_data_buffer_t *buf)
+pmix_status_t prte_pmix_server_derive_proc_data(prte_job_t *jdata, prte_proc_t *proct,
+                                               pmix_data_buffer_t *buf)
 {
     pmix_status_t rc;
     pmix_rank_t vpid;
@@ -491,10 +496,15 @@ static pmix_status_t derive_proc_data(prte_job_t *jdata, prte_proc_t *proct,
         if (PMIX_SUCCESS != rc) {
             return rc;
         }
-    } else {
-        /* an unbound proc still has to answer the locality question, and the
+    } else if (proct->parent == PRTE_PROC_MY_NAME->rank) {
+        /* An unbound proc still has to answer the locality question, and the
          * answer is "nothing to say" - the eager path registers a NULL for
-         * exactly this case */
+         * exactly this case.  Only for a proc we HOST, though: for any other,
+         * a NULL cpuset means the launch message scattered the bindings and
+         * we were not sent this one, which is a different statement.  The
+         * caller above has already refused to derive those two keys in that
+         * case, so what is left here is a request for some other key on a
+         * proc whose binding we cannot speak to - leave both out. */
         PACK_DERIVED(rc, buf, PMIX_LOCALITY_STRING, PMIX_STRING, data.string = NULL);
         if (PMIX_SUCCESS != rc) {
             return rc;

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -110,6 +110,20 @@ typedef struct {
 } prte_pmix_server_req_t;
 PMIX_CLASS_DECLARATION(prte_pmix_server_req_t);
 
+/* Answering for a proc out of the job object rather than out of the local
+ * PMIx server's store.  prte_pmix_server_derivable_key() is the closed set
+ * of keys this DVM is itself the authority for - the placement and binding
+ * it computed when it mapped the job - and
+ * prte_pmix_server_derive_proc_data() builds the blob a direct modex would
+ * have returned for them.  Both live in pmix_server_fence.c; the dmodex
+ * receiver in pmix_server.c uses them too, so that a request that does
+ * reach the hosting daemon is answered from what PRRTE knows rather than
+ * from what the process has published.  See src/prted/pmix/AGENTS.md. */
+PRTE_EXPORT bool prte_pmix_server_derivable_key(const char *key);
+PRTE_EXPORT pmix_status_t prte_pmix_server_derive_proc_data(prte_job_t *jdata,
+                                                            prte_proc_t *proct,
+                                                            pmix_data_buffer_t *buf);
+
 /* object for thread-shifting server operations */
 typedef struct {
     pmix_object_t super;
@@ -488,6 +502,10 @@ typedef struct {
     bool lazy_procdata;
     pmix_list_t psets;
     pmix_list_t groups;
+    /* jobs whose local procs have all departed, so that a direct modex for
+     * one of them can be told "not found" instead of waiting for a job
+     * object that is never coming back - see prte_pmix_server_job_departed() */
+    pmix_list_t departed_jobs;
 } prte_pmix_server_globals_t;
 
 PRTE_EXPORT extern prte_pmix_server_globals_t prte_pmix_server_globals;

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -748,10 +748,19 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
                     }
                 }
                 hwloc_bitmap_free(cpuset.bitmap);
-            } else {
-                /* the proc is not bound */
+            } else if (PRTE_PROC_MY_NAME->rank == node->daemon->name.rank) {
+                /* the proc is not bound, and we are the daemon that will
+                 * fork it, so we know that rather than merely not having
+                 * been told */
                 PMIX_INFO_LIST_ADD(ret, pmap, PMIX_LOCALITY_STRING, NULL, PMIX_STRING);
             }
+            /* Nothing published for a remote proc with no cpuset: the launch
+             * message scatters the bindings, so what we hold for a proc some
+             * other daemon forks is nothing at all - and a NULL locality here
+             * is a positive claim that it is unbound, which the receiver
+             * cannot tell from silence.  A get for it falls through to
+             * dmodex_req, which declines it for the same reason and asks the
+             * daemon that does know. */
             if (PRTE_PROC_MY_NAME->rank == node->daemon->name.rank) {
                 /* create and pass a proc-level session directory */
                 rc = prte_session_dir(&pptr->name);

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -95,6 +95,7 @@
 
 #include "src/mca/errmgr/errmgr.h"
 #include "src/mca/ess/base/base.h"
+#include "src/mca/odls/base/base.h"
 #include "src/mca/odls/odls.h"
 #include "src/mca/plm/plm.h"
 #include "src/mca/rmaps/base/base.h"
@@ -1120,6 +1121,10 @@ PRTE_EXPORT int prte(int argc, char *argv[])
      * prte_daemon_recv ignores the tag it was delivered on. */
     PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_DAEMON_LAUNCH,
                   PRTE_RML_PERSISTENT, prte_daemon_recv, NULL);
+    /* The half of the launch message addressed to us alone: the bindings
+     * of the procs we are about to fork. */
+    PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_LAUNCH_SLICE,
+                  PRTE_RML_PERSISTENT, prte_odls_base_recv_cpuset_slice, NULL);
 
     /* setup to capture job-level info */
     PMIX_INFO_LIST_START(jinfo);

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -187,6 +187,7 @@ static void _daemon_continue(int sd, short args, void *cbdata)
 {
     prte_daemon_caddy_t *cd = (prte_daemon_caddy_t *) cbdata;
     pmix_proc_t pname;
+    prte_job_t *jdata;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
     PMIX_ACQUIRE_OBJECT(cd);
@@ -240,6 +241,21 @@ static void _daemon_continue(int sd, short args, void *cbdata)
          * holding a reference to it */
         PMIX_LOAD_PROCID(&pname, cd->job, PMIX_RANK_WILDCARD);
         prte_pmix_server_clear(&pname);
+        /* ...and now, finally, let the job object go.  A daemon holds it
+         * from the launch message until here, through its own procs
+         * finishing, because until the DVM says the job is over somebody
+         * may still ask it where one of those procs was placed and how it
+         * was bound - it is the only copy of that.  The master runs its own
+         * job lifecycle and is not part of this. */
+        if (!PRTE_PROC_IS_MASTER) {
+            jdata = prte_get_job_data_object(cd->job);
+            if (NULL != jdata) {
+                /* from here on the answer to a question about it is "not
+                 * found" rather than "wait" - the difference is a hang */
+                prte_pmix_server_job_departed(cd->job);
+                PMIX_RELEASE(jdata);
+            }
+        }
         break;
     }
 
@@ -732,10 +748,6 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
             PMIX_ERROR_LOG(ret);
             goto CLEANUP;
         }
-
-        /* the job is over everywhere, so nobody can ask us about it again -
-         * drop the note we made when our own share of it finished */
-        prte_pmix_server_forget_departed(job);
 
         /* look up job data object */
         if (NULL == (jdata = prte_get_job_data_object(job))) {

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -733,6 +733,10 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
             goto CLEANUP;
         }
 
+        /* the job is over everywhere, so nobody can ask us about it again -
+         * drop the note we made when our own share of it finished */
+        prte_pmix_server_forget_departed(job);
+
         /* look up job data object */
         if (NULL == (jdata = prte_get_job_data_object(job))) {
             /* we can safely ignore this request as the job

--- a/src/rml/rml_types.h
+++ b/src/rml/rml_types.h
@@ -122,6 +122,13 @@ typedef void (*prte_rml_buffer_callback_fn_t)(int status, pmix_proc_t *peer,
  * on it. */
 #define PRTE_RML_TAG_DAEMON_LAUNCH 18
 
+/* The part of the launch message that is addressed to one daemon: the
+ * bindings of the procs that daemon is about to fork.  Sent point to point
+ * while the rest of the message is broadcast, so the cpusets cost the tree
+ * their own size once instead of once per daemon they reach.  See
+ * prte_odls_base_send_cpuset_slices(). */
+#define PRTE_RML_TAG_LAUNCH_SLICE 19
+
 #define PRTE_RML_TAG_XCAST         15
 #define PRTE_RML_TAG_XCAST_ACK     16
 /* The bulk broadcast's allgather phase, and the request to abandon it.  Kept

--- a/src/runtime/data_type_support/AGENTS.md
+++ b/src/runtime/data_type_support/AGENTS.md
@@ -89,6 +89,40 @@ the attributes are the proc's own. That is ~13 bytes a proc against the ~25
 the full record cost, on top of the ~46 it cost before the namespace was
 hoisted out of it.
 
+### The buffer says which shape it is: `prte_job_pack_mode_t`
+
+Not every caller packs the same record. The launch message is broadcast to
+every daemon, but a proc's **cpuset** is read only by the daemon that forks
+it, so the launch path packs `PRTE_JOB_PACK_NO_CPUSETS` and sends each
+daemon its own bindings point to point
+(`prte_odls_base_send_cpuset_slices()`, see
+[`src/mca/odls/AGENTS.md`](../../mca/odls/AGENTS.md)). Everything else packs
+`PRTE_JOB_PACK_ALL`.
+
+The mode is **one byte at the head of the buffer**, ahead of the nspace, and
+`prte_job_unpack` hands it back through an out parameter. Two reasons it is
+on the wire rather than agreed out of band:
+
+- The decoder must know before it reads the first per-proc record. Getting
+  it wrong does not fail — it reads the next proc's node rank as this one's
+  cpuset and desynchronizes everything after.
+- The receiver has to tell **"not sent" from "not bound"**. A NULL cpuset
+  means the mapper bound nothing when the mode is `ALL`, and means "this is
+  not my proc" when it is `NO_CPUSETS`, and the two have different right
+  answers everywhere downstream — see
+  [`src/prted/pmix/AGENTS.md`](../../prted/pmix/AGENTS.md).
+
+A *conditional trailing field* was tried instead and does not work:
+`prte_proc_pack` runs in a loop and more job-level fields follow the array,
+so an absent field is ambiguous against both, and `PMIX_ERR_UNPACK_PAST_END`
+never fires because there is always more buffer. Any optional field needs a
+discriminator the decoder has already read.
+
+**`prte_util_pack_job_catchup` also packs `NO_CPUSETS`,** and that is not an
+optimization by analogy: the catchup decoder *discards* a job it already
+knows, so the only daemon that keeps what that message says is one that was
+not in the DVM when the job launched — which hosts none of its procs.
+
 Two consequences to respect:
 
 - **`prte_proc_unpack` no longer creates the proc.** `prte_job_unpack` has

--- a/src/runtime/data_type_support/prte_dt_packing_fns.c
+++ b/src/runtime/data_type_support/prte_dt_packing_fns.c
@@ -134,7 +134,7 @@ static int pack_proc_map(pmix_data_buffer_t *bkt, prte_job_t *job, prte_app_idx_
     return rc;
 }
 
-int prte_job_pack(pmix_data_buffer_t *bkt, prte_job_t *job)
+int prte_job_pack(pmix_data_buffer_t *bkt, prte_job_t *job, prte_job_pack_mode_t mode)
 {
     pmix_status_t rc;
     int32_t j, count, bookmark;
@@ -144,6 +144,16 @@ int prte_job_pack(pmix_data_buffer_t *bkt, prte_job_t *job)
     pmix_list_t *cache;
     prte_info_item_t *val;
     prte_node_t *nptr;
+
+    /* Lead with what this buffer contains.  The per-proc records are not
+     * always the same shape - the launch path scatters the cpusets - and the
+     * decoder has to know which one it is looking at before it reads the
+     * first of them.  One byte, once per job, ahead of everything else. */
+    rc = PMIx_Data_pack(NULL, bkt, &mode, 1, PMIX_UINT8);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return prte_pmix_convert_status(rc);
+    }
 
     /* pack the nspace */
     rc = PMIx_Data_pack(NULL, bkt, (void *) &job->nspace, 1, PMIX_PROC_NSPACE);
@@ -324,7 +334,7 @@ int prte_job_pack(pmix_data_buffer_t *bkt, prte_job_t *job)
             if (NULL == (proc = (prte_proc_t *) pmix_pointer_array_get_item(job->procs, j))) {
                 continue;
             }
-            rc = prte_proc_pack(bkt, proc);
+            rc = prte_proc_pack(bkt, proc, mode);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 return prte_pmix_convert_status(rc);
@@ -482,7 +492,7 @@ int prte_node_pack(pmix_data_buffer_t *bkt, prte_node_t *node)
 /*
  * PROC
  */
-int prte_proc_pack(pmix_data_buffer_t *bkt, prte_proc_t *proc)
+int prte_proc_pack(pmix_data_buffer_t *bkt, prte_proc_t *proc, prte_job_pack_mode_t mode)
 {
     pmix_status_t rc;
 
@@ -510,11 +520,19 @@ int prte_proc_pack(pmix_data_buffer_t *bkt, prte_proc_t *proc)
         return prte_pmix_convert_status(rc);
     }
 
-    /* pack the cpuset */
-    rc = PMIx_Data_pack(NULL, bkt, (void *) &proc->cpuset, 1, PMIX_STRING);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        return prte_pmix_convert_status(rc);
+    /* The cpuset, unless it is being scattered.
+     *
+     * It is the largest of the three and the only one that is of no use to
+     * anybody but the daemon that forks the proc: node rank and state are
+     * read for procs this daemon does not host, the binding is not.  In
+     * PRTE_JOB_PACK_NO_CPUSETS mode it therefore travels to that daemon
+     * alone - see prte_odls_base_send_cpuset_slices(). */
+    if (PRTE_JOB_PACK_NO_CPUSETS != mode) {
+        rc = PMIx_Data_pack(NULL, bkt, (void *) &proc->cpuset, 1, PMIX_STRING);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            return prte_pmix_convert_status(rc);
+        }
     }
 
     /* NO ATTRIBUTE LIST GOES ON THE WIRE.

--- a/src/runtime/data_type_support/prte_dt_packing_fns.c
+++ b/src/runtime/data_type_support/prte_dt_packing_fns.c
@@ -485,8 +485,6 @@ int prte_node_pack(pmix_data_buffer_t *bkt, prte_node_t *node)
 int prte_proc_pack(pmix_data_buffer_t *bkt, prte_proc_t *proc)
 {
     pmix_status_t rc;
-    int32_t count;
-    prte_attribute_t *kv;
 
     /* Only what the job's node and proc maps cannot say.
      *
@@ -519,36 +517,33 @@ int prte_proc_pack(pmix_data_buffer_t *bkt, prte_proc_t *proc)
         return prte_pmix_convert_status(rc);
     }
 
-    /* pack the attributes that will go */
-    count = 0;
+    /* NO ATTRIBUTE LIST GOES ON THE WIRE.
+     *
+     * Exactly one proc attribute exists anywhere in this tree -
+     * PRTE_PROC_NOBARRIER - and it is PRTE_ATTR_LOCAL, which this filter
+     * excluded; it is also set by the odls on the daemon that forks the
+     * proc, which is after this packing and on the far side of it. So the
+     * count was 4 bytes per proc introducing a list that has been empty in
+     * every job ever launched - 512 KB of a 1.9 MB launch message at
+     * 1000 nodes x 128 ppn, buying nothing at any scale.
+     *
+     * If you add a PRTE_ATTR_GLOBAL proc attribute, it has to come back
+     * here and in prte_proc_unpack, together. The check below is what will
+     * tell you, because nothing else would: the attribute would simply not
+     * arrive, and the receiving daemon would read a default. */
+#if PRTE_ENABLE_DEBUG
+    prte_attribute_t *kv;
     PMIX_LIST_FOREACH(kv, &proc->attributes, prte_attribute_t)
     {
         if (PRTE_ATTR_GLOBAL == kv->local) {
-            ++count;
+            pmix_output(0, "%s prte_proc_pack: proc %s carries global attribute %d, "
+                        "which is NOT packed - see the comment here",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                        PRTE_NAME_PRINT(&proc->name), (int) kv->key);
+            break;
         }
     }
-    rc = PMIx_Data_pack(NULL, bkt, &count, 1, PMIX_INT32);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        return prte_pmix_convert_status(rc);
-    }
-    if (0 < count) {
-        PMIX_LIST_FOREACH(kv, &proc->attributes, prte_attribute_t)
-        {
-            if (PRTE_ATTR_GLOBAL == kv->local) {
-                rc = PMIx_Data_pack(NULL, bkt, (void *) &kv->key, 1, PMIX_UINT16);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    return prte_pmix_convert_status(rc);
-                }
-                rc = PMIx_Data_pack(NULL, bkt, (void *) &kv->data, 1, PMIX_VALUE);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    return prte_pmix_convert_status(rc);
-                }
-            }
-        }
-    }
+#endif
 
     return PRTE_SUCCESS;
 }

--- a/src/runtime/data_type_support/prte_dt_unpacking_fns.c
+++ b/src/runtime/data_type_support/prte_dt_unpacking_fns.c
@@ -109,7 +109,8 @@ static int rank_cmp(const void *a, const void *b)
     return (x < y) ? -1 : ((x > y) ? 1 : 0);
 }
 
-static int unpack_layout(pmix_data_buffer_t *bkt, prte_job_t *jptr)
+static int unpack_layout(pmix_data_buffer_t *bkt, prte_job_t *jptr,
+                         prte_job_pack_mode_t mode)
 {
     int32_t nnodes, n, cnt = 1;
     int rc, a, i, j;
@@ -242,7 +243,7 @@ static int unpack_layout(pmix_data_buffer_t *bkt, prte_job_t *jptr)
             rc = PRTE_ERR_NOT_FOUND;
             goto cleanup;
         }
-        rc = prte_proc_unpack(bkt, proc);
+        rc = prte_proc_unpack(bkt, proc, mode);
         if (PRTE_SUCCESS != rc) {
             PRTE_ERROR_LOG(rc);
             goto cleanup;
@@ -272,7 +273,8 @@ cleanup:
     return rc;
 }
 
-int prte_job_unpack(pmix_data_buffer_t *bkt, prte_job_t **job)
+int prte_job_unpack(pmix_data_buffer_t *bkt, prte_job_t **job,
+                    prte_job_pack_mode_t *mode)
 {
     int rc;
     int32_t k, n, count, bookmark;
@@ -283,12 +285,25 @@ int prte_job_unpack(pmix_data_buffer_t *bkt, prte_job_t **job)
     prte_info_item_t *val;
     pmix_info_t pval;
     pmix_list_t *cache;
+    prte_job_pack_mode_t md;
 
     /* create the prte_job_t object */
     jptr = PMIX_NEW(prte_job_t);
     if (NULL == jptr) {
         PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
         return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+
+    /* what this buffer contains - see prte_job_pack */
+    n = 1;
+    rc = PMIx_Data_unpack(NULL, bkt, &md, &n, PMIX_UINT8);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(jptr);
+        return prte_pmix_convert_status(rc);
+    }
+    if (NULL != mode) {
+        *mode = md;
     }
 
     /* unpack the nspace */
@@ -439,7 +454,7 @@ int prte_job_unpack(pmix_data_buffer_t *bkt, prte_job_t **job)
      *               have broken that correspondence, update_local_ranks(),
      *               had no callers and is gone.)
      */
-    rc = unpack_layout(bkt, jptr);
+    rc = unpack_layout(bkt, jptr, md);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
         PMIX_RELEASE(jptr);
@@ -612,7 +627,8 @@ int prte_node_unpack(pmix_data_buffer_t *bkt, prte_node_t **nd)
 /*
  * PROC
  */
-int prte_proc_unpack(pmix_data_buffer_t *bkt, prte_proc_t *proc)
+int prte_proc_unpack(pmix_data_buffer_t *bkt, prte_proc_t *proc,
+                     prte_job_pack_mode_t mode)
 {
     pmix_status_t rc;
     int32_t n;
@@ -640,12 +656,16 @@ int prte_proc_unpack(pmix_data_buffer_t *bkt, prte_proc_t *proc)
         return prte_pmix_convert_status(rc);
     }
 
-    /* unpack the cpuset */
-    n = 1;
-    rc = PMIx_Data_unpack(NULL, bkt, &proc->cpuset, &n, PMIX_STRING);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        return prte_pmix_convert_status(rc);
+    /* The cpuset, if this buffer is carrying it.  When it is not, the proc
+     * keeps the NULL its constructor gave it and the daemon that forks it
+     * fills it in from the slice it is sent - see prte_proc_pack. */
+    if (PRTE_JOB_PACK_NO_CPUSETS != mode) {
+        n = 1;
+        rc = PMIx_Data_unpack(NULL, bkt, &proc->cpuset, &n, PMIX_STRING);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            return prte_pmix_convert_status(rc);
+        }
     }
 
     /* No attribute list is on the wire - see the comment in prte_proc_pack.

--- a/src/runtime/data_type_support/prte_dt_unpacking_fns.c
+++ b/src/runtime/data_type_support/prte_dt_unpacking_fns.c
@@ -615,8 +615,7 @@ int prte_node_unpack(pmix_data_buffer_t *bkt, prte_node_t **nd)
 int prte_proc_unpack(pmix_data_buffer_t *bkt, prte_proc_t *proc)
 {
     pmix_status_t rc;
-    int32_t n, count, k;
-    prte_attribute_t *kv;
+    int32_t n;
 
     /* Everything the job's maps already say has been set on this proc by
      * prte_job_unpack before we are called - its rank, its hosting daemon,
@@ -649,31 +648,12 @@ int prte_proc_unpack(pmix_data_buffer_t *bkt, prte_proc_t *proc)
         return prte_pmix_convert_status(rc);
     }
 
-    /* unpack the attributes */
-    n = 1;
-    rc = PMIx_Data_unpack(NULL, bkt, &count, &n, PMIX_INT32);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        return prte_pmix_convert_status(rc);
-    }
-    for (k = 0; k < count; k++) {
-        kv = PMIX_NEW(prte_attribute_t);
-        n = 1;
-        rc = PMIx_Data_unpack(NULL, bkt, &kv->key, &n, PMIX_UINT16);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(kv);
-            return prte_pmix_convert_status(rc);
-        }
-        rc = PMIx_Data_unpack(NULL, bkt, &kv->data, &n, PMIX_VALUE);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(kv);
-            return prte_pmix_convert_status(rc);
-        }
-        kv->local = PRTE_ATTR_GLOBAL; // obviously not a local value
-        pmix_list_append(&proc->attributes, &kv->super);
-    }
+    /* No attribute list is on the wire - see the comment in prte_proc_pack.
+     * The proc's list stays as its constructor left it, empty, which is what
+     * every job has ever put on the wire anyway. If you restore the packing,
+     * restore the unpacking in the same commit: these two are hand-written
+     * mirrors with no version and nothing that catches a half-done edit. */
+
     return PRTE_SUCCESS;
 }
 

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -590,9 +590,28 @@ PRTE_EXPORT prte_job_t *prte_get_job_data_object(const pmix_nspace_t job);
  */
 PRTE_EXPORT int prte_set_job_data_object(prte_job_t *jdata);
 
-/** Pack/unpack a job object */
-PRTE_EXPORT int prte_job_pack(pmix_data_buffer_t *bkt, prte_job_t *job);
-PRTE_EXPORT int prte_job_unpack(pmix_data_buffer_t *bkt, prte_job_t **job);
+/** What a packed job carries.
+ *
+ * The launch message is broadcast to every daemon, but a proc's cpuset is
+ * of interest only to the daemon that will fork it - so the launch path
+ * leaves the cpusets out and sends each daemon its own slice point to
+ * point (prte_odls_base_send_cpuset_slices). Every other caller packs
+ * everything.
+ *
+ * The mode is packed at the head of the buffer so the decoder reads what
+ * is there rather than being told out of band; prte_job_unpack hands it
+ * back so the caller can tell "not sent" from "not bound".
+ */
+typedef uint8_t prte_job_pack_mode_t;
+#define PRTE_JOB_PACK_ALL        0 // everything, including each proc's cpuset
+#define PRTE_JOB_PACK_NO_CPUSETS 1 // cpusets are being scattered separately
+
+/** Pack/unpack a job object. "mode" may be NULL on the unpack if the
+ * caller does not care which shape arrived. */
+PRTE_EXPORT int prte_job_pack(pmix_data_buffer_t *bkt, prte_job_t *job,
+                              prte_job_pack_mode_t mode);
+PRTE_EXPORT int prte_job_unpack(pmix_data_buffer_t *bkt, prte_job_t **job,
+                                prte_job_pack_mode_t *mode);
 PRTE_EXPORT int prte_job_copy(prte_job_t **dest, prte_job_t *src);
 PRTE_EXPORT void prte_job_print(char **output, prte_job_t *jdata);
 
@@ -603,8 +622,10 @@ PRTE_EXPORT int prte_app_copy(prte_app_context_t **dest, prte_app_context_t *src
 PRTE_EXPORT void prte_app_print(char **output, prte_job_t *jdata, prte_app_context_t *src);
 
 /** Pack/unpack a proc*/
-PRTE_EXPORT int prte_proc_pack(pmix_data_buffer_t *bkt, prte_proc_t *proc);
-PRTE_EXPORT int prte_proc_unpack(pmix_data_buffer_t *bkt, prte_proc_t *proc);
+PRTE_EXPORT int prte_proc_pack(pmix_data_buffer_t *bkt, prte_proc_t *proc,
+                               prte_job_pack_mode_t mode);
+PRTE_EXPORT int prte_proc_unpack(pmix_data_buffer_t *bkt, prte_proc_t *proc,
+                                 prte_job_pack_mode_t mode);
 PRTE_EXPORT int prte_proc_copy(prte_proc_t **dest, prte_proc_t *src);
 PRTE_EXPORT void prte_proc_print(char **output, prte_job_t *jdata, prte_proc_t *src);
 

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -481,6 +481,10 @@ int main(int argc, char *argv[])
      * prte_daemon_recv ignores the tag it was delivered on. */
     PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_DAEMON_LAUNCH,
                   PRTE_RML_PERSISTENT, prte_daemon_recv, NULL);
+    /* The half of the launch message addressed to us alone: the bindings
+     * of the procs we are about to fork. */
+    PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_LAUNCH_SLICE,
+                  PRTE_RML_PERSISTENT, prte_odls_base_recv_cpuset_slice, NULL);
 
     /* output a message indicating we are alive, our name, and our pid
      * for debugging purposes

--- a/src/util/nidmap.c
+++ b/src/util/nidmap.c
@@ -740,8 +740,14 @@ int prte_util_pack_job_catchup(pmix_data_buffer_t *buffer, prte_job_t *exclude)
         /* prte_job_pack carries the job's node and proc maps, from which the
          * receiver rebuilds each proc's rank and hosting daemon - which is
          * why this has to be decoded after the nidmap above, and why the
-         * launch message's second copy of the parent vpid was redundant */
-        rc = prte_job_pack(buffer, jptr);
+         * launch message's second copy of the parent vpid was redundant.
+         *
+         * No cpusets: the only daemon that keeps what this message says is
+         * one that did not already know the job (the decoder discards a job
+         * it has), and a daemon that was not in the DVM when the job was
+         * launched hosts none of its procs.  So the bindings would be
+         * carried to the one place that cannot use them. */
+        rc = prte_job_pack(buffer, jptr, PRTE_JOB_PACK_NO_CPUSETS);
         if (PRTE_SUCCESS != rc) {
             PRTE_ERROR_LOG(rc);
             return rc;
@@ -780,7 +786,7 @@ int prte_util_decode_job_catchup(pmix_data_buffer_t *buffer)
 
     for (n = 0; n < njobs; n++) {
         jptr = NULL;
-        rc = prte_job_unpack(buffer, &jptr);
+        rc = prte_job_unpack(buffer, &jptr, NULL);
         if (PRTE_SUCCESS != rc) {
             PRTE_ERROR_LOG(rc);
             return rc;

--- a/test/unit/runtime/test_runtime.c
+++ b/test/unit/runtime/test_runtime.c
@@ -692,6 +692,8 @@ static int test_pack_roundtrip(void)
     prte_job_t *src, *dst = NULL;
     prte_app_context_t *app, *app2;
     prte_proc_t *proc;
+    prte_job_map_t *saved_map;
+    prte_job_pack_mode_t mode = PRTE_JOB_PACK_NO_CPUSETS;
     char *sval = NULL;
     int rc;
 
@@ -772,11 +774,12 @@ static int test_pack_roundtrip(void)
     src->map->num_nodes = 1;
 
     PMIX_DATA_BUFFER_CONSTRUCT(&buf);
-    rc = prte_job_pack(&buf, src);
+    rc = prte_job_pack(&buf, src, PRTE_JOB_PACK_ALL);
     CHECK("wire: job packs", PRTE_SUCCESS == rc);
     if (PRTE_SUCCESS == rc) {
-        rc = prte_job_unpack(&buf, &dst);
+        rc = prte_job_unpack(&buf, &dst, &mode);
         CHECK("wire: job unpacks", PRTE_SUCCESS == rc && NULL != dst);
+        CHECK("wire: the pack mode round-trips", PRTE_JOB_PACK_ALL == mode);
     }
     PMIX_DATA_BUFFER_DESTRUCT(&buf);
 
@@ -855,12 +858,14 @@ static int test_pack_roundtrip(void)
     }
 
     /* a job with no map packs a flag instead, and unpacks with map == NULL */
+    saved_map = src->map;
+    PMIX_RETAIN(saved_map);
     PMIX_RELEASE(src->map);
     src->map = NULL;
     dst = NULL;
     PMIX_DATA_BUFFER_CONSTRUCT(&buf);
-    if (PRTE_SUCCESS == prte_job_pack(&buf, src)) {
-        rc = prte_job_unpack(&buf, &dst);
+    if (PRTE_SUCCESS == prte_job_pack(&buf, src, PRTE_JOB_PACK_ALL)) {
+        rc = prte_job_unpack(&buf, &dst, NULL);
         CHECK("wire: a mapless job round-trips", PRTE_SUCCESS == rc && NULL != dst);
         if (NULL != dst) {
             CHECK("wire: ...and still has no map", NULL == dst->map);
@@ -868,6 +873,34 @@ static int test_pack_roundtrip(void)
         }
     }
     PMIX_DATA_BUFFER_DESTRUCT(&buf);
+
+    /* The launch path's shape: the same job with the cpusets left out for
+     * the scatter.  Everything else has to arrive exactly as before, and
+     * the mode has to say so - a decoder that guessed wrong here would
+     * read the next proc's node rank as this one's cpuset. */
+    PMIX_RETAIN(saved_map);
+    src->map = saved_map;
+    dst = NULL;
+    mode = PRTE_JOB_PACK_ALL;
+    PMIX_DATA_BUFFER_CONSTRUCT(&buf);
+    if (PRTE_SUCCESS == prte_job_pack(&buf, src, PRTE_JOB_PACK_NO_CPUSETS)) {
+        rc = prte_job_unpack(&buf, &dst, &mode);
+        CHECK("wire: a cpuset-less job round-trips", PRTE_SUCCESS == rc && NULL != dst);
+        CHECK("wire: ...and says so", PRTE_JOB_PACK_NO_CPUSETS == mode);
+        if (NULL != dst) {
+            proc = (prte_proc_t *) pmix_pointer_array_get_item(dst->procs, 0);
+            CHECK("wire: ...the bound proc arrives with no cpuset",
+                  NULL != proc && NULL == proc->cpuset);
+            CHECK("wire: ...and the fields after it are still intact",
+                  NULL != proc && PRTE_PROC_STATE_RUNNING == proc->state
+                      && 2 == dst->num_procs && 1 == dst->stdin_target
+                      && PRTE_JOB_STATE_RUNNING == dst->state
+                      && PMIX_CHECK_NSPACE(dst->launcher, "the.launcher"));
+            PMIX_RELEASE(dst);
+        }
+    }
+    PMIX_DATA_BUFFER_DESTRUCT(&buf);
+    PMIX_RELEASE(saved_map);
 
     PMIX_RELEASE(src);
     reset_globals();


### PR DESCRIPTION
## The problem

The launch message is broadcast to every daemon in the DVM, and most of what is left in it is of interest to exactly one of them. A process's cpuset is read by the daemon that forks it and by nobody else, yet it crossed every link of the routing tree on its way to all of them.

Measured with `--rtos donotlaunch` at 1000 nodes x 128 ppn against a 176-core, 5-NUMA topology, the cpusets are **1,020,000 bytes of a 1,622,647 byte message** - 8 bytes a process, 63% of what remained after the placement became maps and the always-empty attribute list came out.

## What this does

Each daemon in the job's map is sent the bindings of the procs it is about to fork, point to point, while the rest of the message is broadcast as before. The message drops to **602,647 bytes** at that shape. No new data movement was needed: `prte_rml_get_route` sends each slice toward its target, so a subtree's slices share one link out of the master and the bytes leaving it are the sum of the slices rather than the sum replicated per daemon.

`--prtemca odls_base_scatter_cpusets 0` broadcasts them as before.

## Why it is six commits

The scatter is one of them. Making a proc's binding live in one place instead of every place means somebody has to be able to *ask* for it, and that path - a direct modex for a key PRRTE is the authority for - had never been exercised. Measured against the base commit with `--prtemca prte_pmix_lazy_procdata 0`, which forces peer gets onto the wire, `contrib/dockerswarm/peerinfo.c` hung in **6 runs out of 6**. Four of the commits are defects found that way, each of which would be a hang or a silently incomplete answer for anyone reaching that path by another route:

- **Answer a direct modex for a placement key from the job object.** The daemon asked its own PMIx server and, not finding the key, parked the request until the process published something - which a process that only ever calls `PMIx_Get` never does. These keys have never required a `PMIx_Put` from the proc being asked about.
- **Do not drop a peer's request in silence, and do not drop the wrong one.** `prte_pmix_server_clear()` discarded peer daemons' pending requests without replying, leaving them waiting for the life of the DVM; and it matched *monitor* requests, which set no `tproc`, so their empty nspace hit PMIx's wildcard and every completed job quietly took them with it.
- **Keep a job object until the DVM says the job is over.** A daemon released it as soon as its own procs finished, while the job ran on elsewhere - so it could no longer answer for procs whose bindings it alone held. Measured as 50 of 56 peer lookups coming back with no binding, with no error anywhere.

## Testing

- `make check` 21/21, `make -C test/offline check-offline` 1180/0, docs build clean
- **Full `contrib/dockerswarm` suite: 542 passed, 0 failed, 0 skipped** - run twice, after the scatter and again after the job-lifetime change
- Two new swarm cases. The first reads the applied binding out of `/proc/self/status` in the application rather than out of `--display map`, because the map is rendered on the master, which holds every cpuset either way and would show a correct binding for a slice that never arrived. The second covers a daemon hosting none of a job's procs, which the broadcast reaches and the slices do not.
- `peerinfo` across four nodes: 56/56 peer bindings and no mismatches in every completing run, and no daemon refusing a job it was part of.

Note the suite must be built against a PMIx containing openpmix#4124 (`PMIX_SRC=<checkout>`); the image-baked PMIx predates it and its own regression phase fails.