### PR TITLE
Fix a DVM hang when a PMIX_ADD_HOST job outlives its parent

### DIFF
--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -277,8 +277,18 @@ static void proc_errors(int fd, short args, void *cbdata)
                          PRTE_NAME_PRINT(proc), prte_proc_state_to_str(state));
 
     /* get the job object */
-    if (prte_finalizing || NULL == (jdata = prte_get_job_data_object(proc->nspace))) {
-        /* could be a race condition */
+    if (prte_finalizing) {
+        PMIX_RELEASE(caddy);
+        return;
+    }
+    if (NULL == (jdata = prte_get_job_data_object(proc->nspace))) {
+        /* This proc has died and we hold nothing to account it against, so
+         * nothing below can run.  Dropping it silently - which is what "could
+         * be a race condition" amounted to - is what leaves the DVM waiting
+         * forever on a job it can no longer see.  Note the error states land
+         * HERE rather than in track_procs, so this is the arrival point for a
+         * proc that exited non-zero or died on a signal. */
+        prte_state_base_orphaned_proc(proc, state);
         PMIX_RELEASE(caddy);
         return;
     }

--- a/src/mca/errmgr/prted/errmgr_prted.c
+++ b/src/mca/errmgr/prted/errmgr_prted.c
@@ -10,7 +10,7 @@
  *                         All rights reserved.
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      IBM Corporation. All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2026      Sandia National Laboratories  All rights reserved.
  * $COPYRIGHT$
  *
@@ -45,6 +45,7 @@
 #include "src/mca/plm/base/base.h"
 #include "src/mca/plm/plm_types.h"
 #include "src/rml/rml.h"
+#include "src/mca/state/base/base.h"
 #include "src/mca/state/state.h"
 
 #include "src/runtime/prte_globals.h"
@@ -452,10 +453,15 @@ static void proc_errors(int fd, short args, void *cbdata)
 
     /* get the job object */
     if (NULL == (jdata = prte_get_job_data_object(proc->nspace))) {
-        /* must already be complete */
+        /* We hold nothing to account this against, so nothing below can run.
+         * "Must already be complete" is the benign reading and it is not the
+         * only one - a job object released while its procs were still running
+         * arrives here identically, and dropping it leaves this daemon
+         * believing the proc is alive forever. */
         PMIX_OUTPUT_VERBOSE((2, prte_errmgr_base_framework.framework_output,
                              "%s errmgr:prted:proc_errors NULL jdata - ignoring error",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+        prte_state_base_orphaned_proc(proc, state);
         goto cleanup;
     }
 

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -73,6 +73,7 @@
 #include "src/rml/rml_contact.h"
 #include "src/rml/rml.h"
 #include "src/mca/schizo/base/base.h"
+#include "src/mca/state/base/base.h"
 #include "src/mca/state/state.h"
 
 #include "src/prted/pmix/pmix_server.h"
@@ -2266,10 +2267,16 @@ void prte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
         goto MOVEON;
     }
 
-    /* get the jobdat for this child */
+    /* Get the jobdat for this child.  Not having it is an error worth
+     * recording, but it is NOT a reason to stop: a process we forked has
+     * died, and what it died of is knowable from the wait status alone.
+     * Bailing out here jumped over the entire decode below, so the proc was
+     * reported as a clean WAITPID_FIRED however it had actually gone - a
+     * signal death, a non-zero exit - carrying the raw wait status as its
+     * exit code (256 for exit(1)).  The only two things the job object is
+     * read for below both have a defensible answer without it. */
     if (NULL == (jobdat = prte_get_job_data_object(proc->name.nspace))) {
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
-        goto MOVEON;
     }
 
     /* if this child was ordered to die, then just pass that along
@@ -2335,7 +2342,15 @@ void prte_odls_base_default_wait_local_proc(int fd, short sd, void *cbdata)
 
         /* provide a default state */
         state = PRTE_PROC_STATE_WAITPID_FIRED;
-        flag = prte_get_attribute(&jobdat->attributes, PRTE_JOB_ERROR_NONZERO_EXIT, NULL, PMIX_BOOL);
+        /* the job object is the authority on whether a non-zero exit is to be
+         * treated as an error; with no job object, fall back to the framework
+         * default that would have put the attribute there in the first place */
+        if (NULL == jobdat) {
+            flag = prte_state_base.error_non_zero_exit;
+        } else {
+            flag = prte_get_attribute(&jobdat->attributes, PRTE_JOB_ERROR_NONZERO_EXIT, NULL,
+                                      PMIX_BOOL);
+        }
 
         /* check to see if a sync was required and if it was received */
         if (PRTE_FLAG_TEST(proc, PRTE_PROC_FLAG_REG)) {

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -1904,6 +1904,13 @@ int prte_ras_base_add_hosts(prte_job_t *jdata)
     req->key = strdup("hosts");
     req->operation = strdup("ADDHOSTS");
     req->allocdir = PMIX_ALLOC_EXTEND;
+    /* the request OWNS whatever job object it carries - its destructor
+     * releases it - and this one is not ours to give away: the job is
+     * still on its way to launch, and the parent's child list is holding
+     * the only other reference to it.  Every other producer of a request
+     * hands over a job it just created (PRTE_SPN_REQ); we are borrowing a
+     * live one, so take a reference of our own for the request to drop. */
+    PMIX_RETAIN(jdata);
     req->jdata = jdata;
     if (NULL != hostfiles) {
         req->ninfo++;

--- a/src/mca/state/base/base.h
+++ b/src/mca/state/base/base.h
@@ -88,6 +88,11 @@ PRTE_EXPORT void prte_state_base_track_procs(int fd, short argc, void *cbdata);
 PRTE_EXPORT void prte_state_base_check_fds(prte_job_t *jdata);
 PRTE_EXPORT void prte_state_base_notify_data_server(pmix_proc_t *target);
 
+/* A proc reported a state and we hold no job object to account it against.
+ * Both track_procs implementations call this instead of dropping the
+ * report on the floor - see the comment on the definition. */
+PRTE_EXPORT void prte_state_base_orphaned_proc(pmix_proc_t *proc, prte_proc_state_t state);
+
 // resource recovery
 PRTE_EXPORT void prte_state_base_recover_resources(prte_job_t *jdata, prte_proc_t *pptr);
 

--- a/src/mca/state/base/help-state-base.txt
+++ b/src/mca/state/base/help-state-base.txt
@@ -64,3 +64,20 @@ exit status returned for the primary job, because the
 option (or set it to "false") if you want the first non-zero status
 returned by the primary job or any job it spawned to be reported as the
 overall exit status.
+#
+[orphaned-proc]
+%s: a process has terminated, but the runtime holds no record of the job
+it belonged to:
+
+  Process: %s
+
+This is an internal inconsistency - the job object was released while the
+job was still running, so this process's termination cannot be accounted
+for and the job can never be declared complete.  Rather than wait forever
+for a job it can no longer see, the runtime is bringing the DVM down once
+nothing it can still account for is running.  The exit status will be
+non-zero.
+
+Please report this, with the command line that produced it, at:
+
+  https://github.com/openpmix/prrte/issues

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -34,12 +34,15 @@
 
 #include "src/mca/errmgr/errmgr.h"
 #include "src/mca/iof/base/base.h"
+#include "src/mca/plm/plm.h"
 #include "src/mca/rmaps/base/base.h"
 #include "src/rml/rml.h"
 #include "src/prted/pmix/pmix_server_internal.h"
 #include "src/runtime/data_server/prte_data_server.h"
 #include "src/runtime/prte_globals.h"
 #include "src/threads/pmix_threads.h"
+#include "src/util/name_fns.h"
+#include "src/util/prte_show_help.h"
 
 #include "src/mca/state/base/base.h"
 
@@ -413,6 +416,129 @@ void prte_state_base_notify_data_server(pmix_proc_t *target)
     }
 }
 
+/* A proc reported a state and we hold no job object to account it against.
+ *
+ * Both track_procs implementations used to drop such a report with a bare
+ * "goto cleanup", and the silence is what turned a lost job object into a
+ * hang.  Every conclusion about a job is derived HERE, from the job object:
+ * the per-proc counting, the TERMINATED activation it rolls up into, and -
+ * on a one-shot DVM - the "is anything still alive?" scan that only ever
+ * runs when a job reaches TERMINATED.  With no job object none of that
+ * happens, so the DVM waits forever on a job it can no longer see, having
+ * said nothing about why.  (Seen when a spawned job's object was released
+ * one reference early: prterun never exited, and the only output was an
+ * odls "Not found" naming a file and a line.)
+ *
+ * The job itself cannot be recovered - it is gone.  What is still owed is a
+ * report saying so, and a conclusion: a runtime that has lost a job must
+ * stop waiting for it rather than hang.  Nothing here concludes while any
+ * local child is still running, so a straggler is not torn down under.
+ */
+void prte_state_base_orphaned_proc(pmix_proc_t *proc, prte_proc_state_t state)
+{
+    prte_proc_t *proct;
+    prte_job_t *jptr;
+    int i;
+
+    /* Only a report that the process is really gone matters.  The callers are
+     * also reached by the running states (RUNNING, REGISTERED, IOF_COMPLETE,
+     * ...), and those have nothing to account for - complaining about each of
+     * them would bury the one report that does.  Everything above
+     * PRTE_PROC_STATE_ERROR is a way of having died, and with the job gone
+     * none of them is recoverable, so they all count. */
+    if (PRTE_PROC_STATE_WAITPID_FIRED != state &&
+        PRTE_PROC_STATE_TERMINATED != state &&
+        PRTE_PROC_STATE_ERROR >= state) {
+        return;
+    }
+
+    /* A teardown in progress releases job objects as it goes, so procs
+     * reported during one are expected to find no job and there is nothing
+     * left to conclude - the conclusion has already been reached. */
+    if (prte_finalizing || prte_abnormal_term_ordered) {
+        return;
+    }
+
+    prte_show_help("help-state-base.txt", "orphaned-proc", true,
+                   PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(proc));
+
+    /* Retire the proc ourselves.  Clearing PRTE_PROC_FLAG_ALIVE and dropping
+     * the PMIx client are done by the accounted TERMINATED path below, which
+     * reaches the proc THROUGH the job object - so with no job object the
+     * proc stays marked alive forever, and every "is anything still running?"
+     * test in the runtime (including the one right below) answers yes.  The
+     * proc object itself is still perfectly good; only the job that owned it
+     * is gone, and prte_local_children holds the daemon's own reference. */
+    for (i = 0; i < prte_local_children->size; i++) {
+        proct = (prte_proc_t *) pmix_pointer_array_get_item(prte_local_children, i);
+        if (NULL == proct || !PMIX_CHECK_PROCID(&proct->name, proc)) {
+            continue;
+        }
+        if (PRTE_FLAG_TEST(proct, PRTE_PROC_FLAG_ALIVE)) {
+            PRTE_FLAG_UNSET(proct, PRTE_PROC_FLAG_ALIVE);
+            PMIx_server_deregister_client(proc, NULL, NULL);
+        }
+        if (proct->state < PRTE_PROC_STATE_TERMINATED) {
+            proct->state = PRTE_PROC_STATE_TERMINATED;
+        }
+        break;
+    }
+
+    /* nothing concludes while a local child is still running - this is the
+     * same guard the accounted termination paths apply before exiting */
+    for (i = 0; i < prte_local_children->size; i++) {
+        proct = (prte_proc_t *) pmix_pointer_array_get_item(prte_local_children, i);
+        if (NULL != proct && PRTE_FLAG_TEST(proct, PRTE_PROC_FLAG_ALIVE)) {
+            pmix_output_verbose(5, prte_state_base_framework.framework_output,
+                                "%s state:base orphaned proc %s, but %s is still alive",
+                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(proc),
+                                PRTE_NAME_PRINT(&proct->name));
+            return;
+        }
+    }
+
+    if (!PRTE_PROC_IS_MASTER) {
+        /* a daemon concludes only when it has been told to go and its routes
+         * are gone - the identical condition its accounted path checks */
+        if (prte_prteds_term_ordered && 0 == prte_rml_base.n_children) {
+            pmix_output_verbose(5, prte_state_base_framework.framework_output,
+                                "%s state:base orphaned proc, all routes and children gone"
+                                " - exiting",
+                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
+            PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_DAEMONS_TERMINATED);
+        }
+        return;
+    }
+
+    /* On the master: a persistent DVM outlives its jobs and must stay up
+     * whatever it has lost - a later job is still perfectly launchable.  A
+     * one-shot DVM exists only to run these jobs, so once none of the ones
+     * it CAN still see is running, it has to end.  prte_prteds_term_ordered
+     * says the teardown is already under way (terminate_orteds sets it), so
+     * this stays a one-shot however many orphans arrive. */
+    if (prte_persistent || prte_prteds_term_ordered) {
+        return;
+    }
+    for (i = 0; i < prte_job_data->size; i++) {
+        jptr = (prte_job_t *) pmix_pointer_array_get_item(prte_job_data, i);
+        if (NULL == jptr ||
+            PMIX_CHECK_NSPACE(jptr->nspace, PRTE_PROC_MY_NAME->nspace)) {
+            continue;
+        }
+        if (jptr->state < PRTE_JOB_STATE_TERMINATED) {
+            /* something we can still account for is running */
+            return;
+        }
+    }
+
+    pmix_output_verbose(5, prte_state_base_framework.framework_output,
+                        "%s state:base orphaned proc and no job left running - terminating",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
+    /* the run did not do what was asked of it - do not report success */
+    PRTE_UPDATE_EXIT_STATUS(1);
+    prte_plm.terminate_orteds();
+}
+
 void prte_state_base_track_procs(int fd, short argc, void *cbdata)
 {
     prte_state_caddy_t *caddy = (prte_state_caddy_t *) cbdata;
@@ -436,6 +562,7 @@ void prte_state_base_track_procs(int fd, short argc, void *cbdata)
 
     /* get the job object for this proc */
     if (NULL == (jdata = prte_get_job_data_object(proc->nspace))) {
+        prte_state_base_orphaned_proc(proc, state);
         goto cleanup;
     }
     if (PRTE_PROC_STATE_READY_FOR_DEBUG == state) {

--- a/src/mca/state/prted/state_prted.c
+++ b/src/mca/state/prted/state_prted.c
@@ -4,7 +4,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020-2021 IBM Corporation.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -352,6 +352,7 @@ static void track_procs(int fd, short argc, void *cbdata)
 
     /* get the job object for this proc */
     if (NULL == (jdata = prte_get_job_data_object(proc->nspace))) {
+        prte_state_base_orphaned_proc(proc, state);
         goto cleanup;
     }
     if (PRTE_PROC_STATE_READY_FOR_DEBUG == state) {


### PR DESCRIPTION
Fixes #2661.

## The problem

A job spawned with `PMIX_ADD_HOST` that is still running when its parent
job terminates has its `prte_job_t` freed out from under it. Its slot in
`prte_job_data` goes with it, so the termination of its still-live
processes can never be accounted for, the job never reaches
`TERMINATED`, and the DVM waits for it forever.

The visible symptom is one of these per spawned proc, followed by a
hang:

```
PRTE ERROR: Not found in file base/odls_base_default_fns.c at line 2271
```

## The cause

`prte_ras_base_add_hosts()` stores a live, borrowed `jdata` in
`req->jdata`, but `rqdes()` — the `prte_pmix_server_req_t` destructor —
releases that field. A request object owns whatever job it carries;
every other producer of one (`PRTE_SPN_REQ`) hands over a job it has
just created, so ownership really does transfer there. This is the only
place that puts a *live* job in that field, and it took no reference of
its own.

So the ADDHOSTS request drops a reference it never held, and the spawned
job runs one reference short for its whole life — leaving the entry in
its parent's child list as the only thing holding it up. That is exactly
the reference the parent's destructor drops.

Introduced in 35205a0c0b (elastic ras grow/shrink). One line to fix.

Note this also means the orderings that *appeared* to work were not:
a child finishing before its parent reaches `cleanup_job` at a refcount
of one and is then released twice more. Built without `--enable-debug`,
that is a double free that happens to be quiet.

`PMIX_ADD_HOST` is what arms it, and only when the directive reaches the
**app** (`PRTE_APP_ADD_HOST`) — it is the only thing that causes a
request to be created here at all. That is why a pure-PMIx reproducer
putting the key in the job-level info array does not show it.

## Why it was a hang and not an error

The second commit is independent of the first and worth having on its
own merits: a lost job object should be a bounded failure, not an
unbounded silent hang.

Four handlers dropped a proc's terminal report with a bare `goto
cleanup` when they could not find its job — `track_procs` in
`state/base` and `state/prted`, `proc_errors` in `errmgr/dvm` and
`errmgr/prted`. Every conclusion about a job is derived from the job
object, including the "is anything still alive?" scan that decides a
one-shot DVM is done, which only ever runs when a job reaches
`TERMINATED`. Verified against the failing run:

```
job @1 (healthy):  IOF COMPLETE -> WAITPID FIRED -> track_procs -> NORMALLY TERMINATED -> job TERMINATED -> teardown
job @2 (no jdata): IOF COMPLETE -> WAITPID FIRED -> track_procs -> (nothing)
```

All four now hand the report to a new
`prte_state_base_orphaned_proc()`, which reports it through a new
`orphaned-proc` help topic, retires the proc, and then concludes rather
than waiting. Retiring the proc is load-bearing, not tidiness:
`PRTE_PROC_FLAG_ALIVE` is cleared by the accounted path, which reaches
the proc *through* the job, so without it the proc stays marked alive
and every liveness test in the runtime keeps answering yes.

Guards: nothing concludes while a local child is still running (a
straggler is not torn down under), a persistent DVM concludes nothing at
all, and `prte_finalizing`/`prte_abnormal_term_ordered`/
`prte_prteds_term_ordered` keep it out of a teardown already under way.

`odls`'s waitpid handler stopped bailing for the same reason. Its bail
also jumped over the entire exit-status decode below it, so the process
was reported as a clean `WAITPID_FIRED` however it had really died,
carrying the raw wait status as its exit code (256 for `exit(1)`). That
decode is also what routes a failed process to the errmgr rather than to
`track_procs` — which is why all four sites needed this, not just the
two obvious ones.

## Testing

Reproduced on master with a PMIx-only spawner putting `PMIX_ADD_HOST` in
the app info and a child sleeping past its parent — the issue's exact
signature, then a hang outlasting even `--timeout 25`.

| | before | after |
|---|---|---|
| #2661 reproducer | hangs every run | rc=0, 5/5 (+3/3 control) |
| job object lost (fix 1 backed out) | hangs forever, two uninformative `PRTE ERROR` lines | exits rc=1 with one clear diagnostic |

Unaffected: `-n 4 hostname`, `exit 3` -> 3, SIGTERM -> 143, MPMD, and
`prte --daemonize` -> `prun` -> `pterm` — including a `PMIX_ADD_HOST`
spawn into a persistent DVM, the case #2661 lists as untested.
`make check` 21/21; warning-free `--enable-debug` build; help-file
cross-check passes.

Not run: the dockerswarm multi-node suite. Worth a look there before
merge — on a multi-node DVM the orphan path can conclude while the
unaccountable job still has procs on another node. That job is already
beyond accounting, and the alternative is a guaranteed hang, but it is
the one judgment call in this PR.
