### PR TITLE
Report the aborted proc when the launcher job object is gone

### DIFF
--- a/src/runtime/prte_quit.c
+++ b/src/runtime/prte_quit.c
@@ -392,14 +392,22 @@ char *prte_dump_aborted_procs(prte_job_t *jdata)
     }
     PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_ERR_REPORTED);
 
-    /* if this job is not a launcher itself, then get the launcher for this job */
+    /* The launcher is only wanted so we can search its children for the job
+     * that failed; if it is gone, fall back to the job we were handed. Its
+     * absence is routine - a spawned job outlives its parent by default, and
+     * the parent's job object is released as soon as the parent completes. */
     if (PMIX_NSPACE_INVALID(jdata->launcher)) {
         launcher = jdata;
     } else {
         launcher = prte_get_job_data_object(jdata->launcher);
         if (NULL == launcher) {
-            output = strdup("LAUNCHER JOB OBJECT NOT FOUND");
-            return output;
+            PMIX_OUTPUT_VERBOSE((2, prte_state_base_framework.framework_output,
+                                 "%s prte_dump_aborted_procs: launcher %s of job %s is gone - "
+                                 "reporting on that job directly",
+                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                 PRTE_JOBID_PRINT(jdata->launcher),
+                                 PRTE_JOBID_PRINT(jdata->nspace)));
+            launcher = jdata;
         }
     }
 


### PR DESCRIPTION
`prte_dump_aborted_procs()` returns the message describing why a job died. It is delivered to
the terminal by `check_complete_resume()`, and to tools as `PMIX_EVENT_TEXT_MESSAGE` on
`PMIX_EVENT_JOB_END`. The function looks up the launcher only so it can search that job's
children for the one that actually failed, but it returned `"LAUNCHER JOB OBJECT NOT FOUND"`
when the lookup missed — replacing the report with a string that names no proc, no node and no
cause, and reaching tools as the stated reason a job ended.

The lookup misses routinely rather than exceptionally: a spawned job outlives its parent by
default (`PMIX_SPAWN_CHILD_SEP`), and the parent's job object is released as soon as the parent
completes. Every spawned job that aborts after that point hit this.

This falls back to the job that was passed in, as already done for a job that never had a
launcher, and records the absence under `state_base_verbose`.

## Results

A spawned job aborting after its parent job has completed.

Before:

```
--------------------------------------------------------------------------
 LAUNCHER JOB OBJECT NOT FOUND
```

After:

```
prterun has exited due to process rank 0 with PID 0 on node codex-login calling
"abort". This may have caused other processes in the application to be
terminated by signals sent by prterun (as reported here).
--------------------------------------------------------------------------
```

With `--prtemca state_base_verbose 2`, the fallback is recorded and the report is still
produced:

```
[codex-login:506011] [prterun-codex-login-506011@0,0] prte_dump_aborted_procs: launcher
prterun-codex-login-506011@1 of job prterun-codex-login-506011@2 is gone - reporting on
that job directly
```

When the launcher is present the output is unchanged, and the job exit status is unchanged in
both cases.

Credits: AccelCom @ Barcelona Supercomputing Center