### PR TITLE
Add --map-by device=<class|name>

### DIFF
--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -253,6 +253,26 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
                          AC_MSG_WARN([accepts any unambiguous prefix of a qualifier's name.])
                          AC_MSG_ERROR([Please update PMIx and configure again])])
 
+    dnl "--map-by device=<class>" places processes against the devices in a
+    dnl node's topology, which means first knowing what devices it has.  PMIx
+    dnl owns that answer: it already reports devices to applications through
+    dnl PMIX_DEVICE_DISTANCES, and a second enumerator here would let PRRTE
+    dnl and PMIx disagree about the same device's name - which is exactly the
+    dnl string an application correlates its assignment against.  So there is
+    dnl no local fallback to select: without the enumerator the directive
+    dnl cannot be honored at all.
+    AC_MSG_CHECKING([for PMIx device enumeration support])
+    PRTE_CHECK_PMIX_CAP([DEVICE_ENUM],
+                        [AC_MSG_RESULT([yes])],
+                        [AC_MSG_RESULT([no])
+                         AC_MSG_WARN([PRRTE requires pmix_hwloc_get_devices(), which this])
+                         AC_MSG_WARN([PMIx does not provide. It lists the devices in a])
+                         AC_MSG_WARN([topology, which is what "--map-by device=" maps])
+                         AC_MSG_WARN([against. PRRTE deliberately does not carry its own])
+                         AC_MSG_WARN([copy: the device names it hands to a process have to])
+                         AC_MSG_WARN([be the ones PMIx reports to that same process.])
+                         AC_MSG_ERROR([Please update PMIx and configure again])])
+
     dnl The "pattern" qualifier on "--output file=NAME" hands the naming of
     dnl the output files to the user.  Expanding the pattern is PMIx's job -
     dnl PMIx owns the IOF sinks and is the only place that knows the rank and

--- a/src/mca/rmaps/base/help-prte-rmaps-base.txt
+++ b/src/mca/rmaps/base/help-prte-rmaps-base.txt
@@ -498,3 +498,37 @@ requirements:
   cpus/proc:    %d
 
 Please adjust the request and try again.
+#
+[rmaps:bind-above-device]
+A binding was requested that is coarser than the devices the job was
+mapped against:
+
+  Binding:  %s
+  Device:   %s
+  Node:     %s
+
+Mapping by a device means placing each process near that device, and an
+object that contains the device's locality - and more besides - is not
+near it. Binding there would hand the process cpus the device is not
+local to, which is the thing mapping by device is meant to avoid.
+
+Please either bind to an object at or below the device's locality (numa,
+l3cache, core, hwthread are the usual choices), or map by something other
+than a device.
+#
+[rmaps:degenerate-device-locality]
+All of the requested devices on a node are equally close to every cpu on
+it, so binding cannot express "near this device":
+
+  Device:   %s
+  Node:     %s
+  Found:    %d devices sharing one locality
+
+The job will run, and each process is still assigned its own device - on
+this node that assignment is the whole of what mapping by device buys
+you, and it is reported to each process. But the binding will be no more
+specific than it would have been without the directive.
+
+This is a property of the machine, not of the request: it happens when
+every device hangs off one PCI complex rather than off individual NUMA
+domains or packages.

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -84,6 +84,8 @@ static int prte_rmaps_base_register(pmix_mca_base_register_flag_t flags)
     ret = pmix_mca_base_var_register("prte", NULL, NULL, "mapby",
                                      "Default mapping Policy [slot | hwthread | core | l1cache | "
                                       "l2cache | l3cache | numa | package | node | seq | ppr | "
+                                      "device=<class|name> (gpu, network, openfabrics, nic, block, or a\n"
+                                      " device name such as mlx5_0) | "
                                       "rankfile | pe-list=a,b (comma-delimited ranges of cpus to use for this job)],"
                                       " with supported colon-delimited modifiers: PE=y (for multiple cpus/proc), "
                                       "SPAN, OVERSUBSCRIBE, NOOVERSUBSCRIBE, NOLOCAL, HWTCPUS, CORECPUS, "
@@ -909,6 +911,41 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
         PRTE_SET_MAPPING_POLICY(tmp, PRTE_MAPPING_PELIST);
         PRTE_SET_MAPPING_DIRECTIVE(tmp, PRTE_MAPPING_GIVEN);
 
+    } else if (PMIX_CHECK_CLI_OPTION(cptr, PRTE_CLI_DEVICE)) {
+        /* place procs against the devices in each node's topology. The value
+         * is either a device class ("gpu", "network", ...) or the name or
+         * uuid of one particular device, in which case every proc is placed
+         * near that one - which is what the removed "dist" policy did, said
+         * with one directive instead of a policy plus an MCA parameter.
+         * There is deliberately no bare "--map-by gpu": the class is the
+         * directive's value, which is what lets a new class be supported by
+         * adding a value rather than a directive. */
+        if (NULL == jdata) {
+            prte_show_help("help-prte-rmaps-base.txt", "unsupported-default-policy", true,
+                           "mapping", cptr);
+            PMIx_Argv_free(ck);
+            free(cptr);
+            if (NULL != val) {
+                free(val);
+            }
+            return PRTE_ERR_SILENT;
+        }
+        if (NULL == val || 0 == strlen(val)) {
+            /* "device" with nothing after the "=" names no device at all */
+            prte_show_help("help-prte-rmaps-base.txt", "missing-value",
+                           true, "mapping", ck[0]);
+            PMIx_Argv_free(ck);
+            free(cptr);
+            if (NULL != val) {
+                free(val);
+            }
+            return PRTE_ERR_SILENT;
+        }
+        prte_set_attribute(&jdata->attributes, PRTE_JOB_MAP_DEVICE, PRTE_ATTR_GLOBAL,
+                           val, PMIX_STRING);
+        PRTE_SET_MAPPING_POLICY(tmp, PRTE_MAPPING_BYDEVICE);
+        PRTE_SET_MAPPING_DIRECTIVE(tmp, PRTE_MAPPING_GIVEN);
+
     } else {
         prte_show_help("help-prte-rmaps-base.txt", "unrecognized-policy",
                        true, "mapping", cptr);
@@ -1182,6 +1219,24 @@ int prte_rmaps_base_set_app_mapping_policy(prte_app_context_t *app, char *inspec
         prte_set_attribute(&app->attributes, PRTE_APP_CPUSET, PRTE_ATTR_GLOBAL,
                            val, PMIX_STRING);
         PRTE_SET_MAPPING_POLICY(tmp, PRTE_MAPPING_PELIST);
+    } else if (PMIX_CHECK_CLI_OPTION(cptr, PRTE_CLI_DEVICE)) {
+        /* the devices this app is to be placed against - as much its own
+         * business as the object it maps by. Must stay in step with the
+         * job-level arm above: a directive accepted at one level and refused
+         * at the other is the recurring bug in this file */
+        if (NULL == val || 0 == strlen(val)) {
+            prte_show_help("help-prte-rmaps-base.txt", "missing-value",
+                           true, "mapping", ck[0]);
+            PMIx_Argv_free(ck);
+            free(cptr);
+            if (NULL != val) {
+                free(val);
+            }
+            return PRTE_ERR_SILENT;
+        }
+        prte_set_attribute(&app->attributes, PRTE_APP_MAP_DEVICE, PRTE_ATTR_GLOBAL,
+                           val, PMIX_STRING);
+        PRTE_SET_MAPPING_POLICY(tmp, PRTE_MAPPING_BYDEVICE);
     } else if (PMIX_CHECK_CLI_OPTION(cptr, PRTE_CLI_RANKFILE)) {
         /* the file naming this app's rank->host+cpuset assignments. The
          * FILE= qualifier was parsed above onto PRTE_APP_MAP_FILE; without

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -240,6 +240,7 @@ int prte_rmaps_base_resolve_app_options(prte_job_t *jdata,
             case PRTE_MAPPING_BYSLOT:
             case PRTE_MAPPING_PELIST:
             case PRTE_MAPPING_COLOCATE:
+            case PRTE_MAPPING_BYDEVICE:
                 opts->maptype = HWLOC_OBJ_MACHINE;
                 opts->mapdepth = PRTE_BIND_TO_NONE;
                 break;
@@ -329,7 +330,16 @@ int prte_rmaps_base_resolve_app_options(prte_job_t *jdata,
 
     /* 6. PRTE_APP_MAP_FILE — read directly by seq/rank_file components via app->attributes */
 
-    /* 7. PRTE_APP_BINDING_LIMIT → opts->limit */
+    /* 7. PRTE_APP_MAP_DEVICE → opts->map_device */
+    str = NULL;
+    if (prte_get_attribute(&app->attributes, PRTE_APP_MAP_DEVICE, (void **) &str, PMIX_STRING)) {
+        if (NULL != opts->map_device) {
+            free(opts->map_device);
+        }
+        opts->map_device = str;
+    }
+
+    /* 8. PRTE_APP_BINDING_LIMIT → opts->limit */
     if (prte_get_attribute(&app->attributes, PRTE_APP_BINDING_LIMIT, (void **)&u16ptr, PMIX_UINT16)) {
         opts->limit = u16;
     }
@@ -401,6 +411,10 @@ static void free_strings(prte_rmaps_options_t *opts)
     if (NULL != opts->cpuset) {
         free(opts->cpuset);
         opts->cpuset = NULL;
+    }
+    if (NULL != opts->map_device) {
+        free(opts->map_device);
+        opts->map_device = NULL;
     }
 }
 
@@ -1052,6 +1066,7 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
 
     /* set some convenience params */
     prte_get_attribute(&jdata->attributes, PRTE_JOB_CPUSET, (void**)&options.cpuset, PMIX_STRING);
+    prte_get_attribute(&jdata->attributes, PRTE_JOB_MAP_DEVICE, (void**)&options.map_device, PMIX_STRING);
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, (void **) &u16ptr, PMIX_UINT16)) {
         options.cpus_per_rank = u16;
     } else {
@@ -1199,6 +1214,19 @@ ranking:
         case PRTE_MAPPING_BYSLOT:
         case PRTE_MAPPING_PELIST:
         case PRTE_MAPPING_COLOCATE:
+            options.mapdepth = PRTE_BIND_TO_NONE;
+            options.maptype = HWLOC_OBJ_MACHINE;
+            break;
+        case PRTE_MAPPING_BYDEVICE:
+            /* A device's locality is not known until the node is - it is
+             * NUMA-sized on one machine and package-sized on another, and is
+             * frequently an hwloc Group, which has no position in the
+             * PRTE_BIND_TO_* ladder at all. So there is no value mapdepth
+             * could take that would make the fixed "cannot bind above the
+             * map" check below mean the right thing. Leave it at NONE so
+             * that check does not fire on a basis nobody knows yet; the
+             * device mapper applies the real ceiling per node, against the
+             * locality it actually found. */
             options.mapdepth = PRTE_BIND_TO_NONE;
             options.maptype = HWLOC_OBJ_MACHINE;
             break;
@@ -1548,6 +1576,8 @@ ranking:
              * rewrites "cpuset" as it places procs, so each app needs its
              * own copy rather than a second pointer to the job's */
             app_options.cpuset = (NULL == options.cpuset) ? NULL : strdup(options.cpuset);
+            app_options.map_device = (NULL == options.map_device) ? NULL
+                                                                  : strdup(options.map_device);
             app_options.app_idx = n;
             /* where this app's ranks start: the mappers that number their
              * own procs need the cursor the base is threading, or every app

--- a/src/mca/rmaps/base/rmaps_base_print_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_print_fns.c
@@ -158,6 +158,9 @@ char *prte_rmaps_base_print_mapping(prte_mapping_policy_t mapping)
     case PRTE_MAPPING_BYUSER:
         map = "BYUSER";
         break;
+    case PRTE_MAPPING_BYDEVICE:
+        map = "BYDEVICE";
+        break;
     case PRTE_MAPPING_PELIST:
         map = "PE-LIST";
         break;

--- a/src/mca/rmaps/rmaps_types.h
+++ b/src/mca/rmaps/rmaps_types.h
@@ -143,6 +143,10 @@ typedef struct {
      * gave two apps the same ranks, and the second app's procs then replaced
      * the first's in jdata->procs. */
     uint32_t start_vpid;
+    /* the --map-by device= spec: a device class ("gpu") or the name or
+     * uuid of one device. Owned by the struct - it comes out of an
+     * attribute, which returns a copy. */
+    char *map_device;
 
 } prte_rmaps_options_t;
 
@@ -186,6 +190,7 @@ typedef struct {
 #define PRTE_MAPPING_BYHWTHREAD  8
 /* now take the other round-robin options */
 #define PRTE_MAPPING_BYSLOT      9
+#define PRTE_MAPPING_BYDEVICE   10
 #define PRTE_MAPPING_PELIST     11
 /* convenience - declare anything <= 15 to be round-robin*/
 #define PRTE_MAPPING_RR         16

--- a/src/mca/rmaps/round_robin/rmaps_rr.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr.c
@@ -131,6 +131,10 @@ static int prte_rmaps_rr_map(prte_job_t *jdata,
             rc = prte_rmaps_rr_byslot(jdata, app, &node_list,
                                       num_slots, app->num_procs,
                                       options);
+        } else if (PRTE_MAPPING_BYDEVICE == options->map) {
+            rc = prte_rmaps_rr_bydevice(jdata, app, &node_list,
+                                        num_slots, app->num_procs,
+                                        options);
         } else if (PRTE_MAPPING_PELIST == options->map) {
             rc = prte_rmaps_rr_bycpu(jdata, app, &node_list,
                                      num_slots, app->num_procs,

--- a/src/mca/rmaps/round_robin/rmaps_rr.h
+++ b/src/mca/rmaps/round_robin/rmaps_rr.h
@@ -92,6 +92,11 @@ PRTE_MODULE_EXPORT int prte_rmaps_rr_map_targets(prte_job_t *jdata,
                                                  prte_rmaps_options_t *options,
                                                  prte_rmaps_target_enum_t *tgts);
 
+PRTE_MODULE_EXPORT int prte_rmaps_rr_bydevice(prte_job_t *jdata, prte_app_context_t *app,
+                                              pmix_list_t *node_list, int32_t num_slots,
+                                              pmix_rank_t num_procs,
+                                              prte_rmaps_options_t *options);
+
 PRTE_MODULE_EXPORT int prte_rmaps_rr_bycpu(prte_job_t *jdata, prte_app_context_t *app,
                                            pmix_list_t *node_list, int32_t num_slots,
                                            pmix_rank_t num_procs, prte_rmaps_options_t *options);

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -35,6 +35,8 @@
 #include "src/util/name_fns.h"
 #include "src/util/pmix_show_help.h"
 #include "src/util/prte_show_help.h"
+#include "src/pmix/pmix-internal.h"
+#include "src/hwloc/pmix_hwloc.h"
 
 #include "rmaps_rr.h"
 #include "src/mca/rmaps/base/base.h"
@@ -373,6 +375,227 @@ pass:
 }
 
 /* mapping by cpu */
+/* ---------------------------------------------------------------------
+ * Mapping by device
+ *
+ * The targets are the devices in the node's topology, and the object a proc
+ * is placed against is the device's *locality* - the nearest ancestor with a
+ * cpuset.  Everything after that is the shared loop: the proc is set up
+ * against that object and bound within it exactly as it would be against a
+ * package or a core.
+ *
+ * Enumerating the devices is PMIx's job, deliberately.  PMIx already reports
+ * devices to applications through PMIX_DEVICE_DISTANCES, and the name PRRTE
+ * tells a process it was assigned has to be the name that process will see
+ * there - a second enumerator here could differ, and an assignment nobody
+ * can correlate is worth nothing.
+ * --------------------------------------------------------------------- */
+
+/* per-node state: the device list, held for the life of one node's
+ * placement and released when we move on */
+typedef struct {
+    pmix_hwloc_device_t *devs;
+    size_t ndevs;
+} prte_rmaps_devctx_t;
+
+/* Map a --map-by device= value to a device class.  Returns
+ * PMIX_DEVTYPE_UNKNOWN when the value is not a class, in which case it is
+ * taken as the name or uuid of one particular device. */
+static pmix_device_type_t device_class(const char *spec)
+{
+    char *s = (char *) spec;
+
+    if (PMIX_CHECK_CLI_OPTION(s, "gpu")) {
+        /* a coprocessor is a GPU that hwloc happened to learn about through
+         * a vendor backend rather than through DRM */
+        return PMIX_DEVTYPE_GPU | PMIX_DEVTYPE_COPROC;
+    }
+    if (PMIX_CHECK_CLI_OPTION(s, "openfabrics")) {
+        return PMIX_DEVTYPE_OPENFABRICS;
+    }
+    if (PMIX_CHECK_CLI_OPTION(s, "network")) {
+        return PMIX_DEVTYPE_NETWORK;
+    }
+    if (PMIX_CHECK_CLI_OPTION(s, "nic")) {
+        return PMIX_DEVTYPE_NETWORK | PMIX_DEVTYPE_OPENFABRICS;
+    }
+    if (PMIX_CHECK_CLI_OPTION(s, "block")) {
+        return PMIX_DEVTYPE_BLOCK;
+    }
+    return PMIX_DEVTYPE_UNKNOWN;
+}
+
+/* Can we bind where we were asked to, given where the device is?
+ *
+ * "Near this device" is the whole request, and an object that strictly
+ * contains the device's locality is not near it - binding there would hand
+ * the proc cpus the device is not local to, which is the locality loss the
+ * directive exists to avoid.  Compare cpusets rather than PRTE_BIND_TO_*
+ * levels: the locality is frequently an hwloc Group, which has no position
+ * in that ladder, so there is no level to compare against.
+ */
+static bool binding_fits(prte_node_t *node, hwloc_obj_t locality,
+                         prte_rmaps_options_t *options)
+{
+    hwloc_obj_t obj;
+    int nobjs, n;
+
+    if (PRTE_BIND_TO_NONE == options->bind || NULL == locality
+        || NULL == locality->cpuset) {
+        return true;
+    }
+    nobjs = prte_hwloc_base_get_nbobjs_by_type(node->topology->topo, options->hwb);
+    for (n = 0; n < nobjs; n++) {
+        obj = prte_hwloc_base_get_obj_by_type(node->topology->topo, options->hwb, n);
+        if (NULL == obj || NULL == obj->cpuset) {
+            continue;
+        }
+        if (!hwloc_bitmap_intersects(obj->cpuset, locality->cpuset)) {
+            continue;
+        }
+        /* a binding target that covers the locality and more is above it */
+        if (hwloc_bitmap_isincluded(locality->cpuset, obj->cpuset)
+            && !hwloc_bitmap_isequal(locality->cpuset, obj->cpuset)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static int device_targets_begin(prte_node_t *node, prte_rmaps_options_t *opts,
+                                void **ctx)
+{
+    prte_rmaps_devctx_t *dc;
+    pmix_device_type_t type;
+    const char *byname = NULL;
+    pmix_topology_t topo;
+    pmix_status_t prc;
+    size_t n;
+    bool degenerate = true;
+
+    *ctx = NULL;
+
+    type = device_class(opts->map_device);
+    if (PMIX_DEVTYPE_UNKNOWN == type) {
+        /* not a class, so it names one particular device: every proc is
+         * placed near that one */
+        byname = opts->map_device;
+    }
+
+    dc = (prte_rmaps_devctx_t *) calloc(1, sizeof(prte_rmaps_devctx_t));
+    if (NULL == dc) {
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+
+    topo.source = "hwloc";
+    topo.topology = node->topology->topo;
+    prc = pmix_hwloc_get_devices(&topo, type, byname, &dc->devs, &dc->ndevs);
+    if (PMIX_SUCCESS != prc) {
+        free(dc);
+        return prte_pmix_convert_status(prc);
+    }
+
+    /* A node with none of the requested devices cannot answer the request.
+     * Say so rather than dropping the node, which would shrink the
+     * allocation the user gave us without telling them - the shared loop
+     * reports this when the count comes back zero, so just hand it over. */
+    if (0 == dc->ndevs) {
+        *ctx = dc;
+        return PRTE_SUCCESS;
+    }
+
+    /* Refuse a binding coarser than the devices are local to, before any
+     * proc is placed on this node. */
+    for (n = 0; n < dc->ndevs; n++) {
+        if (!binding_fits(node, dc->devs[n].locality, opts)) {
+            prte_show_help("help-prte-rmaps-base.txt", "rmaps:bind-above-device", true,
+                           prte_hwloc_base_print_binding(opts->bind),
+                           opts->map_device, node->name);
+            pmix_hwloc_release_devices(dc->devs, dc->ndevs);
+            free(dc);
+            return PRTE_ERR_SILENT;
+        }
+    }
+
+    /* If every device resolves to the same place, "near this device" is
+     * saying nothing about cpus - each proc still gets a distinct device,
+     * which is half of what was asked for, so proceed and say so. */
+    for (n = 1; n < dc->ndevs; n++) {
+        if (dc->devs[n].locality != dc->devs[0].locality) {
+            degenerate = false;
+            break;
+        }
+    }
+    if (degenerate && 1 < dc->ndevs) {
+        prte_show_help("help-prte-rmaps-base.txt", "rmaps:degenerate-device-locality",
+                       true, opts->map_device, node->name, (int) dc->ndevs);
+    }
+
+    *ctx = dc;
+    return PRTE_SUCCESS;
+}
+
+static unsigned device_targets_count(prte_node_t *node, prte_rmaps_options_t *opts,
+                                     void *ctx)
+{
+    prte_rmaps_devctx_t *dc = (prte_rmaps_devctx_t *) ctx;
+
+    PRTE_HIDE_UNUSED_PARAMS(node, opts);
+    if (NULL == dc) {
+        return 0;
+    }
+    return (unsigned) dc->ndevs;
+}
+
+static hwloc_obj_t device_targets_item(prte_node_t *node, prte_rmaps_options_t *opts,
+                                       void *ctx, unsigned j)
+{
+    prte_rmaps_devctx_t *dc = (prte_rmaps_devctx_t *) ctx;
+
+    PRTE_HIDE_UNUSED_PARAMS(node, opts);
+    if (NULL == dc || (size_t) j >= dc->ndevs) {
+        return NULL;
+    }
+    return dc->devs[j].locality;
+}
+
+static void device_targets_end(void *ctx)
+{
+    prte_rmaps_devctx_t *dc = (prte_rmaps_devctx_t *) ctx;
+
+    if (NULL == dc) {
+        return;
+    }
+    if (NULL != dc->devs) {
+        pmix_hwloc_release_devices(dc->devs, dc->ndevs);
+    }
+    free(dc);
+}
+
+int prte_rmaps_rr_bydevice(prte_job_t *jdata, prte_app_context_t *app,
+                           pmix_list_t *node_list, int32_t num_slots,
+                           pmix_rank_t num_procs,
+                           prte_rmaps_options_t *options)
+{
+    prte_rmaps_target_enum_t tgts = {
+        .begin = device_targets_begin,
+        .count = device_targets_count,
+        .item = device_targets_item,
+        .end = device_targets_end,
+        .name = options->map_device
+    };
+
+    if (NULL == options->map_device) {
+        /* the policy cannot be set without a value - see the two --map-by
+         * parsers - so this is a programming error, not user input */
+        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    return prte_rmaps_rr_map_targets(jdata, app, node_list, num_slots,
+                                     num_procs, options, &tgts);
+}
+
 int prte_rmaps_rr_bycpu(prte_job_t *jdata, prte_app_context_t *app,
                         pmix_list_t *node_list, int32_t num_slots,
                         pmix_rank_t num_procs, prte_rmaps_options_t *options)

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -720,6 +720,8 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
     int n, rc;
     const char *tgt;
     char **vtmp;
+    char **tmp;
+    bool haspe = false;
 
     char *mappers[] = {
         PRTE_CLI_SLOT,
@@ -735,6 +737,7 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
         PRTE_CLI_PPR,
         PRTE_CLI_RANKFILE,
         PRTE_CLI_PELIST,
+        PRTE_CLI_DEVICE,
         NULL
     };
     char *mapquals[] = {
@@ -902,7 +905,29 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
     opt = pmix_cmd_line_get_param(cmd_line, PRTE_CLI_MAPBY);
     newopt = pmix_cmd_line_get_param(cmd_line, PRTE_CLI_BINDTO);
     if (NULL != opt && NULL != newopt) {
-        if (NULL != strcasestr(opt->values[0], "PE")) {
+        /* Asking for specific cpus and then binding to something coarser is
+         * a conflict. Find that request by parsing the directive, not by
+         * searching the whole --map-by value for the letters "PE": that
+         * matched any spelling containing them, so "device=openfabrics" or
+         * a rankfile under /home/pete were refused as PE requests. Split
+         * off the directive, which is what "pe-list=" is, and test the
+         * qualifiers, which is what "PE=n" is. */
+        tmp = PMIx_Argv_split(opt->values[0], ':');
+        if (NULL != tmp) {
+            if (NULL != tmp[0] && 0 < strlen(tmp[0])
+                && PMIX_CHECK_CLI_OPTION(tmp[0], PRTE_CLI_PELIST)) {
+                haspe = true;
+            }
+            for (n = 1; !haspe && NULL != tmp[n]; n++) {
+                /* an empty token matches whatever it is tested against
+                 * first, so skip it rather than let it claim PE */
+                if (0 < strlen(tmp[n]) && PMIX_CHECK_CLI_OPTION(tmp[n], PRTE_CLI_PE)) {
+                    haspe = true;
+                }
+            }
+            PMIx_Argv_free(tmp);
+        }
+        if (haspe) {
             /* if we are binding to a PE, then there is no conflict */
             if (NULL != strcasestr(newopt->values[0], "core") ||
                 NULL != strcasestr(newopt->values[0], "hwt")) {

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -306,6 +306,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "PRTE_APP_BINDTO";
         case PRTE_APP_MAP_FILE:
             return "PRTE_APP_MAP_FILE";
+        case PRTE_APP_MAP_DEVICE:
+            return "PRTE_APP_MAP_DEVICE";
         case PRTE_APP_HWT_CPUS:
             return "PRTE_APP_HWT_CPUS";
         case PRTE_APP_CORE_CPUS:
@@ -484,6 +486,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "JOB_INHERIT";
         case PRTE_JOB_PES_PER_PROC:
             return "JOB_PES_PER_PROC";
+        case PRTE_JOB_MAP_DEVICE:
+            return "JOB_MAP_DEVICE";
         case PRTE_JOB_HWT_CPUS:
             return "JOB_HWT_CPUS";
         case PRTE_JOB_CORE_CPUS:

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -76,6 +76,7 @@ typedef uint8_t prte_app_context_flags_t;
 #define PRTE_APP_RANKBY             27 /* uint16_t ranking policy enum */
 #define PRTE_APP_BINDTO             28 /* uint16_t binding policy enum */
 #define PRTE_APP_MAP_FILE           29 /* char* path to seq or rankfile */
+#define PRTE_APP_MAP_DEVICE         30 /* char* device class or name for --map-by device= */
 #define PRTE_APP_HWT_CPUS           31 /* bool: use hwthreads as CPUs */
 #define PRTE_APP_CORE_CPUS          32 /* bool: use cores as CPUs */
 #define PRTE_APP_CPUSET             33 /* char* comma-delimited CPU ranges */
@@ -216,6 +217,7 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_TRACE_TIMEOUT_EVENT        (PRTE_JOB_START_KEY +  75) // prte_ptr (prte_timer_t*) - timer event for stacktrace collection
 #define PRTE_JOB_INHERIT                    (PRTE_JOB_START_KEY +  76) // bool - job inherits parent's mapping/ranking/binding policies
 #define PRTE_JOB_PES_PER_PROC               (PRTE_JOB_START_KEY +  77) // uint16_t - number of cpus to be assigned to each process
+#define PRTE_JOB_MAP_DEVICE                 (PRTE_JOB_START_KEY +  78) // char* - device class or name for --map-by device=
 #define PRTE_JOB_HWT_CPUS                   (PRTE_JOB_START_KEY +  79) // bool - job requests hwthread cpus
 #define PRTE_JOB_CORE_CPUS                  (PRTE_JOB_START_KEY +  80) // bool - job requests core cpus
 #define PRTE_JOB_PPR                        (PRTE_JOB_START_KEY +  81) // char* - string specifying the procs-per-resource pattern

--- a/src/util/prte_cmd_line.h
+++ b/src/util/prte_cmd_line.h
@@ -180,6 +180,7 @@ BEGIN_C_DECLS
 #define PRTE_CLI_PACKAGE    "package"
 #define PRTE_CLI_NODE       "node"
 #define PRTE_CLI_SEQ        "seq"
+#define PRTE_CLI_DEVICE     "device="
 #define PRTE_CLI_PPR        "ppr"
 #define PRTE_CLI_RANKFILE   "rankfile"
 #define PRTE_CLI_NONE       "none"

--- a/test/unit/rmaps/test_job_policy.c
+++ b/test/unit/rmaps/test_job_policy.c
@@ -201,6 +201,48 @@ int test_job_policy(void)
     CHECK("job pe-list bad range: refused", PRTE_SUCCESS != rc);
     PMIX_RELEASE(jdata);
 
+    /* === device=: must parse to the same result as the per-app parser in
+     * test_policy_parse.c.  A directive accepted at one level and refused at
+     * the other is the recurring bug in rmaps_base_frame.c === */
+    jdata = newjob();
+    rc = prte_rmaps_base_set_mapping_policy(jdata, "device=gpu");
+    CHECK("job device=gpu: rc", PRTE_SUCCESS == rc);
+    CHECK("job device=gpu: policy",
+          PRTE_MAPPING_BYDEVICE == PRTE_GET_MAPPING_POLICY(jdata->map->mapping));
+    CHECK("job device=gpu: marked as the user's",
+          0 != (PRTE_MAPPING_GIVEN & PRTE_GET_MAPPING_DIRECTIVE(jdata->map->mapping)));
+    sval = get_str(&jdata->attributes, PRTE_JOB_MAP_DEVICE);
+    CHECK("job device=gpu: spec", NULL != sval && 0 == strcmp(sval, "gpu"));
+    free(sval);
+    PMIX_RELEASE(jdata);
+
+    /* abbreviated, and the value read after the "=" rather than at a fixed
+     * offset past the full spelling */
+    jdata = newjob();
+    rc = prte_rmaps_base_set_mapping_policy(jdata, "dev=mlx5_0");
+    CHECK("job dev=mlx5_0: rc", PRTE_SUCCESS == rc);
+    sval = get_str(&jdata->attributes, PRTE_JOB_MAP_DEVICE);
+    CHECK("job dev=mlx5_0: spec read after the =",
+          NULL != sval && 0 == strcmp(sval, "mlx5_0"));
+    free(sval);
+    PMIX_RELEASE(jdata);
+
+    jdata = newjob();
+    rc = prte_rmaps_base_set_mapping_policy(jdata, "device=");
+    CHECK("job device= with no value: refused", PRTE_SUCCESS != rc);
+    PMIX_RELEASE(jdata);
+
+    /* no bare "gpu" spelling - the class is the directive's value */
+    jdata = newjob();
+    rc = prte_rmaps_base_set_mapping_policy(jdata, "gpu");
+    CHECK("job bare gpu: refused", PRTE_SUCCESS != rc);
+    PMIX_RELEASE(jdata);
+
+    /* the printer has to name it, or every device-mapping diagnostic and the
+     * map display report the policy as UNKNOWN */
+    CHECK("printer names BYDEVICE",
+          NULL != strstr(prte_rmaps_base_print_mapping(PRTE_MAPPING_BYDEVICE), "BYDEVICE"));
+
     jdata = newjob();
     rc = prte_rmaps_base_set_mapping_policy(jdata, "pe-list=zero");
     CHECK("job pe-list non-numeric: refused", PRTE_SUCCESS != rc);

--- a/test/unit/rmaps/test_policy_parse.c
+++ b/test/unit/rmaps/test_policy_parse.c
@@ -283,6 +283,45 @@ int test_policy_parse(void)
     free(sval);
     PMIX_RELEASE(app);
 
+    /* --- device= is per-app for the same reason: which devices one app of
+     * an MPMD job is placed against is its own business --- */
+    app = PMIX_NEW(prte_app_context_t);
+    rc = prte_rmaps_base_set_app_mapping_policy(app, "device=gpu");
+    CHECK("mapby device=gpu: rc", PRTE_SUCCESS == rc);
+    u16 = get_u16(&app->attributes, PRTE_APP_MAPBY);
+    CHECK("mapby device=gpu: policy", PRTE_MAPPING_BYDEVICE == PRTE_GET_MAPPING_POLICY(u16));
+    sval = get_str(&app->attributes, PRTE_APP_MAP_DEVICE);
+    CHECK("mapby device=gpu: spec", NULL != sval && 0 == strcmp(sval, "gpu"));
+    free(sval);
+    PMIX_RELEASE(app);
+
+    /* the value is read after the "=", not at a fixed offset past the full
+     * spelling - the directive may be abbreviated to any unambiguous prefix */
+    app = PMIX_NEW(prte_app_context_t);
+    rc = prte_rmaps_base_set_app_mapping_policy(app, "dev=mlx5_0");
+    CHECK("mapby dev=mlx5_0: rc", PRTE_SUCCESS == rc);
+    u16 = get_u16(&app->attributes, PRTE_APP_MAPBY);
+    CHECK("mapby dev=mlx5_0: policy", PRTE_MAPPING_BYDEVICE == PRTE_GET_MAPPING_POLICY(u16));
+    sval = get_str(&app->attributes, PRTE_APP_MAP_DEVICE);
+    CHECK("mapby dev=mlx5_0: spec read after the =",
+          NULL != sval && 0 == strcmp(sval, "mlx5_0"));
+    free(sval);
+    PMIX_RELEASE(app);
+
+    /* "device" with nothing after the "=" names no device at all */
+    app = PMIX_NEW(prte_app_context_t);
+    rc = prte_rmaps_base_set_app_mapping_policy(app, "device=");
+    CHECK("mapby device= with no value: refused", PRTE_SUCCESS != rc);
+    PMIX_RELEASE(app);
+
+    /* there is deliberately no bare "gpu" spelling: the class is the
+     * directive's VALUE, which is what lets a new class be supported by
+     * adding a value rather than a directive */
+    app = PMIX_NEW(prte_app_context_t);
+    rc = prte_rmaps_base_set_app_mapping_policy(app, "gpu");
+    CHECK("mapby bare gpu: refused", PRTE_SUCCESS != rc);
+    PMIX_RELEASE(app);
+
     /* the value is validated here, not left for the mapper to trip over */
     app = PMIX_NEW(prte_app_context_t);
     rc = prte_rmaps_base_set_app_mapping_policy(app, "pe-list=0-3-5");

--- a/test/unit/schizo/test_sanity.c
+++ b/test/unit/schizo/test_sanity.c
@@ -140,5 +140,35 @@ int test_sanity(void)
     CHECK("sanity:pe-bind-core-ok", PRTE_SUCCESS == rc);
     PMIX_DESTRUCT(&results);
 
+    /* pe-list= is a directive rather than a qualifier, and dictates the
+     * binding the same way */
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    schizo_test_add(&results, PRTE_CLI_MAPBY, "pe-list=0-3", NULL);
+    schizo_test_add(&results, PRTE_CLI_BINDTO, "package", NULL);
+    fprintf(stderr, "--- expected error output follows (pe-list/bind conflict) ---\n");
+    rc = prte_schizo_base_sanity(&results);
+    CHECK("sanity:pelist-bind-conflict", PRTE_SUCCESS != rc);
+    PMIX_DESTRUCT(&results);
+
+    /*** ...but the conflict is a PE *request*, not the letters "pe" ***/
+    /* This used to be a strcasestr() over the whole --map-by value, so any
+     * spelling containing "pe" anywhere was refused as a PE request.
+     * "openfabrics" contains one, and so does a rankfile living under
+     * /home/pete. Neither asks for a cpu list, and neither conflicts with
+     * binding to a numa domain. */
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    schizo_test_add(&results, PRTE_CLI_MAPBY, "device=openfabrics", NULL);
+    schizo_test_add(&results, PRTE_CLI_BINDTO, "numa", NULL);
+    rc = prte_schizo_base_sanity(&results);
+    CHECK("sanity:pe-substring-not-a-conflict", PRTE_SUCCESS == rc);
+    PMIX_DESTRUCT(&results);
+
+    PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+    schizo_test_add(&results, PRTE_CLI_MAPBY, "rankfile:file=/home/pete/rf", NULL);
+    schizo_test_add(&results, PRTE_CLI_BINDTO, "package", NULL);
+    rc = prte_schizo_base_sanity(&results);
+    CHECK("sanity:pe-in-a-path-not-a-conflict", PRTE_SUCCESS == rc);
+    PMIX_DESTRUCT(&results);
+
     return failures;
 }


### PR DESCRIPTION
Implements [Open MPI #14169](https://github.com/open-mpi/ompi/issues/14169).
Design and build order are in `docs/plans/per_device_mapping/`.

> **Depends on openpmix/openpmix#4144** (and #4143, merged). `configure` will
> refuse to build without the PMIx that has the device enumerator.

### The problem

The reporter's machine is why this cannot be done with what exists: its GPUs
hang off NUMA domains **1 and 2** of socket 0 but **6 and 7** of socket 1. No
`--map-by numa` or `--map-by package` expression reaches the four right
domains, and a `--cpu-set` would have to be written per machine.

### What this adds

`--map-by device=gpu` places one process per device, in PCI bus order,
against the CPUs local to each. The value may also name one particular device
— `--map-by device=mlx5_0` puts every process near that one, which is what
the removed `dist` policy did, said with one directive instead of a policy
plus an MCA parameter.

Classes: `gpu`, `network`, `openfabrics`, `nic` (the union, deduped by PCI
function), `block`. Anything else is taken as a device name or uuid.

**There is deliberately no bare `--map-by gpu`**, though that is the spelling
most of the issue uses. The class is the directive's *value*, which is what
lets a new class be supported later by adding a value rather than a
directive; promoting one class to a directive of its own would leave every
subsequent device type choosing between an inconsistent second spelling and a
bare name. Prefix matching keeps it short — `--map-by dev=gpu` works.

### Two rules that needed deciding

**A binding coarser than the device's locality is refused.** "Near this
device" is the whole request, and an object containing the locality *and more*
is not near it. This cannot use the job-level "cannot bind above the map"
check: a device's locality is not known until the node is — NUMA-sized on the
reporter's machine, package-sized on another — and is frequently an hwloc
`Group`, which has no position in the `PRTE_BIND_TO_*` ladder at all. So the
mapper applies it per node, against the locality it actually found, before
any process is placed there, comparing **cpusets** rather than levels.

**A node whose devices are all equally close to every cpu warns and
proceeds.** Binding can say nothing there, but each process still gets its own
device, and that assignment is a result no other directive produces.

### Results on the reporter's topology

Every row of the table in the issue, against the `hwloc_topology.xml` they
attached:

```
-n 1 --map-by device=gpu --bind-to core      -> core 16
-n 1 --map-by device=gpu --bind-to l3cache   -> cores 16-23
-n 1 --map-by device=gpu --bind-to numa      -> cores 16-31
-n 1 --map-by device=gpu --bind-to package   -> refused
-n 1 --map-by device=gpu:PE=2 --bind-to core -> cores 16-17
-n 2 --map-by device=gpu --bind-to core      -> cores 16, 32
-n 4 --map-by device=gpu --bind-to core      -> cores 16, 32, 96, 112
```

That last line is GPU0 through GPU3 of their `nvidia-smi topo -m` output, in
order. `device=openfabrics` lands the six mlx5 devices on NUMA 1, 2, 3, 3, 6,
7, which is that machine's actual fabric layout.

One row of the issue is answered by a different spelling than asked: `:span`
does not mean "spread across sockets" (it concatenates the per-node target
lists, it does not interleave them), so the rows wanting cores 16 and 96 will
be served by an `interleave` qualifier in a follow-on. `docs/plans` records
that.

### Why the enumerator is in PMIx

PMIx already reports devices to applications through
`PMIX_DEVICE_DISTANCES`, and the name PRRTE tells a process it was assigned
has to be the name that process sees there. A second enumerator could differ,
and an assignment nobody can correlate is worth nothing. `configure` requires
the PMIx that has one rather than PRRTE growing a local copy.

### Included drive-by fix (separate commit)

`--map-by device=openfabrics --bind-to numa` was rejected as a "PE=list
conflict". The check was `strcasestr(value, "PE")` — a substring search over
the whole `--map-by` value, and `o`**pe**`nfabrics` contains it. **So does a
rankfile under `/home/pete`, which is refused on master today.** It now parses
the value instead: `pe-list=` is a directive in the first colon-delimited
field, `PE=n` is a qualifier in a later one. Two regression tests.

### Testing

Clean build at `--enable-debug` (warnings are errors), `make check` 21/21,
`make -C test/offline check-offline` 1180/1180, the help/option cross-check,
and a live DVM cycle. New unit tests cover `device=` at **both** parser levels
(job and per-app — a directive accepted at one and refused at the other is the
recurring bug in that file), the abbreviated spelling, the value being read
after the `=` rather than at a fixed offset, an empty value being refused, and
the bare `gpu` spelling being refused.

The offline harness cases for the reporter's topology, the `interleave`
qualifier, reporting the assignment to the process, and the multi-node cases
are the remaining phases in `docs/plans/per_device_mapping/impl-plan.rst`.