### PR TITLE
Run --enable-mca-dso somewhere, and fix what that found

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -168,6 +168,74 @@ jobs:
         prterun --map-by ppr:1:core examples/hello
         prterun --map-by ppr:1:core examples/legacy
 
+  # Every component built as a run-time loadable DSO rather than linked
+  # into libprrte.  This is a supported build, and the one the stubbed
+  # test-build launchers require, but nothing else in CI exercises it --
+  # so a component that only works when statically linked (a missing
+  # symbol export, a constructor that runs at link time) would otherwise
+  # reach users unnoticed.
+  ubuntuMcaDso:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends software-properties-common libhwloc-dev libevent-dev
+    - name: Git clone OpenPMIx
+      uses: actions/checkout@v6
+      with:
+            submodules: recursive
+            repository: openpmix/openpmix
+            path: openpmix/master
+            ref: master
+    - name: Build OpenPMIx
+      run: |
+        cd openpmix/master
+        ./autogen.pl
+        ./configure --prefix=$RUNNER_TEMP/pmixinstall
+        make -j
+        make install
+    - name: Git clone PRRTE
+      uses: actions/checkout@v6
+      with:
+            submodules: recursive
+            clean: false
+    - name: Build PRRTE
+      run: |
+        ./autogen.pl
+        mkdir build
+        cd build
+        ../configure --prefix=$RUNNER_TEMP/prteinstall --with-pmix=$RUNNER_TEMP/pmixinstall \
+            --enable-devel-check \
+            --enable-testbuild-launchers \
+            --enable-mca-dso
+        make -j
+        make install
+    - name: Confirm the components were built as DSOs
+      run: |
+        # Without this the rest of the job would happily pass on a build
+        # that had quietly linked everything statically, testing nothing.
+        n=$(ls $RUNNER_TEMP/prteinstall/lib/prte/*.so 2>/dev/null | wc -l)
+        echo "installed $n component DSOs"
+        test "$n" -gt 0
+    - name: Run unit tests
+      run: |
+        cd build
+        make check
+    - name: Build examples
+      run: |
+        pushd examples
+        export PATH=$RUNNER_TEMP/prteinstall/bin:$RUNNER_TEMP/pmixinstall/bin:${PATH}
+        export LD_LIBRARY_PATH=$RUNNER_TEMP/prteinstall/lib:${LD_LIBRARY_PATH}
+        make
+        popd
+    - name: Test sanity check
+      run: |
+        export PATH=$RUNNER_TEMP/prteinstall/bin:$RUNNER_TEMP/pmixinstall/bin:${PATH}
+        export LD_LIBRARY_PATH=$RUNNER_TEMP/prteinstall/lib:${LD_LIBRARY_PATH}
+        prterun --map-by ppr:1:core examples/hello
+        prterun --map-by ppr:1:core examples/legacy
+
   ubuntuClang:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -215,9 +215,15 @@ jobs:
       run: |
         # Without this the rest of the job would happily pass on a build
         # that had quietly linked everything statically, testing nothing.
-        n=$(ls $RUNNER_TEMP/prteinstall/lib/prte/*.so 2>/dev/null | wc -l)
-        echo "installed $n component DSOs"
-        test "$n" -gt 0
+        #
+        # The test is a named component, not a count: the DEFAULT build
+        # already installs a DSO or two (the launchers that need
+        # third-party headers are in the default --enable-mca-dso list),
+        # so "some .so exists" would pass without this flag. rmaps is
+        # never in that list, so its components are loadable only because
+        # --enable-mca-dso put them there.
+        ls -1 $RUNNER_TEMP/prteinstall/lib/prte/ || true
+        test -f $RUNNER_TEMP/prteinstall/lib/prte/prte_mca_rmaps_round_robin.so
     - name: Run unit tests
       run: |
         cd build

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -921,6 +921,61 @@ threading defect worth chasing; one that reproduces at 0 as well has nothing
 to do with the OOB threading. Keeping that distinction cheap is the reason the
 knob exists rather than the number being hard-coded.
 
+### Components as DSOs (`PRTE_SWARM_MCA_DSO`)
+
+`--enable-mca-dso` builds every MCA component as a run-time loadable DSO in
+`lib/prte` instead of linking it into `libprrte`. It is a supported build —
+and the one the stubbed test-build launchers require — but the default is
+static, so a component that only works when it is linked in (a symbol that
+needed exporting, a constructor that ran at link time, an inter-component
+dependency the static link resolved for free) breaks nobody's build and
+surfaces at a user's site. CI now builds and smoke-launches it on one Linux
+node (`ubuntuMcaDso` in `.github/workflows/builds.yaml`); this is where it
+gets run across daemons.
+
+```sh
+PRTE_SWARM_MCA_DSO=1 ./build.sh          # into the volume, components as DSOs
+PRTE_SWARM_MCA_DSO=1 ./build.sh macos    # native build, same
+./run-tests.sh linux                     # the ordinary suite, no flag needed
+```
+
+The whole suite is the test: nothing here is DSO-specific, and that is the
+point — every case that exercises a component at all now exercises loading
+it. The preflight prints which of the two it found (`components are N
+run-time DSOs` / `components are linked into libprrte`), asked of the
+install rather than of the variable, because the volume outlives the shell
+that set it.
+
+**It found something the first time it ran**, which is the argument for
+keeping it: `prun` segfaulted in teardown on every single invocation —
+after the job had run correctly, so every affected case reported right
+output and `rc=139`. PRRTE has no component repository of its own, so
+`PMIx_tool_finalize` reaches `pmix_mca_base_close()` and dlcloses PRRTE's
+component DSOs along with PMIx's; `prun` then closed the `ess` framework
+*afterwards* and walked its component list into unmapped memory. In the
+default build those structs live in `libprrte` and are mapped for the life
+of the process, so nothing was ever wrong there. The rule that came out of
+it: **a PRRTE framework must be closed while PMIx is still up.**
+
+Three things to know:
+
+- **The knob is spelled `PRTE_SWARM_MCA_DSO`, not `PRTE_MCA_DSO`.** PRRTE
+  harvests `PRTE_MCA_*` out of the launcher's environment onto the `prted`
+  command line, so the latter name would reach every daemon as
+  `--prtemca DSO 1`.
+- **It is a configure argument**, so `reconfigure_needed` sees it change and
+  reconfigures — the same mechanism that catches a changed `--with-pmix`. No
+  volume wipe needed to switch modes.
+- **Turning it back off removes the installed DSOs.** `make install` only
+  adds, and the install outlives the build dir, so the previous mode's
+  `lib/prte` would otherwise sit there for the static build to `dlopen` —
+  every component present twice, one copy stale. `build.sh` deletes that
+  directory whenever it reconfigures.
+
+Against the baked PMIx this build may not configure at all — PRRTE's floor
+moves ahead of the image — in which case use `PMIX_SRC=<checkout>`, the same
+remedy as for any other configure rejection here.
+
 ## 7. Cleanup hygiene
 
 `run-tests.sh` cleans every node before its first case and between phases.
@@ -977,6 +1032,7 @@ other swarm's `/tmp`, because the containers are different containers.
 |----------|----|
 | pick up a PRRTE source edit | `./build.sh` (incremental into the volume) |
 | pick up an openpmix edit | `PMIX_SRC=/path/to/openpmix ./build.sh` |
+| run the suite against components built as DSOs | `PRTE_SWARM_MCA_DSO=1 ./build.sh` then the ordinary `./run-tests.sh linux` — see §6, "Components as DSOs" |
 | force a clean PRRTE rebuild | `docker volume rm prte-build && ./build.sh` |
 | rebuild the base image (new baked PMIx) | `docker build --no-cache --build-arg PMIX_REF=master -t prte-swarm:latest .` — `./build.sh image` reuses docker's cached `git clone`; then wipe the volume's VPATH dirs and recreate the containers (see "The containers persist too") |
 | tear down the swarm | `docker compose down` (the `prte-build` volume persists) |

--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -941,10 +941,18 @@ PRTE_SWARM_MCA_DSO=1 ./build.sh macos    # native build, same
 
 The whole suite is the test: nothing here is DSO-specific, and that is the
 point — every case that exercises a component at all now exercises loading
-it. The preflight prints which of the two it found (`components are N
-run-time DSOs` / `components are linked into libprrte`), asked of the
-install rather than of the variable, because the volume outlives the shell
-that set it.
+it. The preflight prints which of the two it ran, asked of the install
+rather than of the variable, because the volume outlives the shell that set
+it: `build.sh` records the mode in `/opt/prte/.build-mode` beside the build
+stamp, and the suite reads it there.
+
+**Do not try to infer the mode by counting DSOs in the install.** The
+default build installs a couple of its own — the launchers that need
+third-party headers are in the default `--enable-mca-dso` list, so an
+ordinary swarm build ships `prte_mca_ras_slurm.so` and nothing else. A
+count says "DSO build" for that. The CI job has the same problem and
+solves it by naming a component that is loadable *only* under the flag
+(`rmaps/round_robin`; `rmaps` is never in the default list).
 
 **It found something the first time it ran**, which is the argument for
 keeping it: `prun` segfaulted in teardown on every single invocation —

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -380,7 +380,7 @@ build_linux() {
 
             # invalidate the freshness stamp up front: from here until the
             # build finishes, whatever is installed is NOT this source tree
-            rm -f /opt/prte/.build-stamp
+            rm -f /opt/prte/.build-stamp /opt/prte/.build-mode
 
             echo ">>>> PRRTE VPATH build -> /opt/prte/prte"
             mkdir -p /opt/prte/vpath-linux && cd /opt/prte/vpath-linux
@@ -695,6 +695,16 @@ build_linux() {
             # The stamp is what lets the suite say so.  It is removed first so
             # a build that dies midway cannot leave a stale one behind.
             date -u +%Y-%m-%dT%H:%M:%SZ > /opt/prte/.build-stamp
+            # ...and how the components were linked, for the suite to report.
+            # It has to be recorded here rather than counted from the install:
+            # the default build installs component DSOs too (the launchers
+            # needing third-party headers are in the default --enable-mca-dso
+            # list), so a count cannot tell the two configurations apart.
+            if [ "${PRTE_SWARM_MCA_DSO:-0}" != 0 ]; then
+                echo "mca-dso" > /opt/prte/.build-mode
+            else
+                echo "default" > /opt/prte/.build-mode
+            fi
             echo ">>>> done: install in /opt/prte/prte"
         '
     echo ">>> Linux build complete."

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -65,6 +65,17 @@
 # source too (covering both code bases); otherwise the baked-in PMIx (Linux) or
 # an installed PMIx (macOS, override with PMIX_HOME) is used.
 #
+# Optional: PRTE_SWARM_MCA_DSO=1 builds every MCA component as a run-time
+# loadable DSO (--enable-mca-dso) instead of linking it into libprrte.  That is
+# a supported build nobody runs multi-node, so the whole suite against it is
+# cheap insurance -- see AGENTS.md, "Components as DSOs".  It is off by default
+# because the default build is what users get.
+#
+# NOTE the name: anything called PRTE_MCA_* is harvested out of the launcher's
+# environment onto the prted command line as an MCA parameter, so a knob named
+# PRTE_MCA_DSO would arrive at every daemon as `--prtemca DSO 1`.  Harness
+# knobs take the PRTE_SWARM_ prefix for exactly that reason.
+#
 # Requires: docker (for linux/image), git, and a working autotools toolchain.
 
 set -euo pipefail
@@ -109,6 +120,8 @@ PMIX_HOME="${PMIX_HOME:-}"              # optional installed PMIx prefix (macOS)
 # checkout must be autogen'd and NOT configured in-tree (same rule as
 # PMIX_SRC -- configure runs VPATH over a read-only bind mount).
 OMPI_SRC="${OMPI_SRC:-}"
+# Build every component as a run-time loadable DSO rather than into libprrte.
+MCA_DSO="${PRTE_SWARM_MCA_DSO:-0}"
 
 mode=linux
 distclean=auto                          # auto | always | never
@@ -279,6 +292,7 @@ build_linux() {
     docker run --rm \
         -v "$root":/prrte-src:ro \
         -v "$VOLUME":/opt/prte \
+        -e PRTE_SWARM_MCA_DSO="$MCA_DSO" \
         ${pmix_mount[@]+"${pmix_mount[@]}"} \
         ${ompi_mount[@]+"${ompi_mount[@]}"} \
         "$IMAGE" bash -euo pipefail -c '
@@ -379,9 +393,24 @@ build_linux() {
             # break in those lines surfaces here rather than in the slower
             # sibling.  libjansson-dev is baked into the image.
             prte_args="--prefix=/opt/prte/prte --with-pmix=$PMIX_PREFIX --with-jansson --enable-debug"
+            # Every component as a loadable DSO instead of inside libprrte.
+            # It goes in the argument string, so switching the knob is a
+            # configure-argument change and reconfigure_needed catches it --
+            # the same mechanism that catches a changed --with-pmix.
+            if [ "${PRTE_SWARM_MCA_DSO:-0}" != 0 ]; then
+                prte_args="$prte_args --enable-mca-dso"
+                echo ">>>> components as DSOs (--enable-mca-dso)"
+            fi
             if reconfigure_needed . "$prte_args" /prrte-src; then
                 echo ">>>> (re)configuring PRRTE: $prte_args"
                 drop_orphans . /prrte-src
+                # The install outlives the build dir, and lib/prte holds the
+                # component DSOs of whatever was built last.  Switching the
+                # knob OFF would otherwise leave them there for the static
+                # build to dlopen -- every component present twice, one copy
+                # of it stale.  Nothing else removes them: make install only
+                # adds.
+                rm -rf /opt/prte/prte/lib/prte
                 /prrte-src/configure $prte_args
                 echo "$prte_args" > .configure-args
             fi
@@ -715,10 +744,19 @@ build_macos() {
     # uses PMIx internals, so a tree left pointing at a different PMIx than
     # you asked for builds cleanly and then dies at startup, which reads as
     # "this host is flaky" rather than "you built against the wrong PMIx".
-    local cfg_args="--prefix=$root/vpath-macos/install $pmix_arg --enable-debug ${EXTRA_CONFIGURE_ARGS:-}"
+    local dso_arg=""
+    if [ "$MCA_DSO" != 0 ]; then
+        dso_arg="--enable-mca-dso"
+        echo ">>> components as DSOs (--enable-mca-dso)"
+    fi
+    local cfg_args="--prefix=$root/vpath-macos/install $pmix_arg --enable-debug $dso_arg ${EXTRA_CONFIGURE_ARGS:-}"
     if [ -f config.status ] && [ "$(cat .prte-configure-args 2>/dev/null)" != "$cfg_args" ]; then
         echo ">>> configure arguments changed - reconfiguring"
         rm -f config.status
+        # ...and drop any component DSOs the previous configuration installed,
+        # or turning --enable-mca-dso back off leaves them to be dlopened
+        # alongside the copies now inside libprrte.  See build_linux.
+        rm -rf "$root/vpath-macos/install/lib/prte"
     fi
     # shellcheck disable=SC2086
     if [ ! -f config.status ]; then

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -5008,6 +5008,17 @@ test_linux() {
         else
             ok "...running with $OOB_THREADS OOB progress threads (library default is 0)"
         fi
+        # ...and whether the components are inside libprrte or loaded from
+        # disk.  Asked of the install rather than of a variable, because the
+        # volume outlives any one build.sh run and the knob that produced it
+        # may have been set in a different shell.  A suite log that does not
+        # say which of the two it ran cannot be compared with another.
+        ndso=$(RUN 'ls /opt/prte/prte/lib/prte/*.so 2>/dev/null | wc -l' | tr -d ' \r')
+        if [ "${ndso:-0}" -gt 0 ]; then
+            ok "...components are $ndso run-time DSOs (built --enable-mca-dso)"
+        else
+            ok "...components are linked into libprrte (the default build)"
+        fi
     else
         bad "no build stamp in the volume -- the last ./build.sh did not complete."
         echo "     Re-run ./build.sh and check its exit status; the install now" >&2

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -5013,12 +5013,18 @@ test_linux() {
         # volume outlives any one build.sh run and the knob that produced it
         # may have been set in a different shell.  A suite log that does not
         # say which of the two it ran cannot be compared with another.
+        #
+        # build.sh records this; do NOT try to infer it by counting DSOs in
+        # the install.  The default build installs some too - the launchers
+        # that need third-party headers are in the default --enable-mca-dso
+        # list - so a count says "DSO build" for an ordinary one.
+        mode=$(RUN 'cat /opt/prte/.build-mode 2>/dev/null' | tr -d ' \r')
         ndso=$(RUN 'ls /opt/prte/prte/lib/prte/*.so 2>/dev/null | wc -l' | tr -d ' \r')
-        if [ "${ndso:-0}" -gt 0 ]; then
-            ok "...components are $ndso run-time DSOs (built --enable-mca-dso)"
-        else
-            ok "...components are linked into libprrte (the default build)"
-        fi
+        case "$mode" in
+            mca-dso) ok "...every component is a run-time DSO ($ndso installed)" ;;
+            default) ok "...components are linked into libprrte ($ndso DSOs, the default set)" ;;
+            *)       ok "...component linkage not recorded by this build ($ndso DSOs installed)" ;;
+        esac
     else
         bad "no build stamp in the volume -- the last ./build.sh did not complete."
         echo "     Re-run ./build.sh and check its exit status; the install now" >&2

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -57,6 +57,29 @@ failures in its subtree upward, but not the ancestor chain it now believes
 in — so the new parent cannot confirm that the child agrees with it about the
 shape of the repaired tree.
 
+**Nobody owns marking failed procs ``COMM_FAILED``.**  The recovery
+sequence in ``src/rml/rml_fault_handler.c`` calls each subsystem's
+``fault_handler`` in turn, and the marked question there is whether that
+one place should also be what sets the affected procs to
+``PRTE_PROC_STATE_COMM_FAILED``, instead of leaving each handler to do it.
+It is a question about where the responsibility belongs, not a known
+misbehavior.
+
+**A RELM message-id clash is logged and ignored.**  Two places in
+``src/rml/relm/base/state_updates.c`` detect that a message uid already
+belongs to a different message — a second start for the same uid, or a
+payload whose size disagrees with the one already held — log
+``PRTE_ERR_OP_IN_PROGRESS`` and carry on.  What the right answer is (fail
+the job, or something narrower) has never been decided.  The ids are
+generated, so a clash means something upstream is already wrong.
+
+**A TCP peer that cannot be reached at one address is closed, not
+retried.**  In ``src/rml/oob/oob_tcp_connection.c`` the final
+connect-failure arm closes the peer and returns ``PRTE_ERR_UNREACH``
+where it should force the next address in the peer's list to be tried.
+A peer with several interfaces therefore gets fewer chances than the
+address list implies.
+
 **Routing-tree state is not preserved across a DVM resize.**
 ``prte_rml_compute_routing_tree`` re-initializes the failure bitmaps on every
 grow and restores only the permanent sets (``dead_dmns``, ``absent_dmns``);
@@ -98,6 +121,21 @@ exception — ``contrib/slurmswarm`` runs a real one.
 
 **macOS.**  ``contrib/dockerswarm/run-tests.sh macos`` is a single-host
 subset by construction.  Everything multi-node on that platform is untested.
+
+**``--enable-mca-dso`` beyond one node.**  Building every component as a
+run-time loadable DSO instead of linking it into ``libprrte`` is now built,
+unit-tested and smoke-launched on Linux by the ``ubuntuMcaDso`` job in
+``.github/workflows/builds.yaml``, and the same build was verified by hand
+on macOS (26 components, ``make check`` clean, ``prterun -n 2 hostname``).
+That is a single node, so it proves the components load and that the ones a
+local launch needs work; it does not exercise a component only reached
+across daemons.  ``contrib/dockerswarm`` can now be built that way —
+``PRTE_SWARM_MCA_DSO=1 ./build.sh``, after which the ordinary suite is the
+test — but the arm is **opt-in**, so what is still missing is anyone
+running it as a matter of course.  Note that both the CI job and the
+harness preflight report the DSO count on purpose: a silent fallback to
+static linking would leave every other step passing while testing
+nothing.
 
 **``SLURM_TASKS_PER_NODE`` in its single-node spelling.**  The suite asserts
 the ``2(xN)`` form that a multi-node allocation produces; the ``2(x1)`` form

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -132,10 +132,11 @@ local launch needs work; it does not exercise a component only reached
 across daemons.  ``contrib/dockerswarm`` can now be built that way —
 ``PRTE_SWARM_MCA_DSO=1 ./build.sh``, after which the ordinary suite is the
 test — but the arm is **opt-in**, so what is still missing is anyone
-running it as a matter of course.  Note that both the CI job and the
-harness preflight report the DSO count on purpose: a silent fallback to
-static linking would leave every other step passing while testing
-nothing.
+running it as a matter of course.  Note that the CI job asserts on a
+*named* component being loadable rather than on a count: the default
+build already installs a DSO or two of its own, so a count cannot tell
+the two configurations apart, and a silent fallback to static linking
+would otherwise leave every step passing while testing nothing.
 
 **``SLURM_TASKS_PER_NODE`` in its single-node spelling.**  The suite asserts
 the ``2(xN)`` form that a multi-node allocation produces; the ``2(x1)`` form

--- a/src/mca/plm/pals/Makefile.am
+++ b/src/mca/plm/pals/Makefile.am
@@ -51,8 +51,7 @@ prte_mca_plm_pals_la_SOURCES = $(sources)
 prte_mca_plm_pals_la_CPPFLAGS = $(plm_pals_CPPFLAGS)
 prte_mca_plm_pals_la_LDFLAGS = -module -avoid-version $(plm_pals_LDFLAGS)
 prte_mca_plm_pals_la_LIBADD = $(plm_pals_LIBS) \
-    $(top_builddir)/src/libprrte.la   \
-    $(PRTE_TOP_BUILDDIR)/src/mca/common/pals/libmca_common_pals.la
+    $(top_builddir)/src/libprrte.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libprtemca_plm_pals_la_SOURCES =$(sources)

--- a/src/mca/plm/ssh/AGENTS.md
+++ b/src/mca/plm/ssh/AGENTS.md
@@ -257,3 +257,13 @@ process exits — see the ownership note below.
   never read by anything; it was retired rather than left advertising a
   throttle that did not exist. If inter-launch pacing is ever wanted, it
   belongs in `process_launch_list`.
+- **A component registers its own variables and no others.** This one used
+  to hang three deprecated synonyms off names it does not own —
+  `prte_ssh_agent` and `pls_ssh_agent` for `plm_ssh_agent`, and
+  `prte_assume_same_shell` for `plm_ssh_assume_same_shell`. They were
+  retired rather than moved, because there is nowhere to move them to: a
+  synonym needs the component variable's id, so only the component can
+  register one, and any name it registers outside its own namespace is a
+  project-level name that exists only in builds that include this
+  component. If an old spelling must keep working, that is an argument
+  for keeping the name, not for aliasing it from inside a component.

--- a/src/mca/plm/ssh/plm_ssh_component.c
+++ b/src/mca/plm/ssh/plm_ssh_component.c
@@ -104,7 +104,6 @@ PMIX_MCA_BASE_COMPONENT_INIT(prte, plm, ssh)
 static int ssh_component_register(void)
 {
     pmix_mca_base_component_t *c = &prte_mca_plm_ssh_component.super;
-    int var_id;
 
     prte_mca_plm_ssh_component.num_concurrent = 128;
     (void) pmix_mca_base_component_var_register(c, "num_concurrent",
@@ -161,26 +160,17 @@ static int ssh_component_register(void)
 
     /* local ssh/ssh launch agent */
     prte_mca_plm_ssh_component.agent = "ssh : rsh";
-    var_id = pmix_mca_base_component_var_register(c, "agent",
-                                                  "The command used to launch executables on remote nodes (typically \"ssh\")",
-                                                  PMIX_MCA_BASE_VAR_TYPE_STRING,
-                                                  &prte_mca_plm_ssh_component.agent);
-    (void) pmix_mca_base_var_register_synonym(var_id, "prte", "pls", NULL, "ssh_agent",
-                                              PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
-    (void) pmix_mca_base_var_register_synonym(var_id, "prte", "prte", NULL, "ssh_agent",
-                                              PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
-    agent_var_id = var_id;
+    agent_var_id = pmix_mca_base_component_var_register(c, "agent",
+                                                       "The command used to launch executables on remote nodes (typically \"ssh\")",
+                                                       PMIX_MCA_BASE_VAR_TYPE_STRING,
+                                                       &prte_mca_plm_ssh_component.agent);
 
     prte_mca_plm_ssh_component.assume_same_shell = true;
-    var_id = pmix_mca_base_component_var_register(c, "assume_same_shell",
-                                                  "If set to true, assume that the shell on the remote node is the same as the shell on the "
-                                                  "local node.  Otherwise, probe for what the remote shell [default: 1]",
-                                                  PMIX_MCA_BASE_VAR_TYPE_BOOL,
-                                                  &prte_mca_plm_ssh_component.assume_same_shell);
-    /* XXX -- var_conversion -- Why does this component register prte_assume_same_shell? Components
-     * should ONLY register THEIR OWN variables. */
-    (void) pmix_mca_base_var_register_synonym(var_id, "prte", "prte", NULL, "assume_same_shell",
-                                              PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+    (void) pmix_mca_base_component_var_register(c, "assume_same_shell",
+                                                "If set to true, assume that the shell on the remote node is the same as the shell on the "
+                                                "local node.  Otherwise, probe for what the remote shell [default: 1]",
+                                                PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                                                &prte_mca_plm_ssh_component.assume_same_shell);
 
     prte_mca_plm_ssh_component.pass_environ_mca_params = true;
     (void) pmix_mca_base_component_var_register(c, "pass_environ_mca_params",

--- a/src/prted/AGENTS.md
+++ b/src/prted/AGENTS.md
@@ -279,6 +279,17 @@ report the job's exit status. Signal forwarding is done with
 which is what eventually arrives at `prted_comm.c`'s
 `SIGNAL_LOCAL_PROCS`.
 
+**It also closes the `ess` framework its caller opened, and the ordering
+is load-bearing: every PRRTE framework must be closed while PMIx is still
+up.** PRRTE has no component repository of its own — its components are
+loaded and unloaded by PMIx's — so `PMIx_tool_finalize` reaches
+`pmix_mca_base_close()` and dlcloses PRRTE's component DSOs too. A
+framework closed after that walks its component list into memory that is
+no longer mapped. That is invisible in the default build, where the
+component structs are inside `libprrte`; in an `--enable-mca-dso` build it
+segfaulted `prun` in teardown on every run, after the job had completed
+correctly. Do not move the close back out to `prun.c`/`prte.c`.
+
 ---
 
 ## Testing

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -636,7 +636,9 @@ PRTE_EXPORT int prte(int argc, char *argv[])
         }
 
         // open the ess framework so it can init the signal forwarding
-        // list - we don't actually need the components
+        // list - we don't actually need the components.  prun_common()
+        // closes it, because it has to be closed before PMIx_tool_finalize
+        // unloads our components with its own; see the note there.
         rc = pmix_mca_base_framework_open(&prte_ess_base_framework,
                                         PMIX_MCA_BASE_OPEN_DEFAULT);
         if (PMIX_SUCCESS != rc) {
@@ -646,7 +648,6 @@ PRTE_EXPORT int prte(int argc, char *argv[])
         }
         rc = prun_common(&results, schizo, argc, argv);
 
-        (void) pmix_mca_base_framework_close(&prte_ess_base_framework);
         exit(rc);
     }
 

--- a/src/prted/prun_common.c
+++ b/src/prted/prun_common.c
@@ -840,6 +840,20 @@ DONE:
     if (NULL != papps) {
         PMIX_APP_FREE(papps, napps);
     }
+    /* Close the ess framework our caller opened for us - and close it HERE,
+     * while PMIx is still up.  PRRTE has no component repository of its own:
+     * its components are loaded, and unloaded, by PMIx's.  PMIx_tool_finalize
+     * below reaches pmix_mca_base_close(), which finalizes that repository and
+     * dlcloses every component DSO it opened, ours included.  Closing a PRRTE
+     * framework after that walks its component list into memory that is no
+     * longer mapped, and the tool segfaults in teardown having already done
+     * its work correctly - so the job succeeds and prun exits 139.
+     *
+     * None of that is visible in the default build, where the components are
+     * linked into libprrte and their structs are mapped for the life of the
+     * process.  It is why the callers no longer close this themselves.
+     */
+    (void) pmix_mca_base_framework_close(&prte_ess_base_framework);
     /* cleanup and leave */
     ret = PMIx_tool_finalize();
     if (PMIX_SUCCESS != ret) {

--- a/src/tools/prun/AGENTS.md
+++ b/src/tools/prun/AGENTS.md
@@ -33,7 +33,7 @@ What has to happen here:
 | `--report-pid` | must be written before we could possibly block |
 | `--report-uri` | stashed in `prte_pmix_server_globals` for `prun_common` |
 | `--app <file>` | expands the appfile into `pargv` |
-| open the `ess` framework | only for its signal-name list — no component is selected |
+| open the `ess` framework | only for its signal-name list — no component is selected. `prun_common()` **closes** it, before `PMIx_tool_finalize` unloads PRRTE's components along with PMIx's; see [`../../prted/AGENTS.md`](../../prted/AGENTS.md) |
 
 ---
 

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -293,7 +293,9 @@ int prun(int argc, char *argv[])
     }
 
     // open the ess framework so it can init the signal forwarding
-    // list - we don't actually need the components
+    // list - we don't actually need the components.  prun_common()
+    // closes it, because it has to be closed before PMIx_tool_finalize
+    // unloads our components with its own; see the note there.
     rc = pmix_mca_base_framework_open(&prte_ess_base_framework,
                                       PMIX_MCA_BASE_OPEN_DEFAULT);
     if (PMIX_SUCCESS != rc) {
@@ -307,11 +309,12 @@ int prun(int argc, char *argv[])
     PRTE_UPDATE_EXIT_STATUS(rc);
 
 DONE:
-    // cleanup and leave
+    // cleanup and leave.  The ess framework is NOT closed here: a path that
+    // reached prun_common() has had it closed there, and every other path to
+    // this label either never opened it or is the open's own failure.
     if (NULL != mypidfile) {
         unlink(mypidfile);
     }
-    (void) pmix_mca_base_framework_close(&prte_ess_base_framework);
 
     exit(prte_exit_status);
 }

--- a/test/unit/iof/test_iof.c
+++ b/test/unit/iof/test_iof.c
@@ -94,8 +94,12 @@
 #include "src/mca/iof/base/iof_base_setup.h"
 #include "src/mca/iof/iof.h"
 #include "src/mca/iof/iof_types.h"
-#include "src/mca/iof/hnp/iof_hnp.h"
-#include "src/mca/iof/prted/iof_prted.h"
+
+/* Deliberately NOT the components' headers.  A test links against
+ * libprrte, and a component is only inside libprrte in the default build:
+ * configure --enable-mca-dso builds them as loadable modules instead, and
+ * naming any of their symbols here fails the link outright.  Nothing in
+ * this file needs one -- see the stub handler below. */
 
 #define CHECK(label, cond)                                    \
     do {                                                      \
@@ -706,6 +710,15 @@ static int test_write_handler_drain(void)
  * fd of -1 so the read event's destructor takes its no-close path and this
  * test needs no descriptors of its own.
  */
+/* Stands in for a component's read handler.  The read event below is
+ * defined and never activated, so this is only ever a pointer value --
+ * which is why the real one is not worth a link dependency on a component
+ * that may not be in libprrte at all. */
+static void stub_read_handler(int fd, short event, void *cbdata)
+{
+    PRTE_HIDE_UNUSED_PARAMS(fd, event, cbdata);
+}
+
 static int test_proc_read_event_cycle(void)
 {
     int failures = 0;
@@ -717,7 +730,7 @@ static int test_proc_read_event_cycle(void)
 
     /* one read event, defined but not activated -- the macro retains proct */
     PRTE_IOF_READ_EVENT(&proct->revstdout, proct, -1, PRTE_IOF_STDOUT,
-                        prte_iof_hnp_read_local_handler, false);
+                        stub_read_handler, false);
     CHECK("read event was defined", NULL != proct->revstdout);
     if (NULL == proct->revstdout) {
         PMIX_RELEASE(proct);


### PR DESCRIPTION
Five small changes that came out of one sweep: reading `docs/todo.rst`
against the TODO markers actually in the code, and then closing the
coverage gap the sweep made obvious.

### The bug

`--enable-mca-dso` builds every MCA component as a loadable DSO instead
of linking it into `libprrte`. It is supported, and it is what the
stubbed test-build launchers need, but nothing was running it — so
**`prun` segfaulted in teardown on every invocation** of such a build,
and had for as long as the code has looked like this.

PRRTE has no component repository of its own; its components are loaded
*and unloaded* by PMIx's. `PMIx_tool_finalize` reaches
`pmix_mca_base_close()`, which dlcloses every component DSO, PRRTE's
included — and `prun` closed the `ess` framework afterwards, walking its
component list into unmapped memory. The job itself had already run
correctly, so what a user sees is right output and exit status 139.
Invisible in the default build, where those structs live in `libprrte`.

The rule it leaves behind: **a PRRTE framework must be closed while PMIx
is still up.** The DVM path already obeyed it.

### So it does not happen again

- **CI**: `ubuntuMcaDso` builds `--enable-mca-dso` on Linux, runs the
  unit tests and launches the examples. It asserts component DSOs were
  really produced — a silent fallback to static linking would leave
  every other step green while testing nothing.
- **dockerswarm**: `PRTE_SWARM_MCA_DSO=1 ./build.sh`, after which the
  ordinary suite is the test. That is what found the crash.

### Also here

- `plm/ssh` no longer registers three deprecated synonyms in namespaces
  it does not own (`prte_ssh_agent`, `pls_ssh_agent`,
  `prte_assume_same_shell`). Nothing in the tree, docs or either harness
  refers to them.
- `docs/todo.rst` gains the deferred items that existed only as comments
  in `src/rml`, plus what is left of the DSO coverage.

### Testing

- `--enable-mca-dso` and default builds, macOS and Linux: `make check`
  clean in both; `prun` under the DSO build goes 139 → 0.
- Full `contrib/dockerswarm/run-tests.sh linux` against a DSO build. The
  crash defeated every prun-driven case before the fix; the rerun is
  green through 526 assertions at the time of writing, with two
  unrelated phases still under investigation (per-device mapping and the
  invited-group context id — both in-flight work, and neither touched by
  this branch). I will confirm the attribution with a static A/B and
  report back.

Happy to split this into separate PRs if you would rather review them
apart.
