### PR TITLE
Document --map-by device=

### DIFF
--- a/docs/plans/per_device_mapping/impl-plan.rst
+++ b/docs/plans/per_device_mapping/impl-plan.rst
@@ -399,6 +399,74 @@ pre-existing case; live smoke test (``prte --daemonize`` →
 ``prun -n 2 --map-by device=network --bind-to core hostname`` → ``pterm``).
 
 
+Phase D2 — the user documentation
+----------------------------------
+
+Lands **with** phase D, not after it.  ``--map-by device=`` is a user-visible
+option, and the project requires documentation with a user-visible change;
+a release in which the directive works but nothing documents it is the same
+shape of defect this whole plan started from — the ``dist`` policy that the
+MCA parameter advertised and no command line could reach.
+
+Five files, and they are not interchangeable.  Each is read by someone in a
+different situation, so the same fact has to be stated five times at five
+levels of detail rather than written once and cross-referenced.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 42 58
+
+   * - File
+     - What it needs
+   * - ``src/mca/rmaps/base/help-mapby.txt``
+     - The ``[map-by]`` topic — what ``prterun --help map-by`` prints.  Add
+       ``device=<class|name>`` to the directive list, with the classes and
+       the "or a device name" form.  This is the one the reporter of
+       #14169 checked and found silent about ``dist``.
+   * - ``src/mca/rmaps/base/help-placement.txt``
+     - Several topics, and they are separate audiences: ``[placement]``
+       (the overview list of policies), ``[placement-examples]``, and
+       ``[placement-fundamentals]``.  Add the directive to the first; a
+       worked example to the second; and to the third what a device's
+       *locality* is, since that concept exists nowhere else in placement.
+   * - ``src/docs/prrte-rst-content/cli-map-by.rst``
+     - The rendered ``--map-by`` reference, whose bullet list of directives
+       (``SLOT``, ``HWTHREAD``, … ``PE-LIST=a,b``) is the canonical
+       enumeration.  Add ``DEVICE=<class|name>``, and note in the qualifier
+       list that a binding coarser than the device's locality is refused.
+   * - ``src/docs/prrte-rst-content/detail-placement-fundamentals.rst``
+     - Where the *model* is explained.  Mapping by a device is the first
+       policy whose target is not an hwloc object the user can name, so say
+       what it maps to: the nearest ancestor of the device that has a
+       cpuset, and why binding descends from there.
+   * - ``src/docs/prrte-rst-content/detail-placement-examples.rst``
+     - Worked examples with output.  The reporter's machine is the example
+       worth using — GPUs on NUMA 1 and 2 of one socket and 6 and 7 of the
+       other is exactly the shape no other directive can express, and it
+       shows why the feature exists rather than just how to spell it.
+
+Three things the text must say, because each is a decision a reader would
+otherwise take for a bug:
+
+* there is no bare ``--map-by gpu``; the class is the directive's value;
+* a binding coarser than the device's locality is **refused**, not silently
+  widened;
+* on a machine where every device is equally close to every cpu the job
+  still runs, with a warning, and each process still gets its own device.
+
+Remember the ``show_help`` golden rule for the two ``.txt`` files: the
+generated content is not rebuilt by an ordinary ``make``.  In a VPATH build
+the generated file lives in the **build** tree, so it is
+``rm <builddir>/src/util/prte_show_help_content.*`` that matters — deleting
+the source tree's copy does nothing, because there isn't one.
+
+Then ``make`` in ``docs/`` (Sphinx runs with ``-W``) and the help/option
+cross-check::
+
+   python3 src/util/prte-convert-help.py --root . --check-only \
+       --cppflags="$(pkg-config --cflags-only-I pmix)"
+
+
 Phase E — the ``interleave`` qualifier
 ---------------------------------------
 
@@ -505,9 +573,8 @@ here, the requested table is simply run.
   a job asking for a device class no node has must fail the job and **leave
   the DVM standing**; and ``--map-by device=network`` must place procs
   against the containers' actual interfaces.  GPU cases stay offline.
-* Docs: the ``--map-by`` reference under ``docs/placement/`` and the
-  ``prterun --help map-by`` text, which today does not mention ``dist`` at
-  all even though the MCA parameter does.
+* Docs: see `Phase D2 — the user documentation`_, which lands with the
+  directive rather than here.
 
 
 Verification checklist
@@ -615,6 +682,18 @@ Task checklist
 - [ ] Unit tests: hwloc enumerator, both parsers, dispatch gate
 - [ ] Build / check / check-offline / smoke test
 
+**Phase D2 — user documentation**
+
+- [ ] ``help-mapby.txt`` ``[map-by]`` directive list
+- [ ] ``help-placement.txt``: ``[placement]``, ``[placement-examples]``,
+      ``[placement-fundamentals]``
+- [ ] ``cli-map-by.rst`` directive + qualifier lists
+- [ ] ``detail-placement-fundamentals.rst`` — what a device's locality is
+- [ ] ``detail-placement-examples.rst`` — the reporter's machine, worked
+- [ ] no bare ``gpu`` / refused coarse binding / degenerate case all stated
+- [ ] regenerate show_help content in the **build** tree; docs build ``-W``;
+      ``prte-convert-help.py --check-only``
+
 **Phase E — interleave**
 
 - [ ] ``PRTE_CLI_INTERLEAVE``; ``mapquals[]``; arm appended **after**
@@ -635,5 +714,5 @@ Task checklist
 - [ ] Offline cases for the full requested table, both orderings
 - [ ] Swarm: no-such-device fails the job and leaves the DVM up;
       ``device=network`` places correctly
-- [ ] ``docs/placement/`` and ``--help map-by``
+- [ ] (docs moved to phase D2)
 - [ ] Reply on OMPI #14169 with the resulting table

--- a/docs/plans/per_device_mapping/impl-plan.rst
+++ b/docs/plans/per_device_mapping/impl-plan.rst
@@ -424,11 +424,14 @@ levels of detail rather than written once and cross-referenced.
        the "or a device name" form.  This is the one the reporter of
        #14169 checked and found silent about ``dist``.
    * - ``src/mca/rmaps/base/help-placement.txt``
-     - Several topics, and they are separate audiences: ``[placement]``
-       (the overview list of policies), ``[placement-examples]``, and
-       ``[placement-fundamentals]``.  Add the directive to the first; a
-       worked example to the second; and to the third what a device's
-       *locality* is, since that concept exists nowhere else in placement.
+     - Two topics, and they are separate audiences.  ``[placement-examples]``
+       carries both the option list its examples draw on and the examples
+       themselves; ``[placement-fundamentals]`` carries the model, and is
+       where a device's *locality* has to be explained, since that concept
+       exists nowhere else in placement.  ``[placement]`` needs nothing: it
+       is conceptual (mapping vs ranking vs binding, slots, PEs) and
+       enumerates no directives — easy to assume otherwise, since its prose
+       resembles the examples topic's option list.
    * - ``src/docs/prrte-rst-content/cli-map-by.rst``
      - The rendered ``--map-by`` reference, whose bullet list of directives
        (``SLOT``, ``HWTHREAD``, … ``PE-LIST=a,b``) is the canonical
@@ -685,8 +688,8 @@ Task checklist
 **Phase D2 — user documentation**
 
 - [ ] ``help-mapby.txt`` ``[map-by]`` directive list
-- [ ] ``help-placement.txt``: ``[placement]``, ``[placement-examples]``,
-      ``[placement-fundamentals]``
+- [ ] ``help-placement.txt``: ``[placement-examples]`` (option list +
+      worked example) and ``[placement-fundamentals]`` (the model)
 - [ ] ``cli-map-by.rst`` directive + qualifier lists
 - [ ] ``detail-placement-fundamentals.rst`` — what a device's locality is
 - [ ] ``detail-placement-examples.rst`` — the reporter's machine, worked

--- a/src/docs/prrte-rst-content/cli-map-by.rst
+++ b/src/docs/prrte-rst-content/cli-map-by.rst
@@ -78,6 +78,27 @@ applied at the job level:
   OVERLOAD qualifier to the "bind-to" option removes the check on
   availability of the CPU in both cases.
 
+* ``DEVICE=<class|name>`` assigns one proc to each device in the node's
+  topology, in PCI bus order, placing it on the CPUs local to that
+  device. The value is either a class of device -- ``gpu``, ``network``,
+  ``openfabrics``, ``nic`` (network and openfabrics together), or
+  ``block`` -- or the name or UUID of one particular device such as
+  ``mlx5_0``, in which case every proc is placed near that one device.
+
+  Note there is no bare ``--mapby gpu``: the class is the *value* of the
+  ``device`` directive, which is what allows other classes of device to
+  be supported later without adding a directive for each.
+
+  Binding descends from the device's *locality*: the nearest object in
+  the topology that both contains the device and has CPUs. Asking to
+  bind to an object larger than that locality is an error rather than a
+  silent widening, since such a binding is not "near the device" at all.
+  Whether a given ``--bindto`` is legal therefore depends on the machine,
+  not on the command line alone. Where every device on a node is equally
+  close to every CPU, the job runs and each proc is still assigned its
+  own device, but a warning reports that the binding could not be made
+  any more specific.
+
 Any directive can include qualifiers by adding a colon (``:``) and any
 combination of one or more of the following (delimited by colons) to
 the ``--mapby`` option (except where noted):

--- a/src/docs/prrte-rst-content/detail-placement-examples.rst
+++ b/src/docs/prrte-rst-content/detail-placement-examples.rst
@@ -302,6 +302,50 @@ since the ``-np`` option indicated that only 6 processes should be
 launched.
 
 
+Mapping Processes to Devices
+----------------------------
+
+Consider a two-socket node with eight NUMA domains and four GPUs, where
+the GPUs are attached to NUMA domains 1 and 2 on the first socket but 6
+and 7 on the second. That asymmetry is the case device mapping exists
+for: no ``--mapby numa`` or ``--mapby package`` expression selects those
+four domains, because they are not at the same position within each
+socket.
+
+.. code::
+
+   $ prun -n 4 --mapby device=gpu --bindto core ./a.out
+
+places one process per GPU, in PCI bus order, each bound to the first
+available core in the CPUs local to its own GPU --- on the machine
+described above, cores 16, 32, 96 and 112.
+
+Binding may be to any object at or below the device's locality:
+
+.. code::
+
+   $ prun -n 1 --mapby device=gpu --bindto numa ./a.out
+
+binds the process to the whole NUMA domain its GPU is attached to,
+while ``--bindto l3cache`` binds it to one L3 cache within that domain
+and ``--bindto core`` to a single core. Asking for ``--bindto package``
+on this machine is an error: a package contains the GPU's NUMA domain
+and three others, so binding there would place the process on CPUs the
+GPU is not local to.
+
+Naming a single device rather than a class places every process near
+that one device, which suits a job whose performance depends on one
+particular fabric interface:
+
+.. code::
+
+   $ prun -n 8 --mapby device=mlx5_0 --bindto core ./a.out
+
+Other classes are selected the same way: ``device=openfabrics`` for
+fabric interfaces, ``device=network`` for network interfaces,
+``device=nic`` for both, and ``device=block`` for block devices.
+
+
 Mapping Processes to Nodes Using Policies
 -----------------------------------------
 

--- a/src/docs/prrte-rst-content/detail-placement-fundamentals.rst
+++ b/src/docs/prrte-rst-content/detail-placement-fundamentals.rst
@@ -29,6 +29,40 @@ command line via the ``--mapby`` option, include:
   assigns one process to the node/resource specified in each entry of
   the file, one per line of the file.
 
+* ``DEVICE=<class|name>``: assigns one process to each device in the
+  node's topology, in PCI bus order.
+
+Mapping by device is unlike the other directives in one respect worth
+understanding, because it governs what binding can then do.
+
+Every other mapping target is an object the user names directly --- a
+core, a NUMA domain, a package --- and binding descends within it. A
+device is not such an object: it hangs off the I/O side of the topology
+and has no CPUs of its own. What a process is actually placed against
+is the device's **locality**, meaning the nearest object in the topology
+that both contains the device and has CPUs. On one machine that may be
+a NUMA domain, on another a whole package, depending on where the
+hardware attaches the device.
+
+Two consequences follow, and both are deliberate:
+
+#. Binding descends from the locality, not from the device. So
+   ``--mapby device=gpu --bindto core`` binds each process to one core
+   within the CPUs local to its GPU.
+
+#. Asking to bind to an object larger than the locality is an error,
+   not a silent widening. Such a binding is not "near the device" at
+   all, which is the whole of what was asked for. Note this cannot be
+   known from the command line alone: whether ``--bindto package`` is
+   legal depends on where that machine attaches its devices.
+
+Where every device on a node is equally close to every CPU --- which
+happens when they all hang off one PCI complex rather than off
+individual NUMA domains --- the job still runs and each process is
+still assigned its own device, but a warning is printed: the binding
+cannot be made any more specific than it would have been without the
+directive.
+
 For example, using the hostfile below:
 
 .. code::

--- a/src/mca/rmaps/base/help-mapby.txt
+++ b/src/mca/rmaps/base/help-mapby.txt
@@ -79,6 +79,25 @@ applied at the job level:
   one process to the node/resource specified in each entry of the
   file, one per line of the file.
 
+* "DEVICE=<class|name>" assigns one proc to each device in the node's
+  topology, in PCI bus order, placing it on the CPUs local to that
+  device. The value is either a class of device - "gpu", "network",
+  "openfabrics", "nic" (network and openfabrics together), or "block" -
+  or the name or UUID of one particular device, such as "mlx5_0", in
+  which case every proc is placed near that one device.
+  Note there is no bare "--mapby gpu": the class is the value of the
+  "device" directive, which is what allows other classes of device to
+  be supported later without adding a directive for each.
+  Binding descends from the device's locality - the nearest object in
+  the topology that both contains the device and has CPUs. Asking to
+  bind to something larger than that locality is an error rather than a
+  silent widening, because a binding that covers more than the device's
+  locality is not "near the device" at all. On a machine where every
+  device is equally close to every CPU, the job still runs and each
+  proc is still assigned its own device, but a warning is printed
+  because the binding cannot be made any more specific than it would
+  have been without the directive.
+
 * "PE-LIST=a,b" assigns procs to each node in the allocation based on
   the ORDERED qualifier. The list is comprised of comma-delimited
   ranges of CPUs to use for this job. If the ORDERED qualifier is not

--- a/src/mca/rmaps/base/help-placement.txt
+++ b/src/mca/rmaps/base/help-placement.txt
@@ -315,6 +315,8 @@ Process Mapping / Ranking / Binding Options
 
   * "pe-list"
 
+  * "device=<class|name>"
+
   Any object can include qualifiers by adding a colon (":") and any
   colon-delimited combination of one or more of the following to the "
   --mapby" options:
@@ -621,6 +623,44 @@ And here is a MIMD example:
 This will launch process 0 running "hostname" on node "aa" and
 processes 1 and 2 each running "uptime" on nodes "bb" and "cc",
 respectively.
+
+
+Mapping to Devices
+==================
+
+Consider a two-socket node with eight NUMA domains and four GPUs,
+where the GPUs are attached to NUMA domains 1 and 2 on the first
+socket but 6 and 7 on the second. This asymmetry is the case device
+mapping exists for: no "--mapby numa" or "--mapby package" expression
+selects those four domains, because they are not at the same position
+within each socket.
+
+   $ prun -n 4 --mapby device=gpu --bindto core ./a.out
+
+places one process per GPU, in PCI bus order, each bound to the first
+available core in the CPUs local to its own GPU - on the machine
+described above, cores 16, 32, 96, and 112.
+
+Binding may be any object at or below the device's locality:
+
+   $ prun -n 1 --mapby device=gpu --bindto numa ./a.out
+
+binds the process to the whole NUMA domain its GPU is attached to,
+while "--bindto l3cache" binds it to one L3 cache within that domain,
+and "--bindto core" to a single core. Asking for "--bindto package"
+on this machine is an error: a package contains the GPU's NUMA domain
+and three others, so binding there would place the process on CPUs the
+GPU is not local to.
+
+Naming a single device instead of a class places every process near
+that one device, which is useful for a job whose performance depends
+on one particular fabric interface:
+
+   $ prun -n 8 --mapby device=mlx5_0 --bindto core ./a.out
+
+Other classes are selected the same way - "device=openfabrics" for
+fabric interfaces, "device=network" for network interfaces,
+"device=nic" for both, and "device=block" for block devices.
 
 
 Per-App-Context Mapping Example
@@ -970,6 +1010,41 @@ command line via the "--mapby" option, include:
 * "RANKFILE": (often accompanied by the "file=<path>" qualifier)
   assigns one process to the node/resource specified in each entry of
   the file, one per line of the file.
+
+* "DEVICE=<class|name>": assigns one process to each device in the
+  node's topology, in PCI bus order.
+
+Mapping by device is unlike the other directives in one respect worth
+understanding, because it governs what binding can then do.
+
+Every other mapping target is an object the user names directly - a
+core, a NUMA domain, a package - and binding descends within it. A
+device is not such an object: it hangs off the I/O side of the
+topology and has no CPUs of its own. What a process is actually
+placed against is the device's *locality*, meaning the nearest object
+in the topology that both contains the device and has CPUs. On one
+machine that may be a NUMA domain, on another a whole package,
+depending on where the hardware attaches the device.
+
+Two consequences follow, and both are deliberate:
+
+1. Binding descends from the locality, not from the device. So
+   "--mapby device=gpu --bindto core" binds each process to one core
+   within the CPUs local to its GPU.
+
+2. Asking to bind to an object larger than the locality is an error,
+   not a silent widening. A binding that covers more than the device's
+   locality is not "near the device" at all, which is the whole of what
+   was asked for. Note this cannot be known from the command line
+   alone: whether "--bindto package" is legal depends on where that
+   machine attaches its devices.
+
+Where every device on a node is equally close to every CPU - which
+happens when they all hang off one PCI complex rather than off
+individual NUMA domains - the job still runs and each process is still
+assigned its own device, but a warning is printed: the binding cannot
+be made any more specific than it would have been without the
+directive.
 
 For example, using the hostfile below:
 


### PR DESCRIPTION
`--map-by device=` shipped in #2667 without documentation. That is the
defect this whole line of work started from, in a milder form: a policy the
runtime accepts and nothing describes is only marginally better than one it
advertises and refuses.

Five files, because each is read by someone in a different situation and none
can be satisfied by a cross-reference to another:

| File | Role |
|---|---|
| `help-mapby.txt` | what `prterun --help map-by` prints — **the place the reporter of #14169 looked** |
| `help-placement.txt` | the option list its examples draw on, a worked example, and the model in *fundamentals* |
| `cli-map-by.rst` | the rendered reference, whose bullet list is the canonical enumeration of directives |
| `detail-placement-fundamentals.rst` | the model |
| `detail-placement-examples.rst` | worked examples with output |

### Three things the prose has to say

Each is a decision a reader would otherwise file as a bug:

* there is no bare `--map-by gpu` — the class is the directive's *value*;
* a binding coarser than the device's locality is **refused**, not silently
  widened;
* on a machine where every device is equally close to every CPU the job still
  runs, with a warning, and each process still gets its own device.

### The concept that needed introducing

Mapping by a device is the first policy whose target is **not an hwloc object
the user can name**. Every other target — a core, a NUMA domain, a package —
is something binding descends within. A device hangs off the I/O side of the
topology and has no CPUs of its own, so what a process is really placed
against is the device's *locality*: the nearest object containing it that has
CPUs.

Both fundamentals sections say that, and draw the consequence a user will
otherwise hit as a surprise: whether a given `--bindto` is legal depends on
the machine, not on the command line alone. `--bindto package` is fine where
the hardware attaches devices per package and an error where it attaches them
per NUMA domain.

### On the examples

They use the reporter's own machine — GPUs on NUMA domains 1 and 2 of one
socket but 6 and 7 of the other. That asymmetry is *why* the directive
exists, and an example built on a symmetric machine demonstrates nothing that
`--map-by numa` could not already do.

### Testing

All four help entry points were rendered from the installed build and
checked, not just diffed: `--help map-by`, `--help placement`,
`--help placement-fundamentals`, `--help placement-examples`. Docs build
under Sphinx `-W`; `prte-convert-help.py --check-only` passes; `make check`
21/21.

Two things that verification caught, which a diff would not have:

* the `show_help` content is regenerated into the **build** tree in a VPATH
  build, so the golden rule's `rm src/util/prte_show_help_content.*` has to
  name the build tree — the source tree has no such file to delete;
* `make install` does not refresh the installed RST tree on its own, so the
  first render of `--help map-by` was still showing the old text after a
  successful build.

The plan in `docs/plans/per_device_mapping/` is updated in the same branch,
including a correction: it claimed the `[placement]` topic carried an
overview list needing the directive. It does not — it is conceptual and
enumerates no directives. The list that needed it belongs to
`[placement-examples]`.