### PR TITLE
State each framework's interface version, and check it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,53 @@ Each component directory must contain:
 The component's `query` function returns a priority; the highest-priority
 component that successfully opens wins selection.
 
+### Framework interface versions
+
+A framework states the version of the interface its components are built
+against, and PMIx's `pmix_mca_base_components_open()` refuses a component
+that does not match. That matters because components are run-time
+loadable: an installed plugin older than the library loading it is what
+any partial upgrade produces, and it presents whatever module struct its
+header had at the time.
+
+**The numbers live in one place: the framework's own header.** Three
+macros — `PRTE_MCA_<name>_MAJOR_VERSION`, `_MINOR_VERSION`,
+`_RELEASE_VERSION` — feed both the component stamp and the framework
+declaration, which reach them by pasting the framework's name through
+`PRTE_MCA_FW_VER()` in [`src/pmix/pmix-internal.h`](src/pmix/pmix-internal.h):
+
+```c
+/* in plm.h */
+#define PRTE_MCA_plm_MAJOR_VERSION   2
+#define PRTE_MCA_plm_MINOR_VERSION   0
+#define PRTE_MCA_plm_RELEASE_VERSION 0
+
+/* in each plm component */
+    PRTE_MCA_BASE_VERSION(plm),
+
+/* in plm_base_frame.c */
+PRTE_MCA_BASE_FRAMEWORK_DECLARE(plm, NULL, ...);
+```
+
+Neither side restates the numbers, so bumping an interface is one edit in
+one header. **Bump it whenever you change `prte_<fw>_base_module_t` in a
+way a component built against the previous version would not survive** —
+adding an entry point is the usual case, since an older component leaves
+it NULL and the caller has no reason to expect that.
+
+The framework name is a **bare token, lower case, and must be the
+framework's directory name**: the same token is stringified into the
+component struct and pasted into the macro names, so `plm` and not
+`"plm"` or `PLM`. (This is why `prtebacktrace` components now stamp
+`prtebacktrace` where they used to say `backtrace` — the old spelling did
+not match the framework, which would have put any MCA parameter they
+registered under the wrong prefix.)
+
+PRRTE keeps its own `PRTE_MCA_BASE_VERSION` / `PRTE_MCA_BASE_FRAMEWORK_DECLARE`
+rather than using PMIx's because PMIx's stamp the project as `"pmix"`
+with PMIx's version numbers; these say `"prte"` with PRRTE's. Everything
+below that level is PMIx's code.
+
 ---
 
 ## PRRTE's Relationship with PMIx

--- a/src/grpcomm/grpcomm_group.c
+++ b/src/grpcomm/grpcomm_group.c
@@ -1653,6 +1653,12 @@ static void group_op_remember(prte_grpcomm_group_signature_t *sig)
            pmix_list_get_size(&prte_grpcomm_globals.completed_group_ops)) {
         memo = (prte_grpcomm_group_memo_t *)
             pmix_list_remove_first(&prte_grpcomm_globals.completed_group_ops);
+        /* answers NULL for an empty list, and the loop bound above is the
+         * only thing that says this one is not - screen it rather than hand
+         * a NULL to the reference count */
+        if (NULL == memo) {
+            break;
+        }
         PMIX_RELEASE(memo);
     }
     memo = PMIX_NEW(prte_grpcomm_group_memo_t);

--- a/src/mca/errmgr/AGENTS.md
+++ b/src/mca/errmgr/AGENTS.md
@@ -133,7 +133,7 @@ through `prte_errmgr_base_framework.framework_output`. The version macro
 components must use is:
 
 ```c
-#define PRTE_ERRMGR_BASE_VERSION_3_0_0 PRTE_MCA_BASE_VERSION_3_0_0("errmgr", 3, 0, 0)
+#define PRTE_MCA_BASE_VERSION(errmgr) PRTE_MCA_BASE_VERSION("errmgr", 3, 0, 0)
 ```
 
 ---
@@ -146,7 +146,7 @@ the components).
 
 ### `errmgr_base_frame.c` — framework plumbing and the default module
 
-- `PMIX_MCA_BASE_FRAMEWORK_DECLARE(prte, errmgr, …, prte_errmgr_base_open,
+- `PRTE_MCA_BASE_FRAMEWORK_DECLARE(errmgr, …, prte_errmgr_base_open,
   prte_errmgr_base_close, prte_errmgr_base_static_components, …)` declares
   `prte_errmgr_base_framework`. Because the register hook is `NULL`, the
   only framework-level MCA param is the auto-provided `errmgr_base_verbose`.

--- a/src/mca/errmgr/base/errmgr_base_frame.c
+++ b/src/mca/errmgr/base/errmgr_base_frame.c
@@ -90,6 +90,6 @@ static int prte_errmgr_base_open(pmix_mca_base_open_flag_t flags)
     return pmix_mca_base_framework_components_open(&prte_errmgr_base_framework, flags);
 }
 
-PMIX_MCA_BASE_FRAMEWORK_DECLARE(prte, errmgr, "PRTE Error Manager", NULL, prte_errmgr_base_open,
+PRTE_MCA_BASE_FRAMEWORK_DECLARE(errmgr, "PRTE Error Manager", NULL, prte_errmgr_base_open,
                                 prte_errmgr_base_close, prte_errmgr_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);

--- a/src/mca/errmgr/dvm/errmgr_dvm_component.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm_component.c
@@ -46,7 +46,7 @@ prte_errmgr_base_component_t prte_mca_errmgr_dvm_component = {
      *  meta information about the component dvm
      */
     .base_version = {
-        PRTE_ERRMGR_BASE_VERSION_3_0_0,
+        PRTE_MCA_BASE_VERSION(errmgr),
         /* Component name and version */
         .pmix_mca_component_name = "dvm",
         PMIX_MCA_BASE_MAKE_VERSION(component,

--- a/src/mca/errmgr/errmgr.h
+++ b/src/mca/errmgr/errmgr.h
@@ -132,10 +132,15 @@ struct prte_errmgr_base_component_3_0_0_t {
 typedef struct prte_errmgr_base_component_3_0_0_t prte_errmgr_base_component_3_0_0_t;
 typedef prte_errmgr_base_component_3_0_0_t prte_errmgr_base_component_t;
 
-/*
- * Macro for use in components that are of type errmgr
- */
-#define PRTE_ERRMGR_BASE_VERSION_3_0_0 PRTE_MCA_BASE_VERSION_3_0_0("errmgr", 3, 0, 0)
+/* The errmgr framework interface version. It is stated here and nowhere
+ * else: components stamp it into their struct with
+ * PRTE_MCA_BASE_VERSION(errmgr), and the framework's declaration reaches
+ * the same three by pasting its name, so the two cannot drift apart.
+ * Bump it on any change to the module interface that a component built
+ * against the previous one would not survive. */
+#define PRTE_MCA_errmgr_MAJOR_VERSION   3
+#define PRTE_MCA_errmgr_MINOR_VERSION   0
+#define PRTE_MCA_errmgr_RELEASE_VERSION 0
 
 END_C_DECLS
 

--- a/src/mca/errmgr/prted/errmgr_prted_component.c
+++ b/src/mca/errmgr/prted/errmgr_prted_component.c
@@ -45,7 +45,7 @@ prte_errmgr_base_component_t prte_mca_errmgr_prted_component =
      *  meta information about the component itself
      */
     .base_version = {
-        PRTE_ERRMGR_BASE_VERSION_3_0_0,
+        PRTE_MCA_BASE_VERSION(errmgr),
         /* Component name and version */
         .pmix_mca_component_name = "prted",
         PMIX_MCA_BASE_MAKE_VERSION(component,

--- a/src/mca/ess/AGENTS.md
+++ b/src/mca/ess/AGENTS.md
@@ -110,7 +110,7 @@ struct prte_ess_base_module_3_0_0_t {
 The component struct is a bare `pmix_mca_base_component_t` (typedef'd to
 `prte_ess_base_component_t`) — `ess` has **no** component-level data
 beyond the standard MCA header. The version macro is
-`PRTE_ESS_BASE_VERSION_3_0_0` (declared in `ess.h`).
+`PRTE_MCA_BASE_VERSION(ess)` (declared in `ess.h`).
 
 The selected module's two function pointers are copied into the single
 global:
@@ -176,7 +176,7 @@ plus a call to the base's `prted_setup`.
 
 ### `ess_base_frame.c` — framework plumbing + signal forwarding
 
-- Standard `PMIX_MCA_BASE_FRAMEWORK_DECLARE(prte, ess, ...)` with
+- Standard `PRTE_MCA_BASE_FRAMEWORK_DECLARE(ess, ...)` with
   register/open/close hooks.
 - **MCA parameters** (registered in `prte_ess_base_register`), each with
   a deprecated `prte_ess_*` synonym:
@@ -474,7 +474,7 @@ trap for the next reader.
 - **Order is load-bearing in `prted_setup`.** Comms must be up before
   `plm.init()`; the PMIx server must be init'd before gathering aliases;
   IOF comes after routes. Do not reorder the framework opens casually.
-- **Version macro is `PRTE_ESS_BASE_VERSION_3_0_0`.** Bump deliberately;
+- **Version macro is `PRTE_MCA_BASE_VERSION(ess)`.** Bump deliberately;
   the module struct is `prte_ess_base_module_3_0_0_t`.
 - Standard PRRTE rules still apply: `prte_config.h` first, braces on
   every block, `NULL ==`/constant-on-left comparisons, no new compiler

--- a/src/mca/ess/base/ess_base_frame.c
+++ b/src/mca/ess/base/ess_base_frame.c
@@ -128,7 +128,7 @@ static int prte_ess_base_open(pmix_mca_base_open_flag_t flags)
     return pmix_mca_base_framework_components_open(&prte_ess_base_framework, flags);
 }
 
-PMIX_MCA_BASE_FRAMEWORK_DECLARE(prte, ess, "PRTE Environmenal System Setup", prte_ess_base_register,
+PRTE_MCA_BASE_FRAMEWORK_DECLARE(ess, "PRTE Environmenal System Setup", prte_ess_base_register,
                                 prte_ess_base_open, prte_ess_base_close,
                                 prte_ess_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);

--- a/src/mca/ess/env/ess_env_component.c
+++ b/src/mca/ess/env/ess_env_component.c
@@ -45,7 +45,7 @@ extern prte_ess_base_module_t prte_ess_env_module;
  * and pointers to our public functions in it
  */
 prte_ess_base_component_t prte_mca_ess_env_component = {
-    PRTE_ESS_BASE_VERSION_3_0_0,
+    PRTE_MCA_BASE_VERSION(ess),
 
     /* Component name and version */
     .pmix_mca_component_name = "env",

--- a/src/mca/ess/ess.h
+++ b/src/mca/ess/ess.h
@@ -71,10 +71,15 @@ typedef struct prte_ess_base_module_3_0_0_t prte_ess_base_module_t;
  */
 typedef pmix_mca_base_component_t prte_ess_base_component_t;
 
-/*
- * Macro for use in components that are of type ess
- */
-#define PRTE_ESS_BASE_VERSION_3_0_0 PRTE_MCA_BASE_VERSION_3_0_0("ess", 3, 0, 0)
+/* The ess framework interface version. It is stated here and nowhere
+ * else: components stamp it into their struct with
+ * PRTE_MCA_BASE_VERSION(ess), and the framework's declaration reaches
+ * the same three by pasting its name, so the two cannot drift apart.
+ * Bump it on any change to the module interface that a component built
+ * against the previous one would not survive. */
+#define PRTE_MCA_ess_MAJOR_VERSION   3
+#define PRTE_MCA_ess_MINOR_VERSION   0
+#define PRTE_MCA_ess_RELEASE_VERSION 0
 
 /* Global structure for accessing ESS functions */
 PRTE_EXPORT extern prte_ess_base_module_t prte_ess; /* holds selected module's function pointers */

--- a/src/mca/ess/hnp/ess_hnp_component.c
+++ b/src/mca/ess/hnp/ess_hnp_component.c
@@ -52,7 +52,7 @@ static int hnp_component_query(pmix_mca_base_module_t **module, int *priority);
  * and pointers to our public functions in it
  */
 prte_ess_base_component_t prte_mca_ess_hnp_component = {
-    PRTE_ESS_BASE_VERSION_3_0_0,
+    PRTE_MCA_BASE_VERSION(ess),
 
     /* Component name and version */
     .pmix_mca_component_name = "hnp",

--- a/src/mca/ess/lsf/ess_lsf_component.c
+++ b/src/mca/ess/lsf/ess_lsf_component.c
@@ -39,7 +39,7 @@ extern prte_ess_base_module_t prte_ess_lsf_module;
  * and pointers to our public functions in it
  */
 prte_ess_base_component_t prte_mca_ess_lsf_component = {
-    PRTE_ESS_BASE_VERSION_3_0_0,
+    PRTE_MCA_BASE_VERSION(ess),
 
     /* Component name and version */
     .pmix_mca_component_name = "lsf",

--- a/src/mca/ess/pals/ess_pals_component.c
+++ b/src/mca/ess/pals/ess_pals_component.c
@@ -47,7 +47,7 @@ extern prte_ess_base_module_t prte_ess_pals_module;
  * and pointers to our public functions in it
  */
 prte_ess_base_component_t prte_mca_ess_pals_component = {
-    PRTE_ESS_BASE_VERSION_3_0_0,
+    PRTE_MCA_BASE_VERSION(ess),
 
     /* Component name and version */
     .pmix_mca_component_name = "pals",

--- a/src/mca/ess/slurm/ess_slurm_component.c
+++ b/src/mca/ess/slurm/ess_slurm_component.c
@@ -46,7 +46,7 @@ extern prte_ess_base_module_t prte_ess_slurm_module;
  * and pointers to our public functions in it
  */
 prte_ess_base_component_t prte_mca_ess_slurm_component = {
-    PRTE_ESS_BASE_VERSION_3_0_0,
+    PRTE_MCA_BASE_VERSION(ess),
 
     /* Component name and version */
     .pmix_mca_component_name = "slurm",

--- a/src/mca/filem/AGENTS.md
+++ b/src/mca/filem/AGENTS.md
@@ -113,8 +113,8 @@ work through the preposition/link pair, not put/get.
 
 ### The version macro
 
-Components declare `PRTE_FILEM_BASE_VERSION_2_0_0`
-(`PRTE_MCA_BASE_VERSION_3_0_0("filem", 2, 0, 0)`). Note the module
+Components declare `PRTE_MCA_BASE_VERSION(filem)`
+(`PRTE_MCA_BASE_VERSION("filem", 2, 0, 0)`). Note the module
 *struct* is still named `..._1_0_0_t`; the framework version and the
 struct version are independent numbers here.
 

--- a/src/mca/filem/base/filem_base_frame.c
+++ b/src/mca/filem/base/filem_base_frame.c
@@ -71,6 +71,6 @@ static int prte_filem_base_open(pmix_mca_base_open_flag_t flags)
     return pmix_mca_base_framework_components_open(&prte_filem_base_framework, flags);
 }
 
-PMIX_MCA_BASE_FRAMEWORK_DECLARE(prte, filem, NULL, NULL, prte_filem_base_open,
+PRTE_MCA_BASE_FRAMEWORK_DECLARE(filem, NULL, NULL, prte_filem_base_open,
                                 prte_filem_base_close, prte_filem_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);

--- a/src/mca/filem/filem.h
+++ b/src/mca/filem/filem.h
@@ -382,10 +382,15 @@ typedef struct prte_filem_base_module_1_0_0_t prte_filem_base_module_t;
 
 PRTE_EXPORT extern prte_filem_base_module_t prte_filem;
 
-/**
- * Macro for use in components that are of type FILEM
- */
-#define PRTE_FILEM_BASE_VERSION_2_0_0 PRTE_MCA_BASE_VERSION_3_0_0("filem", 2, 0, 0)
+/* The filem framework interface version. It is stated here and nowhere
+ * else: components stamp it into their struct with
+ * PRTE_MCA_BASE_VERSION(filem), and the framework's declaration reaches
+ * the same three by pasting its name, so the two cannot drift apart.
+ * Bump it on any change to the module interface that a component built
+ * against the previous one would not survive. */
+#define PRTE_MCA_filem_MAJOR_VERSION   2
+#define PRTE_MCA_filem_MINOR_VERSION   0
+#define PRTE_MCA_filem_RELEASE_VERSION 0
 
 END_C_DECLS
 

--- a/src/mca/filem/raw/filem_raw_component.c
+++ b/src/mca/filem/raw/filem_raw_component.c
@@ -39,7 +39,7 @@ static int filem_raw_query(pmix_mca_base_module_t **module, int *priority);
 bool prte_filem_raw_flatten_trees = false;
 
 prte_filem_base_component_t prte_mca_filem_raw_component = {
-    PRTE_FILEM_BASE_VERSION_2_0_0,
+    PRTE_MCA_BASE_VERSION(filem),
     /* Component name and version */
     .pmix_mca_component_name = "raw",
     PMIX_MCA_BASE_MAKE_VERSION(component,

--- a/src/mca/iof/AGENTS.md
+++ b/src/mca/iof/AGENTS.md
@@ -567,7 +567,7 @@ no other thread touching this state. Consequences:
   its own terminal stdin directly; they were never defined and have been
   removed. Stdin arrives via the PMIx server calling
   `prte_iof.push_stdin` — don't reintroduce a direct-read path.
-- **The version macro is `PRTE_IOF_BASE_VERSION_2_0_0`.** Match it in any
+- **The version macro is `PRTE_MCA_BASE_VERSION(iof)`.** Match it in any
   new component's struct.
 - Standard PRRTE rules still apply: `prte_config.h` first, braces on every
   block, `NULL ==`/constant-on-left comparisons, no new compiler warnings,

--- a/src/mca/iof/base/iof_base_frame.c
+++ b/src/mca/iof/base/iof_base_frame.c
@@ -94,7 +94,7 @@ static int prte_iof_base_open(pmix_mca_base_open_flag_t flags)
     return pmix_mca_base_framework_components_open(&prte_iof_base_framework, flags);
 }
 
-PMIX_MCA_BASE_FRAMEWORK_DECLARE(prte, iof, "PRTE I/O Forwarding",
+PRTE_MCA_BASE_FRAMEWORK_DECLARE(iof, "PRTE I/O Forwarding",
                                 prte_iof_base_register,
                                 prte_iof_base_open, prte_iof_base_close,
                                 prte_iof_base_static_components,

--- a/src/mca/iof/hnp/iof_hnp_component.c
+++ b/src/mca/iof/hnp/iof_hnp_component.c
@@ -51,7 +51,7 @@ const char *prte_mca_iof_hnp_component_version_string
 
 prte_mca_iof_hnp_component_t prte_mca_iof_hnp_component = {
     .super = {
-        PRTE_IOF_BASE_VERSION_2_0_0,
+        PRTE_MCA_BASE_VERSION(iof),
 
         .pmix_mca_component_name = "hnp",
         PMIX_MCA_BASE_MAKE_VERSION(component,

--- a/src/mca/iof/iof.h
+++ b/src/mca/iof/iof.h
@@ -161,9 +161,14 @@ typedef pmix_mca_base_component_t prte_iof_base_component_t;
 
 END_C_DECLS
 
-/*
- * Macro for use in components that are of type iof
- */
-#define PRTE_IOF_BASE_VERSION_2_0_0 PRTE_MCA_BASE_VERSION_3_0_0("iof", 2, 0, 0)
+/* The iof framework interface version. It is stated here and nowhere
+ * else: components stamp it into their struct with
+ * PRTE_MCA_BASE_VERSION(iof), and the framework's declaration reaches
+ * the same three by pasting its name, so the two cannot drift apart.
+ * Bump it on any change to the module interface that a component built
+ * against the previous one would not survive. */
+#define PRTE_MCA_iof_MAJOR_VERSION   2
+#define PRTE_MCA_iof_MINOR_VERSION   0
+#define PRTE_MCA_iof_RELEASE_VERSION 0
 
 #endif /* PRTE_IOF_H */

--- a/src/mca/iof/prted/iof_prted_component.c
+++ b/src/mca/iof/prted/iof_prted_component.c
@@ -47,7 +47,7 @@ const char *prte_mca_iof_prted_component_version_string
 
 prte_mca_iof_prted_component_t prte_mca_iof_prted_component = {
     .super = {
-        PRTE_IOF_BASE_VERSION_2_0_0,
+        PRTE_MCA_BASE_VERSION(iof),
 
         .pmix_mca_component_name = "prted",
         PMIX_MCA_BASE_MAKE_VERSION(component,

--- a/src/mca/odls/AGENTS.md
+++ b/src/mca/odls/AGENTS.md
@@ -118,7 +118,7 @@ returning up the stack, because the launch runs asynchronously on the
 event loop (`PRTE_ACTIVATE_PROC_STATE(..., PRTE_PROC_STATE_FAILED_TO_LAUNCH)`,
 `PRTE_ACTIVATE_JOB_STATE(..., PRTE_JOB_STATE_NEVER_LAUNCHED)`).
 
-The version macro is `PRTE_ODLS_BASE_VERSION_2_0_0`.
+The version macro is `PRTE_MCA_BASE_VERSION(odls)`.
 
 ---
 

--- a/src/mca/odls/base/odls_base_frame.c
+++ b/src/mca/odls/base/odls_base_frame.c
@@ -357,7 +357,7 @@ static int prte_odls_base_open(pmix_mca_base_open_flag_t flags)
     return pmix_mca_base_framework_components_open(&prte_odls_base_framework, flags);
 }
 
-PMIX_MCA_BASE_FRAMEWORK_DECLARE(prte, odls, "PRTE Daemon Launch Subsystem", prte_odls_base_register,
+PRTE_MCA_BASE_FRAMEWORK_DECLARE(odls, "PRTE Daemon Launch Subsystem", prte_odls_base_register,
                                 prte_odls_base_open, prte_odls_base_close,
                                 prte_odls_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);

--- a/src/mca/odls/odls.h
+++ b/src/mca/odls/odls.h
@@ -102,10 +102,15 @@ typedef struct prte_odls_base_module_1_3_0_t prte_odls_base_module_t;
  */
 typedef pmix_mca_base_component_t prte_odls_base_component_t;
 
-/**
- * Macro for use in modules that are of type odls
- */
-#define PRTE_ODLS_BASE_VERSION_2_0_0 PRTE_MCA_BASE_VERSION_3_0_0("odls", 2, 0, 0)
+/* The odls framework interface version. It is stated here and nowhere
+ * else: components stamp it into their struct with
+ * PRTE_MCA_BASE_VERSION(odls), and the framework's declaration reaches
+ * the same three by pasting its name, so the two cannot drift apart.
+ * Bump it on any change to the module interface that a component built
+ * against the previous one would not survive. */
+#define PRTE_MCA_odls_MAJOR_VERSION   2
+#define PRTE_MCA_odls_MINOR_VERSION   0
+#define PRTE_MCA_odls_RELEASE_VERSION 0
 
 /* Global structure for accessing ODLS functions
  */

--- a/src/mca/odls/pdefault/odls_pdefault_component.c
+++ b/src/mca/odls/pdefault/odls_pdefault_component.c
@@ -53,7 +53,7 @@ static int component_query(pmix_mca_base_module_t **module, int *priority);
  */
 
 prte_odls_base_component_t prte_mca_odls_pdefault_component = {
-    PRTE_ODLS_BASE_VERSION_2_0_0,
+    PRTE_MCA_BASE_VERSION(odls),
     /* Component name and version */
     .pmix_mca_component_name = "pdefault",
     PMIX_MCA_BASE_MAKE_VERSION(component,

--- a/src/mca/plm/AGENTS.md
+++ b/src/mca/plm/AGENTS.md
@@ -106,7 +106,7 @@ Note the sequences deliberately **skip** some offsets (e.g. job error
 
 Every component fills in the same vtable, declared in `plm.h` as
 `prte_plm_base_module_t` (version macro
-`PRTE_PLM_BASE_VERSION_2_0_0`). **All entries are mandatory** in
+`PRTE_MCA_BASE_VERSION(plm)`). **All entries are mandatory** in
 principle, but in practice most components reuse the base implementations
 for everything except `spawn`, `init`, and `finalize`. The selected
 module is copied wholesale into the global `prte_plm`.
@@ -554,7 +554,7 @@ placed daemons) or wireup stalls.
   parsed and never applied. Both are gone. A dead knob is worse than no
   knob — it makes a user's correct diagnosis look wrong. `prte_plm_globals_t`
   is likewise down to the fields something actually reads.
-- **The version macro is `PRTE_PLM_BASE_VERSION_2_0_0`** (`plm` 2.0.0).
+- **The version macro is `PRTE_MCA_BASE_VERSION(plm)`** (`plm` 2.0.0).
 - Standard PRRTE rules still apply: `prte_config.h` first, braces on
   every block, `NULL ==`/constant-on-left comparisons, no new compiler
   warnings, `PRTE_ERROR_LOG` for unexpected errors.

--- a/src/mca/plm/base/plm_base_frame.c
+++ b/src/mca/plm/base/plm_base_frame.c
@@ -160,7 +160,7 @@ static int prte_plm_base_open(pmix_mca_base_open_flag_t flags)
     return pmix_mca_base_framework_components_open(&prte_plm_base_framework, flags);
 }
 
-PMIX_MCA_BASE_FRAMEWORK_DECLARE(prte, plm, NULL, mca_plm_base_register, prte_plm_base_open,
+PRTE_MCA_BASE_FRAMEWORK_DECLARE(plm, NULL, mca_plm_base_register, prte_plm_base_open,
                                 prte_plm_base_close, prte_plm_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);
 

--- a/src/mca/plm/lsf/plm_lsf_component.c
+++ b/src/mca/plm/lsf/plm_lsf_component.c
@@ -68,7 +68,7 @@ static int prte_mca_plm_lsf_component_query(pmix_mca_base_module_t **module, int
 
 prte_mca_plm_lsf_component_t prte_mca_plm_lsf_component = {
     .super = {
-        PRTE_PLM_BASE_VERSION_2_0_0,
+        PRTE_MCA_BASE_VERSION(plm),
 
         /* Component name and version */
         .pmix_mca_component_name = "lsf",

--- a/src/mca/plm/pals/plm_pals_component.c
+++ b/src/mca/plm/pals/plm_pals_component.c
@@ -65,7 +65,7 @@ static int prte_mca_plm_pals_component_query(pmix_mca_base_module_t **module, in
 
 prte_mca_plm_pals_component_t prte_mca_plm_pals_component = {
     .super = {
-        PRTE_PLM_BASE_VERSION_2_0_0,
+        PRTE_MCA_BASE_VERSION(plm),
 
         /* Component name and version */
         .pmix_mca_component_name = "pals",

--- a/src/mca/plm/plm.h
+++ b/src/mca/plm/plm.h
@@ -127,10 +127,15 @@ typedef struct prte_plm_base_module_1_0_0_t prte_plm_base_module_t;
  */
 typedef pmix_mca_base_component_t prte_plm_base_component_t;
 
-/**
- * Macro for use in modules that are of type plm
- */
-#define PRTE_PLM_BASE_VERSION_2_0_0 PRTE_MCA_BASE_VERSION_3_0_0("plm", 2, 0, 0)
+/* The plm framework interface version. It is stated here and nowhere
+ * else: components stamp it into their struct with
+ * PRTE_MCA_BASE_VERSION(plm), and the framework's declaration reaches
+ * the same three by pasting its name, so the two cannot drift apart.
+ * Bump it on any change to the module interface that a component built
+ * against the previous one would not survive. */
+#define PRTE_MCA_plm_MAJOR_VERSION   2
+#define PRTE_MCA_plm_MINOR_VERSION   0
+#define PRTE_MCA_plm_RELEASE_VERSION 0
 
 /* Global structure for accessing PLM functions */
 PRTE_EXPORT extern prte_plm_base_module_t prte_plm; /* holds selected module's function pointers */

--- a/src/mca/plm/slurm/plm_slurm_component.c
+++ b/src/mca/plm/slurm/plm_slurm_component.c
@@ -66,7 +66,7 @@ static int prte_mca_plm_slurm_component_query(pmix_mca_base_module_t **module, i
 
 prte_mca_plm_slurm_component_t prte_mca_plm_slurm_component = {
     .super = {
-        PRTE_PLM_BASE_VERSION_2_0_0,
+        PRTE_MCA_BASE_VERSION(plm),
 
         /* Component name and version */
         .pmix_mca_component_name = "slurm",

--- a/src/mca/plm/ssh/plm_ssh_component.c
+++ b/src/mca/plm/ssh/plm_ssh_component.c
@@ -83,7 +83,7 @@ static int agent_var_id = -1;
 
 prte_mca_plm_ssh_component_t prte_mca_plm_ssh_component = {
     .super = {
-        PRTE_PLM_BASE_VERSION_2_0_0,
+        PRTE_MCA_BASE_VERSION(plm),
 
         /* Component name and version */
         .pmix_mca_component_name = "ssh",

--- a/src/mca/prtebacktrace/AGENTS.md
+++ b/src/mca/prtebacktrace/AGENTS.md
@@ -87,8 +87,8 @@ of which are called directly. The joy of link-time components."
   `prte_backtrace_base_component_t` — a `typedef` for
   `pmix_mca_base_component_t` — with **no `query`, no module, no
   function pointers.** It carries only the version/name header
-  (`PRTE_BACKTRACE_BASE_VERSION_2_0_0`, which expands to
-  `PRTE_MCA_BASE_VERSION_3_0_0("backtrace", 2, 0, 0)`).
+  (`PRTE_MCA_BASE_VERSION(prtebacktrace)`, which expands to
+  `PRTE_MCA_BASE_VERSION("backtrace", 2, 0, 0)`).
 - Each component provides the *same two global symbols*,
   `prte_backtrace_print` and `prte_backtrace_buffer`. Because these are
   fixed names, **only one component can be linked into a binary** — two
@@ -134,7 +134,7 @@ functions** to walk, because there is no runtime module to select or
 drive. `base/` contains only the framework object itself:
 
 - `base/backtrace_component.c` declares the framework via
-  `PMIX_MCA_BASE_FRAMEWORK_DECLARE(prte, prtebacktrace, NULL, NULL, NULL,
+  `PRTE_MCA_BASE_FRAMEWORK_DECLARE(prtebacktrace, NULL, NULL, NULL,
   NULL, prte_prtebacktrace_base_static_components,
   PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT)`. All four hook slots
   (register / open / close / query) are `NULL`: the framework uses the

--- a/src/mca/prtebacktrace/base/backtrace_component.c
+++ b/src/mca/prtebacktrace/base/backtrace_component.c
@@ -39,6 +39,6 @@
  */
 
 /* Uses default register/open/close functions */
-PMIX_MCA_BASE_FRAMEWORK_DECLARE(prte, prtebacktrace, NULL, NULL, NULL, NULL,
+PRTE_MCA_BASE_FRAMEWORK_DECLARE(prtebacktrace, NULL, NULL, NULL, NULL,
                                 prte_prtebacktrace_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);

--- a/src/mca/prtebacktrace/execinfo/backtrace_execinfo_component.c
+++ b/src/mca/prtebacktrace/execinfo/backtrace_execinfo_component.c
@@ -29,7 +29,7 @@
 #include "src/mca/prtebacktrace/prtebacktrace.h"
 
 const pmix_mca_base_component_t prte_mca_prtebacktrace_execinfo_component = {
-    PRTE_BACKTRACE_BASE_VERSION_2_0_0,
+    PRTE_MCA_BASE_VERSION(prtebacktrace),
 
     /* Component name and version */
     .pmix_mca_component_name = "execinfo",

--- a/src/mca/prtebacktrace/none/backtrace_none_component.c
+++ b/src/mca/prtebacktrace/none/backtrace_none_component.c
@@ -33,7 +33,7 @@ PRTE_EXPORT extern const pmix_mca_base_component_t prte_mca_backtrace_none_compo
 END_C_DECLS
 
 const pmix_mca_base_component_t prte_mca_prtebacktrace_none_component = {
-    PRTE_BACKTRACE_BASE_VERSION_2_0_0,
+    PRTE_MCA_BASE_VERSION(prtebacktrace),
 
     /* Component name and version */
     .pmix_mca_component_name = "none",

--- a/src/mca/prtebacktrace/printstack/backtrace_printstack_component.c
+++ b/src/mca/prtebacktrace/printstack/backtrace_printstack_component.c
@@ -29,7 +29,7 @@
 #include "src/mca/prtebacktrace/prtebacktrace.h"
 
 const pmix_mca_base_component_t prte_mca_prtebacktrace_printstack_component = {
-    PRTE_BACKTRACE_BASE_VERSION_2_0_0,
+    PRTE_MCA_BASE_VERSION(prtebacktrace),
 
     /* Component name and version */
     .pmix_mca_component_name = "printstack",

--- a/src/mca/prtebacktrace/prtebacktrace.h
+++ b/src/mca/prtebacktrace/prtebacktrace.h
@@ -65,10 +65,15 @@ PRTE_EXPORT int prte_backtrace_buffer(char ***messages, int *len);
  */
 typedef pmix_mca_base_component_t prte_backtrace_base_component_t;
 
-/*
- * Macro for use in components that are of type backtrace
- */
-#define PRTE_BACKTRACE_BASE_VERSION_2_0_0 PRTE_MCA_BASE_VERSION_3_0_0("backtrace", 2, 0, 0)
+/* The prtebacktrace framework interface version. It is stated here and
+ * nowhere else: components stamp it into their struct with
+ * PRTE_MCA_BASE_VERSION(prtebacktrace), and the framework's declaration
+ * reaches the same three by pasting its name, so the two cannot drift
+ * apart. Bump it on any change to the module interface that a component
+ * built against the previous one would not survive. */
+#define PRTE_MCA_prtebacktrace_MAJOR_VERSION   2
+#define PRTE_MCA_prtebacktrace_MINOR_VERSION   0
+#define PRTE_MCA_prtebacktrace_RELEASE_VERSION 0
 
 END_C_DECLS
 

--- a/src/mca/prteinstalldirs/AGENTS.md
+++ b/src/mca/prteinstalldirs/AGENTS.md
@@ -156,8 +156,8 @@ have no opinion about this directory." The two components differ only in
   the empty string) leaves that field `NULL`.
 
 The version macro every component uses is
-`PRTE_INSTALLDIRS_BASE_VERSION_2_0_0`
-(`PRTE_MCA_BASE_VERSION_3_0_0("prteinstalldirs", 2, 0, 0)`).
+`PRTE_MCA_BASE_VERSION(prteinstalldirs)`
+(`PRTE_MCA_BASE_VERSION("prteinstalldirs", 2, 0, 0)`).
 
 ---
 

--- a/src/mca/prteinstalldirs/base/prteinstalldirs_base_components.c
+++ b/src/mca/prteinstalldirs/base/prteinstalldirs_base_components.c
@@ -141,7 +141,7 @@ static int prte_prteinstalldirs_base_close(void)
 }
 
 /* Declare the prteinstalldirs framework */
-PMIX_MCA_BASE_FRAMEWORK_DECLARE(prte, prteinstalldirs, NULL, NULL, prte_prteinstalldirs_base_open,
+PRTE_MCA_BASE_FRAMEWORK_DECLARE(prteinstalldirs, NULL, NULL, prte_prteinstalldirs_base_open,
                                 prte_prteinstalldirs_base_close,
                                 prte_prteinstalldirs_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_NOREGISTER

--- a/src/mca/prteinstalldirs/config/prte_installdirs_config.c
+++ b/src/mca/prteinstalldirs/config/prte_installdirs_config.c
@@ -20,7 +20,7 @@
 
 const prte_prteinstalldirs_base_component_t prte_mca_prteinstalldirs_config_component = {
     .component = {
-        PRTE_INSTALLDIRS_BASE_VERSION_2_0_0,
+        PRTE_MCA_BASE_VERSION(prteinstalldirs),
 
         /* Component name and version */
         .pmix_mca_component_name = "config",

--- a/src/mca/prteinstalldirs/env/AGENTS.md
+++ b/src/mca/prteinstalldirs/env/AGENTS.md
@@ -46,7 +46,7 @@ by the registered open callback:
 
 ```c
 .component = {
-    PRTE_INSTALLDIRS_BASE_VERSION_2_0_0,
+    PRTE_MCA_BASE_VERSION(prteinstalldirs),
     .pmix_mca_component_name = "env",
     ...
     .pmix_mca_open_component = prteinstalldirs_env_open

--- a/src/mca/prteinstalldirs/env/prte_installdirs_env.c
+++ b/src/mca/prteinstalldirs/env/prte_installdirs_env.c
@@ -25,7 +25,7 @@ static int prteinstalldirs_env_open(void);
 
 prte_prteinstalldirs_base_component_t prte_mca_prteinstalldirs_env_component = {
     .component = {
-        PRTE_INSTALLDIRS_BASE_VERSION_2_0_0,
+        PRTE_MCA_BASE_VERSION(prteinstalldirs),
 
         /* Component name and version */
         .pmix_mca_component_name = "env",

--- a/src/mca/prteinstalldirs/prteinstalldirs.h
+++ b/src/mca/prteinstalldirs/prteinstalldirs.h
@@ -46,10 +46,15 @@ struct prte_prteinstalldirs_base_component_2_0_0_t {
  */
 typedef struct prte_prteinstalldirs_base_component_2_0_0_t prte_prteinstalldirs_base_component_t;
 
-/*
- * Macro for use in components that are of type prteinstalldirs
- */
-#define PRTE_INSTALLDIRS_BASE_VERSION_2_0_0 PRTE_MCA_BASE_VERSION_3_0_0("prteinstalldirs", 2, 0, 0)
+/* The prteinstalldirs framework interface version. It is stated here and
+ * nowhere else: components stamp it into their struct with
+ * PRTE_MCA_BASE_VERSION(prteinstalldirs), and the framework's
+ * declaration reaches the same three by pasting its name, so the two
+ * cannot drift apart. Bump it on any change to the module interface that
+ * a component built against the previous one would not survive. */
+#define PRTE_MCA_prteinstalldirs_MAJOR_VERSION   2
+#define PRTE_MCA_prteinstalldirs_MINOR_VERSION   0
+#define PRTE_MCA_prteinstalldirs_RELEASE_VERSION 0
 
 END_C_DECLS
 

--- a/src/mca/prtereachable/AGENTS.md
+++ b/src/mca/prtereachable/AGENTS.md
@@ -138,7 +138,7 @@ and owns the matrix's memory management.
 ### `reachable_base_frame.c` — framework plumbing
 
 Standard MCA framework scaffolding via
-`PMIX_MCA_BASE_FRAMEWORK_DECLARE(prte, prtereachable, …)`:
+`PRTE_MCA_BASE_FRAMEWORK_DECLARE(prtereachable, …)`:
 `open` opens all available components, `close` closes them, `register` is
 a no-op. This file also **defines the framework-global module**:
 
@@ -237,8 +237,8 @@ is always built.
 - Standard PRRTE rules still apply: `prte_config.h` first, braces on
   every block, `NULL ==`/constant-on-left comparisons, no new compiler
   warnings, `PRTE_EXPORT` only where cross-unit visibility is needed.
-- **The version macro is `PRTE_REACHABLE_BASE_VERSION_2_0_0`**
-  (`PRTE_MCA_BASE_VERSION_3_0_0("prtereachable", 2, 0, 0)`). Every
+- **The version macro is `PRTE_MCA_BASE_VERSION(prtereachable)`**
+  (`PRTE_MCA_BASE_VERSION("prtereachable", 2, 0, 0)`). Every
   component's `base_version` must use it.
 
 ---

--- a/src/mca/prtereachable/base/reachable_base_frame.c
+++ b/src/mca/prtereachable/base/reachable_base_frame.c
@@ -48,7 +48,7 @@ static int prte_reachable_base_frame_open(pmix_mca_base_open_flag_t flags)
     return pmix_mca_base_framework_components_open(&prte_prtereachable_base_framework, flags);
 }
 
-PMIX_MCA_BASE_FRAMEWORK_DECLARE(prte, prtereachable, "PRTE Reachability Framework",
+PRTE_MCA_BASE_FRAMEWORK_DECLARE(prtereachable, "PRTE Reachability Framework",
                                 prte_reachable_base_frame_register, prte_reachable_base_frame_open,
                                 prte_reachable_base_frame_close,
                                 prte_prtereachable_base_static_components,

--- a/src/mca/prtereachable/netlink/reachable_netlink_component.c
+++ b/src/mca/prtereachable/netlink/reachable_netlink_component.c
@@ -45,7 +45,7 @@ prte_reachable_base_component_t prte_mca_prtereachable_netlink_component = {
         /* Indicate that we are a reachable v1.1.0 component (which also
            implies a specific MCA version) */
 
-        PRTE_REACHABLE_BASE_VERSION_2_0_0,
+        PRTE_MCA_BASE_VERSION(prtereachable),
 
         /* Component name and version */
 

--- a/src/mca/prtereachable/prtereachable.h
+++ b/src/mca/prtereachable/prtereachable.h
@@ -97,10 +97,15 @@ typedef struct {
     int priority;
 } prte_reachable_base_component_t;
 
-/*
- * Macro for use in components that are of type reachable
- */
-#define PRTE_REACHABLE_BASE_VERSION_2_0_0 PRTE_MCA_BASE_VERSION_3_0_0("prtereachable", 2, 0, 0)
+/* The prtereachable framework interface version. It is stated here and
+ * nowhere else: components stamp it into their struct with
+ * PRTE_MCA_BASE_VERSION(prtereachable), and the framework's declaration
+ * reaches the same three by pasting its name, so the two cannot drift
+ * apart. Bump it on any change to the module interface that a component
+ * built against the previous one would not survive. */
+#define PRTE_MCA_prtereachable_MAJOR_VERSION   2
+#define PRTE_MCA_prtereachable_MINOR_VERSION   0
+#define PRTE_MCA_prtereachable_RELEASE_VERSION 0
 
 /* Global structure for accessing reachability functions */
 PRTE_EXPORT extern prte_reachable_base_module_t prte_reachable;

--- a/src/mca/prtereachable/weighted/reachable_weighted_component.c
+++ b/src/mca/prtereachable/weighted/reachable_weighted_component.c
@@ -58,7 +58,7 @@ prte_mca_prtereachable_weighted_component_t prte_mca_prtereachable_weighted_comp
             /* Indicate that we are a reachable v1.1.0 component (which also
                implies a specific MCA version) */
 
-            PRTE_REACHABLE_BASE_VERSION_2_0_0,
+            PRTE_MCA_BASE_VERSION(prtereachable),
 
             /* Component name and version */
 

--- a/src/mca/ras/AGENTS.md
+++ b/src/mca/ras/AGENTS.md
@@ -55,7 +55,7 @@ see below.
 
 ```
 ras/
-  ras.h                    # module/component vtable + PRTE_RAS_BASE_VERSION_2_0_0
+  ras.h                    # module/component vtable + PRTE_MCA_BASE_VERSION(ras)
   base/
     base.h                 # framework-global struct (prte_ras_base) + all base API prototypes
     ras_base_frame.c       # framework open/close/register; ras_base MCA params; globals

--- a/src/mca/ras/base/ras_base_frame.c
+++ b/src/mca/ras/base/ras_base_frame.c
@@ -114,7 +114,7 @@ static int prte_ras_base_open(pmix_mca_base_open_flag_t flags)
     return pmix_mca_base_framework_components_open(&prte_ras_base_framework, flags);
 }
 
-PMIX_MCA_BASE_FRAMEWORK_DECLARE(prte, ras, "PRTE Resource Allocation Subsystem", ras_register,
+PRTE_MCA_BASE_FRAMEWORK_DECLARE(ras, "PRTE Resource Allocation Subsystem", ras_register,
                                 prte_ras_base_open, prte_ras_base_close,
                                 prte_ras_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);

--- a/src/mca/ras/bootstrap/ras_boot_component.c
+++ b/src/mca/ras/bootstrap/ras_boot_component.c
@@ -42,7 +42,7 @@
 static int component_query(pmix_mca_base_module_t **module, int *priority);
 
 prte_ras_base_component_t prte_mca_ras_bootstrap_component = {
-    PRTE_RAS_BASE_VERSION_2_0_0,
+    PRTE_MCA_BASE_VERSION(ras),
 
     /* Component name and version */
     .pmix_mca_component_name = "bootstrap",

--- a/src/mca/ras/flux/ras_flux_component.c
+++ b/src/mca/ras/flux/ras_flux_component.c
@@ -63,7 +63,7 @@ static int prte_mca_ras_flux_component_query(pmix_mca_base_module_t **module, in
 
 prte_mca_ras_flux_component_t prte_mca_ras_flux_component = {
     .super = {
-        PRTE_RAS_BASE_VERSION_2_0_0,
+        PRTE_MCA_BASE_VERSION(ras),
 
         /* Component name and version */
         .pmix_mca_component_name = "flux",

--- a/src/mca/ras/gridengine/ras_gridengine_component.c
+++ b/src/mca/ras/gridengine/ras_gridengine_component.c
@@ -55,7 +55,7 @@ static int prte_ras_gridengine_verbose;
 
 prte_mca_ras_gridengine_component_t prte_mca_ras_gridengine_component = {
     .super = {
-        PRTE_RAS_BASE_VERSION_2_0_0,
+        PRTE_MCA_BASE_VERSION(ras),
         .pmix_mca_component_name = "gridengine",
         PMIX_MCA_BASE_MAKE_VERSION(component,
                                    PRTE_MAJOR_VERSION,

--- a/src/mca/ras/hosts/ras_hosts_component.c
+++ b/src/mca/ras/hosts/ras_hosts_component.c
@@ -42,7 +42,7 @@
 static int ras_hosts_component_query(pmix_mca_base_module_t **module, int *priority);
 
 prte_ras_base_component_t prte_mca_ras_hosts_component = {
-    PRTE_RAS_BASE_VERSION_2_0_0,
+    PRTE_MCA_BASE_VERSION(ras),
 
     /* Component name and version */
     .pmix_mca_component_name = "hosts",

--- a/src/mca/ras/lsf/ras_lsf_component.c
+++ b/src/mca/ras/lsf/ras_lsf_component.c
@@ -52,7 +52,7 @@ prte_ras_base_component_t prte_mca_ras_lsf_component = {
     /* Indicate that we are a ras v2.0.0 component (which also
        implies a specific MCA version) */
 
-    PRTE_RAS_BASE_VERSION_2_0_0,
+    PRTE_MCA_BASE_VERSION(ras),
 
     .pmix_mca_component_name = "lsf",
     PMIX_MCA_BASE_MAKE_VERSION(component,

--- a/src/mca/ras/pbs/ras_pbs_component.c
+++ b/src/mca/ras/pbs/ras_pbs_component.c
@@ -48,7 +48,7 @@ static int prte_mca_ras_pbs_component_query(pmix_mca_base_module_t **module, int
 
 prte_mca_ras_pbs_component_t prte_mca_ras_pbs_component = {
     .super = {
-        PRTE_RAS_BASE_VERSION_2_0_0,
+        PRTE_MCA_BASE_VERSION(ras),
 
         /* Component name and version */
         .pmix_mca_component_name = "pbs",

--- a/src/mca/ras/pmix/ras_pmix_component.c
+++ b/src/mca/ras/pmix/ras_pmix_component.c
@@ -45,7 +45,7 @@ static int ras_pmix_component_query(pmix_mca_base_module_t **module, int *priori
 
 prte_ras_pmix_component_t prte_mca_ras_pmix_component = {
     .super = {
-        PRTE_RAS_BASE_VERSION_2_0_0,
+        PRTE_MCA_BASE_VERSION(ras),
 
         /* Component name and version */
         .pmix_mca_component_name = "pmix",

--- a/src/mca/ras/ras.h
+++ b/src/mca/ras/ras.h
@@ -142,10 +142,15 @@ typedef prte_ras_base_module_2_0_0_t prte_ras_base_module_t;
 /** Convenience typedef */
 typedef pmix_mca_base_component_t prte_ras_base_component_t;
 
-/**
- * Macro for use in components that are of type ras
- */
-#define PRTE_RAS_BASE_VERSION_2_0_0 PRTE_MCA_BASE_VERSION_3_0_0("ras", 2, 0, 0)
+/* The ras framework interface version. It is stated here and nowhere
+ * else: components stamp it into their struct with
+ * PRTE_MCA_BASE_VERSION(ras), and the framework's declaration reaches
+ * the same three by pasting its name, so the two cannot drift apart.
+ * Bump it on any change to the module interface that a component built
+ * against the previous one would not survive. */
+#define PRTE_MCA_ras_MAJOR_VERSION   2
+#define PRTE_MCA_ras_MINOR_VERSION   0
+#define PRTE_MCA_ras_RELEASE_VERSION 0
 
 END_C_DECLS
 

--- a/src/mca/ras/simulator/ras_sim_component.c
+++ b/src/mca/ras/simulator/ras_sim_component.c
@@ -43,7 +43,7 @@ static int ras_sim_component_query(pmix_mca_base_module_t **module, int *priorit
 
 prte_ras_sim_component_t prte_mca_ras_simulator_component = {
     .super = {
-        PRTE_RAS_BASE_VERSION_2_0_0,
+        PRTE_MCA_BASE_VERSION(ras),
 
         /* Component name and version */
         .pmix_mca_component_name = "simulator",

--- a/src/mca/ras/slurm/ras_slurm_component.c
+++ b/src/mca/ras/slurm/ras_slurm_component.c
@@ -52,7 +52,7 @@ static int prte_mca_ras_slurm_component_query(pmix_mca_base_module_t **module, i
 
 prte_mca_ras_slurm_component_t prte_mca_ras_slurm_component = {
     .super = {
-        PRTE_RAS_BASE_VERSION_2_0_0,
+        PRTE_MCA_BASE_VERSION(ras),
 
         /* Component name and version */
         .pmix_mca_component_name = "slurm",

--- a/src/mca/ras/testrm/ras_testrm_component.c
+++ b/src/mca/ras/testrm/ras_testrm_component.c
@@ -43,7 +43,7 @@ static int ras_testrm_component_query(pmix_mca_base_module_t **module, int *prio
 
 prte_ras_testrm_component_t prte_mca_ras_testrm_component = {
     .super = {
-        PRTE_RAS_BASE_VERSION_2_0_0,
+        PRTE_MCA_BASE_VERSION(ras),
 
         /* Component name and version */
         .pmix_mca_component_name = "testrm",

--- a/src/mca/rmaps/AGENTS.md
+++ b/src/mca/rmaps/AGENTS.md
@@ -502,7 +502,7 @@ node→session deviation.
   their parsed rank map and rank count in file statics. Reset them at the
   start of every map and reclaim them on *every* exit, success or failure —
   a stale count is handed to the next job as its process count.
-- **The version macro is `PRTE_RMAPS_BASE_VERSION_5_0_0`.** The `4_0_0`
+- **The version macro is `PRTE_MCA_BASE_VERSION(rmaps)`.** The `4_0_0`
   alias is deliberately redefined to `5_0_0` so stale out-of-tree
   components fail loudly instead of silently violating ABI.
 - Standard PRRTE rules still apply: `prte_config.h` first, braces on

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -173,7 +173,7 @@ static int prte_rmaps_base_open(pmix_mca_base_open_flag_t flags)
     return pmix_mca_base_framework_components_open(&prte_rmaps_base_framework, flags);
 }
 
-PMIX_MCA_BASE_FRAMEWORK_DECLARE(prte, rmaps, "PRTE Mapping Subsystem", prte_rmaps_base_register,
+PRTE_MCA_BASE_FRAMEWORK_DECLARE(rmaps, "PRTE Mapping Subsystem", prte_rmaps_base_register,
                                 prte_rmaps_base_open, prte_rmaps_base_close,
                                 prte_rmaps_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);

--- a/src/mca/rmaps/lsf/rmaps_lsf_component.c
+++ b/src/mca/rmaps/lsf/rmaps_lsf_component.c
@@ -47,7 +47,7 @@ static int lsf_query(pmix_mca_base_module_t **module, int *priority);
 
 prte_rmaps_rf_component_t prte_mca_rmaps_lsf_component = {
     .super = {
-        PRTE_RMAPS_BASE_VERSION_5_0_0,
+        PRTE_MCA_BASE_VERSION(rmaps),
 
         .pmix_mca_component_name = "lsf",
         PMIX_MCA_BASE_MAKE_VERSION(component,

--- a/src/mca/rmaps/ppr/rmaps_ppr_component.c
+++ b/src/mca/rmaps/ppr/rmaps_ppr_component.c
@@ -34,7 +34,7 @@ static int prte_rmaps_ppr_query(pmix_mca_base_module_t **module, int *priority);
 static int prte_rmaps_ppr_register(void);
 
 prte_rmaps_base_component_t prte_mca_rmaps_ppr_component = {
-    PRTE_RMAPS_BASE_VERSION_5_0_0,
+    PRTE_MCA_BASE_VERSION(rmaps),
 
     .pmix_mca_component_name = "ppr",
     PMIX_MCA_BASE_MAKE_VERSION(component,

--- a/src/mca/rmaps/rank_file/rmaps_rank_file_component.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file_component.c
@@ -48,7 +48,7 @@ static int prte_rmaps_rank_file_query(pmix_mca_base_module_t **module, int *prio
 
 prte_rmaps_rf_component_t prte_mca_rmaps_rank_file_component = {
     .super = {
-        PRTE_RMAPS_BASE_VERSION_5_0_0,
+        PRTE_MCA_BASE_VERSION(rmaps),
 
         .pmix_mca_component_name = "rank_file",
         PMIX_MCA_BASE_MAKE_VERSION(component,

--- a/src/mca/rmaps/rmaps_types.h
+++ b/src/mca/rmaps/rmaps_types.h
@@ -162,15 +162,23 @@ typedef struct {
 } prte_rmaps_options_t;
 
 
-/*
- **
- * Macro for use in components that are of type rmaps
- */
-#define PRTE_RMAPS_BASE_VERSION_5_0_0 PRTE_MCA_BASE_VERSION_3_0_0("rmaps", 5, 0, 0)
-/* deprecated alias — out-of-tree components get a version mismatch rather than
- * a silent ABI violation */
-#undef  PRTE_RMAPS_BASE_VERSION_4_0_0
-#define PRTE_RMAPS_BASE_VERSION_4_0_0 PRTE_RMAPS_BASE_VERSION_5_0_0
+/* The rmaps framework interface version. It is stated here and nowhere
+ * else: components stamp it into their struct with
+ * PRTE_MCA_BASE_VERSION(rmaps), and the framework's declaration reaches
+ * the same three by pasting its name, so the two cannot drift apart.
+ * Bump it on any change to the module interface that a component built
+ * against the previous one would not survive. */
+#define PRTE_MCA_rmaps_MAJOR_VERSION   5
+#define PRTE_MCA_rmaps_MINOR_VERSION   0
+#define PRTE_MCA_rmaps_RELEASE_VERSION 0
+/* The PRTE_RMAPS_BASE_VERSION_4_0_0 alias that used to sit here is gone
+ * along with the numbered macros generally. It aliased to the 5.0.0
+ * definition, so an out-of-tree component using that spelling stamped
+ * 5.0.0 and passed for current - the opposite of the "version mismatch
+ * rather than a silent ABI violation" it was there to produce. Now that
+ * the framework states its version and the loader checks it, a component
+ * genuinely built against rmaps 4.0.0 is refused on its own merits, and
+ * one carrying the old spelling fails to compile rather than lying. */
 
 /* define map-related directives */
 #define PRTE_MAPPING_NO_USE_LOCAL     0x0100

--- a/src/mca/rmaps/round_robin/rmaps_rr_component.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_component.c
@@ -44,7 +44,7 @@ static int prte_rmaps_round_robin_query(pmix_mca_base_module_t **module, int *pr
 static int my_priority;
 
 prte_rmaps_base_component_t prte_mca_rmaps_round_robin_component = {
-    PRTE_RMAPS_BASE_VERSION_5_0_0,
+    PRTE_MCA_BASE_VERSION(rmaps),
 
     .pmix_mca_component_name = "round_robin",
     PMIX_MCA_BASE_MAKE_VERSION(component,

--- a/src/mca/rmaps/seq/rmaps_seq_component.c
+++ b/src/mca/rmaps/seq/rmaps_seq_component.c
@@ -44,7 +44,7 @@ static int prte_rmaps_seq_query(pmix_mca_base_module_t **module, int *priority);
 static int my_priority;
 
 prte_rmaps_base_component_t prte_mca_rmaps_seq_component = {
-    PRTE_RMAPS_BASE_VERSION_5_0_0,
+    PRTE_MCA_BASE_VERSION(rmaps),
 
     .pmix_mca_component_name = "seq",
     PMIX_MCA_BASE_MAKE_VERSION(component,

--- a/src/mca/schizo/AGENTS.md
+++ b/src/mca/schizo/AGENTS.md
@@ -98,7 +98,7 @@ each component calls from its own `parse_cli`.
 | `check_sanity` | `(pmix_cli_result_t *cmd_line)` | Validate directives/qualifiers and flag conflicts. Both use `prte_schizo_base_sanity`. |
 | `finalize` | `(void)` | Cleanup. Both `NULL`. |
 
-The MCA version macro is `PRTE_MCA_SCHIZO_BASE_VERSION_1_0_0`. The
+The MCA version macro is `PRTE_MCA_BASE_VERSION(schizo)`. The
 `prte_schizo_base_component_t` is a bare `pmix_mca_base_component_t`;
 each component wraps it in its own struct (`..._prte_component_t`,
 `..._ompi_component_t`) that adds `priority`, `warn_deprecations`, and a

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -147,7 +147,7 @@ static int prte_schizo_base_open(pmix_mca_base_open_flag_t flags)
     return rc;
 }
 
-PMIX_MCA_BASE_FRAMEWORK_DECLARE(prte, schizo, "PRTE Schizo Subsystem", prte_schizo_base_register,
+PRTE_MCA_BASE_FRAMEWORK_DECLARE(schizo, "PRTE Schizo Subsystem", prte_schizo_base_register,
                                 prte_schizo_base_open, prte_schizo_base_close,
                                 prte_schizo_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);

--- a/src/mca/schizo/ompi/schizo_ompi_component.c
+++ b/src/mca/schizo/ompi/schizo_ompi_component.c
@@ -32,7 +32,7 @@ static int component_register(void);
  */
 prte_schizo_ompi_component_t prte_mca_schizo_ompi_component = {
     .super = {
-        PRTE_MCA_SCHIZO_BASE_VERSION_1_0_0,
+        PRTE_MCA_BASE_VERSION(schizo),
         .pmix_mca_component_name = "ompi",
         PMIX_MCA_BASE_MAKE_VERSION(component,
                                    PRTE_MAJOR_VERSION,

--- a/src/mca/schizo/prte/schizo_prte_component.c
+++ b/src/mca/schizo/prte/schizo_prte_component.c
@@ -33,7 +33,7 @@ static int component_close(void);
  */
 prte_schizo_prte_component_t prte_mca_schizo_prte_component = {
     .super = {
-        PRTE_MCA_SCHIZO_BASE_VERSION_1_0_0,
+        PRTE_MCA_BASE_VERSION(schizo),
         .pmix_mca_component_name = "prte",
         PMIX_MCA_BASE_MAKE_VERSION(component,
                                    PRTE_MAJOR_VERSION,

--- a/src/mca/schizo/schizo.h
+++ b/src/mca/schizo/schizo.h
@@ -147,10 +147,15 @@ typedef struct {
  */
 typedef pmix_mca_base_component_t prte_schizo_base_component_t;
 
-/**
- * Macro for use in components that are of type schizo
- */
-#define PRTE_MCA_SCHIZO_BASE_VERSION_1_0_0 PRTE_MCA_BASE_VERSION_3_0_0("schizo", 1, 0, 0)
+/* The schizo framework interface version. It is stated here and nowhere
+ * else: components stamp it into their struct with
+ * PRTE_MCA_BASE_VERSION(schizo), and the framework's declaration reaches
+ * the same three by pasting its name, so the two cannot drift apart.
+ * Bump it on any change to the module interface that a component built
+ * against the previous one would not survive. */
+#define PRTE_MCA_schizo_MAJOR_VERSION   1
+#define PRTE_MCA_schizo_MINOR_VERSION   0
+#define PRTE_MCA_schizo_RELEASE_VERSION 0
 
 END_C_DECLS
 

--- a/src/mca/state/AGENTS.md
+++ b/src/mca/state/AGENTS.md
@@ -175,7 +175,7 @@ The winning module is copied into the global `prte_state` instance;
 callers reach the vtable through it (`prte_state.activate_job_state(...)`).
 You should almost never call the vtable directly — use the macros.
 
-The version macro is `PRTE_STATE_BASE_VERSION_1_0_0`.
+The version macro is `PRTE_MCA_BASE_VERSION(state)`.
 
 ### Return protocol
 

--- a/src/mca/state/base/state_base_frame.c
+++ b/src/mca/state/base/state_base_frame.c
@@ -126,7 +126,7 @@ static int prte_state_base_open(pmix_mca_base_open_flag_t flags)
     return pmix_mca_base_framework_components_open(&prte_state_base_framework, flags);
 }
 
-PMIX_MCA_BASE_FRAMEWORK_DECLARE(prte, state, "PRTE State Machine", prte_state_base_register,
+PRTE_MCA_BASE_FRAMEWORK_DECLARE(state, "PRTE State Machine", prte_state_base_register,
                                 prte_state_base_open, prte_state_base_close,
                                 prte_state_base_static_components,
                                 PMIX_MCA_BASE_FRAMEWORK_FLAG_DEFAULT);

--- a/src/mca/state/dvm/state_dvm_component.c
+++ b/src/mca/state/dvm/state_dvm_component.c
@@ -40,7 +40,7 @@ static int state_dvm_component_query(pmix_mca_base_module_t **module, int *prior
  */
 prte_state_base_component_t prte_mca_state_dvm_component =
 {
-    PRTE_STATE_BASE_VERSION_1_0_0,
+    PRTE_MCA_BASE_VERSION(state),
     /* Component name and version */
     .pmix_mca_component_name = "dvm",
     PMIX_MCA_BASE_MAKE_VERSION(component,

--- a/src/mca/state/prted/state_prted_component.c
+++ b/src/mca/state/prted/state_prted_component.c
@@ -40,7 +40,7 @@ static int state_prted_component_query(pmix_mca_base_module_t **module, int *pri
  */
 prte_state_base_component_t prte_mca_state_prted_component =
 {
-    PRTE_STATE_BASE_VERSION_1_0_0,
+    PRTE_MCA_BASE_VERSION(state),
     /* Component name and version */
     .pmix_mca_component_name = "prted",
     PMIX_MCA_BASE_MAKE_VERSION(component,

--- a/src/mca/state/state.h
+++ b/src/mca/state/state.h
@@ -283,10 +283,15 @@ PRTE_EXPORT extern prte_state_base_module_t prte_state;
  */
 typedef pmix_mca_base_component_t prte_state_base_component_t;
 
-/*
- * Macro for use in components that are of type state
- */
-#define PRTE_STATE_BASE_VERSION_1_0_0 PRTE_MCA_BASE_VERSION_3_0_0("state", 1, 0, 0)
+/* The state framework interface version. It is stated here and nowhere
+ * else: components stamp it into their struct with
+ * PRTE_MCA_BASE_VERSION(state), and the framework's declaration reaches
+ * the same three by pasting its name, so the two cannot drift apart.
+ * Bump it on any change to the module interface that a component built
+ * against the previous one would not survive. */
+#define PRTE_MCA_state_MAJOR_VERSION   1
+#define PRTE_MCA_state_MINOR_VERSION   0
+#define PRTE_MCA_state_RELEASE_VERSION 0
 
 END_C_DECLS
 #endif

--- a/src/pmix/pmix-internal.h
+++ b/src/pmix/pmix-internal.h
@@ -235,9 +235,74 @@ PRTE_EXPORT int prte_pmix_convert_status(pmix_status_t status);
 PRTE_EXPORT pmix_status_t prte_pmix_convert_job_state_to_error(int state);
 PRTE_EXPORT pmix_status_t prte_pmix_convert_proc_state_to_error(int state);
 
-#define PRTE_MCA_BASE_VERSION_3_0_0(type, type_major, type_minor, type_release) \
-    PMIX_MCA_BASE_VERSION_2_1_0("prte", PRTE_MAJOR_VERSION, PRTE_MINOR_VERSION, \
-                                PRTE_RELEASE_VERSION, type, type_major, type_minor, type_release)
+/* Reach the interface version a framework's own header states.
+ *
+ * The PRRTE counterpart of PMIX_MCA_FW_VER() in PMIx's mca.h, and the
+ * reason PRRTE needs one of its own: that macro pastes a PMIX_ prefix,
+ * and these are PRRTE's frameworks, so the numbers belong in PRRTE's
+ * namespace. A framework states its version once, as three macros in its
+ * <framework>.h - for example, in plm.h:
+ *
+ *   #define PRTE_MCA_plm_MAJOR_VERSION   2
+ *   #define PRTE_MCA_plm_MINOR_VERSION   0
+ *   #define PRTE_MCA_plm_RELEASE_VERSION 0
+ *
+ * Both sides of the load-time version check reach those same three
+ * integers by pasting the framework's name: the component stamp below,
+ * and the framework's declaration. Nothing restates them, so the version
+ * a component carries and the version it is checked against cannot drift
+ * apart, and bumping an interface is one edit in one header.
+ *
+ * The name carries the framework's directory name verbatim, lower case
+ * and all: the preprocessor pastes tokens, it does not upper-case them. */
+#define PRTE_MCA_FW_VER_(name, level) PRTE_MCA_##name##_##level##_VERSION
+#define PRTE_MCA_FW_VER(name, level)  PRTE_MCA_FW_VER_(name, level)
+
+/* Open a component struct.
+ *
+ * Every PRRTE component begins its base struct with this, naming its
+ * framework as a bare token - the framework's directory name, so that the
+ * same token both stringifies into the struct and pastes into the version
+ * macros above:
+ *
+ *   prte_plm_base_component_t prte_mca_plm_ssh_component = {
+ *       .base_version = {
+ *           PRTE_MCA_BASE_VERSION(plm),
+ *           .pmix_mca_component_name = "ssh",
+ *           ...
+ *
+ * PMIx's PMIX_MCA_BASE_VERSION() cannot serve here: it stamps the project
+ * as "pmix" with PMIx's own version numbers. This one says "prte" and
+ * PRRTE's, which is the whole reason PRRTE keeps a macro of its own at
+ * this level. */
+#define PRTE_MCA_BASE_VERSION(type)                                                \
+    PMIX_MCA_BASE_VERSION_2_1_0("prte", PRTE_MAJOR_VERSION, PRTE_MINOR_VERSION,    \
+                                PRTE_RELEASE_VERSION, #type,                       \
+                                PRTE_MCA_FW_VER(type, MAJOR),                      \
+                                PRTE_MCA_FW_VER(type, MINOR),                      \
+                                PRTE_MCA_FW_VER(type, RELEASE))
+
+/* Declare a PRRTE framework, stating its interface version.
+ *
+ * The PRRTE counterpart of PMIX_MCA_BASE_VERSIONED_FRAMEWORK_DECLARE,
+ * built on the same underlying declaration so that the framework reports
+ * the version its header states and pmix_mca_base_components_open() can
+ * refuse a component built against a different one. It takes no version
+ * arguments and no project argument: every framework here is "prte", and
+ * the numbers come from the header.
+ *
+ * A framework that uses this without defining the three macros above does
+ * not compile, which is the point. Using PMIX_MCA_BASE_FRAMEWORK_DECLARE
+ * instead still works and is what PRRTE did until August 2026 - it simply
+ * reports version 0.0, which the loader reads as "no version stated" and
+ * skips the check for, so the framework's components are never screened. */
+#define PRTE_MCA_BASE_FRAMEWORK_DECLARE(name, description, registerfn, openfn,     \
+                                        closefn, static_components, flags)         \
+    PMIX_MCA_BASE_FRAMEWORK_DECLARE_FULL(prte, name,                               \
+                                         PRTE_MCA_FW_VER(name, MAJOR),             \
+                                         PRTE_MCA_FW_VER(name, MINOR),             \
+                                         description, registerfn, openfn, closefn, \
+                                         static_components, flags)
 
 
 END_C_DECLS

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -1359,6 +1359,12 @@ void prte_pmix_server_job_departed(const pmix_nspace_t nspace)
     }
     while (PRTE_MAX_DEPARTED_JOBS <= pmix_list_get_size(&prte_pmix_server_globals.departed_jobs)) {
         nm = (prte_namelist_t *) pmix_list_remove_first(&prte_pmix_server_globals.departed_jobs);
+        /* answers NULL for an empty list, and the loop bound above is the
+         * only thing that says this one is not - screen it rather than hand
+         * a NULL to the reference count */
+        if (NULL == nm) {
+            break;
+        }
         PMIX_RELEASE(nm);
     }
     nm = PMIX_NEW(prte_namelist_t);

--- a/test/unit/ess/test_ess.c
+++ b/test/unit/ess/test_ess.c
@@ -129,6 +129,12 @@ static int test_setup_signals_rejects(void)
     /* whatever a partial parse appended must not block a later good one */
     while (0 < pmix_list_get_size(&prte_ess_base_signals)) {
         pmix_list_item_t *item = pmix_list_remove_first(&prte_ess_base_signals);
+        /* answers NULL for an empty list, and the loop bound above is the
+         * only thing that says this one is not - screen it rather than hand
+         * a NULL to the reference count */
+        if (NULL == item) {
+            break;
+        }
         PMIX_RELEASE(item);
     }
 


### PR DESCRIPTION
PMIx now refuses to open a component built against a different version of its
framework's interface than the framework itself speaks
(openpmix/openpmix#4108). PRRTE got **none** of that protection: every
framework here was declared with `PMIX_MCA_BASE_FRAMEWORK_DECLARE`, which
states no version, so each reported 0.0 and the loader skipped the check for
every component it owns.

That is the wrong side of the bargain for this project in particular. A
component is run-time loadable, so an installed `prte_mca_plm_ssh` left over
from an older build is what any partial upgrade produces — and it presents
whatever `prte_plm_base_module_t` its header had at the time, which for a
grown interface means a NULL entry point the current library has no reason to
expect, and jumps to.

### One place for the number

Each framework now states its interface version in its own header, as three
macros that the component stamp and the framework declaration both reach by
pasting the framework's name:

```c
#define PRTE_MCA_plm_MAJOR_VERSION   2      /* in plm.h */
    PRTE_MCA_BASE_VERSION(plm),             /* in each component */
PRTE_MCA_BASE_FRAMEWORK_DECLARE(plm, ...)   /* in plm_base_frame.c */
```

Neither side restates the numbers, so bumping an interface is one edit in one
header. **The versions kept here are the ones the fourteen numbered macros
already carried**, so no component's standing changes — this makes the numbers
mean something.

### Why the numbered macros go

They restated their numbers in their own names, so a name went stale the moment
anyone bumped the interface — and three already named something other than
their framework: `PRTE_BACKTRACE_` for `prtebacktrace`, `PRTE_REACHABLE_` for
`prtereachable`, `PRTE_INSTALLDIRS_` for `prteinstalldirs`. Naming the
framework instead is what lets one bare token both stringify into the struct
and paste into the version macros.

That fixes a real if latent thing: **`prtebacktrace` components stamped their
type as `"backtrace"`** while the framework registers as `prtebacktrace`, and
`pmix_mca_base_component_var_register()` builds a variable's name from the
*component's* type string. No `prtebacktrace` component registers an MCA
parameter today, so nothing is currently misfiled — but the first one to try
would have landed under a prefix no `--prtemca prtebacktrace_…` could reach.

### `PRTE_MCA_BASE_VERSION_3_0_0` → `PRTE_MCA_BASE_VERSION`

The wrapper stays, because PMIx's own `PMIX_MCA_BASE_VERSION` stamps the
project as `"pmix"` with PMIx's version numbers where PRRTE needs `"prte"` and
PRRTE's. But its `3_0_0` named nothing — it expanded to
`PMIX_MCA_BASE_VERSION_2_1_0` and always had — so it loses the tail and the
version arguments. `PRTE_MCA_BASE_FRAMEWORK_DECLARE` joins it, built on the
same `PMIX_MCA_BASE_FRAMEWORK_DECLARE_FULL` the versioned PMIx form uses and
taking neither a project nor a version argument, since both are already known.

### The rmaps alias was backwards

`PRTE_RMAPS_BASE_VERSION_4_0_0` aliased to the **5.0.0** definition, so a
component using that spelling stamped 5.0.0 and passed for current — the
opposite of the "version mismatch rather than a silent ABI violation" its
comment promised. It is gone; with the framework stating its version, a
component genuinely built against rmaps 4.0.0 is now refused on its own merits,
and one carrying the old spelling fails to compile rather than lying.

### Testing

Verified by simulating exactly the skew this exists to catch — stamping the
`ppr` component with rmaps 4.0.0, rebuilding, and watching it be declined while
the run carried on through the other rmaps components:

```
mca: base: components_open: component ppr speaks rmaps v4.0.0 but this build
speaks v5.0 -- ignored. This is an installed component left over from an older
build; remove or rebuild it.
```

Otherwise: warning-free build under `--enable-devel-check`, `make check` green
(21/21), and `prterun -n 2 hostname` launches with no component refused.

---

## Second commit — screen the list item an eviction loop releases

Independent of the above, and needed before this tree builds with gcc at all.

Three drain loops — the departed-jobs cache, the group-operation memo, and the
signal-list reset in `test_ess` — empty a list without checking what
`pmix_list_remove_first()` handed back, and it answers NULL for an empty list.
The loop's own bound is the only thing that says the list is not empty, which
is true but not something the compiler can see through the cast and the inlined
reference count.

Since PMIx made that reference count a C11 atomic (openpmix `203205d88`, July
2026), gcc traces the possible NULL into a four-byte atomic write and refuses
the build:

```
pmix_object.h: error: '__atomic_add_fetch_4' writing 4 bytes into a region of
size 0 overflows the destination [-Werror=stringop-overflow=]
```

Screening the pointer is the right answer rather than silencing the warning:
every other drain loop in the tree already spells this
`while (NULL != (item = pmix_list_remove_first(&list)))`, so these three were
the outliers. The `test_ess` one is only reachable through `make check`, which
is why it does not show up in a plain build.

---

**Requires** openpmix/openpmix#4108 (merged) — the version check and
`PMIX_MCA_BASE_FRAMEWORK_DECLARE_FULL` contract this builds on.
