### PR TITLE
Assign a context id to a group formed by invitation

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -58,6 +58,7 @@ It is **not** a Docker Swarm in the orchestration sense — just ten plain
 | `proctable.c` | A bare PMIx client for the **proc-table and server-URI queries** (`proctable` in the install): `procs`/`localprocs`/`serveruri`. Those are the only callers of `prte_pmix_convert_state()`, and the local-vs-global proc-table split has no meaning on one host. Drives `src/pmix`. |
 | `peerinfo.c` | A bare PMIx client in which every rank asks **every other rank of its own job** where it is (`peerinfo` in the install): rank, app rank, local/node rank, node id, hostname, cpuset, locality string. The only client here that reads a *peer's* reserved keys, and so the only one that reaches the daemon's derive-on-demand path — everything else either reads back what it put itself or asks about the job. Drives `derive_proc_data()` in `src/prted/pmix/pmix_server_fence.c`. See §20. |
 | `groupcon.c` | A bare PMIx client that drives a **group construct/destruct** (`groupcon` in the install): every rank contributes a local cid, asks for a context id, constructs, reads every peer's contribution back, destructs. Drives grpcomm's `grp_release` on daemons that merely *received* the broadcast. See §15. |
+| `groupinv.c` | A bare PMIx client that forms a group by **invitation** and asks for a context id (`groupinv` in the install). The highest rank leads, so mapped by node the leader is never the HNP - which is the point: that method runs no collective, so its leader asks for the id through job control and only the HNP holds the pool, so the request has to be relayed. Drives `PRTE_PMIX_GROUP_CTXID` in `src/prted/pmix`. See §15. |
 | `envspawn.c` | A PMIx client that spawns a child job carrying one of every **envar directive** (`envspawn` in the install): SET/ADD/UNSET/PREPEND/APPEND, pinned to a named host, with the child reporting the environment it actually got into a file on its own node. Those directives have no command-line surface — they arrive only on a spawn request — and `odls` applies them on whichever daemon forks the process, so the child has to land somewhere the parent is not. Drives `prte_odls_base_process_envars`. |
 | `slowcat.c` | A deliberately **slow** stdin reader (`slowcat` in the install, no PMIx dependency): copies stdin to a file in small reads with a pause between them, so the daemon feeding it keeps hitting *partial* writes. That is the only way to reach the iof short-write path. |
 | `scaletest.c` | A PMIx client that **times** a full-data fence and a bare barrier over the whole job (`scaletest` in the install). Not a pass/fail case — a measurement. See §18. |
@@ -1227,6 +1228,33 @@ the local participants are never released — the construct does not fail,
 it *hangs*, on every daemon at once. Deleting the thread-shift and
 re-running turns 7 of the phase's 10 assertions red, which is how the
 teeth were confirmed rather than assumed.
+
+### ...and the invited group, which has no collective at all
+
+`PMIx_Group_invite` forms a group purely through event notification, so
+nothing about it reaches grpcomm. That leaves its leader with no way to ask
+the host for a `PMIX_GROUP_ASSIGN_CONTEXT_ID`, and until August 2026 the
+directive was simply dropped. It now goes out as a `PMIx_Job_control`
+request, which arrives at whichever daemon hosts the leader - and only the
+HNP holds the id pool, so any other daemon has to relay it to the HNP and
+hand the answer back.
+
+`groupinv` is the probe, and **it makes the highest rank the leader on
+purpose**: mapped by node that rank is on the last node of the DVM and never
+on the HNP. Run it with the leader on node1 and the relay is skipped and the
+case passes having tested nothing, which is why this cannot live in a
+single-host suite.
+
+```sh
+groupinv <groupID>
+```
+
+Every rank also posts one `PMIx_Put` value at `PMIX_REMOTE` scope and never
+commits or fences it, then reads every peer's back once the group has formed
+- with `PMIX_OPTIONAL` gets, so they cannot leave the process to find it, and
+with the context id as a *qualifier*, because that is how a contribution to a
+group holding one is stored. Nothing but the group exchange can have carried
+those values.
 
 The probe is `groupcon`, compiled by `build.sh` the same way as
 `elastic`/`dataserver`/`proctable`:

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -464,6 +464,20 @@ build_linux() {
                 /prrte-src/contrib/dockerswarm/groupcon.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
+            # groupinv: a bare PMIx client that forms a group by INVITATION
+            # and asks for a context id.  That method runs no server
+            # collective, so its leader requests the id through job control,
+            # which lands on the daemon hosting the leader -- and only the HNP
+            # holds the id pool, so that daemon has to relay it.  The client
+            # makes the HIGHEST rank the leader precisely so that, mapped by
+            # node, the leader is never the HNP.  On one host the relay is
+            # skipped entirely and the test proves nothing.
+            # (No apostrophes here: see the note further down.)
+            echo ">>>> groupinv (group invite/join context id) test client"
+            gcc -O0 -g -o /opt/prte/prte/bin/groupinv \
+                /prrte-src/contrib/dockerswarm/groupinv.c \
+                -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
+
             # scaletest: a PMIx client that times a full-data fence and a
             # bare barrier over the whole job, so the cost of the DVM
             # collectives can be plotted against DVM size, process count,

--- a/contrib/dockerswarm/groupinv.c
+++ b/contrib/dockerswarm/groupinv.c
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * groupinv -- a minimal PMIx client that forms a group by INVITATION across
+ * a real, multi-node DVM, asking for a context id.
+ *
+ *   groupinv <groupID>
+ *
+ * The highest rank is the leader: it calls PMIx_Group_invite for the whole
+ * job with PMIX_GROUP_ASSIGN_CONTEXT_ID.  Every other rank registers a
+ * PMIX_GROUP_INVITED handler and accepts with PMIx_Group_join_nb.  Every rank
+ * also posts one PMIx_Put value at PMIX_REMOTE scope beforehand and never
+ * commits or fences it, then reads every peer's value back once the group has
+ * formed.
+ *
+ * **The leader being the highest rank is the whole point of this client.**
+ * Mapped by node, that rank is on the last node of the DVM and never on the
+ * HNP.  A group formed by invitation runs no server collective, so its leader
+ * asks for the context id through PMIx_Job_control -- which lands on the
+ * daemon hosting the leader.  Only the DVM master holds the id pool, so that
+ * daemon has to relay the request to the HNP and hand the answer back
+ * (PRTE_PMIX_GROUP_CTXID in src/prted/pmix).  On one host the leader IS the
+ * HNP and the whole relay is skipped, so this cannot be a single-host test.
+ * Run it with the leader on node1 and it will pass without proving anything.
+ *
+ * Output lines, one per rank, all prefixed GINV so the harness can grep:
+ *
+ *   GINV <rank> HOST <hostname>
+ *   GINV <rank> ROLE <LEADER|MEMBER>
+ *   GINV <rank> INVITE <status>            (leader only)
+ *   GINV <rank> COMPLETE CID <cid> ASSIGNED <T|F>
+ *   GINV <rank> ENDPT-OK <n>               (read back n peers' values)
+ *   GINV <rank> ENDPT-FAIL <peer> <status>
+ *   GINV <rank> DONE <rc>
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <pmix.h>
+
+#define ENDPT_KEY "ginv-endpt"
+
+static pmix_proc_t myproc;
+static volatile bool complete_seen = false;
+static volatile bool aborted = false;
+static size_t mycid = SIZE_MAX;
+static char *grpid = NULL;
+
+typedef struct {
+    volatile bool active;
+    pmix_status_t status;
+} milock_t;
+
+static void regcb(pmix_status_t status, size_t evref, void *cbdata)
+{
+    milock_t *lk = (milock_t *) cbdata;
+    (void) evref;
+
+    lk->status = status;
+    lk->active = false;
+}
+
+/* accept the invitation - which is also what contributes our endpoint data */
+static void invite_handler(size_t evid, pmix_status_t status, const pmix_proc_t *source,
+                           pmix_info_t info[], size_t ninfo, pmix_info_t results[],
+                           size_t nresults, pmix_event_notification_cbfunc_fn_t cbfunc,
+                           void *cbdata)
+{
+    size_t n;
+    char *grp = NULL;
+    pmix_status_t rc;
+    (void) evid; (void) status; (void) results; (void) nresults;
+
+    if (PMIX_CHECK_PROCID(source, &myproc)) {
+        /* our own invitation reflected back */
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+        }
+        return;
+    }
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_ID)) {
+            grp = info[n].value.data.string;
+            break;
+        }
+    }
+    rc = PMIx_Group_join_nb(grp, source, PMIX_GROUP_ACCEPT, NULL, 0, NULL, NULL);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "GINV %u JOIN-FAIL %s\n", myproc.rank, PMIx_Error_string(rc));
+    }
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+static void complete_handler(size_t evid, pmix_status_t status, const pmix_proc_t *source,
+                             pmix_info_t info[], size_t ninfo, pmix_info_t results[],
+                             size_t nresults, pmix_event_notification_cbfunc_fn_t cbfunc,
+                             void *cbdata)
+{
+    size_t n;
+    (void) evid; (void) source; (void) results; (void) nresults;
+
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_CONTEXT_ID)) {
+            if (PMIX_SUCCESS != PMIx_Value_get_number(&info[n].value, &mycid, PMIX_SIZE)) {
+                mycid = SIZE_MAX;
+            }
+            break;
+        }
+    }
+    if (PMIX_GROUP_CONSTRUCT_ABORT == status) {
+        aborted = true;
+    }
+    complete_seen = true;
+
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+static pmix_status_t reg(pmix_status_t code, pmix_notification_fn_t fn)
+{
+    milock_t lk = {true, PMIX_SUCCESS};
+
+    PMIx_Register_event_handler(&code, 1, NULL, 0, fn, regcb, (void *) &lk);
+    while (lk.active) {
+        usleep(10000);
+    }
+    return (0 > lk.status) ? lk.status : PMIX_SUCCESS;
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_value_t *val, value;
+    pmix_proc_t proc, *procs;
+    uint32_t nprocs, n;
+    pmix_info_t dir, quals[2], *results;
+    size_t nresults, nok = 0;
+    char hostname[256];
+    int waited;
+    bool leader;
+
+    if (2 > argc) {
+        fprintf(stderr, "usage: groupinv <groupID>\n");
+        return 1;
+    }
+    grpid = argv[1];
+
+    gethostname(hostname, sizeof(hostname));
+    hostname[sizeof(hostname) - 1] = '\0';
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "GINV ? INIT-FAIL %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+    printf("GINV %u HOST %s\n", myproc.rank, hostname);
+    fflush(stdout);
+
+    PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "GINV %u JOBSIZE-FAIL %s\n", myproc.rank, PMIx_Error_string(rc));
+        PMIx_Finalize(NULL, 0);
+        return 1;
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    if (2 > nprocs) {
+        fprintf(stderr, "GINV %u needs at least 2 ranks\n", myproc.rank);
+        PMIx_Finalize(NULL, 0);
+        return 1;
+    }
+
+    /* The HIGHEST rank leads - see the header. Mapped by node it is never on
+     * the HNP, so the leader's context-id request has to be relayed. */
+    leader = (myproc.rank == (nprocs - 1));
+    printf("GINV %u ROLE %s\n", myproc.rank, leader ? "LEADER" : "MEMBER");
+    fflush(stdout);
+
+    /* post our contribution - deliberately NOT committed or fenced, so only
+     * the group exchange can carry it to the other members */
+    value.type = PMIX_UINT64;
+    value.data.uint64 = 1234UL + (unsigned long) myproc.rank;
+    if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_REMOTE, ENDPT_KEY, &value))) {
+        fprintf(stderr, "GINV %u PUT-FAIL %s\n", myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+    if (PMIX_SUCCESS != (rc = reg(PMIX_GROUP_INVITED, invite_handler)) ||
+        PMIX_SUCCESS != (rc = reg(PMIX_GROUP_CONSTRUCT_COMPLETE, complete_handler)) ||
+        PMIX_SUCCESS != (rc = reg(PMIX_GROUP_CONSTRUCT_ABORT, complete_handler))) {
+        fprintf(stderr, "GINV %u REG-FAIL %s\n", myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+    /* everyone has posted and registered before anyone invites */
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "GINV %u FENCE-FAIL %s\n", myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+    if (leader) {
+        PMIX_PROC_CREATE(procs, nprocs);
+        for (n = 0; n < nprocs; n++) {
+            PMIX_PROC_LOAD(&procs[n], myproc.nspace, n);
+        }
+        PMIX_INFO_LOAD(&dir, PMIX_GROUP_ASSIGN_CONTEXT_ID, NULL, PMIX_BOOL);
+        results = NULL;
+        nresults = 0;
+        rc = PMIx_Group_invite(grpid, procs, nprocs, &dir, 1, &results, &nresults);
+        PMIX_PROC_FREE(procs, nprocs);
+        PMIX_INFO_DESTRUCT(&dir);
+        if (NULL != results) {
+            PMIX_INFO_FREE(results, nresults);
+        }
+        printf("GINV %u INVITE %s\n", myproc.rank, PMIx_Error_string(rc));
+        fflush(stdout);
+        if (PMIX_SUCCESS != rc) {
+            goto done;
+        }
+    }
+
+    for (waited = 0; !complete_seen && waited < 300; waited++) {
+        usleep(100000); /* 0.1s; up to 30s */
+    }
+    if (!complete_seen) {
+        fprintf(stderr, "GINV %u NO-COMPLETE\n", myproc.rank);
+        rc = PMIX_ERR_TIMEOUT;
+        goto done;
+    }
+    if (aborted) {
+        fprintf(stderr, "GINV %u ABORTED\n", myproc.rank);
+        rc = PMIX_GROUP_CONSTRUCT_ABORT;
+        goto done;
+    }
+    printf("GINV %u COMPLETE CID %lu ASSIGNED %s\n", myproc.rank,
+           (unsigned long) mycid, (SIZE_MAX == mycid) ? "F" : "T");
+    fflush(stdout);
+    if (SIZE_MAX == mycid) {
+        rc = PMIX_ERR_NOT_FOUND;
+        goto done;
+    }
+
+    /* read back every peer's contribution. OPTIONAL keeps the request from
+     * leaving this process, and the context id is a QUALIFIER because that is
+     * how a contribution to a group holding one is stored. */
+    PMIX_INFO_LOAD(&quals[0], PMIX_GROUP_CONTEXT_ID, &mycid, PMIX_SIZE);
+    PMIX_INFO_SET_QUALIFIER(&quals[0]);
+    PMIX_INFO_LOAD(&quals[1], PMIX_OPTIONAL, NULL, PMIX_BOOL);
+    for (n = 0; n < nprocs; n++) {
+        if (n == myproc.rank) {
+            continue;
+        }
+        PMIX_LOAD_PROCID(&proc, myproc.nspace, n);
+        rc = PMIx_Get(&proc, ENDPT_KEY, quals, 2, &val);
+        if (PMIX_SUCCESS != rc) {
+            printf("GINV %u ENDPT-FAIL %u %s\n", myproc.rank, n, PMIx_Error_string(rc));
+            fflush(stdout);
+            continue;
+        }
+        if (PMIX_UINT64 == val->type && (1234UL + (unsigned long) n) == val->data.uint64) {
+            ++nok;
+        } else {
+            printf("GINV %u ENDPT-FAIL %u BADVALUE\n", myproc.rank, n);
+            fflush(stdout);
+        }
+        PMIX_VALUE_RELEASE(val);
+    }
+    PMIX_INFO_DESTRUCT(&quals[0]);
+    PMIX_INFO_DESTRUCT(&quals[1]);
+    printf("GINV %u ENDPT-OK %lu\n", myproc.rank, (unsigned long) nok);
+    fflush(stdout);
+    rc = (nok == (size_t)(nprocs - 1)) ? PMIX_SUCCESS : PMIX_ERR_NOT_FOUND;
+
+    if (PMIX_SUCCESS == rc) {
+        /* every member destructs - it is a collective over the membership */
+        rc = PMIx_Group_destruct(grpid, NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "GINV %u DESTRUCT-FAIL %s\n", myproc.rank,
+                    PMIx_Error_string(rc));
+        }
+    }
+
+done:
+    printf("GINV %u DONE %s\n", myproc.rank, PMIx_Error_string(rc));
+    fflush(stdout);
+    PMIx_Finalize(NULL, 0);
+    return (PMIX_SUCCESS == rc) ? 0 : 1;
+}

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -2979,6 +2979,7 @@ test_hwloc() {
 
 # Absolute path, deliberately -- see the note above DS.
 GC=/opt/prte/prte/bin/groupcon
+GINV=/opt/prte/prte/bin/groupinv
 FENCER=/opt/prte/prte/bin/fencer
 
 test_grpcomm() {
@@ -3128,7 +3129,73 @@ test_grpcomm() {
     RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     cleanup_swarm
 
+    test_grpcomm_invite
     test_grpcomm_ft
+}
+
+# A group formed by INVITATION, asking for a context id.
+#
+# This is the one group path with no server collective: PMIx_Group_invite is
+# realized entirely through event notification, so there is no group up-call
+# through which its leader could ask the host for a context id.  The leader
+# asks through PMIx_Job_control instead, and that lands on whichever daemon
+# hosts the leader -- but only the HNP holds the id pool, so a leader anywhere
+# else has to have its request relayed (PRTE_PMIX_GROUP_CTXID) and the answer
+# handed back.
+#
+# groupinv makes the HIGHEST rank the leader for exactly that reason: mapped
+# by node, that rank is on the last node of the DVM and never on the HNP.  Run
+# with the leader on node1 and the relay is skipped and the case proves
+# nothing, which is why this cannot be a single-host test.
+#
+# The endpoint read-back is the second half.  Every rank posts one value and
+# never commits or fences it, so nothing but the group exchange can carry it;
+# the gets are OPTIONAL, so they cannot leave the process to find it.
+test_grpcomm_invite() {
+    local out n
+
+    banner "grpcomm: an invited group gets a context id from the HNP"
+    cleanup_swarm
+    if ! RUN "test -x $GINV"; then
+        skp "groupinv client not installed -- re-run ./build.sh"
+        return
+    fi
+    if ! prted_dvm_start 'node1:1,node2:1,node3:1,node4:1'; then
+        bad "could not start a DVM for the invited-group test"
+        cleanup_swarm
+        return
+    fi
+
+    out=$(PRUN "--host node1:1,node2:1,node3:1,node4:1 -n 4 --map-by node $GINV inv1" 2>&1)
+
+    # the leader must NOT be on the HNP, or the relay was never exercised
+    n=$(echo "$out" | awk '$1=="GINV" && $3=="ROLE" && $4=="LEADER" {print $2}')
+    if [ -z "$n" ]; then
+        bad "no rank declared itself the leader: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    else
+        echo "$out" | awk -v r="$n" '$1=="GINV" && $2==r && $3=="HOST" {print $4}' \
+            | grep -qv '^node1$' \
+            && ok "the leader (rank $n) is not on the HNP -- the request was relayed" \
+            || bad "the leader landed on node1, so nothing was relayed"
+    fi
+
+    n=$(echo "$out" | grep -c 'ASSIGNED T')
+    [ "$n" = 4 ] \
+        && ok "all 4 members were given a group context id" \
+        || bad "$n of 4 members got a context id: $(echo "$out" | grep -E 'COMPLETE|INVITE' | tr '\n' ' ' | tail -c 300)"
+
+    n=$(echo "$out" | grep -c 'ENDPT-OK 3')
+    [ "$n" = 4 ] \
+        && ok "...and every member read back all 3 peers' endpoint data" \
+        || bad "$n of 4 members read a full peer set: $(echo "$out" | grep -E 'ENDPT' | tr '\n' ' ' | tail -c 300)"
+
+    n=$(echo "$out" | grep -c 'DONE PMIX_SUCCESS')
+    [ "$n" = 4 ] \
+        && ok "...and all 4 finished cleanly" \
+        || bad "$n of 4 finished cleanly: $(echo "$out" | grep DONE | tr '\n' ' ' | tail -c 300)"
+
+    RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    cleanup_swarm
 }
 
 # Losing a whole daemon mid-construct.  This is the daemon-death analog of the

--- a/src/grpcomm/AGENTS.md
+++ b/src/grpcomm/AGENTS.md
@@ -145,7 +145,7 @@ always one thing.
 | Field | Meaning |
 |-------|---------|
 | `output` | Verbosity stream. `-1` until the `grpcomm_base_verbose` MCA parameter opens it. The parameter deliberately **keeps its old framework spelling**, because it is in every debugging recipe and in the guides. |
-| `context_id` | The group context-id pool. A construct asking for `PMIX_GROUP_ASSIGN_CONTEXT_ID` gets this value, and it **decrements** — it counts *down* from `UINT32_MAX` so DVM-assigned ids cannot collide with ids assigned from the bottom of the range elsewhere. |
+| `context_id` | The group context-id pool. A construct asking for `PMIX_GROUP_ASSIGN_CONTEXT_ID` gets this value, and it **decrements** — it counts *down* from `UINT32_MAX` so DVM-assigned ids cannot collide with ids assigned from the bottom of the range elsewhere. Spend it only through `prte_grpcomm_assign_context_id()`, which refuses a non-master caller: the group collective is no longer its only consumer (see below), and two doors onto one counter is how two callers end up with one id. |
 | `xcast_ops` | In-flight broadcasts, the `pending_completions` FIFO, and the three op-id sequence counters. |
 | `fence_ops` | List of `prte_grpcomm_fence_t`. A tracker is found here by its signature alone, so it must come **off** this list before its result is delivered — see *Retire before you deliver* below. |
 | `group_ops` | List of `prte_grpcomm_group_t`. |
@@ -787,6 +787,25 @@ live DVM) but it guards the invariants that hold with no DVM:
 - `prte_grpcomm_globals.context_id` starts at `UINT32_MAX`, and every
   signature/tracker/caddy class constructs with the documented defaults
   and destructs without leaking or crashing.
+
+### The pool has a second consumer, and it is not in this directory
+
+A group formed by `PMIx_Group_invite` runs **no collective at all** — it is
+realized entirely through PMIx event notification, so nothing ever reaches
+`prte_grpcomm_group()` and there is no signature to carry an `assignID`. Its
+leader asks for a context id through `PMIx_Job_control` instead, which lands
+on whichever daemon hosts that leader; see `assign_group_ctxid()` in
+[`src/prted/pmix/pmix_server_job_ctrl.c`](../prted/pmix/pmix_server_job_ctrl.c)
+and the `PRTE_PMIX_GROUP_CTXID` relay beside it.
+
+That is why the pool is now reached through `prte_grpcomm_assign_context_id()`
+rather than touched directly: the two paths spend from one counter, and the
+accessor is where "only the master may mint" is enforced once instead of at
+each caller. A leader is an application process and sits wherever it was
+mapped, so the job-control path is usually *not* on the master and has to
+relay — which is the half a single-host run cannot reach.
+`contrib/dockerswarm/groupinv.c` makes the highest rank the leader for exactly
+that reason.
 - **Building a fence tracker**: what a signature naming the daemon job, a
   signature naming nobody, and an unresolvable signature each produce —
   the last of which must leave *nothing* on the tracker list.

--- a/src/grpcomm/grpcomm.c
+++ b/src/grpcomm/grpcomm.c
@@ -142,6 +142,22 @@ void prte_grpcomm_finalize(void)
     return;
 }
 
+int prte_grpcomm_assign_context_id(size_t *ctxid)
+{
+    if (NULL == ctxid) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+    /* The pool is this daemon's own counter, and nothing reconciles two of
+     * them - see the header. Refusing here is what keeps the "only the master
+     * assigns" rule in one place, rather than repeated at each caller. */
+    if (!PRTE_PROC_IS_MASTER) {
+        return PRTE_ERR_NOT_SUPPORTED;
+    }
+    *ctxid = (size_t) prte_grpcomm_globals.context_id;
+    --prte_grpcomm_globals.context_id;
+    return PRTE_SUCCESS;
+}
+
 bool prte_grpcomm_proc_departed(const pmix_proc_t *proc)
 {
     prte_job_t *jdata;

--- a/src/grpcomm/grpcomm.h
+++ b/src/grpcomm/grpcomm.h
@@ -138,6 +138,21 @@ PRTE_EXPORT int prte_grpcomm_group(pmix_group_operation_t op, char *grpid,
                                    const pmix_info_t directives[], size_t ndirs,
                                    pmix_info_cbfunc_t cbfunc, void *cbdata);
 
+/* Take the next group context id from the DVM's pool.
+ *
+ * The pool lives here because the group collective is what has always spent
+ * from it, but a group formed by PMIx_Group_invite has no collective - its
+ * leader asks for an id through job control instead - so the two callers need
+ * a common way in rather than a second pool that could hand out the same
+ * number.
+ *
+ * **Only the DVM master may call this.** The pool is per-daemon state and
+ * nothing reconciles two of them, so an id minted anywhere else is unique to
+ * the daemon that minted it and to nobody else. A non-master caller is
+ * refused with PRTE_ERR_NOT_SUPPORTED rather than quietly served; relay the
+ * request to the master instead. */
+PRTE_EXPORT int prte_grpcomm_assign_context_id(size_t *ctxid);
+
 END_C_DECLS
 
 #endif

--- a/src/grpcomm/grpcomm_group.c
+++ b/src/grpcomm/grpcomm_group.c
@@ -1162,11 +1162,15 @@ static void check_complete(prte_grpcomm_group_t *coll)
                 goto answer;
 #endif
             }
-            /* if we were asked to provide a context id, do so */
+            /* if we were asked to provide a context id, do so. This runs
+             * only on the master (see the guard above), which is what
+             * prte_grpcomm_assign_context_id() requires - it is shared with
+             * the job-control path an invited group's leader uses, so that
+             * the two cannot hand out the same number */
             if (coll->sig->assignID) {
-                coll->sig->ctxid = prte_grpcomm_globals.context_id;
-                --prte_grpcomm_globals.context_id;
-                coll->sig->ctxid_assigned = true;
+                if (PRTE_SUCCESS == prte_grpcomm_assign_context_id(&coll->sig->ctxid)) {
+                    coll->sig->ctxid_assigned = true;
+                }
             }
 
             // construct the final membership

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -2303,6 +2303,14 @@ static void send_alloc_resp(pmix_status_t status,
     PRTE_PMIX_THREADSHIFT(cd, prte_event_base, _send_alloc_resp);
 }
 
+/* release the one-element context-id result once it has been packed */
+static void ctxid_relfn(void *cbdata)
+{
+    pmix_info_t *results = (pmix_info_t *) cbdata;
+
+    PMIX_INFO_FREE(results, 1);
+}
+
 static void pmix_server_sched(int status, pmix_proc_t *sender,
                               pmix_data_buffer_t *buffer,
                               prte_rml_tag_t tg, void *cbdata)
@@ -2313,9 +2321,10 @@ static void pmix_server_sched(int status, pmix_proc_t *sender,
     size_t ninfo = 0;
     pmix_alloc_directive_t allocdir;
     uint32_t sessionID;
-    pmix_info_t *info = NULL;
+    pmix_info_t *info = NULL, *ctxinfo;
     pmix_proc_t source;
     prte_pmix_server_req_t *req = NULL;
+    size_t ctxid;
     int refid;
     PRTE_HIDE_UNUSED_PARAMS(status, tg, cbdata);
 
@@ -2353,7 +2362,7 @@ static void pmix_server_sched(int status, pmix_proc_t *sender,
             PMIX_ERROR_LOG(rc);
             goto reply;
         }
-    } else {
+    } else if (PRTE_PMIX_SESSION_CTRL == cmd) {
         /* session control request */
         cnt = 1;
         rc = PMIx_Data_unpack(NULL, buffer, &sessionID, &cnt, PMIX_UINT32);
@@ -2362,6 +2371,8 @@ static void pmix_server_sched(int status, pmix_proc_t *sender,
             goto reply;
         }
     }
+    /* a group context-id request carries no field of its own - see the
+     * matching pack in prte_server_send_request() */
 
    /* unpack the number of info */
    cnt = 1;
@@ -2390,6 +2401,43 @@ static void pmix_server_sched(int status, pmix_proc_t *sender,
     }
     PMIX_INFO_LOAD(&info[ninfo], PMIX_REQUESTOR, &source, PMIX_PROC);
     ++ninfo;
+
+    if (PRTE_PMIX_GROUP_CTXID == cmd) {
+        /* A group formed by PMIx_Group_invite has no collective through which
+         * to ask for a context id, so its leader asks through job control -
+         * which lands on whichever daemon hosts the leader. The pool lives
+         * only here on the master, so that daemon relayed it to us. Mint one
+         * and answer; there is nothing asynchronous about it. */
+        req = PMIX_NEW(prte_pmix_server_req_t);
+        pmix_asprintf(&req->operation, "GROUPCTXID");
+        req->remote_index = refid;
+        req->copy = true;
+        req->info = info;
+        req->ninfo = ninfo;
+        PMIX_PROC_LOAD(&req->proxy, sender->nspace, sender->rank);
+        PMIX_PROC_LOAD(&req->tproc, source.nspace, source.rank);
+        /* as on the session-control branch below, being on the tracker array
+         * is not a reference - send_alloc_resp takes the second one that its
+         * two releases consume */
+        req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
+        req->infocbfunc = send_alloc_resp;
+        req->cbdata = req;
+        rc = prte_grpcomm_assign_context_id(&ctxid);
+        if (PRTE_SUCCESS != rc) {
+            send_alloc_resp(prte_pmix_convert_rc(rc), NULL, 0, req, NULL, NULL);
+            return;
+        }
+        PMIX_INFO_CREATE(ctxinfo, 1);
+        if (NULL == ctxinfo) {
+            send_alloc_resp(PMIX_ERR_NOMEM, NULL, 0, req, NULL, NULL);
+            return;
+        }
+        PMIX_INFO_LOAD(&ctxinfo[0], PMIX_GROUP_CONTEXT_ID, &ctxid, PMIX_SIZE);
+        /* the reply is packed after a thread shift, so the array is handed
+         * over with a release function rather than freed here */
+        send_alloc_resp(PMIX_SUCCESS, ctxinfo, 1, req, ctxid_relfn, ctxinfo);
+        return;
+    }
 
     if (PRTE_PMIX_ALLOC_REQ == cmd) {
         req = PMIX_NEW(prte_pmix_server_req_t);

--- a/src/prted/pmix/pmix_server_allocate.c
+++ b/src/prted/pmix/pmix_server_allocate.c
@@ -208,7 +208,7 @@ pmix_status_t prte_server_send_request(uint8_t cmd, prte_pmix_server_req_t *req)
             PMIX_DATA_BUFFER_RELEASE(buf);
             return rc;
         }
-    } else {
+    } else if (PRTE_PMIX_SESSION_CTRL == cmd) {
         /* pack the sessionID */
         rc = PMIx_Data_pack(NULL, buf, &req->sessionID, 1, PMIX_UINT32);
         if (PMIX_SUCCESS != rc) {
@@ -217,6 +217,9 @@ pmix_status_t prte_server_send_request(uint8_t cmd, prte_pmix_server_req_t *req)
             return rc;
         }
     }
+    /* PRTE_PMIX_GROUP_CTXID has no field of its own - it asks for a number
+     * and nothing about that number depends on the requestor. Keep this in
+     * step with the matching unpack in pmix_server_sched(). */
 
     /* pack the number of info */
     rc = PMIx_Data_pack(NULL, buf, &req->ninfo, 1, PMIX_SIZE);

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -420,6 +420,10 @@ PRTE_EXPORT extern void pmix_server_monitor_resp(int status, pmix_proc_t *sender
 
 #define PRTE_PMIX_ALLOC_REQ      0
 #define PRTE_PMIX_SESSION_CTRL   1
+/* Ask the DVM master for a group context id. Unlike its two siblings this
+ * command carries nothing of its own - the id does not depend on anything the
+ * requestor knows - so the relay packs only the common header. */
+#define PRTE_PMIX_GROUP_CTXID    2
 
 PRTE_EXPORT extern pmix_status_t
 pmix_server_session_ctrl_fn(const pmix_proc_t *requestor,

--- a/src/prted/pmix/pmix_server_job_ctrl.c
+++ b/src/prted/pmix/pmix_server_job_ctrl.c
@@ -236,13 +236,112 @@ static pmix_status_t process_job_ctrl(const pmix_proc_t *requestor, const pmix_p
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
+/* release the one-element context-id result once it has been packed */
+static void ctxid_relfn(void *cbdata)
+{
+    pmix_info_t *results = (pmix_info_t *) cbdata;
+
+    PMIX_INFO_FREE(results, 1);
+}
+
+/* Answer a PMIX_GROUP_ASSIGN_CONTEXT_ID directive.
+ *
+ * This arrives as a job-control request because the group it is for is being
+ * formed by PMIx_Group_invite, which runs no server collective - so unlike
+ * PMIx_Group_construct there is no group up-call to carry the request, and
+ * the PMIx library asks this way instead.
+ *
+ * Only the DVM master holds the id pool, and the leader of an invited group
+ * is an application process that may sit anywhere, so this usually has to be
+ * relayed. Nothing about the id depends on the directives, so the relay
+ * carries none of them.
+ *
+ * On PMIX_SUCCESS this has taken over the caddy and answered (or will
+ * answer) the request; the caller must do neither. Any other return means it
+ * did neither and the caller still owns both. */
+static pmix_status_t assign_group_ctxid(prte_pmix_server_op_caddy_t *cd)
+{
+    prte_pmix_server_req_t *req;
+    pmix_info_t *results;
+    size_t ctxid;
+    int rc;
+
+    if (PRTE_PROC_IS_MASTER) {
+        rc = prte_grpcomm_assign_context_id(&ctxid);
+        if (PRTE_SUCCESS != rc) {
+            return prte_pmix_convert_rc(rc);
+        }
+        PMIX_INFO_CREATE(results, 1);
+        if (NULL == results) {
+            return PMIX_ERR_NOMEM;
+        }
+        PMIX_INFO_LOAD(&results[0], PMIX_GROUP_CONTEXT_ID, &ctxid, PMIX_SIZE);
+        /* the reply is packed after a thread shift, so hand the array over
+         * with a release function rather than freeing it here */
+        cd->infocbfunc(PMIX_SUCCESS, results, 1, cd->cbdata, ctxid_relfn, results);
+        PMIX_RELEASE(cd);
+        return PMIX_SUCCESS;
+    }
+
+    req = PMIX_NEW(prte_pmix_server_req_t);
+    if (NULL == req) {
+        return PMIX_ERR_NOMEM;
+    }
+    pmix_asprintf(&req->operation, "GROUPCTXID");
+    PMIX_PROC_LOAD(&req->tproc, cd->proc.nspace, cd->proc.rank);
+    req->infocbfunc = cd->infocbfunc;
+    req->cbdata = cd->cbdata;
+    req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
+    rc = prte_server_send_request(PRTE_PMIX_GROUP_CTXID, req);
+    if (PRTE_SUCCESS != rc) {
+        /* nothing will answer it, so take it back off the tracker and let the
+         * caller report the failure */
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs,
+                                    req->local_index, NULL);
+        PMIX_RELEASE(req);
+        return prte_pmix_convert_rc(rc);
+    }
+    PMIX_RELEASE(cd);
+    return PMIX_SUCCESS;
+}
+
 static void _job_ctrl(int sd, short args, void *cbdata)
 {
     prte_pmix_server_op_caddy_t *cd = (prte_pmix_server_op_caddy_t *) cbdata;
     pmix_status_t rc;
+    size_t n;
+    bool ctxid_req = false;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
     PMIX_ACQUIRE_OBJECT(cd);
+
+    /* A context-id request is the one directive here that produces a result
+     * rather than a status, and it may have to be relayed to the master, so
+     * it is handled ahead of process_job_ctrl() - which can express neither.
+     * It takes over the caddy when it succeeds. */
+    for (n = 0; n < cd->ndirs; n++) {
+        if (PMIX_CHECK_KEY(&cd->directives[n], PMIX_GROUP_ASSIGN_CONTEXT_ID) &&
+            PMIX_INFO_TRUE(&cd->directives[n])) {
+            ctxid_req = true;
+            break;
+        }
+    }
+    if (ctxid_req) {
+        if (NULL == cd->infocbfunc) {
+            /* there would be nowhere to put the answer */
+            rc = PMIX_ERR_NOT_SUPPORTED;
+        } else {
+            rc = assign_group_ctxid(cd);
+            if (PMIX_SUCCESS == rc) {
+                return;
+            }
+        }
+        if (NULL != cd->infocbfunc) {
+            cd->infocbfunc(rc, NULL, 0, cd->cbdata, NULL, NULL);
+        }
+        PMIX_RELEASE(cd);
+        return;
+    }
 
     rc = process_job_ctrl(&cd->proc, cd->procs, cd->nprocs, cd->directives, cd->ndirs);
     if (PMIX_OPERATION_SUCCEEDED == rc) {


### PR DESCRIPTION
The host half of openpmix/openpmix#4150 — see openpmix/openpmix#4068 for the
background.

### The problem

`PMIX_GROUP_ASSIGN_CONTEXT_ID` has always worked for `PMIx_Group_construct`
and never for `PMIx_Group_invite`, and the reason is structural rather than an
oversight: the invite method is realized entirely through PMIx event
notification, so nothing about it reaches `prte_grpcomm_group()` and there is
no signature to carry an `assignID`.

PMIx now asks on the leader's behalf through `PMIx_Job_control`. This is the
other half.

### The relay

A job-control request lands on whichever daemon hosts the requestor, and the
leader of an invited group is an application process sitting wherever it was
mapped — so on most nodes this has to reach the DVM master, the only daemon
holding the id pool.

It reuses the relay that already carries allocation and session-control
requests there: a third command, `PRTE_PMIX_GROUP_CTXID`, over
`PRTE_RML_TAG_SCHED` with the answer on `PRTE_RML_TAG_SCHED_RESP`. It carries
no field of its own — nothing about the id depends on what the requestor
knows — so the pack and unpack simply skip the command-specific slot. The
master mints and answers immediately; there is nothing asynchronous on its
side.

### One pool, one door

`prte_grpcomm_globals.context_id` now has two consumers, so it is reached
through `prte_grpcomm_assign_context_id()` rather than touched directly, and
the group collective goes through it too. Two doors onto one counter is
precisely how two callers end up with the same number.

The accessor is also where **only the master may mint** is enforced — once,
rather than at each caller. A non-master caller is refused rather than quietly
served an id that is unique to nobody but itself.

### Failure stays safe

`process_job_ctrl()` already reports `PMIX_ERR_NOT_SUPPORTED` for a directive
it does not recognize, and PMIx treats that as "no id" and forms the group
without one — which is what happened on this path before any of this. So an
older PRRTE against the new PMIx degrades to exactly the old behavior, and
this PR can land in either order relative to its companion.

### Testing

`contrib/dockerswarm/groupinv.c` forms a group by invitation across a real
multi-node DVM and asks for an id. **It makes the highest rank the leader on
purpose**: mapped by node that rank is on the last node of the DVM and never
on the HNP, so the relay is actually exercised. Run it with the leader on
node1 and the relay is skipped and the case passes having proven nothing —
which is why this cannot live in a single-host suite. The new `run-tests.sh`
phase asserts the leader is not on node1 *before* asserting anything else, so
a mapping change cannot quietly turn it into a test of the local path.

Verified on a four-node DVM with the leader on node4:

```
GINV 3 HOST node4
GINV 3 ROLE LEADER
GINV 3 INVITE PMIX_SUCCESS
GINV 0..3 COMPLETE CID 4294967295 ASSIGNED T
GINV 0..3 ENDPT-OK 3
```

...and the next `groupcon` construct on the same DVM took 4294967294 — the
following number from the same pool, which is the shared accessor doing its
job.

Also built clean under `-Werror` in the Linux container and warning-free
natively on macOS with `--enable-debug`.
