### PR TITLE
rmaps: remove the stale dist policy, and share the object-mapping loop

### DIFF
--- a/src/mca/rmaps/AGENTS.md
+++ b/src/mca/rmaps/AGENTS.md
@@ -41,7 +41,7 @@ Three concepts govern the whole framework, and they are **orthogonal**:
 | **Binding** | Which CPUs is each proc restricted to? | `--bind-to` | `jdata->map->binding` |
 
 `--map-by slot`/`node`/`core`/`l3cache`/`numa`/`package`/`hwthread`/
-`seq`/`ppr`/`rankfile`/`pe-list=…`/`dist` plus colon modifiers
+`seq`/`ppr`/`rankfile`/`pe-list=…` plus colon modifiers
 (`PE=n`, `SPAN`, `OVERSUBSCRIBE`, `NOLOCAL`, `HWTCPUS`, `INHERIT`,
 `ORDERED`, `FILE=…`, …). `--rank-by slot`/`node`/`fill`/`span`.
 
@@ -337,12 +337,12 @@ offers nothing and is reported unusable through the normal path, and
 [`src/hwloc/AGENTS.md`](../../hwloc/AGENTS.md).
 
 `job_cpuset` and `target` are hwloc bitmaps the mappers recycle per node;
-`cpuset` and `dist_device` are strings the *struct* owns (they come out of an
-attribute, which returns a copy). `bind_to_cpuset` consumes `cpuset` one
+`cpuset` is a string the *struct* owns (it comes out of an attribute, which
+returns a copy). `bind_to_cpuset` consumes `cpuset` one
 entry at a time and rewrites it, so the pointer at the end of a map is
 whatever the mapper left, not what was read in. `prte_rmaps_base_map_job()`
-frees all four at `cleanup`, and the per-app copy gets its own `strdup` of
-the strings so two structs never share one allocation.
+frees all three at `cleanup`, and the per-app copy gets its own `strdup` of
+the string so two structs never share one allocation.
 
 ---
 

--- a/src/mca/rmaps/base/base.h
+++ b/src/mca/rmaps/base/base.h
@@ -67,8 +67,6 @@ typedef struct {
     prte_ranking_policy_t ranking;
     // default ppr setting
     char *ppr;
-    /* default device for dist mapping */
-    char *device;
     /* whether or not child jobs should inherit mapping/ranking/binding directives from their parent
      * by default */
     bool inherit;

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -62,7 +62,6 @@ prte_rmaps_base_t prte_rmaps_base = {
     .mapping = 0,
     .ranking = 0,
     .ppr = NULL,
-    .device = NULL,
     .inherit = false,
     .hwthread_cpus = false,
     .file = NULL,
@@ -84,11 +83,11 @@ static int prte_rmaps_base_register(pmix_mca_base_register_flag_t flags)
     prte_rmaps_base.default_mapping_policy = NULL;
     ret = pmix_mca_base_var_register("prte", NULL, NULL, "mapby",
                                      "Default mapping Policy [slot | hwthread | core | l1cache | "
-                                      "l2cache | l3cache | numa | package | node | seq | dist | ppr | "
+                                      "l2cache | l3cache | numa | package | node | seq | ppr | "
                                       "rankfile | pe-list=a,b (comma-delimited ranges of cpus to use for this job)],"
                                       " with supported colon-delimited modifiers: PE=y (for multiple cpus/proc), "
                                       "SPAN, OVERSUBSCRIBE, NOOVERSUBSCRIBE, NOLOCAL, HWTCPUS, CORECPUS, "
-                                      "DEVICE=dev (for dist policy), INHERIT, NOINHERIT, ORDERED, FILE=%s (path to file containing sequential "
+                                      "INHERIT, NOINHERIT, ORDERED, FILE=%s (path to file containing sequential "
                                       "or rankfile entries). For more details, see \"prterun --help map-by\". "
                                       "The full directive need not be provided — "
                                       "only enough characters are required to uniquely identify the "

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -238,7 +238,6 @@ int prte_rmaps_base_resolve_app_options(prte_job_t *jdata,
         switch (opts->map) {
             case PRTE_MAPPING_BYNODE:
             case PRTE_MAPPING_BYSLOT:
-            case PRTE_MAPPING_BYDIST:
             case PRTE_MAPPING_PELIST:
             case PRTE_MAPPING_COLOCATE:
                 opts->maptype = HWLOC_OBJ_MACHINE;
@@ -330,16 +329,7 @@ int prte_rmaps_base_resolve_app_options(prte_job_t *jdata,
 
     /* 6. PRTE_APP_MAP_FILE — read directly by seq/rank_file components via app->attributes */
 
-    /* 7. PRTE_APP_DIST_DEVICE → opts->dist_device */
-    str = NULL;
-    if (prte_get_attribute(&app->attributes, PRTE_APP_DIST_DEVICE, (void **)&str, PMIX_STRING)) {
-        if (NULL != opts->dist_device) {
-            free(opts->dist_device);
-        }
-        opts->dist_device = str;
-    }
-
-    /* 8. PRTE_APP_BINDING_LIMIT → opts->limit */
+    /* 7. PRTE_APP_BINDING_LIMIT → opts->limit */
     if (prte_get_attribute(&app->attributes, PRTE_APP_BINDING_LIMIT, (void **)&u16ptr, PMIX_UINT16)) {
         opts->limit = u16;
     }
@@ -411,10 +401,6 @@ static void free_strings(prte_rmaps_options_t *opts)
     if (NULL != opts->cpuset) {
         free(opts->cpuset);
         opts->cpuset = NULL;
-    }
-    if (NULL != opts->dist_device) {
-        free(opts->dist_device);
-        opts->dist_device = NULL;
     }
 }
 
@@ -1211,7 +1197,6 @@ ranking:
     switch (options.map) {
         case PRTE_MAPPING_BYNODE:
         case PRTE_MAPPING_BYSLOT:
-        case PRTE_MAPPING_BYDIST:
         case PRTE_MAPPING_PELIST:
         case PRTE_MAPPING_COLOCATE:
             options.mapdepth = PRTE_BIND_TO_NONE;
@@ -1559,12 +1544,10 @@ ranking:
              * the mappers compute their own per node */
             app_options.job_cpuset = NULL;
             app_options.target = NULL;
-            /* nor of the job-level strings: a pe-list mapper frees and
+            /* nor of the job-level string: a pe-list mapper frees and
              * rewrites "cpuset" as it places procs, so each app needs its
              * own copy rather than a second pointer to the job's */
             app_options.cpuset = (NULL == options.cpuset) ? NULL : strdup(options.cpuset);
-            app_options.dist_device = (NULL == options.dist_device) ? NULL
-                                                                   : strdup(options.dist_device);
             app_options.app_idx = n;
             /* where this app's ranks start: the mappers that number their
              * own procs need the cursor the base is threading, or every app

--- a/src/mca/rmaps/base/rmaps_base_print_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_print_fns.c
@@ -158,9 +158,6 @@ char *prte_rmaps_base_print_mapping(prte_mapping_policy_t mapping)
     case PRTE_MAPPING_BYUSER:
         map = "BYUSER";
         break;
-    case PRTE_MAPPING_BYDIST:
-        map = "MINDIST";
-        break;
     case PRTE_MAPPING_PELIST:
         map = "PE-LIST";
         break;

--- a/src/mca/rmaps/rmaps_types.h
+++ b/src/mca/rmaps/rmaps_types.h
@@ -143,7 +143,6 @@ typedef struct {
      * gave two apps the same ranks, and the second app's procs then replaced
      * the first's in jdata->procs. */
     uint32_t start_vpid;
-    char *dist_device;  /* device name for dist mapping, from PRTE_APP_DIST_DEVICE */
 
 } prte_rmaps_options_t;
 
@@ -187,7 +186,6 @@ typedef struct {
 #define PRTE_MAPPING_BYHWTHREAD  8
 /* now take the other round-robin options */
 #define PRTE_MAPPING_BYSLOT      9
-#define PRTE_MAPPING_BYDIST     10
 #define PRTE_MAPPING_PELIST     11
 /* convenience - declare anything <= 15 to be round-robin*/
 #define PRTE_MAPPING_RR         16

--- a/src/mca/rmaps/round_robin/AGENTS.md
+++ b/src/mca/rmaps/round_robin/AGENTS.md
@@ -23,8 +23,8 @@ Files:
 |------|----------|
 | `rmaps_rr_component.c` | Registration, `priority` MCA param (default 10), `query` returning the module. |
 | `rmaps_rr.c` | `prte_rmaps_rr_map()` — the module entry: gate checks + per-app dispatch to the four algorithms. |
-| `rmaps_rr_mappers.c` | The four algorithms: `byslot`, `bynode`, `bycpu`, `byobj`. |
-| `rmaps_rr.h` | Prototypes for the four algorithm functions. |
+| `rmaps_rr_mappers.c` | The four algorithms: `byslot`, `bynode`, `bycpu`, `byobj` — the last of which is a wrapper around the shared `map_targets` loop. |
+| `rmaps_rr.h` | Prototypes for the four algorithm functions, plus `prte_rmaps_target_enum_t` — the vtable that says how a node's placement targets are listed. |
 
 ---
 
@@ -100,7 +100,21 @@ overflow handling as byslot.
 
 ### `prte_rmaps_rr_byobj` — spread across hwloc objects
 Maps by an object type (`options->maptype`: package/numa/cache/core/
-hwthread). Two sub-modes:
+hwthread). It is a thin wrapper: it builds a `prte_rmaps_target_enum_t`
+naming the hwloc objects of that type and hands it to
+`prte_rmaps_rr_map_targets()`, which is the loop described below.
+
+**Add a new kind of target by writing an enumerator, not by copying the
+loop.** The enumerator answers three questions about one node — how many
+targets, give me the *j*-th, and (optionally) set up and tear down per-node
+state — and `map_targets` does everything else. That split exists because
+the loop is the subtlest code in this component: the `redo:`/`check_avail`
+interplay and the oversubscribe accounting have each been the source of a
+real bug, and a second copy would acquire them again. `.name` is what the
+diagnostics call a target, so an enumerator that is not an hwloc type still
+produces a message that names what the user asked for.
+
+Two sub-modes:
 - **non-span** (default): fill all objects on a node before the next node
   (the `redo:` loop keeps working a node's objects until full) —
   byslot-like, front-loaded.
@@ -166,6 +180,8 @@ struct must be left holding a pointer its owner can free.
 - **Don't skip the base vpid call except in per-app mode.** The
   `if (options->app_idx < 0)` guard around `compute_vpids` is what keeps
   MPMD ranks from colliding.
-- **The byobj → byslot fallback rewrites the policy** on `jdata->map`
-  and `options->map`; downstream code (ranking, display) reads those, so
-  the rewrite is intentional, not a shortcut.
+- **`map_targets` is shared; keep it that way.** Anything that needs a
+  different set of placement targets belongs in a `prte_rmaps_target_enum_t`,
+  not in a second copy of the loop. If the enumerator allocates per-node
+  state in `begin`, every exit from the node body has to reach `end` — the
+  normal "move to the next node" tail and the `errout` label both do.

--- a/src/mca/rmaps/round_robin/rmaps_rr.h
+++ b/src/mca/rmaps/round_robin/rmaps_rr.h
@@ -47,12 +47,50 @@ PRTE_MODULE_EXPORT int prte_rmaps_rr_byslot(prte_job_t *jdata, prte_app_context_
                                             pmix_list_t *node_list, int32_t num_slots,
                                             pmix_rank_t nprocs, prte_rmaps_options_t *options);
 
+/* How a node's placement targets are enumerated.
+ *
+ * "Map one proc per target, wrapping until the node is full or the procs run
+ * out" is the same loop whatever the targets are; only the way they are
+ * listed differs.  byobj lists the hwloc objects of a single type, and that
+ * is the only enumerator today - but the loop it drives is the subtlest one
+ * in this component (the redo/check_avail interplay and the oversubscribe
+ * second pass have both been the source of real bugs), so a second kind of
+ * target is added by writing an enumerator rather than by copying the loop.
+ *
+ * "ctx" is enumerator-private per-node state: "begin" may allocate it and
+ * "end" releases it.  An enumerator that needs neither leaves both NULL, in
+ * which case "ctx" is always NULL. */
+typedef struct {
+    /* Called once per node before anything is placed on it.  Returns
+     * PRTE_SUCCESS, or an error that fails the map.  May be NULL. */
+    int (*begin)(prte_node_t *node, prte_rmaps_options_t *opts, void **ctx);
+    /* How many targets this node offers.  Zero is not an error here - the
+     * caller decides what it means. */
+    unsigned (*count)(prte_node_t *node, prte_rmaps_options_t *opts, void *ctx);
+    /* The j-th target, or NULL if there is no such target. */
+    hwloc_obj_t (*item)(prte_node_t *node, prte_rmaps_options_t *opts, void *ctx,
+                        unsigned j);
+    /* Release whatever "begin" allocated.  May be NULL. */
+    void (*end)(void *ctx);
+    /* What a target is called, for diagnostics ("core", "numa", ...). */
+    const char *name;
+} prte_rmaps_target_enum_t;
+
 PRTE_MODULE_EXPORT int prte_rmaps_rr_byobj(prte_job_t *jdata,
                                            prte_app_context_t *app,
                                            pmix_list_t *node_list,
                                            int32_t num_slots,
                                            pmix_rank_t num_procs,
                                            prte_rmaps_options_t *options);
+
+/* The shared placement loop.  byobj is a thin wrapper around this. */
+PRTE_MODULE_EXPORT int prte_rmaps_rr_map_targets(prte_job_t *jdata,
+                                                 prte_app_context_t *app,
+                                                 pmix_list_t *node_list,
+                                                 int32_t num_slots,
+                                                 pmix_rank_t num_procs,
+                                                 prte_rmaps_options_t *options,
+                                                 prte_rmaps_target_enum_t *tgts);
 
 PRTE_MODULE_EXPORT int prte_rmaps_rr_bycpu(prte_job_t *jdata, prte_app_context_t *app,
                                            pmix_list_t *node_list, int32_t num_slots,

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -580,10 +580,47 @@ errout:
  * but has the added complication of possibly having different
  * numbers of objects on each node
  */
+/* The hwloc-object enumerator: the targets are every object of
+ * options->maptype on the node.  Stateless - no begin/end needed. */
+static unsigned hwloc_targets_count(prte_node_t *node,
+                                    prte_rmaps_options_t *opts,
+                                    void *ctx)
+{
+    PRTE_HIDE_UNUSED_PARAMS(ctx);
+    return prte_hwloc_base_get_nbobjs_by_type(node->topology->topo, opts->maptype);
+}
+
+static hwloc_obj_t hwloc_targets_item(prte_node_t *node,
+                                      prte_rmaps_options_t *opts,
+                                      void *ctx, unsigned j)
+{
+    PRTE_HIDE_UNUSED_PARAMS(ctx);
+    return prte_hwloc_base_get_obj_by_type(node->topology->topo, opts->maptype, j);
+}
+
 int prte_rmaps_rr_byobj(prte_job_t *jdata, prte_app_context_t *app,
                         pmix_list_t *node_list, int32_t num_slots,
                         pmix_rank_t num_procs,
                         prte_rmaps_options_t *options)
+{
+    prte_rmaps_target_enum_t tgts = {
+        .begin = NULL,
+        .count = hwloc_targets_count,
+        .item = hwloc_targets_item,
+        .end = NULL,
+        /* hwloc_obj_type_string() returns a static string */
+        .name = hwloc_obj_type_string(options->maptype)
+    };
+
+    return prte_rmaps_rr_map_targets(jdata, app, node_list, num_slots,
+                                     num_procs, options, &tgts);
+}
+
+int prte_rmaps_rr_map_targets(prte_job_t *jdata, prte_app_context_t *app,
+                              pmix_list_t *node_list, int32_t num_slots,
+                              pmix_rank_t num_procs,
+                              prte_rmaps_options_t *options,
+                              prte_rmaps_target_enum_t *tgts)
 {
     int rc=PRTE_SUCCESS, nprocs_mapped;
     prte_node_t *node, *nnext;
@@ -592,10 +629,12 @@ int prte_rmaps_rr_byobj(prte_job_t *jdata, prte_app_context_t *app,
     bool nodefull, allfull, outofcpus=false;
     hwloc_obj_t obj = NULL;
     unsigned j, nobjs;
+    void *ctx = NULL;
+    bool began = false;
 
     pmix_output_verbose(2, prte_rmaps_base_framework.framework_output,
                         "mca:rmaps:rr:byobj mapping by %s for job %s slots %d num_procs %lu",
-                        hwloc_obj_type_string(options->maptype),
+                        tgts->name,
                         PRTE_JOBID_PRINT(jdata->nspace),
                         (int) num_slots, (unsigned long) num_procs);
 
@@ -652,9 +691,17 @@ int prte_rmaps_rr_byobj(prte_job_t *jdata, prte_app_context_t *app,
             options->nobjs = 0;
             /* have to delay checking for availability until we have the object */
 
-            /* get the number of objects of this type on this node */
-            nobjs = prte_hwloc_base_get_nbobjs_by_type(node->topology->topo,
-                                             options->maptype);
+            /* let the enumerator set up whatever it needs for this node */
+            if (NULL != tgts->begin) {
+                rc = tgts->begin(node, options, &ctx);
+                if (PRTE_SUCCESS != rc) {
+                    goto errout;
+                }
+                began = true;
+            }
+
+            /* get the number of targets on this node */
+            nobjs = tgts->count(node, options, ctx);
             if (0 == nobjs) {
                 /* We only ever map by an object because the user asked us
                  * to, so a node that has no such object is a request we
@@ -664,22 +711,21 @@ int prte_rmaps_rr_byobj(prte_job_t *jdata, prte_app_context_t *app,
                  * caller used to do) placed the job by a rule they never
                  * asked for. */
                 prte_show_help("help-prte-rmaps-base.txt", "rmaps:mapping-target-not-found",
-                               true, hwloc_obj_type_string(options->maptype), node->name);
-                return PRTE_ERR_SILENT;
+                               true, tgts->name, node->name);
+                rc = PRTE_ERR_SILENT;
+                goto errout;
             }
             pmix_output_verbose(2, prte_rmaps_base_framework.framework_output,
                                 "mca:rmaps:rr: found %u %s objects on node %s",
-                                nobjs, hwloc_obj_type_string(options->maptype),
-                                node->name);
+                                nobjs, tgts->name, node->name);
 
             nodefull = false;
         redo:
             for (j=0; j < nobjs && nprocs_mapped < app->num_procs && !nodefull; j++) {
                 pmix_output_verbose(10, prte_rmaps_base_framework.framework_output,
                                     "mca:rmaps:rr: assigning proc to object %d", j);
-                /* get the hwloc object */
-                obj = prte_hwloc_base_get_obj_by_type(node->topology->topo,
-                                            options->maptype, j);
+                /* get the target object */
+                obj = tgts->item(node, options, ctx, j);
                 if (NULL == obj) {
                     /* out of objects on this node */
                     break;
@@ -747,6 +793,13 @@ int prte_rmaps_rr_byobj(prte_job_t *jdata, prte_app_context_t *app,
                 goto redo;
             }
             // move to the next node
+            if (began) {
+                if (NULL != tgts->end) {
+                    tgts->end(ctx);
+                }
+                ctx = NULL;
+                began = false;
+            }
             if (NULL != options->target) {
                 hwloc_bitmap_free(options->target);
                 options->target = NULL;
@@ -759,6 +812,10 @@ int prte_rmaps_rr_byobj(prte_job_t *jdata, prte_app_context_t *app,
     }
 
 errout:
+    /* an early exit can leave the enumerator holding this node's state */
+    if (began && NULL != tgts->end) {
+        tgts->end(ctx);
+    }
     if (PRTE_ERR_SILENT == rc) {
         return rc;
     }

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -306,8 +306,6 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "PRTE_APP_BINDTO";
         case PRTE_APP_MAP_FILE:
             return "PRTE_APP_MAP_FILE";
-        case PRTE_APP_DIST_DEVICE:
-            return "PRTE_APP_DIST_DEVICE";
         case PRTE_APP_HWT_CPUS:
             return "PRTE_APP_HWT_CPUS";
         case PRTE_APP_CORE_CPUS:
@@ -486,8 +484,6 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "JOB_INHERIT";
         case PRTE_JOB_PES_PER_PROC:
             return "JOB_PES_PER_PROC";
-        case PRTE_JOB_DIST_DEVICE:
-            return "JOB_DIST_DEVICE";
         case PRTE_JOB_HWT_CPUS:
             return "JOB_HWT_CPUS";
         case PRTE_JOB_CORE_CPUS:

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -76,7 +76,6 @@ typedef uint8_t prte_app_context_flags_t;
 #define PRTE_APP_RANKBY             27 /* uint16_t ranking policy enum */
 #define PRTE_APP_BINDTO             28 /* uint16_t binding policy enum */
 #define PRTE_APP_MAP_FILE           29 /* char* path to seq or rankfile */
-#define PRTE_APP_DIST_DEVICE        30 /* char* dist device name */
 #define PRTE_APP_HWT_CPUS           31 /* bool: use hwthreads as CPUs */
 #define PRTE_APP_CORE_CPUS          32 /* bool: use cores as CPUs */
 #define PRTE_APP_CPUSET             33 /* char* comma-delimited CPU ranges */
@@ -217,7 +216,6 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_TRACE_TIMEOUT_EVENT        (PRTE_JOB_START_KEY +  75) // prte_ptr (prte_timer_t*) - timer event for stacktrace collection
 #define PRTE_JOB_INHERIT                    (PRTE_JOB_START_KEY +  76) // bool - job inherits parent's mapping/ranking/binding policies
 #define PRTE_JOB_PES_PER_PROC               (PRTE_JOB_START_KEY +  77) // uint16_t - number of cpus to be assigned to each process
-#define PRTE_JOB_DIST_DEVICE                (PRTE_JOB_START_KEY +  78) // char* - device to use for dist mapping
 #define PRTE_JOB_HWT_CPUS                   (PRTE_JOB_START_KEY +  79) // bool - job requests hwthread cpus
 #define PRTE_JOB_CORE_CPUS                  (PRTE_JOB_START_KEY +  80) // bool - job requests core cpus
 #define PRTE_JOB_PPR                        (PRTE_JOB_START_KEY +  81) // char* - string specifying the procs-per-resource pattern

--- a/src/util/prte_cmd_line.h
+++ b/src/util/prte_cmd_line.h
@@ -180,7 +180,6 @@ BEGIN_C_DECLS
 #define PRTE_CLI_PACKAGE    "package"
 #define PRTE_CLI_NODE       "node"
 #define PRTE_CLI_SEQ        "seq"
-#define PRTE_CLI_DIST       "dist"
 #define PRTE_CLI_PPR        "ppr"
 #define PRTE_CLI_RANKFILE   "rankfile"
 #define PRTE_CLI_NONE       "none"


### PR DESCRIPTION
Two rmaps changes, split so each stands on its own. Both are groundwork for
mapping by device ([Open MPI #14169](https://github.com/open-mpi/ompi/issues/14169)),
but neither depends on that landing and the first is a bug fix in its own right.

### Remove the stale "dist" mapping policy

The `mindist` mapper was removed in the 3.x series for lack of a maintainer
and the `dist` directive went with it. The *advertisement* did not go. The
`mapby` MCA parameter still listed `dist` among the policies and
`DEVICE=dev (for dist policy)` among the modifiers, and the rmaps guide still
named it — while schizo's front door has no such entry, so every command line
asking for it is refused as an unrecognized directive.

That combination is worse than a plain absence: a user who checks what the
runtime supports is told the policy exists, tries it, and is told it does
not, with nothing to distinguish that from a typo or a broken install. It is
what happened in the issue above, where the reporter quoted the parameter
description back at us.

So all of it goes — the advertisement in both places, the CLI keyword, the
mapping value, **two** switch arms (the job-level one and its per-app mirror
in `resolve_app_options()`), the `"MINDIST"` printer arm, both
`*_DIST_DEVICE` attribute keys with their name strings, `options->dist_device`
and the three sites that filled, copied and freed it, and
`prte_rmaps_base.device`, which had never been read or written anywhere in
the tree.

Nothing here needed preserving for compatibility: a DVM is built from a
single build, so an attribute key value carries no meaning beyond the tree it
is compiled in.

### Drive the object-mapping loop from a target enumerator

`prte_rmaps_rr_byobj()` hard-codes what it places procs against. The loop
around that question is the subtlest code in the component — the
`redo:`/`check_avail` interplay, where a `break` without `nodefull` sends the
retry back onto a node `check_avail` has already removed and released, and the
oversubscribe accounting that chooses between the overload and failed-map
diagnostics. Both have been the source of real bugs.

Mapping against something that is not an hwloc object type needs that same
loop with a different answer to that one question, and copying it would mean
maintaining those two paths twice.

So `prte_rmaps_rr_map_targets()` is now the loop, taking a
`prte_rmaps_target_enum_t` that says how a node's targets are listed — how
many, give me the *j*-th, and optionally set up and tear down per-node state.
`byobj` becomes a wrapper filling one in for `options->maptype`, and is the
only enumerator today. The enumerator also carries what a target is *called*,
so the three diagnostics that named an hwloc type now name whatever was
actually asked for.

One structural consequence: the "node has no such object" arm returned
directly, which would skip an enumerator's teardown. It now sets `rc` and
jumps to `errout`, where teardown happens once — `errout` returns
`PRTE_ERR_SILENT` immediately for that code, so the user-visible result is
unchanged.

### Testing

Clean build at `--enable-debug` (warnings are errors), `make check` 21/21,
`make -C test/offline check-offline` 1180/1180, and a live DVM cycle
including an MPMD line (which is what actually drives `resolve_app_options`),
`--map-by ppr:2:package`, and a rejected directive exiting non-zero while the
DVM keeps serving.

For the refactor specifically, "no behavior change" is the whole claim, so it
was measured rather than asserted: the normalized `--display map` output of
**every** one of the 1180 offline cases was snapshotted before the change and
compared after — all identical. (The harness pins only a curated subset by
default, so the comparison was widened to every case for this.) The check was
itself verified by corrupting one snapshot and confirming it fails.