### PR TITLE
Device mapping: sharing, ndev, and verifying the assignment reaches the process

### DIFF
--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -429,6 +429,18 @@ build_linux() {
                 /prrte-src/contrib/dockerswarm/jobinfo.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
+            # devinfo: reads back the device this proc was mapped against.
+            # The point is that it asks the PROCESS, not the head node: the
+            # assignment is computed on the HNP, packed into the launch
+            # message, unpacked by the daemon that forks the proc, and then
+            # published by the PMIx server in that daemon, whereas
+            # "--display map" shows only the first of those steps.
+            # (No apostrophes here: see the note further down.)
+            echo ">>>> devinfo (device assignment) test client"
+            gcc -O0 -g -o /opt/prte/prte/bin/devinfo \
+                /prrte-src/contrib/dockerswarm/devinfo.c \
+                -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
+
             # dataserver: a bare PMIx client for the publish/lookup service
             # in src/runtime/data_server.  The store is a single array on
             # the HNP and every client reaches it through its own daemon, so

--- a/contrib/dockerswarm/devinfo.c
+++ b/contrib/dockerswarm/devinfo.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * devinfo -- print the device this process was mapped against.
+ *
+ *   DEV <rank> <device-id>
+ *
+ * or, when the job was not mapped by device:
+ *
+ *   NODEV <rank>
+ *
+ * Why this exists, rather than reading "--display map" on the head node:
+ *
+ * PRRTE cannot restrict a process to a device the way it restricts one to a
+ * set of CPUs; no such mechanism exists.  The whole value of mapping by
+ * device therefore rests on the *process* being able to read its own
+ * assignment - and that is a different question from whether the HNP
+ * computed one.  The assignment is computed on the HNP, packed into the
+ * launch message, unpacked by the daemon that forks the process, and
+ * published by that daemon's PMIx server.  "--display map" shows only the
+ * first of those four steps.
+ *
+ * The distinction is not hypothetical.  The assignment was originally
+ * recorded as a PRTE_ATTR_GLOBAL proc attribute on the assumption that
+ * global attributes travel; they do not - no proc attribute list goes on
+ * the wire at all - so it reached the map display and nothing else.  A test
+ * that read the map display would have passed throughout.
+ *
+ * The process also prints the device's distance vector, which is what an
+ * application would really do with the assignment: PMIX_DEVICE_ID names one
+ * device, and PMIX_DEVICE_DISTANCES lists them all with distances, so a
+ * process that cannot find its own id among the distances has been handed an
+ * assignment it cannot act on.  Those two answers come from different code
+ * paths in PMIx and used to enumerate devices separately.
+ */
+
+#include <pmix.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(int argc, char **argv)
+{
+    pmix_proc_t myproc;
+    pmix_value_t *val = NULL;
+    pmix_status_t rc;
+    pmix_info_t *dinfo = NULL;
+    size_t ndinfo = 0, n;
+    char *devid = NULL;
+    int found = 0;
+
+    (void) argc;
+    (void) argv;
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "DEVFAIL init %d\n", (int) rc);
+        return 1;
+    }
+
+    rc = PMIx_Get(&myproc, PMIX_DEVICE_ID, NULL, 0, &val);
+    if (PMIX_SUCCESS != rc || NULL == val) {
+        /* not a device-mapped job, which is a legitimate answer */
+        fprintf(stdout, "NODEV %u\n", myproc.rank);
+        fflush(stdout);
+        PMIx_Finalize(NULL, 0);
+        return 0;
+    }
+    if (PMIX_STRING != val->type || NULL == val->data.string) {
+        fprintf(stderr, "DEVFAIL %u type %d\n", myproc.rank, (int) val->type);
+        PMIX_VALUE_RELEASE(val);
+        PMIx_Finalize(NULL, 0);
+        return 1;
+    }
+    devid = strdup(val->data.string);
+    PMIX_VALUE_RELEASE(val);
+
+    fprintf(stdout, "DEV %u %s\n", myproc.rank, devid);
+
+    /* the assignment has to be findable among the devices this process can
+     * see, or it names something the process cannot act on */
+    rc = PMIx_Get(&myproc, PMIX_DEVICE_DISTANCES, NULL, 0, &val);
+    if (PMIX_SUCCESS == rc && NULL != val && PMIX_DATA_ARRAY == val->type
+        && NULL != val->data.darray && PMIX_DEVICE_DIST == val->data.darray->type) {
+        pmix_device_distance_t *dd
+            = (pmix_device_distance_t *) val->data.darray->array;
+        ndinfo = val->data.darray->size;
+        for (n = 0; n < ndinfo; n++) {
+            if (NULL != dd[n].uuid && 0 == strcmp(dd[n].uuid, devid)) {
+                found = 1;
+                break;
+            }
+        }
+        fprintf(stdout, "DEVDIST %u %s %d\n", myproc.rank,
+                found ? "found" : "MISSING", (int) ndinfo);
+    } else {
+        /* distances are only generated when the DVM was asked for them */
+        fprintf(stdout, "DEVDIST %u none 0\n", myproc.rank);
+    }
+    if (NULL != val) {
+        PMIX_VALUE_RELEASE(val);
+    }
+    (void) dinfo;
+
+    fflush(stdout);
+    free(devid);
+    PMIx_Finalize(NULL, 0);
+    return 0;
+}

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -654,9 +654,74 @@ test_rmaps() {
                 && ok "each proc was told which device it was mapped against" \
                 || bad "no device assignment was reported to the procs"
         fi
+        # The assignment has to reach the PROCESS, which is a different
+        # question from whether the HNP computed one: it is packed into the
+        # launch message, unpacked by the daemon that forks the proc, and
+        # published by that daemon's PMIx server.  "--display map" shows
+        # only the first of those steps - and the assignment was once
+        # recorded as an attribute that never travelled, reaching the map
+        # display and nothing else.
+        if RUN 'test -x /opt/prte/prte/bin/devinfo'; then
+            out=$(RUN 'timeout 60 prun --map-by device=network -n 2 devinfo' 2>&1)
+            rc=$?
+            if [ "$rc" != 0 ]; then
+                skp "devinfo under device=network (no network device here)"
+            else
+                n=$(echo "$out" | grep -c '^DEV ')
+                [ "$n" = 2 ] && ok "both procs read back their own device assignment" \
+                             || bad "only $n of 2 procs could read PMIX_DEVICE_ID: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+                echo "$out" | grep -q '^NODEV ' \
+                    && bad "a proc of a device-mapped job reported no device" \
+                    || ok "no proc reported a missing assignment"
+                # two procs on two devices must not be told the same one
+                n=$(echo "$out" | grep '^DEV ' | awk '{print $3}' | sort -u | wc -l | tr -d ' ')
+                [ "$n" = 2 ] && ok "the two procs were given different devices" \
+                             || bad "both procs were told the same device"
+                # and the id must name something the proc can actually see
+                echo "$out" | grep -q 'DEVDIST .* MISSING' \
+                    && bad "the assigned device is not among the proc's device distances" \
+                    || ok "the assigned device is findable in the proc's own device list"
+            fi
+
+            # a job NOT mapped by device must not carry a stale assignment
+            out=$(RUN 'timeout 60 prun --map-by core -n 2 devinfo' 2>&1)
+            n=$(echo "$out" | grep -c '^NODEV ')
+            [ "$n" = 2 ] && ok "a job not mapped by device reports no device" \
+                         || bad "a non-device job carried a device assignment: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        else
+            skp "devinfo client not installed -- re-run ./build.sh"
+        fi
         RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     else
         bad "could not start a DVM for the device mapping test"
+    fi
+    cleanup_swarm
+
+    banner "rmaps: a device is assigned, not shared, unless overload is given"
+    # More procs than devices is an error by default: a device is assigned to
+    # a process rather than subdivided between them, which is not true of a
+    # core.  "overload-allowed" is the existing way to say "more procs here
+    # than there are things to put them on, and I know".
+    RUN 'nohup prte --daemonize --host node1:4,node2:4 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    if RUN 'pgrep -x prte >/dev/null'; then
+        out=$(RUN 'timeout 60 prun --map-by device=network -n 64 hostname' 2>&1)
+        rc=$?
+        if echo "$out" | grep -q 'no object of that type'; then
+            skp "device overload rule (no network device in these topologies)"
+        else
+            [ "$rc" != 0 ] && ok "more procs than devices was refused" \
+                           || bad "more procs than devices was allowed without overload"
+            echo "$out" | grep -q 'overload-allowed' \
+                && ok "the refusal names the qualifier that permits it" \
+                || bad "the refusal did not say how to permit sharing"
+            out=$(RUN 'timeout 60 prun --map-by device=network --bind-to core:overload-allowed -n 64 hostname' 2>&1)
+            n=$(echo "$out" | grep -cE '^node[0-9]+$')
+            [ "$n" = 64 ] && ok "overload-allowed permits sharing the devices" \
+                          || bad "overload-allowed placed $n of 64 procs"
+        fi
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start a DVM for the device overload test"
     fi
     cleanup_swarm
 }

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -697,11 +697,12 @@ test_rmaps() {
     fi
     cleanup_swarm
 
-    banner "rmaps: a device is assigned, not shared, unless overload is given"
+    banner "rmaps: a device is assigned, not shared, unless shared is given"
     # More procs than devices is an error by default: a device is assigned to
     # a process rather than subdivided between them, which is not true of a
-    # core.  "overload-allowed" is the existing way to say "more procs here
-    # than there are things to put them on, and I know".
+    # core.  It has its own qualifier rather than riding on the binding
+    # "overload-allowed", which is about CPUs - a different resource and a
+    # different decision, and the two must not be confusable.
     RUN 'nohup prte --daemonize --host node1:4,node2:4 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
     if RUN 'pgrep -x prte >/dev/null'; then
         out=$(RUN 'timeout 60 prun --map-by device=network -n 64 hostname' 2>&1)
@@ -711,13 +712,19 @@ test_rmaps() {
         else
             [ "$rc" != 0 ] && ok "more procs than devices was refused" \
                            || bad "more procs than devices was allowed without overload"
-            echo "$out" | grep -q 'overload-allowed' \
+            echo "$out" | grep -q 'shared' \
                 && ok "the refusal names the qualifier that permits it" \
                 || bad "the refusal did not say how to permit sharing"
-            out=$(RUN 'timeout 60 prun --map-by device=network --bind-to core:overload-allowed -n 64 hostname' 2>&1)
+            out=$(RUN 'timeout 60 prun --map-by device=network:shared -n 64 hostname' 2>&1)
             n=$(echo "$out" | grep -cE '^node[0-9]+$')
-            [ "$n" = 64 ] && ok "overload-allowed permits sharing the devices" \
-                          || bad "overload-allowed placed $n of 64 procs"
+            [ "$n" = 64 ] && ok "the shared qualifier permits sharing the devices" \
+                          || bad "device=network:shared placed $n of 64 procs"
+            # "shared" is about devices; "overload-allowed" is about CPUs.
+            # The CPU qualifier must NOT quietly permit sharing a device.
+            out=$(RUN 'timeout 60 prun --map-by device=network --bind-to core:overload-allowed -n 64 hostname' 2>&1)
+            rc=$?
+            [ "$rc" != 0 ] && ok "binding overload does not permit sharing a device" \
+                           || bad "overload-allowed on --bind-to shared the devices"
         fi
         RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     else

--- a/docs/plans/per_device_mapping/per-device-mapping.rst
+++ b/docs/plans/per_device_mapping/per-device-mapping.rst
@@ -885,19 +885,29 @@ Decisions already taken
   The device class is a *value*, so a future class is a new value rather
   than a new directive, and no later device type has to choose between an
   inconsistent second spelling and a bare name of its own.
+* **A device is assigned, not shared**, and sharing has its own qualifier.
+  Left to ``byobj``'s wrap, ``-n 8`` on a four-GPU node would have put two
+  processes on each GPU by inheritance rather than by decision.  A device is
+  assigned to a process rather than subdivided between them — which is not
+  true of a core — so more processes than devices is an error, and
+  ``--map-by device=<class>:shared`` is what permits it.  ``shared``
+  defaults to false, pending user feedback.
+
+  It deliberately does **not** ride on ``--bind-to``'s
+  ``overload-allowed``.  That qualifier is about running more processes
+  than there are CPUs; this one is about handing one device to several
+  processes.  Different resource, different decision — and answering both
+  with one word would leave neither sayable on its own, so a job that wants
+  to share GPUs while still refusing to overload its cores could not say
+  so.  ``shared`` is tested *after* ``span`` in the qualifier chain for the
+  same reason ``interleave`` is tested after ``inherit``: ``:s`` has meant
+  ``SPAN`` for as long as there has been one.
 
 
 Decisions still to make
 -----------------------
 
-Neither of these blocks writing the enumerator.
-
-1. **What happens with more processes than devices?**  ``byobj``'s ``redo:``
-   loop wraps and puts a second process on each object in turn, which gives
-   two processes per GPU for ``-n 8`` on a 4-GPU node.  That is almost
-   certainly right, but it is a policy choice and should be stated in the
-   docs rather than inherited by accident.
-2. **Does ``device=`` need a per-app spelling test in the swarm?**  Per-app
+1. **Does ``device=`` need a per-app spelling test in the swarm?**  Per-app
    and job-level ``--map-by`` parsers disagreeing is the single most
    repeated bug in ``rmaps_base_frame.c``; the unit test covers it, but an
    MPMD line with a different device class per app is the shape that would

--- a/src/docs/prrte-rst-content/cli-map-by.rst
+++ b/src/docs/prrte-rst-content/cli-map-by.rst
@@ -152,6 +152,12 @@ the ``--mapby`` option (except where noted):
   ``overload-allowed`` qualifier to ``--bindto``, which concerns running
   more processes than there are CPUs.
 
+* ``NDEV=<n>`` only applies to the ``DEVICE`` directive. It assigns *n*
+  devices to each process rather than one. The process is then local to
+  whatever object contains all of its devices --- two GPUs on different
+  NUMA domains make their package the locality --- so binding descends from
+  there.
+
 * ``ORDERED`` only applies to the ``PE-LIST`` option to indicate that
   procs are to be bound to each of the specified CPUs in the order in
   which they are assigned (i.e., the first proc on a node shall be

--- a/src/docs/prrte-rst-content/cli-map-by.rst
+++ b/src/docs/prrte-rst-content/cli-map-by.rst
@@ -89,6 +89,10 @@ applied at the job level:
   ``device`` directive, which is what allows other classes of device to
   be supported later without adding a directive for each.
 
+  A device is assigned to a process rather than subdivided between them,
+  so each device takes one process and asking for more processes than
+  there are devices is an error unless ``SHARED`` is given.
+
   Binding descends from the device's *locality*: the nearest object in
   the topology that both contains the device and has CPUs. Asking to
   bind to an object larger than that locality is an error rather than a
@@ -139,6 +143,14 @@ the ``--mapby`` option (except where noted):
   expresses. A level that does not divide the devices into groups leaves
   the order unchanged, so the qualifier is safe to leave in a default
   mapping policy.
+
+* ``SHARED[=true|false]`` only applies to the ``DEVICE`` directive. It
+  permits several processes to be assigned the same device. The default is
+  ``false``: a device is assigned to a process rather than subdivided
+  between them, so a job asking for more processes than there are devices
+  is an error unless this is given. This is a separate question from the
+  ``overload-allowed`` qualifier to ``--bindto``, which concerns running
+  more processes than there are CPUs.
 
 * ``ORDERED`` only applies to the ``PE-LIST`` option to indicate that
   procs are to be bound to each of the specified CPUs in the order in

--- a/src/docs/prrte-rst-content/detail-placement-examples.rst
+++ b/src/docs/prrte-rst-content/detail-placement-examples.rst
@@ -360,6 +360,17 @@ different packages --- on the machine above, cores 16 and 96 rather than
 16 and 32. The level may be given explicitly (``interleave=numa``, for
 instance); it defaults to ``package``.
 
+Where a process needs more than one device, ``ndev`` says how many:
+
+.. code::
+
+   $ prun -n 2 --mapby device=gpu:ndev=2 --bindto package ./a.out
+
+gives each of the two processes two GPUs. A process holding devices in
+different NUMA domains is local to neither of them alone, so its locality
+becomes whatever contains them both --- here the package, which is why
+binding to a package is legal in this case and an error without ``ndev``.
+
 Naming a single device rather than a class places every process near
 that one device, which suits a job whose performance depends on one
 particular fabric interface:

--- a/src/docs/prrte-rst-content/detail-placement-examples.rst
+++ b/src/docs/prrte-rst-content/detail-placement-examples.rst
@@ -333,6 +333,21 @@ on this machine is an error: a package contains the GPU's NUMA domain
 and three others, so binding there would place the process on CPUs the
 GPU is not local to.
 
+A device is assigned to a process rather than subdivided between processes,
+so by default each device takes one process: asking for more processes than
+there are devices is an error. Where sharing the devices is intended, say so
+with the ``shared`` qualifier:
+
+.. code::
+
+   $ prun -n 8 --mapby device=gpu:shared --bindto core ./a.out
+
+On the four-GPU machine above that runs two processes per GPU. Note the
+processes still get separate cores: sharing a device and overloading a CPU
+are different resources and different decisions, which is why they have
+different qualifiers --- ``shared`` here, and ``overload-allowed`` on
+``--bindto`` for the CPUs.
+
 Where a job wants its processes spread across sockets rather than filling
 the first, add the ``interleave`` qualifier:
 

--- a/src/mca/rmaps/base/help-mapby.txt
+++ b/src/mca/rmaps/base/help-mapby.txt
@@ -174,6 +174,12 @@ the "--mapby" option (except where noted):
   question from the "overload-allowed" qualifier to "--bindto", which
   concerns running more processes than there are CPUs.
 
+* "NDEV=<n>" only applies to the "DEVICE" directive. It assigns n
+  devices to each process rather than one. The process is then local to
+  whatever object contains all of its devices - two GPUs on different
+  NUMA domains make their package the locality - so binding descends
+  from there.
+
 * "ORDERED" only applies to the "PE-LIST" option to indicate that
   procs are to be bound to each of the specified CPUs in the order in
   which they are assigned (i.e., the first proc on a node shall be

--- a/src/mca/rmaps/base/help-mapby.txt
+++ b/src/mca/rmaps/base/help-mapby.txt
@@ -88,6 +88,10 @@ applied at the job level:
   Note there is no bare "--mapby gpu": the class is the value of the
   "device" directive, which is what allows other classes of device to
   be supported later without adding a directive for each.
+  A device is assigned to a process rather than subdivided between
+  them, so each device takes one process and asking for more processes
+  than there are devices is an error unless the "SHARED" qualifier is
+  given.
   Binding descends from the device's locality - the nearest object in
   the topology that both contains the device and has CPUs. Asking to
   bind to something larger than that locality is an error rather than a
@@ -161,6 +165,14 @@ the "--mapby" option (except where noted):
   the "SPAN" qualifier already expresses. A level that does not divide
   the devices into groups leaves the order unchanged, so the qualifier
   is safe to leave in a default mapping policy.
+
+* "SHARED[=true|false]" only applies to the "DEVICE" directive. It
+  permits several processes to be assigned the same device. The default
+  is false: a device is assigned to a process rather than subdivided
+  between them, so a job asking for more processes than there are
+  devices is an error unless this is given. Note this is a separate
+  question from the "overload-allowed" qualifier to "--bindto", which
+  concerns running more processes than there are CPUs.
 
 * "ORDERED" only applies to the "PE-LIST" option to indicate that
   procs are to be bound to each of the specified CPUs in the order in

--- a/src/mca/rmaps/base/help-placement.txt
+++ b/src/mca/rmaps/base/help-placement.txt
@@ -357,6 +357,10 @@ Process Mapping / Ranking / Binding Options
     reorders the device list so consecutive procs land on different
     objects of the given level (default "package")
 
+  * "SHARED[=true|false]" only applies to the "device" directive;
+    permits several procs to be assigned the same device (default
+    false)
+
   * "ORDERED" only applies to the PE-LIST option to indicate that
     procs are to be bound to each of the specified CPUs in the order
     in which they are assigned (i.e., the first proc on a node shall
@@ -655,6 +659,19 @@ and "--bindto core" to a single core. Asking for "--bindto package"
 on this machine is an error: a package contains the GPU's NUMA domain
 and three others, so binding there would place the process on CPUs the
 GPU is not local to.
+
+A device is assigned to a process rather than subdivided between
+processes, so by default each device takes one process: asking for more
+processes than there are devices is an error. Where sharing the devices
+is intended, say so with the "shared" qualifier:
+
+   $ prun -n 8 --mapby device=gpu:shared --bindto core ./a.out
+
+On the four-GPU machine above that runs two processes per GPU. Note the
+processes still get separate cores: sharing a device and overloading a
+CPU are different resources and different decisions, which is why they
+have different qualifiers - "shared" here, and "overload-allowed" on
+"--bindto" for the CPUs.
 
 Where a job wants its processes spread across sockets rather than
 filling the first, add the "interleave" qualifier:

--- a/src/mca/rmaps/base/help-placement.txt
+++ b/src/mca/rmaps/base/help-placement.txt
@@ -361,6 +361,9 @@ Process Mapping / Ranking / Binding Options
     permits several procs to be assigned the same device (default
     false)
 
+  * "NDEV=<n>" only applies to the "device" directive; assigns n
+    devices to each proc rather than one
+
   * "ORDERED" only applies to the PE-LIST option to indicate that
     procs are to be bound to each of the specified CPUs in the order
     in which they are assigned (i.e., the first proc on a node shall
@@ -682,6 +685,16 @@ This reorders the device list so consecutive processes land on
 different packages - on the machine above, cores 16 and 96 rather than
 16 and 32. The level may be given explicitly ("interleave=numa", for
 instance); it defaults to "package".
+
+Where a process needs more than one device, "ndev" says how many:
+
+   $ prun -n 2 --mapby device=gpu:ndev=2 --bindto package ./a.out
+
+gives each of the two processes two GPUs. A process holding devices in
+different NUMA domains is local to neither of them alone, so its
+locality becomes whatever contains them both - here the package, which
+is why binding to a package is legal in this case and an error without
+"ndev".
 
 Naming a single device instead of a class places every process near
 that one device, which is useful for a job whose performance depends

--- a/src/mca/rmaps/base/help-prte-rmaps-base.txt
+++ b/src/mca/rmaps/base/help-prte-rmaps-base.txt
@@ -553,3 +553,41 @@ apply to:
 
 "interleave" reorders the list of devices a job is mapped against, so it
 is meaningful only in combination with "--map-by device=<class|name>".
+#
+[rmaps:too-few-devices]
+More processes were requested than there are devices to map them
+against:
+
+  Processes requested: %d
+  Device:              %s
+  Devices available:   %d
+
+A device is assigned to a process rather than subdivided between
+processes, so by default each device takes one process and a job asking
+for more than there are devices cannot be mapped.
+
+If sharing the devices is what you intended, say so with the "shared"
+qualifier:
+
+  --map-by device=<class>:shared
+
+Otherwise reduce the number of processes, or map by something other than
+a device.
+
+Note this is a separate question from the "overload-allowed" qualifier
+on "--bind-to", which concerns running more processes than there are
+CPUs. Sharing a device and overloading a CPU are different resources and
+different decisions.
+#
+[rmaps:shared-needs-device]
+The "shared" qualifier was given with a mapping policy it cannot apply
+to:
+
+  Mapping policy: %s
+
+"shared" says that several processes may be assigned the same device, so
+it is meaningful only in combination with
+"--map-by device=<class|name>".
+
+If you meant to run more processes than there are CPUs, that is the
+"overload-allowed" qualifier on "--bind-to" instead.

--- a/src/mca/rmaps/base/help-prte-rmaps-base.txt
+++ b/src/mca/rmaps/base/help-prte-rmaps-base.txt
@@ -560,7 +560,11 @@ against:
 
   Processes requested: %d
   Device:              %s
-  Devices available:   %d
+  Processes placeable: %d
+
+("Processes placeable" counts assignments, not devices: with the "ndev"
+qualifier each process takes several devices, so the number of processes
+that fit is smaller than the number of devices present.)
 
 A device is assigned to a process rather than subdivided between
 processes, so by default each device takes one process and a job asking
@@ -591,3 +595,11 @@ it is meaningful only in combination with
 
 If you meant to run more processes than there are CPUs, that is the
 "overload-allowed" qualifier on "--bind-to" instead.
+#
+[rmaps:ndev-needs-device]
+The "ndev" qualifier was given with a mapping policy it cannot apply to:
+
+  Mapping policy: %s
+
+"ndev" says how many devices each process is to be assigned, so it is
+meaningful only in combination with "--map-by device=<class|name>".

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -311,6 +311,9 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
     bool oversubscribe_given = false;
     bool nooversubscribe_given = false;
     bool shared = false;
+    long ndev;
+    char *eptr;
+    uint16_t ndev16;
 
     pmix_output_verbose(5, prte_rmaps_base_framework.framework_output,
                         "%s rmaps:base check modifiers with %s",
@@ -528,6 +531,35 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
             prte_set_attribute(attrs,
                                (NULL != app) ? PRTE_APP_MAP_INTERLEAVE : PRTE_JOB_MAP_INTERLEAVE,
                                PRTE_ATTR_GLOBAL, val, PMIX_STRING);
+
+        } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_NDEV)) {
+            /* how many devices each proc is given.  Tested before SHARED
+             * only because they share no prefix; both sit after SPAN for
+             * the reason given below. */
+            val = pmix_cli_qualifier_value(ck2[i]);
+            if (NULL == val) {
+                prte_show_help("help-prte-rmaps-base.txt", "missing-value", true,
+                               "mapping policy", "NDEV", ck2[i]);
+                PMIx_Argv_free(ck2);
+                return PRTE_ERR_SILENT;
+            }
+            ndev = strtol(val, &eptr, 10);
+            if ('\0' != *eptr || 0 >= ndev || UINT16_MAX < ndev) {
+                prte_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
+                               "mapping policy", "NDEV", ck2[i]);
+                PMIx_Argv_free(ck2);
+                return PRTE_ERR_SILENT;
+            }
+            if (NULL == attrs) {
+                prte_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier",
+                               true, "mapping policy", PRTE_CLI_NDEV);
+                PMIx_Argv_free(ck2);
+                return PRTE_ERR_SILENT;
+            }
+            ndev16 = (uint16_t) ndev;
+            prte_set_attribute(attrs,
+                               (NULL != app) ? PRTE_APP_MAP_NDEV : PRTE_JOB_MAP_NDEV,
+                               PRTE_ATTR_GLOBAL, &ndev16, PMIX_UINT16);
 
         } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_SHARED)) {
             /* NOTE: like the interleave arm above, this must stay near the
@@ -1092,6 +1124,13 @@ setpolicy:
                        prte_rmaps_base_print_mapping(tmp));
         return PRTE_ERR_SILENT;
     }
+    if (NULL != jdata
+        && prte_get_attribute(&jdata->attributes, PRTE_JOB_MAP_NDEV, NULL, PMIX_UINT16)
+        && PRTE_MAPPING_BYDEVICE != PRTE_GET_MAPPING_POLICY(tmp)) {
+        prte_show_help("help-prte-rmaps-base.txt", "rmaps:ndev-needs-device", true,
+                       prte_rmaps_base_print_mapping(tmp));
+        return PRTE_ERR_SILENT;
+    }
 
     if (NULL == jdata) {
         prte_rmaps_base.mapping = tmp;
@@ -1417,6 +1456,12 @@ setpolicy:
     if (prte_get_attribute(&app->attributes, PRTE_APP_MAP_SHARED, NULL, PMIX_BOOL)
         && PRTE_MAPPING_BYDEVICE != PRTE_GET_MAPPING_POLICY(tmp)) {
         prte_show_help("help-prte-rmaps-base.txt", "rmaps:shared-needs-device", true,
+                       prte_rmaps_base_print_mapping(tmp));
+        return PRTE_ERR_SILENT;
+    }
+    if (prte_get_attribute(&app->attributes, PRTE_APP_MAP_NDEV, NULL, PMIX_UINT16)
+        && PRTE_MAPPING_BYDEVICE != PRTE_GET_MAPPING_POLICY(tmp)) {
+        prte_show_help("help-prte-rmaps-base.txt", "rmaps:ndev-needs-device", true,
                        prte_rmaps_base_print_mapping(tmp));
         return PRTE_ERR_SILENT;
     }

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -310,6 +310,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
     bool core_cpus_given = false;
     bool oversubscribe_given = false;
     bool nooversubscribe_given = false;
+    bool shared = false;
 
     pmix_output_verbose(5, prte_rmaps_base_framework.framework_output,
                         "%s rmaps:base check modifiers with %s",
@@ -527,6 +528,44 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
             prte_set_attribute(attrs,
                                (NULL != app) ? PRTE_APP_MAP_INTERLEAVE : PRTE_JOB_MAP_INTERLEAVE,
                                PRTE_ATTR_GLOBAL, val, PMIX_STRING);
+
+        } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_SHARED)) {
+            /* NOTE: like the interleave arm above, this must stay near the
+             * END of the chain - and in particular after SPAN.  The option
+             * matcher compares only as far as the shorter of its two
+             * arguments and has no view of the other options, so the first
+             * arm that prefix-matches wins, and ":s" has meant SPAN for as
+             * long as there has been one. */
+            val = pmix_cli_qualifier_value(ck2[i]);
+            if (NULL == val) {
+                /* the bare qualifier asks for it */
+                shared = true;
+            } else if (0 == strcasecmp(val, "true") || 0 == strcasecmp(val, "1")
+                       || 0 == strcasecmp(val, "yes")) {
+                shared = true;
+            } else if (0 == strcasecmp(val, "false") || 0 == strcasecmp(val, "0")
+                       || 0 == strcasecmp(val, "no")) {
+                shared = false;
+            } else {
+                prte_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
+                               "mapping policy", "SHARED", ck2[i]);
+                PMIx_Argv_free(ck2);
+                return PRTE_ERR_SILENT;
+            }
+            if (NULL == attrs) {
+                prte_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier",
+                               true, "mapping policy", PRTE_CLI_SHARED);
+                PMIx_Argv_free(ck2);
+                return PRTE_ERR_SILENT;
+            }
+            /* a bool attribute means "true" by its presence, and setting it
+             * false removes it - which is exactly the default, so nothing
+             * needs recording for shared=false */
+            if (shared) {
+                prte_set_attribute(attrs,
+                                   (NULL != app) ? PRTE_APP_MAP_SHARED : PRTE_JOB_MAP_SHARED,
+                                   PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+            }
 
         } else {
             /* unrecognized modifier */
@@ -1043,6 +1082,16 @@ setpolicy:
                        prte_rmaps_base_print_mapping(tmp));
         return PRTE_ERR_SILENT;
     }
+    /* "shared" says devices may be shared, so it means nothing where there
+     * are no devices - refuse it by name rather than as an unknown
+     * qualifier, since the spelling is legal, just not here */
+    if (NULL != jdata
+        && prte_get_attribute(&jdata->attributes, PRTE_JOB_MAP_SHARED, NULL, PMIX_BOOL)
+        && PRTE_MAPPING_BYDEVICE != PRTE_GET_MAPPING_POLICY(tmp)) {
+        prte_show_help("help-prte-rmaps-base.txt", "rmaps:shared-needs-device", true,
+                       prte_rmaps_base_print_mapping(tmp));
+        return PRTE_ERR_SILENT;
+    }
 
     if (NULL == jdata) {
         prte_rmaps_base.mapping = tmp;
@@ -1362,6 +1411,12 @@ setpolicy:
     if (prte_get_attribute(&app->attributes, PRTE_APP_MAP_INTERLEAVE, NULL, PMIX_STRING)
         && PRTE_MAPPING_BYDEVICE != PRTE_GET_MAPPING_POLICY(tmp)) {
         prte_show_help("help-prte-rmaps-base.txt", "rmaps:interleave-needs-device", true,
+                       prte_rmaps_base_print_mapping(tmp));
+        return PRTE_ERR_SILENT;
+    }
+    if (prte_get_attribute(&app->attributes, PRTE_APP_MAP_SHARED, NULL, PMIX_BOOL)
+        && PRTE_MAPPING_BYDEVICE != PRTE_GET_MAPPING_POLICY(tmp)) {
+        prte_show_help("help-prte-rmaps-base.txt", "rmaps:shared-needs-device", true,
                        prte_rmaps_base_print_mapping(tmp));
         return PRTE_ERR_SILENT;
     }

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -352,7 +352,13 @@ int prte_rmaps_base_resolve_app_options(prte_job_t *jdata,
     opts->map_shared = prte_get_attribute(&app->attributes, PRTE_APP_MAP_SHARED,
                                           NULL, PMIX_BOOL);
 
-    /* 10. PRTE_APP_BINDING_LIMIT → opts->limit */
+    /* 10. PRTE_APP_MAP_NDEV → opts->map_ndev */
+    u16 = 0;
+    if (prte_get_attribute(&app->attributes, PRTE_APP_MAP_NDEV, (void **) &u16ptr, PMIX_UINT16)) {
+        opts->map_ndev = u16;
+    }
+
+    /* 11. PRTE_APP_BINDING_LIMIT → opts->limit */
     if (prte_get_attribute(&app->attributes, PRTE_APP_BINDING_LIMIT, (void **)&u16ptr, PMIX_UINT16)) {
         opts->limit = u16;
     }
@@ -1086,6 +1092,12 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     prte_get_attribute(&jdata->attributes, PRTE_JOB_MAP_DEVICE, (void**)&options.map_device, PMIX_STRING);
     prte_get_attribute(&jdata->attributes, PRTE_JOB_MAP_INTERLEAVE, (void**)&options.map_interleave, PMIX_STRING);
     options.map_shared = prte_get_attribute(&jdata->attributes, PRTE_JOB_MAP_SHARED, NULL, PMIX_BOOL);
+    {
+        uint16_t nd = 0, *ndptr = &nd;
+        if (prte_get_attribute(&jdata->attributes, PRTE_JOB_MAP_NDEV, (void**)&ndptr, PMIX_UINT16)) {
+            options.map_ndev = nd;
+        }
+    }
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, (void **) &u16ptr, PMIX_UINT16)) {
         options.cpus_per_rank = u16;
     } else {
@@ -1600,6 +1612,7 @@ ranking:
             app_options.map_interleave = (NULL == options.map_interleave) ? NULL
                                                                           : strdup(options.map_interleave);
             app_options.map_shared = options.map_shared;
+            app_options.map_ndev = options.map_ndev;
             app_options.app_idx = n;
             /* where this app's ranks start: the mappers that number their
              * own procs need the cursor the base is threading, or every app

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -348,7 +348,11 @@ int prte_rmaps_base_resolve_app_options(prte_job_t *jdata,
         opts->map_interleave = str;
     }
 
-    /* 9. PRTE_APP_BINDING_LIMIT → opts->limit */
+    /* 9. PRTE_APP_MAP_SHARED → opts->map_shared */
+    opts->map_shared = prte_get_attribute(&app->attributes, PRTE_APP_MAP_SHARED,
+                                          NULL, PMIX_BOOL);
+
+    /* 10. PRTE_APP_BINDING_LIMIT → opts->limit */
     if (prte_get_attribute(&app->attributes, PRTE_APP_BINDING_LIMIT, (void **)&u16ptr, PMIX_UINT16)) {
         opts->limit = u16;
     }
@@ -1081,6 +1085,7 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     prte_get_attribute(&jdata->attributes, PRTE_JOB_CPUSET, (void**)&options.cpuset, PMIX_STRING);
     prte_get_attribute(&jdata->attributes, PRTE_JOB_MAP_DEVICE, (void**)&options.map_device, PMIX_STRING);
     prte_get_attribute(&jdata->attributes, PRTE_JOB_MAP_INTERLEAVE, (void**)&options.map_interleave, PMIX_STRING);
+    options.map_shared = prte_get_attribute(&jdata->attributes, PRTE_JOB_MAP_SHARED, NULL, PMIX_BOOL);
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC, (void **) &u16ptr, PMIX_UINT16)) {
         options.cpus_per_rank = u16;
     } else {
@@ -1594,6 +1599,7 @@ ranking:
                                                                   : strdup(options.map_device);
             app_options.map_interleave = (NULL == options.map_interleave) ? NULL
                                                                           : strdup(options.map_interleave);
+            app_options.map_shared = options.map_shared;
             app_options.app_idx = n;
             /* where this app's ranks start: the mappers that number their
              * own procs need the cursor the base is threading, or every app

--- a/src/mca/rmaps/rmaps_types.h
+++ b/src/mca/rmaps/rmaps_types.h
@@ -155,6 +155,9 @@ typedef struct {
      * --map-by device=X:shared. False by default: a device is assigned to
      * a proc rather than subdivided between them. */
     bool map_shared;
+    /* how many devices each proc is assigned, from
+     * --map-by device=X:ndev=N. Zero means the default of one. */
+    uint16_t map_ndev;
 
 } prte_rmaps_options_t;
 

--- a/src/mca/rmaps/rmaps_types.h
+++ b/src/mca/rmaps/rmaps_types.h
@@ -151,6 +151,10 @@ typedef struct {
      * --map-by device=X:interleave[=level]; NULL when not asked for.
      * Owned by the struct. */
     char *map_interleave;
+    /* whether several procs may be assigned the same device, from
+     * --map-by device=X:shared. False by default: a device is assigned to
+     * a proc rather than subdivided between them. */
+    bool map_shared;
 
 } prte_rmaps_options_t;
 

--- a/src/mca/rmaps/round_robin/rmaps_rr.h
+++ b/src/mca/rmaps/round_robin/rmaps_rr.h
@@ -78,6 +78,11 @@ typedef struct {
     void (*end)(void *ctx);
     /* What a target is called, for diagnostics ("core", "numa", ...). */
     const char *name;
+    /* When true, a target takes at most one proc: the loop lays one proc on
+     * each target and stops rather than coming round again.  A target that
+     * cannot be shared - a device, which is assigned rather than subdivided
+     * - sets this unless the user has allowed overloading. */
+    bool nowrap;
 } prte_rmaps_target_enum_t;
 
 PRTE_MODULE_EXPORT int prte_rmaps_rr_byobj(prte_job_t *jdata,

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -700,18 +700,47 @@ static void device_targets_end(void *ctx)
     free(dc);
 }
 
+/* How many devices of the requested class the whole node list offers.  Used
+ * only to answer "are there enough?" before any proc is placed; the mapper
+ * enumerates each node again as it reaches it. */
+static size_t count_devices(pmix_list_t *node_list, prte_rmaps_options_t *options)
+{
+    prte_node_t *node;
+    void *ctx = NULL;
+    size_t total = 0;
+
+    PMIX_LIST_FOREACH(node, node_list, prte_node_t) {
+        if (PRTE_SUCCESS != device_targets_begin(node, options, &ctx)) {
+            continue;
+        }
+        total += device_targets_count(node, options, ctx);
+        device_targets_end(ctx);
+        ctx = NULL;
+    }
+    return total;
+}
+
 int prte_rmaps_rr_bydevice(prte_job_t *jdata, prte_app_context_t *app,
                            pmix_list_t *node_list, int32_t num_slots,
                            pmix_rank_t num_procs,
                            prte_rmaps_options_t *options)
 {
+    size_t ndevs;
     prte_rmaps_target_enum_t tgts = {
         .begin = device_targets_begin,
         .count = device_targets_count,
         .item = device_targets_item,
         .placed = device_targets_placed,
         .end = device_targets_end,
-        .name = options->map_device
+        .name = options->map_device,
+        /* A device is assigned to a process, not subdivided between them:
+         * two procs sharing a GPU is a different thing from two procs
+         * sharing a core.  So it has its own qualifier rather than riding on
+         * binding's "overload-allowed", which is about running more procs
+         * than there are CPUs - a different resource, a different question,
+         * and answering both with one word would leave neither sayable on
+         * its own. */
+        .nowrap = !options->map_shared
     };
 
     if (NULL == options->map_device) {
@@ -719,6 +748,18 @@ int prte_rmaps_rr_bydevice(prte_job_t *jdata, prte_app_context_t *app,
          * parsers - so this is a programming error, not user input */
         PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
         return PRTE_ERR_BAD_PARAM;
+    }
+
+    /* Say up front when there are not enough devices to go round, rather
+     * than letting the placement run out partway and report a generic
+     * failure. */
+    if (!options->map_shared) {
+        ndevs = count_devices(node_list, options);
+        if (0 < ndevs && ndevs < (size_t) app->num_procs) {
+            prte_show_help("help-prte-rmaps-base.txt", "rmaps:too-few-devices", true,
+                           (int) app->num_procs, options->map_device, (int) ndevs);
+            return PRTE_ERR_SILENT;
+        }
     }
 
     return prte_rmaps_rr_map_targets(jdata, app, node_list, num_slots,
@@ -1147,7 +1188,8 @@ int prte_rmaps_rr_map_targets(prte_job_t *jdata, prte_app_context_t *app,
                 allfull = false;
             }
             if (nprocs_mapped < app->num_procs && !allfull &&
-                !nodefull && !outofcpus && !options->mapspan) {
+                !nodefull && !outofcpus && !options->mapspan &&
+                !tgts->nowrap) {
                 // keep working these objects until full
                 goto redo;
             }
@@ -1163,6 +1205,11 @@ int prte_rmaps_rr_map_targets(prte_job_t *jdata, prte_app_context_t *app,
                 hwloc_bitmap_free(options->target);
                 options->target = NULL;
             }
+        }
+        /* one pass is all an unshareable target gets: coming round again
+         * would put a second proc on a target already assigned */
+        if (tgts->nowrap) {
+            break;
         }
     } while (nprocs_mapped < app->num_procs && !allfull);
 

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -396,6 +396,15 @@ pass:
 typedef struct {
     pmix_hwloc_device_t *devs;
     size_t ndevs;
+    /* Devices are handed out in groups of "ndev" - one group per proc.  The
+     * group's locality is the common ancestor of its members' localities,
+     * because a proc given two GPUs on different NUMA domains is local to
+     * neither of them alone; it is local to whatever contains both.  With
+     * the default of one device per proc a group IS a device and the
+     * ancestor is that device's own locality, so nothing changes. */
+    hwloc_obj_t *grouploc;
+    size_t ngroups;
+    size_t per;                 /* devices per group */
 } prte_rmaps_devctx_t;
 
 /* Map a --map-by device= value to a device class.  Returns
@@ -608,10 +617,44 @@ static int device_targets_begin(prte_node_t *node, prte_rmaps_options_t *opts,
         }
     }
 
+    /* Group the devices, one group per proc */
+    dc->per = (0 == opts->map_ndev) ? 1 : opts->map_ndev;
+    dc->ngroups = dc->ndevs / dc->per;
+    if (0 == dc->ngroups) {
+        /* not enough devices on this node to make even one group - the
+         * caller reports it as "no such device", naming what was asked for */
+        pmix_hwloc_release_devices(dc->devs, dc->ndevs);
+        dc->devs = NULL;
+        dc->ndevs = 0;
+        *ctx = dc;
+        return PRTE_SUCCESS;
+    }
+    dc->grouploc = (hwloc_obj_t *) calloc(dc->ngroups, sizeof(hwloc_obj_t));
+    if (NULL == dc->grouploc) {
+        pmix_hwloc_release_devices(dc->devs, dc->ndevs);
+        free(dc);
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+    for (n = 0; n < dc->ngroups; n++) {
+        size_t m;
+        hwloc_obj_t loc = dc->devs[n * dc->per].locality;
+        for (m = 1; m < dc->per; m++) {
+            hwloc_obj_t other = dc->devs[n * dc->per + m].locality;
+            if (NULL == loc || NULL == other) {
+                loc = NULL;
+                break;
+            }
+            loc = hwloc_get_common_ancestor_obj(node->topology->topo, loc, other);
+        }
+        dc->grouploc[n] = loc;
+    }
+
     /* Refuse a binding coarser than the devices are local to, before any
-     * proc is placed on this node. */
-    for (n = 0; n < dc->ndevs; n++) {
-        if (!binding_fits(node, dc->devs[n].locality, opts)) {
+     * proc is placed on this node.  Checked against the GROUP locality:
+     * with several devices per proc that is deliberately coarser, and a
+     * binding matching it is then legitimate. */
+    for (n = 0; n < dc->ngroups; n++) {
+        if (!binding_fits(node, dc->grouploc[n], opts)) {
             prte_show_help("help-prte-rmaps-base.txt", "rmaps:bind-above-device", true,
                            prte_hwloc_base_print_binding(opts->bind),
                            opts->map_device, node->name);
@@ -624,15 +667,15 @@ static int device_targets_begin(prte_node_t *node, prte_rmaps_options_t *opts,
     /* If every device resolves to the same place, "near this device" is
      * saying nothing about cpus - each proc still gets a distinct device,
      * which is half of what was asked for, so proceed and say so. */
-    for (n = 1; n < dc->ndevs; n++) {
-        if (dc->devs[n].locality != dc->devs[0].locality) {
+    for (n = 1; n < dc->ngroups; n++) {
+        if (dc->grouploc[n] != dc->grouploc[0]) {
             degenerate = false;
             break;
         }
     }
-    if (degenerate && 1 < dc->ndevs) {
+    if (degenerate && 1 < dc->ngroups) {
         prte_show_help("help-prte-rmaps-base.txt", "rmaps:degenerate-device-locality",
-                       true, opts->map_device, node->name, (int) dc->ndevs);
+                       true, opts->map_device, node->name, (int) dc->ngroups);
     }
 
     *ctx = dc;
@@ -648,7 +691,7 @@ static unsigned device_targets_count(prte_node_t *node, prte_rmaps_options_t *op
     if (NULL == dc) {
         return 0;
     }
-    return (unsigned) dc->ndevs;
+    return (unsigned) dc->ngroups;
 }
 
 static hwloc_obj_t device_targets_item(prte_node_t *node, prte_rmaps_options_t *opts,
@@ -657,10 +700,10 @@ static hwloc_obj_t device_targets_item(prte_node_t *node, prte_rmaps_options_t *
     prte_rmaps_devctx_t *dc = (prte_rmaps_devctx_t *) ctx;
 
     PRTE_HIDE_UNUSED_PARAMS(node, opts);
-    if (NULL == dc || (size_t) j >= dc->ndevs) {
+    if (NULL == dc || (size_t) j >= dc->ngroups) {
         return NULL;
     }
-    return dc->devs[j].locality;
+    return dc->grouploc[j];
 }
 
 /* Record which device this proc was placed against.  PRRTE cannot bind a
@@ -673,9 +716,11 @@ static void device_targets_placed(prte_proc_t *proc, prte_rmaps_options_t *opts,
                                   void *ctx, unsigned j)
 {
     prte_rmaps_devctx_t *dc = (prte_rmaps_devctx_t *) ctx;
+    char *ids = NULL;
+    size_t m;
 
     PRTE_HIDE_UNUSED_PARAMS(opts);
-    if (NULL == dc || (size_t) j >= dc->ndevs || NULL == dc->devs[j].dev.uuid) {
+    if (NULL == dc || (size_t) j >= dc->ngroups) {
         return;
     }
     /* LOCAL, even though the daemon that forks this proc needs it: no proc
@@ -683,8 +728,29 @@ static void device_targets_placed(prte_proc_t *proc, prte_rmaps_options_t *opts,
      * value travels as its own field, packed only for a job that was mapped
      * by device. Marking it global would put it in a list nothing packs and
      * trip the guard that exists to catch exactly that. */
+    /* several devices come back as a comma-delimited list, which keeps the
+     * single-device case - overwhelmingly the common one - exactly a plain
+     * uuid */
+    for (m = 0; m < dc->per; m++) {
+        char *u = dc->devs[j * dc->per + m].dev.uuid;
+        if (NULL == u) {
+            continue;
+        }
+        if (NULL == ids) {
+            ids = strdup(u);
+        } else {
+            char *t;
+            pmix_asprintf(&t, "%s,%s", ids, u);
+            free(ids);
+            ids = t;
+        }
+    }
+    if (NULL == ids) {
+        return;
+    }
     prte_set_attribute(&proc->attributes, PRTE_PROC_DEVICE_ID, PRTE_ATTR_LOCAL,
-                       dc->devs[j].dev.uuid, PMIX_STRING);
+                       ids, PMIX_STRING);
+    free(ids);
 }
 
 static void device_targets_end(void *ctx)
@@ -696,6 +762,9 @@ static void device_targets_end(void *ctx)
     }
     if (NULL != dc->devs) {
         pmix_hwloc_release_devices(dc->devs, dc->ndevs);
+    }
+    if (NULL != dc->grouploc) {
+        free(dc->grouploc);
     }
     free(dc);
 }

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -754,6 +754,7 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
         PRTE_CLI_ORDERED,
         PRTE_CLI_INTERLEAVE,
         PRTE_CLI_SHARED,
+        PRTE_CLI_NDEV,
         NULL
     };
 

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -753,6 +753,7 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
         PRTE_CLI_QFILE,
         PRTE_CLI_ORDERED,
         PRTE_CLI_INTERLEAVE,
+        PRTE_CLI_SHARED,
         NULL
     };
 

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -310,6 +310,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "PRTE_APP_MAP_DEVICE";
         case PRTE_APP_MAP_INTERLEAVE:
             return "PRTE_APP_MAP_INTERLEAVE";
+        case PRTE_APP_MAP_SHARED:
+            return "PRTE_APP_MAP_SHARED";
         case PRTE_APP_HWT_CPUS:
             return "PRTE_APP_HWT_CPUS";
         case PRTE_APP_CORE_CPUS:
@@ -492,6 +494,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "JOB_MAP_DEVICE";
         case PRTE_JOB_MAP_INTERLEAVE:
             return "JOB_MAP_INTERLEAVE";
+        case PRTE_JOB_MAP_SHARED:
+            return "JOB_MAP_SHARED";
         case PRTE_JOB_HWT_CPUS:
             return "JOB_HWT_CPUS";
         case PRTE_JOB_CORE_CPUS:

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -312,6 +312,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "PRTE_APP_MAP_INTERLEAVE";
         case PRTE_APP_MAP_SHARED:
             return "PRTE_APP_MAP_SHARED";
+        case PRTE_APP_MAP_NDEV:
+            return "PRTE_APP_MAP_NDEV";
         case PRTE_APP_HWT_CPUS:
             return "PRTE_APP_HWT_CPUS";
         case PRTE_APP_CORE_CPUS:
@@ -496,6 +498,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "JOB_MAP_INTERLEAVE";
         case PRTE_JOB_MAP_SHARED:
             return "JOB_MAP_SHARED";
+        case PRTE_JOB_MAP_NDEV:
+            return "JOB_MAP_NDEV";
         case PRTE_JOB_HWT_CPUS:
             return "JOB_HWT_CPUS";
         case PRTE_JOB_CORE_CPUS:

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -78,6 +78,7 @@ typedef uint8_t prte_app_context_flags_t;
 #define PRTE_APP_MAP_FILE           29 /* char* path to seq or rankfile */
 #define PRTE_APP_MAP_DEVICE         30 /* char* device class or name for --map-by device= */
 #define PRTE_APP_MAP_INTERLEAVE     39 /* char* level to interleave the device list across */
+#define PRTE_APP_MAP_SHARED         40 /* bool: devices may be shared by several procs */
 #define PRTE_APP_HWT_CPUS           31 /* bool: use hwthreads as CPUs */
 #define PRTE_APP_CORE_CPUS          32 /* bool: use cores as CPUs */
 #define PRTE_APP_CPUSET             33 /* char* comma-delimited CPU ranges */
@@ -220,6 +221,7 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_PES_PER_PROC               (PRTE_JOB_START_KEY +  77) // uint16_t - number of cpus to be assigned to each process
 #define PRTE_JOB_MAP_DEVICE                 (PRTE_JOB_START_KEY +  78) // char* - device class or name for --map-by device=
 #define PRTE_JOB_MAP_INTERLEAVE             (PRTE_JOB_START_KEY + 128) // char* - level to interleave the device list across
+#define PRTE_JOB_MAP_SHARED                 (PRTE_JOB_START_KEY + 129) // bool - devices may be shared by several procs
 #define PRTE_JOB_HWT_CPUS                   (PRTE_JOB_START_KEY +  79) // bool - job requests hwthread cpus
 #define PRTE_JOB_CORE_CPUS                  (PRTE_JOB_START_KEY +  80) // bool - job requests core cpus
 #define PRTE_JOB_PPR                        (PRTE_JOB_START_KEY +  81) // char* - string specifying the procs-per-resource pattern

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -79,6 +79,7 @@ typedef uint8_t prte_app_context_flags_t;
 #define PRTE_APP_MAP_DEVICE         30 /* char* device class or name for --map-by device= */
 #define PRTE_APP_MAP_INTERLEAVE     39 /* char* level to interleave the device list across */
 #define PRTE_APP_MAP_SHARED         40 /* bool: devices may be shared by several procs */
+#define PRTE_APP_MAP_NDEV           41 /* uint16_t: devices assigned to each proc */
 #define PRTE_APP_HWT_CPUS           31 /* bool: use hwthreads as CPUs */
 #define PRTE_APP_CORE_CPUS          32 /* bool: use cores as CPUs */
 #define PRTE_APP_CPUSET             33 /* char* comma-delimited CPU ranges */
@@ -222,6 +223,7 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_MAP_DEVICE                 (PRTE_JOB_START_KEY +  78) // char* - device class or name for --map-by device=
 #define PRTE_JOB_MAP_INTERLEAVE             (PRTE_JOB_START_KEY + 128) // char* - level to interleave the device list across
 #define PRTE_JOB_MAP_SHARED                 (PRTE_JOB_START_KEY + 129) // bool - devices may be shared by several procs
+#define PRTE_JOB_MAP_NDEV                   (PRTE_JOB_START_KEY + 130) // uint16_t - devices assigned to each proc
 #define PRTE_JOB_HWT_CPUS                   (PRTE_JOB_START_KEY +  79) // bool - job requests hwthread cpus
 #define PRTE_JOB_CORE_CPUS                  (PRTE_JOB_START_KEY +  80) // bool - job requests core cpus
 #define PRTE_JOB_PPR                        (PRTE_JOB_START_KEY +  81) // char* - string specifying the procs-per-resource pattern

--- a/src/util/prte_cmd_line.h
+++ b/src/util/prte_cmd_line.h
@@ -262,6 +262,7 @@ BEGIN_C_DECLS
 #define PRTE_CLI_ORDERED    "ordered"
 #define PRTE_CLI_INTERLEAVE "interleave"
 #define PRTE_CLI_SHARED     "shared"
+#define PRTE_CLI_NDEV       "ndev"
 #define PRTE_CLI_REPORT     "report"
 #define PRTE_CLI_DISPALLOC  "displayalloc"
 // PRTE_CLI_DISPLAY reused here

--- a/src/util/prte_cmd_line.h
+++ b/src/util/prte_cmd_line.h
@@ -261,6 +261,7 @@ BEGIN_C_DECLS
 #define PRTE_CLI_IF_SUPP    "if-supported"
 #define PRTE_CLI_ORDERED    "ordered"
 #define PRTE_CLI_INTERLEAVE "interleave"
+#define PRTE_CLI_SHARED     "shared"
 #define PRTE_CLI_REPORT     "report"
 #define PRTE_CLI_DISPALLOC  "displayalloc"
 // PRTE_CLI_DISPLAY reused here

--- a/test/offline/golden/turin-4gpu/device.turin-4gpu.gpu-ndev2.map
+++ b/test/offline/golden/turin-4gpu/device.turin-4gpu.gpu-ndev2.map
@@ -1,0 +1,18 @@
+--------------------------------------------------------------------------
+A deprecated MCA variable value was specified in the environment or
+on the command line.  Deprecated MCA variables should be avoided;
+they may disappear in future releases.
+
+Deprecated variable: rmaps_default_mapping_policy
+New variable:        mapby
+--------------------------------------------------------------------------
+
+========================   JOB MAP   ========================
+Data for JOB prterun-JOBID@N offset 0 Total slots allocated N
+    Mapping policy: BYDEVICE:NOOVERSUBSCRIBE  Ranking policy: SLOT Binding policy: PACKAGE
+    Cpu set: N/A  PPR: N/A  Cpus-per-rank: N/A  Cpu Type: CORE
+
+
+Data for node: node0	Num slots: 8	Max slots: 0	Num procs: 2
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 0 Bound: package[0][core:L0-63] Device: gpu://Mac::renderD128,gpu://Mac::renderD129
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 1 Bound: package[1][core:L64-127] Device: gpu://Mac::renderD130,gpu://Mac::renderD131

--- a/test/offline/golden/turin-4gpu/device.turin-4gpu.gpu-overload.map
+++ b/test/offline/golden/turin-4gpu/device.turin-4gpu.gpu-overload.map
@@ -1,0 +1,24 @@
+--------------------------------------------------------------------------
+A deprecated MCA variable value was specified in the environment or
+on the command line.  Deprecated MCA variables should be avoided;
+they may disappear in future releases.
+
+Deprecated variable: rmaps_default_mapping_policy
+New variable:        mapby
+--------------------------------------------------------------------------
+
+========================   JOB MAP   ========================
+Data for JOB prterun-JOBID@N offset 0 Total slots allocated N
+    Mapping policy: BYDEVICE:NOOVERSUBSCRIBE  Ranking policy: SLOT Binding policy: CORE:OVERLOAD-ALLOWED
+    Cpu set: N/A  PPR: N/A  Cpus-per-rank: N/A  Cpu Type: CORE
+
+
+Data for node: node0	Num slots: 8	Max slots: 0	Num procs: 8
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 0 Bound: package[0][core:L16] Device: gpu://Mac::renderD128
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 1 Bound: package[0][core:L32] Device: gpu://Mac::renderD129
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 2 Bound: package[1][core:L96] Device: gpu://Mac::renderD130
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 3 Bound: package[1][core:L112] Device: gpu://Mac::renderD131
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 4 Bound: package[0][core:L17] Device: gpu://Mac::renderD128
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 5 Bound: package[0][core:L33] Device: gpu://Mac::renderD129
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 6 Bound: package[1][core:L97] Device: gpu://Mac::renderD130
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 7 Bound: package[1][core:L113] Device: gpu://Mac::renderD131

--- a/test/offline/golden/turin-4gpu/device.turin-4gpu.gpu-shared.map
+++ b/test/offline/golden/turin-4gpu/device.turin-4gpu.gpu-shared.map
@@ -1,0 +1,24 @@
+--------------------------------------------------------------------------
+A deprecated MCA variable value was specified in the environment or
+on the command line.  Deprecated MCA variables should be avoided;
+they may disappear in future releases.
+
+Deprecated variable: rmaps_default_mapping_policy
+New variable:        mapby
+--------------------------------------------------------------------------
+
+========================   JOB MAP   ========================
+Data for JOB prterun-JOBID@N offset 0 Total slots allocated N
+    Mapping policy: BYDEVICE:NOOVERSUBSCRIBE  Ranking policy: SLOT Binding policy: CORE
+    Cpu set: N/A  PPR: N/A  Cpus-per-rank: N/A  Cpu Type: CORE
+
+
+Data for node: node0	Num slots: 8	Max slots: 0	Num procs: 8
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 0 Bound: package[0][core:L16] Device: gpu://Mac::renderD128
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 1 Bound: package[0][core:L32] Device: gpu://Mac::renderD129
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 2 Bound: package[1][core:L96] Device: gpu://Mac::renderD130
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 3 Bound: package[1][core:L112] Device: gpu://Mac::renderD131
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 4 Bound: package[0][core:L17] Device: gpu://Mac::renderD128
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 5 Bound: package[0][core:L33] Device: gpu://Mac::renderD129
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 6 Bound: package[1][core:L97] Device: gpu://Mac::renderD130
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 7 Bound: package[1][core:L113] Device: gpu://Mac::renderD131

--- a/test/offline/run_offline_maps.py
+++ b/test/offline/run_offline_maps.py
@@ -642,10 +642,18 @@ def device_cases(topo):
     yield Case("device.%s.gpu-toomany" % topo.name, "device", topo, "single",
                hostspec, pool, map_by="device=gpu", rank_by="slot",
                bind_to="core", n=2 * n, expect="reject",
-               expect_banner="Devices available")
+               expect_banner="Processes placeable")
     yield Case("device.%s.gpu-shared" % topo.name, "device", topo, "single",
                hostspec, pool, map_by="device=gpu:shared", rank_by="slot",
                bind_to="core", n=2 * n, expect="map")
+
+    # several devices to each proc: the locality widens to whatever
+    # contains them all, so a binding that would be refused with one device
+    # per proc becomes legitimate
+    if 0 == n % 2:
+        yield Case("device.%s.gpu-ndev2" % topo.name, "device", topo, "single",
+                   hostspec, pool, map_by="device=gpu:ndev=2", rank_by="slot",
+                   bind_to="package", n=n // 2, expect="map")
 
     # fewer procs than devices is where the two orders visibly differ
     if 2 <= n // 2:

--- a/test/offline/run_offline_maps.py
+++ b/test/offline/run_offline_maps.py
@@ -637,6 +637,16 @@ def device_cases(topo):
     yield Case("device.%s.gpu-interleave" % topo.name, "device", topo,
                "single", hostspec, pool, map_by="device=gpu:interleave",
                rank_by="slot", bind_to="core", n=n, expect="map")
+    # a device is assigned, not subdivided: more procs than devices is an
+    # error unless the user says they meant it
+    yield Case("device.%s.gpu-toomany" % topo.name, "device", topo, "single",
+               hostspec, pool, map_by="device=gpu", rank_by="slot",
+               bind_to="core", n=2 * n, expect="reject",
+               expect_banner="Devices available")
+    yield Case("device.%s.gpu-shared" % topo.name, "device", topo, "single",
+               hostspec, pool, map_by="device=gpu:shared", rank_by="slot",
+               bind_to="core", n=2 * n, expect="map")
+
     # fewer procs than devices is where the two orders visibly differ
     if 2 <= n // 2:
         yield Case("device.%s.gpu-half" % topo.name, "device", topo, "single",
@@ -799,10 +809,13 @@ def check_universal(case, pmap):
         if pmap.rank_policy != case.rank_by.upper():
             v.append(("U1", "rank policy %s != %s"
                       % (pmap.rank_policy, case.rank_by.upper())))
-    if case.bind_to and case.bind_to in BIND_DISPLAY:
-        if pmap.bind_policy not in BIND_DISPLAY[case.bind_to]:
+    if case.bind_to and bind_object(case.bind_to) in BIND_DISPLAY:
+        # the display carries the qualifiers too ("CORE:OVERLOAD-ALLOWED"),
+        # so compare the object each side names, not the whole word
+        shown = (pmap.bind_policy or "").split(":", 1)[0]
+        if shown not in BIND_DISPLAY[bind_object(case.bind_to)]:
             v.append(("U1", "bind policy %s not in %s"
-                      % (pmap.bind_policy, BIND_DISPLAY[case.bind_to])))
+                      % (pmap.bind_policy, BIND_DISPLAY[bind_object(case.bind_to)])))
 
     # U2 total procs
     total = len(flat)
@@ -904,19 +917,32 @@ def check_ranking(case, pmap):
     return v
 
 
+def bind_object(bind_to):
+    """The object named by a --bind-to spec, with any qualifiers dropped.
+
+    "core:overload-allowed" binds to a core; the qualifier says what may
+    happen when the cores run out, not what is bound to.  Looking the whole
+    string up in BIND_LEVEL raised a KeyError and failed the case as a
+    checker error - which reads like a defect in the mapper rather than a
+    gap in the harness."""
+    if not bind_to:
+        return bind_to
+    return bind_to.split(":", 1)[0]
+
+
 def check_binding(case, pmap):
     v = []
     if not case.bind_to:
         return v
     flat = _flat_procs(pmap)
-    if case.bind_to == "none":
+    if bind_object(case.bind_to) == "none":
         for _, p in flat:
             if p.bound is not None:
                 v.append(("B-none", "rank %d is bound but bind-to none"
                           % p.rank))
                 break
         return v
-    level = BIND_LEVEL[case.bind_to]
+    level = BIND_LEVEL[bind_object(case.bind_to)]
     spans = case.topo.spans_at(level)
     for _, p in flat:
         if p.bound is None:
@@ -949,7 +975,7 @@ def check_perapp_binding(case, pmap):
                               % (idx, p.rank)))
                     break
             continue
-        level = BIND_LEVEL[app.bind_to]
+        level = BIND_LEVEL[bind_object(app.bind_to)]
         spans = case.topo.spans_at(level)
         for _, p in flat:
             if p.app != idx:

--- a/test/unit/rmaps/test_policy_parse.c
+++ b/test/unit/rmaps/test_policy_parse.c
@@ -405,6 +405,34 @@ int test_policy_parse(void)
           && prte_get_attribute(&app->attributes, PRTE_APP_MAP_SHARED, NULL, PMIX_BOOL));
     PMIX_RELEASE(app);
 
+    /* --- ndev: several devices to each proc --- */
+    app = PMIX_NEW(prte_app_context_t);
+    rc = prte_rmaps_base_set_app_mapping_policy(app, "device=gpu:ndev=2");
+    CHECK("mapby ndev=2: rc", PRTE_SUCCESS == rc);
+    u16 = get_u16(&app->attributes, PRTE_APP_MAP_NDEV);
+    CHECK("mapby ndev=2: value", 2 == u16);
+    PMIX_RELEASE(app);
+
+    app = PMIX_NEW(prte_app_context_t);
+    rc = prte_rmaps_base_set_app_mapping_policy(app, "device=gpu:ndev");
+    CHECK("mapby ndev with no value: refused", PRTE_SUCCESS != rc);
+    PMIX_RELEASE(app);
+
+    app = PMIX_NEW(prte_app_context_t);
+    rc = prte_rmaps_base_set_app_mapping_policy(app, "device=gpu:ndev=0");
+    CHECK("mapby ndev=0: refused", PRTE_SUCCESS != rc);
+    PMIX_RELEASE(app);
+
+    app = PMIX_NEW(prte_app_context_t);
+    rc = prte_rmaps_base_set_app_mapping_policy(app, "device=gpu:ndev=two");
+    CHECK("mapby ndev=two: refused", PRTE_SUCCESS != rc);
+    PMIX_RELEASE(app);
+
+    app = PMIX_NEW(prte_app_context_t);
+    rc = prte_rmaps_base_set_app_mapping_policy(app, "numa:ndev=2");
+    CHECK("mapby numa:ndev: refused", PRTE_SUCCESS != rc);
+    PMIX_RELEASE(app);
+
     /* THE regression that matters: "interleave" and "inherit" share a first
      * letter, and the option matcher has no view of the other options - the
      * first arm of the chain that prefix-matches wins. ":i" has meant

--- a/test/unit/rmaps/test_policy_parse.c
+++ b/test/unit/rmaps/test_policy_parse.c
@@ -351,6 +351,60 @@ int test_policy_parse(void)
     CHECK("mapby numa:interleave: refused", PRTE_SUCCESS != rc);
     PMIX_RELEASE(app);
 
+    /* --- shared: a device may be given to more than one proc --- */
+    app = PMIX_NEW(prte_app_context_t);
+    rc = prte_rmaps_base_set_app_mapping_policy(app, "device=gpu:shared");
+    CHECK("mapby shared: rc", PRTE_SUCCESS == rc);
+    CHECK("mapby shared: recorded",
+          prte_get_attribute(&app->attributes, PRTE_APP_MAP_SHARED, NULL, PMIX_BOOL));
+    PMIX_RELEASE(app);
+
+    app = PMIX_NEW(prte_app_context_t);
+    rc = prte_rmaps_base_set_app_mapping_policy(app, "device=gpu:shared=true");
+    CHECK("mapby shared=true: recorded",
+          PRTE_SUCCESS == rc
+          && prte_get_attribute(&app->attributes, PRTE_APP_MAP_SHARED, NULL, PMIX_BOOL));
+    PMIX_RELEASE(app);
+
+    /* false is the default, so it records nothing - and must not be an error */
+    app = PMIX_NEW(prte_app_context_t);
+    rc = prte_rmaps_base_set_app_mapping_policy(app, "device=gpu:shared=false");
+    CHECK("mapby shared=false: accepted", PRTE_SUCCESS == rc);
+    CHECK("mapby shared=false: not recorded",
+          !prte_get_attribute(&app->attributes, PRTE_APP_MAP_SHARED, NULL, PMIX_BOOL));
+    PMIX_RELEASE(app);
+
+    app = PMIX_NEW(prte_app_context_t);
+    rc = prte_rmaps_base_set_app_mapping_policy(app, "device=gpu:shared=maybe");
+    CHECK("mapby shared=maybe: refused", PRTE_SUCCESS != rc);
+    PMIX_RELEASE(app);
+
+    /* it says devices may be shared, so it means nothing without devices */
+    app = PMIX_NEW(prte_app_context_t);
+    rc = prte_rmaps_base_set_app_mapping_policy(app, "numa:shared");
+    CHECK("mapby numa:shared: refused", PRTE_SUCCESS != rc);
+    PMIX_RELEASE(app);
+
+    /* The same prefix hazard as interleave, against a different neighbour:
+     * "shared" and "span" both begin with 's', and ":s" has meant SPAN for
+     * as long as there has been one.  The shared arm sits after it. */
+    app = PMIX_NEW(prte_app_context_t);
+    rc = prte_rmaps_base_set_app_mapping_policy(app, "device=gpu:s");
+    CHECK("mapby ':s' : rc", PRTE_SUCCESS == rc);
+    CHECK("mapby ':s' still means SPAN, not shared",
+          !prte_get_attribute(&app->attributes, PRTE_APP_MAP_SHARED, NULL, PMIX_BOOL));
+    u16 = get_u16(&app->attributes, PRTE_APP_MAPBY);
+    CHECK("mapby ':s' set the SPAN directive",
+          0 != (PRTE_MAPPING_SPAN & PRTE_GET_MAPPING_DIRECTIVE(u16)));
+    PMIX_RELEASE(app);
+
+    app = PMIX_NEW(prte_app_context_t);
+    rc = prte_rmaps_base_set_app_mapping_policy(app, "device=gpu:sh");
+    CHECK("mapby ':sh' is shared",
+          PRTE_SUCCESS == rc
+          && prte_get_attribute(&app->attributes, PRTE_APP_MAP_SHARED, NULL, PMIX_BOOL));
+    PMIX_RELEASE(app);
+
     /* THE regression that matters: "interleave" and "inherit" share a first
      * letter, and the option matcher has no view of the other options - the
      * first arm of the chain that prefix-matches wins. ":i" has meant


### PR DESCRIPTION
Three commits. Supersedes the `overload`-based approach the branch originally
carried — see the first section.

> Pairs with **openpmix/openpmix#4145**, which makes `compute_distances()`
> enumerate through the same walk as `get_devices()`.

### 1. Sharing gets its own qualifier: `device=<class>:shared`

Sharing a device between processes and running more processes than there are
CPUs are different decisions about different resources, and the first
revision of this branch made both with one word — `--bind-to
<obj>:overload-allowed`. That left a job wanting to share GPUs while still
refusing to overload its cores with no way to say so, and gave the former
silently to a job that meant only the latter.

```
$ prun -n 8 --map-by device=gpu ./a.out
  Processes requested: 8
  Device:              gpu
  Processes placeable: 4
  ... say so with the "shared" qualifier:  --map-by device=<class>:shared

$ prun -n 8 --map-by device=gpu:shared ./a.out      # two procs per GPU
```

`shared` takes an optional value (`shared=true`, `shared=false`) and
**defaults to false**, pending user feedback rather than because the other
answer is wrong. It is refused by name on a map with no devices, and its
diagnostic points at `overload-allowed` for the case the user probably meant.

> **Chain position is load-bearing again.** `shared` and `span` both begin
> with `s`, and the option matcher compares only as far as the shorter of its
> two arguments with no view of the other options — so `:s` has meant `SPAN`
> for as long as there has been one. The arm sits after it; tests pin `:s` to
> SPAN and `:sh` to shared. Second qualifier to need this, after `interleave`
> against `inherit`.

### 2. `device=<class>:ndev=N` — several devices per process

A job whose processes each drive several GPUs had no way to say so.

```
$ prun -n 2 --map-by device=gpu:ndev=2 --bind-to package ./a.out
  rank 0 -> package[0][core:L0-63]   Device: gpu://n::renderD128,gpu://n::renderD129
  rank 1 -> package[1][core:L64-127] Device: gpu://n::renderD130,gpu://n::renderD131
```

The interesting part is what a process is placed *against*. Holding two GPUs
on different NUMA domains, it is local to neither alone — it is local to
whatever contains both. So a group's locality is the **common ancestor** of
its members', and binding descends from there. That is why `--bind-to
package` is legitimate above and remains an error without `ndev`. With the
default of one device per process a group *is* a device, so nothing changes.

Groups are contiguous runs of the existing order, so `interleave` composes
with it. The assignment is reported as a comma-delimited list, leaving the
single-device case exactly a plain uuid.

### 3. Verifying the assignment reaches the process

The multi-node coverage read the head node's `--display map`. **That is the
wrong end of the wire** — the assignment is computed on the HNP, packed into
the launch message, unpacked by the daemon that forks the process, and
published by that daemon's PMIx server. The map display shows only the first
step, and the assignment was once recorded as an attribute that never
travelled, reaching the map display and nothing else.

`devinfo` asks the process instead: it prints the device it was given and
whether that device is findable among the distances it can query. Four things
the map display cannot show — both procs read an id back, neither reports
none, the two get *different* devices, and a job **not** mapped by device
carries no assignment at all.

The swarm also checks the separation directly: binding overload must **not**
permit sharing a device.

### A harness gap this turned up

`test/offline` looked up the whole `--bind-to` spec in its level table, so any
qualifier raised a `KeyError` and failed the case as a *checker error* —
reading like a mapper defect rather than a harness gap. It now compares the
object each side names, on both the level lookup and the displayed-policy
comparison.

### Testing

Clean build at `--enable-debug`, `make check` 21/21, offline harness
**1777/1777** and stable across regenerate→compare, help/option cross-check,
docs under Sphinx `-W`, live DVM cycle. Docs updated across the same four
user-facing files; the plan records the decisions.