### PR TITLE
Ask PMIx for the versioned framework declaration at configure time

### DIFF
--- a/config/prte_setup_pmix.m4
+++ b/config/prte_setup_pmix.m4
@@ -253,6 +253,31 @@ AC_DEFUN([PRTE_CHECK_PMIX],[
                          AC_MSG_WARN([accepts any unambiguous prefix of a qualifier's name.])
                          AC_MSG_ERROR([Please update PMIx and configure again])])
 
+    dnl Every PRRTE framework states the interface version its components
+    dnl are built against, and it does so through PMIx's machinery: the
+    dnl framework declaration expands to PMIX_MCA_BASE_FRAMEWORK_DECLARE_FULL
+    dnl and each component stamps PMIX_MCA_BASE_VERSION_2_1_0.  There is
+    dnl nothing to fall back to - the version fields live in PMIx's framework
+    dnl struct, and PMIx's component-open is what compares them - so this is
+    dnl a requirement rather than a feature to switch off.
+    dnl
+    dnl Ask here because the failure otherwise lands nowhere near its cause:
+    dnl against an older PMIx the numbers reach a macro that has no room for
+    dnl them, and the build stops with "expected ')' before numeric constant"
+    dnl pointing at a #define in whichever framework header compiled first.
+    AC_MSG_CHECKING([for PMIx versioned framework declaration])
+    PRTE_CHECK_PMIX_CAP([MCA_FW_VERSION],
+                        [AC_MSG_RESULT([yes])],
+                        [AC_MSG_RESULT([no])
+                         AC_MSG_WARN([PRRTE states each framework's interface version through])
+                         AC_MSG_WARN([PMIX_MCA_BASE_FRAMEWORK_DECLARE_FULL and the])
+                         AC_MSG_WARN([PMIX_MCA_BASE_VERSION_2_1_0 component stamp, which this])
+                         AC_MSG_WARN([PMIx does not provide. Those version fields live in])
+                         AC_MSG_WARN([PMIx's framework struct and PMIx compares them when it])
+                         AC_MSG_WARN([opens a component, so there is nothing PRRTE can supply])
+                         AC_MSG_WARN([in their place.])
+                         AC_MSG_ERROR([Please update PMIx and configure again])])
+
     dnl "--map-by device=<class>" places processes against the devices in a
     dnl node's topology, which means first knowing what devices it has.  PMIx
     dnl owns that answer: it already reports devices to applications through


### PR DESCRIPTION
Every PRRTE framework now states the interface version its components are
built against (`6a7d387`), and does so through PMIx's machinery: the
framework declaration expands to `PMIX_MCA_BASE_FRAMEWORK_DECLARE_FULL`
and each component stamps `PMIX_MCA_BASE_VERSION_2_1_0`. Both arrived
inside the PMIx 7.0 development series, so **the version floor does not
screen out an install that predates them** — two PMIx installs calling
themselves 7.0.0 differ on this.

Against such an install the numbers reach a macro with no room for them,
and the build stops with

```
src/mca/errmgr/errmgr.h:141:41: error: expected ')' before numeric constant
error: 'prte_errmgr_base_open' defined but not used [-Werror=unused-function]
```

Nothing in that message names PMIx, and nothing about that `#define` is
wrong. It is what anyone whose PMIx install is a few hours older than
their PRRTE checkout sees today — I hit it myself immediately after
`6a7d387` merged.

This asks for `PMIX_CAP_MCA_FW_VERSION` instead and says what is missing.
Two notes on the shape:

- It is placed **ahead** of the feature probes (device enumeration, IOF
  patterns, …) because it is the more basic dependency: a PMIx that fails
  this cannot build PRRTE at all, while those govern features.
- It is a hard `AC_MSG_ERROR`, not a fallback. The version fields live in
  PMIx's framework struct and PMIx's component-open is what compares them,
  so there is nothing PRRTE could supply in their place.

**Depends on openpmix/openpmix#4154**, which defines the flag. Until that
lands this check fails against every PMIx, so it should merge second.

### Testing

- **Positive**: `autogen.pl` + reconfigure against a PMIx carrying the flag
  gives `checking for PMIx versioned framework declaration... yes`; build
  is warning-free (`--enable-debug`), `make check` 21/21, install clean.
- **Negative**: worth describing, because the obvious version of this test
  proves nothing. Configuring against an *older* PMIx does not exercise
  the new probe — it fails an earlier one (`CLI_QUAL_VALUE`) and never
  reaches it. So the test prefix differs from a working install by exactly
  one line: a hard-link copy with `PMIX_CAP_MCA_FW_VERSION` stripped from
  its `pmix_version.h`, and its `pmix.pc` repointed at the copy (without
  that, pkg-config sends configure straight back to the real install and
  the probe cheerfully answers "yes"). Against that, configure exits 1
  with the diagnostic instead of the compile error above.
