### PR TITLE
Carry one nspace in the OOB header, and close two deferred-work entries

### DIFF
--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -146,29 +146,33 @@ goes through the same parser and is not separately covered.
 Performance work not landed
 ---------------------------
 
-**Aggregate the launch-message cpuset slices per next hop.**  The scatter
-itself has landed: the launch message is packed ``PRTE_JOB_PACK_NO_CPUSETS``
-and each daemon is sent the bindings of the procs it will fork, point to
-point (``prte_odls_base_send_cpuset_slices``).  Measured with ``--rtos
-donotlaunch`` at 1000 x 128 on a 176-core, 5-NUMA topology, that takes the
-raw launch message from **1,622,647 to 602,647 bytes** — 8 B/proc, 63% of
-what was left after the maps and the empty attribute list came out.
+**Take the nspace out of the OOB header entirely.**  ``prte_oob_tcp_hdr_t``
+rides every RML message, and it used to carry the origin and the destination
+as two ``pmix_proc_t`` — 552 bytes, of which 512 were two fixed 256-byte
+nspace arrays holding the same short string.  On small messages that was most
+of the traffic: a launch-message cpuset slice for an eight-process node is
+101 bytes of payload, so the header was 85% of it.  The header now carries
+the two ranks and one length-prefixed nspace, and only the characters the
+nspace uses go on the wire — about 50 bytes for a typical DVM.
 
-What is left to do is how those slices leave the master.  Today it is one
-routed send per daemon: the *bytes* aggregate, because
-``prte_rml_get_route`` sends each toward its target and the tree carries a
-subtree's slices over one link, but the *messages* do not — a 1000-node job
-posts 1000 sends from the master on the launch path.  Sending one message
-per next hop, each carrying the slices for that child's whole subtree, and
-having the relay split it, makes that O(radix) per daemon instead.  It needs
-a relay step the point-to-point form does not.
+The ~22 bytes that remain are still per *message* for something that is a
+property of the *DVM*: every daemon in it shares one nspace for the whole of
+its life.  It could be dropped altogether, because a receiver can reconstruct
+it — every send entry point takes a rank, so a message is always addressed
+within the sender's own job, and a relay only ever forwards traffic of its
+own job — which makes the origin's nspace always the connection peer's, and
+that is known from the IDENT handshake.  What stopped it here is that this is
+an *invariant*, not a field: nothing enforces it, and the failure mode if it
+is ever broken is a message delivered under the wrong sender identity rather
+than an error.  Doing it means first making the invariant something the code
+states and checks, not something a reader has to derive.
 
 **Judge this kind of change on wire bytes, not on the raw message size.**
-The figures above are raw, which is the right unit for "how much buffer does
-the master build and deflate" and the wrong one for "how much crosses the
-network": the xcast compresses before it forwards, and a field holding the
-same value in every record can compress away to nothing while looking
-enormous raw.  Measured on a live 32-node broadcast at 8 ppn
+A launch-message size is usually quoted raw, which is the right unit for "how
+much buffer does the master build and deflate" and the wrong one for "how
+much crosses the network": the xcast compresses before it forwards, and a
+field holding the same value in every record can compress away to nothing
+while looking enormous raw.  Measured on a live 32-node broadcast at 8 ppn
 (``grpcomm_base_verbose 1``, tag 18 is the launch message):
 
 =====================  ===========  ============  =====
@@ -245,6 +249,56 @@ so that the next person does not rediscover the idea and spend the effort
 again: each says what was measured and what the measurement decided.  Moving
 one back up the page takes new evidence, not a fresh reading of the same
 facts.
+
+**Aggregating the launch-message cpuset slices per next hop.**  The scatter
+itself has landed: the launch message is packed ``PRTE_JOB_PACK_NO_CPUSETS``
+and each daemon is sent the bindings of the procs it will fork, point to
+point (``prte_odls_base_send_cpuset_slices``).  Measured with ``--rtos
+donotlaunch`` at 1000 x 128 on a 176-core, 5-NUMA topology, that takes the
+raw launch message from **1,622,647 to 602,647 bytes** — 8 B/proc, 63% of
+what was left after the maps and the empty attribute list came out.
+
+What was proposed on top of that was how those slices leave the master.  It
+is one routed send per daemon: the *bytes* aggregate, because
+``prte_rml_get_route`` sends each toward its target and the tree carries a
+subtree's slices over one link, but the *messages* do not — a 1000-node job
+posts 999 sends from the master on the launch path.  One message per next
+hop, each carrying the slices for that child's whole subtree and split by the
+relay, would make that O(radix).
+
+Measured, that buys very little.  The payload is unchanged either way: a
+slice crosses exactly the links between the master and its daemon whichever
+way it is bundled.  What aggregation removes is one *message header* per
+crossing it saves, and at the default radix of 64 the crossings (Σ depth over
+the daemons) fall from 1,934 to 999 at a thousand nodes and from 25,773 to
+9,999 at ten thousand.  With the header at 552 bytes — what it was when this
+was measured — that is 0.52 MB saved at 1000 x 128 and 8.7 MB at 10,000 x
+128, against a launch broadcast that moves ~240 MB and ~24 GB respectively.
+The scatter that this entry follows saved ~98 MB at the first of those
+shapes; this would save another half.
+
+The master-side argument does not survive either.  The pre-broadcast pack
+loop is real — 5.7 ms at 1000 x 128, 51 ms at 10,000 x 128, measured against
+the swarm's PMIx — but it is ~22 ns per *pack call* and there are two per
+process, so the cost is per process, not per buffer.  Aggregating packs the
+same rank/cpuset pairs into fewer buffers and the loop takes just as long.
+
+**So this shall not be done.**  It removes message headers, not payload, and
+the headers it removes are two parts in a thousand of what the launch already
+broadcasts — while adding a relay protocol on the launch path, with its own
+failure handling, that has to work while the tree changes under an elastic
+grow.  Fusing the slices into the xcast instead is worse, not better:
+``grpcomm_xcast.c`` forwards one packed buffer shared by every child, and
+says where it says so that a forward which must differ per child puts the
+packing back inside the loop.
+
+What the measurement did turn up is that the **header** was the overhead
+worth attacking, and not only here: at 8 processes a node a slice message was
+101 bytes of payload behind 552 bytes of header, and every RML message in the
+system paid the same.  512 of those bytes were two fixed 256-byte nspace
+arrays holding the same short string.  That is now fixed — the header carries
+two ranks and one length-prefixed nspace, about 50 bytes on the wire — which
+takes more off this traffic than aggregating it ever would have.
 
 **Lazy proc-data registration: the withholding half.**  The *deriving*
 half is in: ``dmodex_req`` answers a request for one of the placement keys

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -11,7 +11,8 @@ been able to take.  Each entry says where the evidence is, so that the next
 person can decide whether it is still true before acting on it.
 
 Add to it when you leave something undone, and delete from it when you do
-the work.
+the work.  The last section is the other outcome: work that was investigated
+and decided against, kept so nobody spends the effort a second time.
 
 Runtime behavior
 ----------------
@@ -145,29 +146,6 @@ goes through the same parser and is not separately covered.
 Performance work not landed
 ---------------------------
 
-**Lazy proc-data registration is only half landed.**  The *deriving* half is
-in: ``dmodex_req`` answers a request for one of the placement keys out of
-``jdata->procs[rank]`` rather than going to the hosting daemon
-(``prte_pmix_lazy_procdata``, on by default).  The *withholding* half is not.
-``prte_pmix_server_register_nspace`` still publishes a PMIx proc-data entry
-for **every** proc in the job on **every** daemon — a table that grows with
-the whole job on a node running a fixed slice of it, and
-``prte_hostname_cutoff`` is the record of that wall having been met once
-already.  Only the two location keys are now withheld, and for a different
-reason (see below).  Narrowing the rest is what the commit message claims
-and the code does not do.
-
-The rule it must keep to: switch on what PRRTE is the *authority* for (the
-placement and binding it decided, a closed set), never on what an
-application is expected to ask for.  And the thing to measure first is
-whether a **partial** entry is even usable — whether a get for a key absent
-from a published proc-data array still reaches the host, or whether PMIx
-treats the array as the complete answer for that rank.  Nothing here
-currently depends on that (the two location keys are withheld from *remote*
-procs only, and a remote proc's locality is a question almost nobody asks),
-but withholding the rest would.  ``contrib/dockerswarm/peerinfo.c`` is the
-probe: every rank asks every other rank in its job where it is.
-
 **Aggregate the launch-message cpuset slices per next hop.**  The scatter
 itself has landed: the launch message is packed ``PRTE_JOB_PACK_NO_CPUSETS``
 and each daemon is sent the bindings of the procs it will fork, point to
@@ -259,3 +237,81 @@ the xcast payload helps (an effect of 1–7%) produced overlapping ranges whose
 microseconds of every broadcast).  See ``contrib/dockerswarm/AGENTS.md``,
 §18.
 
+Decided against
+---------------
+
+Work that was looked into and deliberately not done.  These entries are here
+so that the next person does not rediscover the idea and spend the effort
+again: each says what was measured and what the measurement decided.  Moving
+one back up the page takes new evidence, not a fresh reading of the same
+facts.
+
+**Lazy proc-data registration: the withholding half.**  The *deriving*
+half is in: ``dmodex_req`` answers a request for one of the placement keys
+out of ``jdata->procs[rank]`` rather than going to the hosting daemon
+(``prte_pmix_lazy_procdata``, on by default).  The *withholding* half is not,
+and not by omission from the design — the commit that landed the derivation
+does not touch ``pmix_server_register_fns.c`` at all.  That file's per-proc
+loop still emits a ``PMIX_PROC_INFO_ARRAY`` for **every** proc in the job on
+**every** daemon, a table that grows with the whole job on a node running a
+fixed slice of it, and ``prte_hostname_cutoff`` is the record of that wall
+having been met once already.  Only the two location keys are withheld, and
+for a different reason (the cpuset scatter, in the section above).
+Narrowing the rest is what the commit message claims and the code does not
+do.
+
+The rule it must keep to: switch on what PRRTE is the *authority* for (the
+placement and binding it decided, a closed set), never on what an
+application is expected to ask for.
+
+What the derivation is worth as it stands is small, and worth knowing before
+anyone spends effort on the other half.  Measured with
+``contrib/dockerswarm/peerinfo.c`` — every rank asks every other rank in its
+job where it is — at eight ranks over four nodes, with
+``--prtemca prte_pmix_server_verbose 2``, the twenty-four peer lookups split
+six answered by the derivation and eighteen by a wire round trip to the
+hosting daemon; with ``prte_pmix_lazy_procdata 0`` it is zero and
+twenty-four.  Every one of the six is on the master, and every one is for
+``PMIX_RANK``.  That is the only key PMIx never has: it consumes the rank
+entry as the array's identifier rather than storing it.  Everything else the
+eager registration publishes is found locally and never reaches the
+derivation, and the two keys it does not publish the derivation declines by
+design (a daemon that does not fork the proc holds no cpuset, so it cannot
+tell "unbound" from "not sent").  The master is the exception only because it
+keeps every cpuset, so its own lookups are complete and ``PMIX_RANK`` is all
+that is left to ask for.
+
+The question this entry used to say had to be measured first — whether a
+**partial** entry is usable, or whether PMIx treats a published array as the
+complete answer for that rank — is answered, and the answer is that a partial
+entry works.  ``pmix_server_get.c`` fetches per key; a rank present with
+other keys but missing this one falls through to ``direct_modex``.  Those
+eighteen wire answers above *are* that path in production: since the cpuset
+scatter, a daemon publishes an entry for a remote proc with no
+``PMIX_CPUSET`` in it, and the get is answered by the daemon that holds one.
+The one constraint is the reverse case — for a proc the daemon **hosts**, a
+missing reserved key returns ``PMIX_ERR_NOT_FOUND`` with no up-call at all,
+so nothing may ever be withheld from a proc this daemon forks.
+
+What is left to weigh is whether the withholding is worth having, because it
+saves less than it appears to.  PRRTE registers ``PMIX_NODE_MAP`` and
+``PMIX_PROC_MAP``, and PMIx's ``store_map`` already materializes
+``PMIX_HOSTNAME``, ``PMIX_NODEID``, ``PMIX_LOCAL_RANK`` and
+``PMIX_NODE_RANK`` per rank for the whole job out of them, on every daemon,
+wherever the host has not spoken to that key itself.  Dropping the proc
+arrays therefore does not remove the job-sized table; it removes
+``PMIX_GLOBAL_RANK``, ``PMIX_APP_RANK``, ``PMIX_APPNUM``,
+``PMIX_REINCARNATION``, and the three keys only the hosting daemon publishes
+anyway.  It also hands the node rank to a derivation PMIx documents as
+assuming this is the only job on the node, which on a shared node replaces a
+right answer with a wrong one rather than with silence.
+
+**So the withholding half shall not be done.**  It cannot remove the
+job-sized per-rank table, because PMIx rebuilds most of that table from the
+maps whether PRRTE publishes the proc arrays or not; what it can remove is a
+handful of keys, and it pays for them with a node rank that is wrong instead
+of absent wherever two jobs share a node.  The derivation already in the tree
+stays — it is what lets the cpuset scatter be answered — but this entry is
+closed, not deferred.  Reopen it only on a measurement showing that the table
+PMIx actually builds is what hurts, and that is a PMIx question, not a PRRTE
+one.

--- a/src/rml/AGENTS.md
+++ b/src/rml/AGENTS.md
@@ -382,7 +382,10 @@ worth stating rather than re-deriving:
   its layout, but every daemon must agree — there is no versioning. It *is*
   byte-order converted, though, so keep `MCA_OOB_TCP_HDR_HTON`/`_NTOH` covering
   every multi-byte field you add, and zero a header before filling it — the
-  whole struct goes on the wire, padding included.
+  fixed part goes on the wire whole, padding included. Note that the struct is
+  **not** the message: it ends in a variable-length nspace, so a send or a read
+  is sized by `PRTE_OOB_TCP_HDR_FIXED`/`PRTE_OOB_TCP_HDR_LEN()` and never by
+  `sizeof`. See [`oob/AGENTS.md`](oob/AGENTS.md), *The wire header*.
 - **One transport, one router.** Do not reintroduce component/module
   abstraction to "make it pluggable" unless there is a real second
   implementation; that abstraction is exactly what was removed.

--- a/src/rml/oob/AGENTS.md
+++ b/src/rml/oob/AGENTS.md
@@ -64,23 +64,47 @@ relaying is just "send again from here."
 
 ## The wire header
 
-Every message carries a `prte_oob_tcp_hdr_t` (`oob_tcp_hdr.h`): `origin`, final
-`dst`, `tag`, a sequence number, payload length, the origin's boot `epoch`, and
-a message `type` (`IDENT`/`PROBE` for the handshake, `USER` for a normal
-message). It is exchanged **only** among daemons of the same DVM, which all run
-the same build, so it is **not** a stable ABI — you may change its layout, but
+Every message carries a `prte_oob_tcp_hdr_t` (`oob_tcp_hdr.h`): the origin's
+boot `epoch`, the `origin` and final `dst` **ranks**, the `tag`, a sequence
+number, the payload length, a message `type` (`IDENT`/`PROBE` for the
+handshake, `USER` for a normal message), and the nspace those two ranks belong
+to. It is exchanged **only** among daemons of the same DVM, which all run the
+same build, so it is **not** a stable ABI — you may change its layout, but
 every daemon must agree; there is no versioning.
 
-Two rules that are not obvious from the struct:
+Five rules that are not obvious from the struct:
 
+- **Only `PRTE_OOB_TCP_HDR_LEN()` bytes of it go on the wire.** The nspace is
+  last and variable: `nslen` characters are sent, without a terminator, and
+  the receiver supplies one (`PRTE_OOB_TCP_HDR_END_NSPACE`). Anything that
+  sends or reads a header uses `PRTE_OOB_TCP_HDR_FIXED` and
+  `PRTE_OOB_TCP_HDR_LEN()`, **never** `sizeof(prte_oob_tcp_hdr_t)` — the
+  struct is bigger than the message, because the nspace array is the
+  receiver's landing space for a string that is usually ~20 bytes. That is
+  not a micro-optimization: holding the two names as `pmix_proc_t` made this
+  header 552 bytes, and it rides *every* RML message. A cpuset slice for an
+  eight-process node carries 101 bytes of payload.
+- **One nspace covers both ends**, because they have never differed on a
+  message that carries data: every send entry point takes a rank
+  (`prte_rml_send_buffer_nb` and friends), so a message is always addressed
+  within the sender's own job, the origin is the sender, and a relay copies
+  both through. The queueing macros assert it. The connect handshake is the
+  one place the two names can differ — there `dst` is the peer being
+  introduced to — and the receiver reads only the origin, so the field carries
+  the origin's nspace there too.
+- **Reading a name out of a header takes two reads off the socket.** The
+  ranks arrive with the fixed part, the nspace after it, so `hdr_recvd` is not
+  enough to build a `pmix_proc_t` — `nspace_recvd` is the flag that says the
+  names are complete. Rebuild a procid with `PRTE_OOB_TCP_HDR_PROC()`.
 - **Every multi-byte field is byte-order converted**, by
   `MCA_OOB_TCP_HDR_HTON`/`_NTOH`. Add a field, extend both macros — a field
   that is quietly not converted works perfectly until two daemons differ in
-  endianness.
-- **The whole struct goes on the wire, padding included.** The handshake builds
-  its header on the stack, so zero it before filling it in; leaving a field (or
-  the padding) undefined ships uninitialized bytes and trips every memory
-  checker.
+  endianness. `nslen` is a single byte and needs no conversion, which is why
+  the length macros may be used on a header in either order.
+- **The fixed part goes on the wire whole, padding included.** The handshake
+  builds its header on the stack, so zero it before filling it in; leaving a
+  field (or the padding) undefined ships uninitialized bytes and trips every
+  memory checker.
 
 ## Message-size bound
 

--- a/src/rml/oob/oob_tcp.c
+++ b/src/rml/oob/oob_tcp.c
@@ -762,7 +762,12 @@ static void recv_handler(int sd, short flg, void *cbdata)
 
     /* finish processing ident */
     if (MCA_OOB_TCP_IDENT == hdr.type) {
-        if (NULL == (peer = prte_oob_tcp_peer_lookup(&hdr.origin))) {
+        pmix_proc_t sender;
+
+        /* the header carries the sender as a rank plus the nspace it
+         * belongs to, so put the two back together */
+        PRTE_OOB_TCP_HDR_PROC(&hdr, hdr.origin, &sender);
+        if (NULL == (peer = prte_oob_tcp_peer_lookup(&sender))) {
             /* should never happen */
             goto cleanup;
         }
@@ -788,7 +793,7 @@ static void recv_handler(int sd, short flg, void *cbdata)
                             "%s-%s prte_oob_tcp_recv_connect: "
                             "rejected connection from %s connection state %d",
                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&(peer->name)),
-                            PRTE_NAME_PRINT(&(hdr.origin)), peer->state);
+                            PRTE_NAME_PRINT(&sender), peer->state);
             }
             CLOSE_THE_SOCKET(sd);
         }

--- a/src/rml/oob/oob_tcp_connection.c
+++ b/src/rml/oob/oob_tcp_connection.c
@@ -565,7 +565,7 @@ static int tcp_peer_send_connect_ack(prte_oob_tcp_peer_t *peer)
     char *msg;
     prte_oob_tcp_hdr_t hdr;
     uint16_t ack_flag = htons(1);
-    size_t sdsize, offset = 0;
+    size_t sdsize, hdrsize, offset = 0;
 
     pmix_output_verbose(OOB_TCP_DEBUG_CONNECT, prte_oob_base.output,
                         "%s SEND CONNECT ACK", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
@@ -573,8 +573,11 @@ static int tcp_peer_send_connect_ack(prte_oob_tcp_peer_t *peer)
     /* load the header. Zero it first: the whole struct goes on the wire, so
      * every field - including the epoch and any padding - has to be defined */
     memset(&hdr, 0, sizeof(hdr));
-    hdr.origin = *PRTE_PROC_MY_NAME;
-    hdr.dst = peer->name;
+    hdr.origin = PRTE_PROC_MY_NAME->rank;
+    hdr.dst = peer->name.rank;
+    /* the header carries one nspace and the receiver reads it as the
+     * origin's, which is the only one this handshake is asked about */
+    PRTE_OOB_TCP_HDR_LOAD_NSPACE(&hdr, PRTE_PROC_MY_NAME->nspace);
     hdr.type = MCA_OOB_TCP_IDENT;
     hdr.tag = 0;
     hdr.seq_num = 0;
@@ -583,18 +586,19 @@ static int tcp_peer_send_connect_ack(prte_oob_tcp_peer_t *peer)
     /* payload size */
     sdsize = sizeof(ack_flag) + strlen(prte_version_string) + 1;
     hdr.nbytes = sdsize;
+    hdrsize = PRTE_OOB_TCP_HDR_LEN(&hdr);
     MCA_OOB_TCP_HDR_HTON(&hdr);
 
     /* create a space for our message */
-    sdsize += sizeof(hdr);
+    sdsize += hdrsize;
     if (NULL == (msg = (char *) malloc(sdsize))) {
         return PRTE_ERR_OUT_OF_RESOURCE;
     }
     memset(msg, 0, sdsize);
 
-    /* load the message */
-    memcpy(msg + offset, &hdr, sizeof(hdr));
-    offset += sizeof(hdr);
+    /* load the message - only the used part of the header goes on the wire */
+    memcpy(msg + offset, &hdr, hdrsize);
+    offset += hdrsize;
     memcpy(msg + offset, &ack_flag, sizeof(ack_flag));
     offset += sizeof(ack_flag);
     memcpy(msg + offset, prte_version_string, strlen(prte_version_string) + 1);
@@ -622,15 +626,16 @@ static int tcp_peer_send_connect_nack(int sd, pmix_proc_t *name)
     prte_oob_tcp_hdr_t hdr;
     uint16_t ack_flag = htons(0);
     int rc = PRTE_SUCCESS;
-    size_t sdsize, offset = 0;
+    size_t sdsize, hdrsize, offset = 0;
 
     pmix_output_verbose(OOB_TCP_DEBUG_CONNECT, prte_oob_base.output,
                         "%s SEND CONNECT NACK", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
 
     /* load the header - see the note in tcp_peer_send_connect_ack */
     memset(&hdr, 0, sizeof(hdr));
-    hdr.origin = *PRTE_PROC_MY_NAME;
-    hdr.dst = *name;
+    hdr.origin = PRTE_PROC_MY_NAME->rank;
+    hdr.dst = name->rank;
+    PRTE_OOB_TCP_HDR_LOAD_NSPACE(&hdr, PRTE_PROC_MY_NAME->nspace);
     hdr.type = MCA_OOB_TCP_IDENT;
     hdr.tag = 0;
     hdr.seq_num = 0;
@@ -639,18 +644,19 @@ static int tcp_peer_send_connect_nack(int sd, pmix_proc_t *name)
     /* payload size */
     sdsize = sizeof(ack_flag);
     hdr.nbytes = sdsize;
+    hdrsize = PRTE_OOB_TCP_HDR_LEN(&hdr);
     MCA_OOB_TCP_HDR_HTON(&hdr);
 
     /* create a space for our message */
-    sdsize += sizeof(hdr);
+    sdsize += hdrsize;
     if (NULL == (msg = (char *) malloc(sdsize))) {
         return PRTE_ERR_OUT_OF_RESOURCE;
     }
     memset(msg, 0, sdsize);
 
-    /* load the message */
-    memcpy(msg + offset, &hdr, sizeof(hdr));
-    offset += sizeof(hdr);
+    /* load the message - only the used part of the header goes on the wire */
+    memcpy(msg + offset, &hdr, hdrsize);
+    offset += hdrsize;
     memcpy(msg + offset, &ack_flag, sizeof(ack_flag));
     offset += sizeof(ack_flag);
 
@@ -949,6 +955,7 @@ int prte_oob_tcp_peer_recv_connect_ack(prte_oob_tcp_peer_t *pr, int sd, prte_oob
     size_t offset = 0, cnt;
     prte_oob_tcp_hdr_t hdr;
     prte_oob_tcp_peer_t *peer;
+    pmix_proc_t sender;
     uint16_t ack_flag;
     bool is_new = (NULL == pr);
 
@@ -958,8 +965,9 @@ int prte_oob_tcp_peer_recv_connect_ack(prte_oob_tcp_peer_t *pr, int sd, prte_oob
                         (NULL == pr) ? "UNKNOWN" : PRTE_NAME_PRINT(&pr->name), sd);
 
     peer = pr;
-    /* get the header */
-    if (tcp_peer_recv_blocking(peer, sd, &hdr, sizeof(prte_oob_tcp_hdr_t))) {
+    /* get the fixed part of the header - the nspace that trails it is only
+     * as long as the header says, so it takes a second read */
+    if (tcp_peer_recv_blocking(peer, sd, &hdr, PRTE_OOB_TCP_HDR_FIXED)) {
         if (NULL != peer) {
             /* If the peer state is CONNECT_ACK, then we were waiting for
              * the connection to be ack'd
@@ -982,24 +990,41 @@ int prte_oob_tcp_peer_recv_connect_ack(prte_oob_tcp_peer_t *pr, int sd, prte_oob
         return PRTE_ERR_UNREACH;
     }
 
+    /* and now the nspace those ranks belong to.  nslen is a single byte and
+     * PMIX_MAX_NSLEN is 255, so it cannot overrun the field */
+    if (0 < hdr.nslen && !tcp_peer_recv_blocking(peer, sd, hdr.nspace, hdr.nslen)) {
+        pmix_output_verbose(OOB_TCP_DEBUG_CONNECT, prte_oob_base.output,
+                            "%s unable to complete recv of connect-ack nspace from %s ON SOCKET %d",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                            (NULL == peer) ? "UNKNOWN" : PRTE_NAME_PRINT(&peer->name), sd);
+        return PRTE_ERR_UNREACH;
+    }
+    PRTE_OOB_TCP_HDR_END_NSPACE(&hdr);
+
     pmix_output_verbose(OOB_TCP_DEBUG_CONNECT, prte_oob_base.output,
                         "%s connect-ack recvd from %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                         (NULL == peer) ? "UNKNOWN" : PRTE_NAME_PRINT(&peer->name));
 
     /* convert the header */
     MCA_OOB_TCP_HDR_NTOH(&hdr);
+    /* rebuild the sender's identity, which the header carries as a rank
+     * plus the nspace read above */
+    PRTE_OOB_TCP_HDR_PROC(&hdr, hdr.origin, &sender);
     /* if the requestor wanted the header returned, then do so now */
     if (NULL != dhdr) {
         *dhdr = hdr;
     }
 
     if (MCA_OOB_TCP_PROBE == hdr.type) {
+        size_t hdrsize;
         /* send a header back */
         hdr.type = MCA_OOB_TCP_PROBE;
         hdr.dst = hdr.origin;
-        hdr.origin = *PRTE_PROC_MY_NAME;
+        hdr.origin = PRTE_PROC_MY_NAME->rank;
+        PRTE_OOB_TCP_HDR_LOAD_NSPACE(&hdr, PRTE_PROC_MY_NAME->nspace);
+        hdrsize = PRTE_OOB_TCP_HDR_LEN(&hdr);
         MCA_OOB_TCP_HDR_HTON(&hdr);
-        tcp_peer_send_blocking(sd, &hdr, sizeof(prte_oob_tcp_hdr_t));
+        tcp_peer_send_blocking(sd, &hdr, hdrsize);
         CLOSE_THE_SOCKET(sd);
         return PRTE_SUCCESS;
     }
@@ -1017,23 +1042,23 @@ int prte_oob_tcp_peer_recv_connect_ack(prte_oob_tcp_peer_t *pr, int sd, prte_oob
 
     /* if we don't already have it, get the peer */
     if (NULL == peer) {
-        peer = prte_oob_tcp_peer_lookup(&hdr.origin);
+        peer = prte_oob_tcp_peer_lookup(&sender);
         if (NULL == peer) {
             pmix_output_verbose(OOB_TCP_DEBUG_CONNECT, prte_oob_base.output,
                                 "%s prte_oob_tcp_recv_connect: connection from new peer",
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
             peer = PMIX_NEW(prte_oob_tcp_peer_t);
-            PMIX_XFER_PROCID(&peer->name, &hdr.origin);
+            PMIX_XFER_PROCID(&peer->name, &sender);
             peer->state = MCA_OOB_TCP_ACCEPTING;
             pmix_list_append(&prte_oob_base.peers, &peer->super);
         }
     } else {
         /* compare the peers name to the expected value */
-        if (!PMIX_CHECK_PROCID(&peer->name, &hdr.origin)) {
+        if (!PMIX_CHECK_PROCID(&peer->name, &sender)) {
             pmix_output(0,
                         "%s tcp_peer_recv_connect_ack: "
                         "received unexpected process identifier %s from %s\n",
-                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&(hdr.origin)),
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&sender),
                         PRTE_NAME_PRINT(&(peer->name)));
             peer->state = MCA_OOB_TCP_FAILED;
             prte_oob_tcp_peer_close(peer);

--- a/src/rml/oob/oob_tcp_hdr.h
+++ b/src/rml/oob/oob_tcp_hdr.h
@@ -29,6 +29,9 @@
 
 #include "prte_config.h"
 
+#include <stddef.h>
+#include <string.h>
+
 #include "types.h"
 
 /* Message types carried in the TCP header. IDENT and PROBE are used
@@ -41,36 +44,89 @@ typedef uint8_t prte_oob_tcp_msg_type_t;
 #define MCA_OOB_TCP_PROBE 2
 #define MCA_OOB_TCP_USER  4
 
-/* header for tcp msgs */
+/* header for tcp msgs
+ *
+ * Only the first PRTE_OOB_TCP_HDR_LEN() bytes of this struct go on the wire.
+ * The nspace is last, and only the characters it actually uses are sent - the
+ * rest of the array is scratch space for the receiver to land them in.  That
+ * is the whole reason for the layout: this header rides *every* RML message,
+ * and holding the names as two `pmix_proc_t` made it 552 bytes, of which 512
+ * were two fixed 256-byte nspace arrays holding the same short string.  On a
+ * launch-message cpuset slice for an eight-process node - 101 bytes of
+ * payload - that header was 85% of the message.
+ *
+ * One nspace covers both ends, because they have never differed on a message
+ * that carries data: every send entry point takes a *rank*
+ * (prte_rml_send_buffer_nb and friends), so the destination is always a peer
+ * of the sender's own job, the origin is the sender itself, and a relay
+ * copies both through unchanged.  The connect handshake is the one place the
+ * two names can differ - there `dst` is the peer being introduced to - and
+ * the receiver there reads only the origin, so the field carries the origin's
+ * nspace in that case too.
+ */
 typedef struct {
-    /* the originator of the message - when relaying, this is the
+    /* boot epoch (incarnation) of the origin. A daemon that departs and reboots
+     * into the same rank comes back with a strictly-greater epoch, so a hop can
+     * drop late traffic stamped with the stale incarnation's epoch. Leading,
+     * so that the 8-byte field needs no padding ahead of it. */
+    uint64_t epoch;
+    /* the rank of the originator of the message - when relaying, this is the
      * process that first sent the message, not necessarily our peer
      */
-    pmix_proc_t origin;
-    /* the intended final recipient. If it is not us, we relay the
+    pmix_rank_t origin;
+    /* the rank of the intended final recipient. If it is not us, we relay the
      * message onward toward that process using the routing tree
      */
-    pmix_proc_t dst;
+    pmix_rank_t dst;
     /* the rml tag where this message is headed */
     prte_rml_tag_t tag;
     /* the seq number of this message */
     uint32_t seq_num;
     /* number of bytes in message */
     uint32_t nbytes;
-    /* boot epoch (incarnation) of the origin. A daemon that departs and reboots
-     * into the same rank comes back with a strictly-greater epoch, so a hop can
-     * drop late traffic stamped with the stale incarnation's epoch. */
-    uint64_t epoch;
     /* type of message */
     prte_oob_tcp_msg_type_t type;
+    /* characters of nspace that follow, NOT counting a terminator - none is
+     * sent.  A uint8_t holds every legal length because PMIX_MAX_NSLEN is
+     * 255, which is also why no bound check is needed on the receiving side. */
+    uint8_t nslen;
+    /* the nspace both ranks above belong to.  Sent as nslen characters; the
+     * receiver terminates it itself. */
+    char nspace[PMIX_MAX_NSLEN + 1];
 } prte_oob_tcp_hdr_t;
+
+/* the part of the header that is always present, and the length of a
+ * particular header on the wire.  Both take the nslen in *host* order, which
+ * is every order: it is a single byte. */
+#define PRTE_OOB_TCP_HDR_FIXED   ((size_t) offsetof(prte_oob_tcp_hdr_t, nspace))
+#define PRTE_OOB_TCP_HDR_LEN(h)  (PRTE_OOB_TCP_HDR_FIXED + (size_t) (h)->nslen)
+
+/* load the nspace the two ranks share */
+#define PRTE_OOB_TCP_HDR_LOAD_NSPACE(h, ns)                 \
+    do {                                                    \
+        size_t _l = strlen(ns);                             \
+        if (PMIX_MAX_NSLEN < _l) {                          \
+            _l = PMIX_MAX_NSLEN;                            \
+        }                                                   \
+        memcpy((h)->nspace, (ns), _l);                      \
+        (h)->nspace[_l] = '\0';                             \
+        (h)->nslen = (uint8_t) _l;                          \
+    } while (0)
+
+/* terminate the nspace a peer just handed us.  Called once the nslen
+ * characters have been read, and before anything reads the field. */
+#define PRTE_OOB_TCP_HDR_END_NSPACE(h)  ((h)->nspace[(h)->nslen] = '\0')
+
+/* rebuild one of the two procids the header no longer carries whole */
+#define PRTE_OOB_TCP_HDR_PROC(h, r, p)  PMIX_LOAD_PROCID((p), (h)->nspace, (r))
+
 /**
  * Convert the message header to host byte order
  */
 #define MCA_OOB_TCP_HDR_NTOH(h)                     \
     do {                                            \
-        (h)->origin.rank = ntohl((h)->origin.rank); \
-        (h)->dst.rank = ntohl((h)->dst.rank);       \
+        (h)->origin = ntohl((h)->origin);           \
+        (h)->dst = ntohl((h)->dst);                 \
         (h)->tag = PRTE_RML_TAG_NTOH((h)->tag);     \
         (h)->seq_num = ntohl((h)->seq_num);         \
         (h)->nbytes = ntohl((h)->nbytes);           \
@@ -82,8 +138,8 @@ typedef struct {
  */
 #define MCA_OOB_TCP_HDR_HTON(h)                     \
     do {                                            \
-        (h)->origin.rank = htonl((h)->origin.rank); \
-        (h)->dst.rank = htonl((h)->dst.rank);       \
+        (h)->origin = htonl((h)->origin);           \
+        (h)->dst = htonl((h)->dst);                 \
         (h)->tag = PRTE_RML_TAG_HTON((h)->tag);     \
         (h)->seq_num = htonl((h)->seq_num);         \
         (h)->nbytes = htonl((h)->nbytes);           \

--- a/src/rml/oob/oob_tcp_sendrecv.c
+++ b/src/rml/oob/oob_tcp_sendrecv.c
@@ -488,48 +488,27 @@ void prte_oob_tcp_recv_handler(int sd, short flags, void *cbdata)
                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&(peer->name)));
                 return;
             }
-            /* start by reading the header */
+            /* start by reading the fixed part of the header - the nspace
+             * that trails it is only as long as the header says it is, and
+             * the header has to be in hand to know that */
             peer->recv_msg->rdptr = (char *) &peer->recv_msg->hdr;
-            peer->recv_msg->rdbytes = sizeof(prte_oob_tcp_hdr_t);
+            peer->recv_msg->rdbytes = PRTE_OOB_TCP_HDR_FIXED;
         }
         /* if the header hasn't been completely read, read it */
         if (!peer->recv_msg->hdr_recvd) {
             pmix_output_verbose(OOB_TCP_DEBUG_CONNECT, prte_oob_base.output,
                                 "%s:tcp:recv:handler read hdr", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
             if (PRTE_SUCCESS == (rc = read_bytes(peer))) {
-                /* completed reading the header */
+                /* completed reading the fixed part of the header */
                 peer->recv_msg->hdr_recvd = true;
                 /* convert the header */
                 MCA_OOB_TCP_HDR_NTOH(&peer->recv_msg->hdr);
-                /* if this is a zero-byte message, then we are done */
-                if (0 == peer->recv_msg->hdr.nbytes) {
-                    pmix_output_verbose(OOB_TCP_DEBUG_CONNECT,
-                                        prte_oob_base.output,
-                                        "%s RECVD ZERO-BYTE MESSAGE FROM %s for tag %d",
-                                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                                        PRTE_NAME_PRINT(&peer->name), peer->recv_msg->hdr.tag);
-                    peer->recv_msg->data = NULL; // make sure
-                } else {
-                    pmix_output_verbose(OOB_TCP_DEBUG_CONNECT,
-                                        prte_oob_base.output,
-                                        "%s:tcp:recv:handler allocate data region of size %lu",
-                                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                                        (unsigned long) peer->recv_msg->hdr.nbytes);
-                    if (peer->recv_msg->hdr.nbytes > (uint32_t)(prte_oob_base.max_msg_size * 1024 * 1024)) {
-                        prte_show_help("help-oob-tcp.txt", "msg-too-big", true,
-                                        PRTE_NAME_PRINT(&peer->name), PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                                        peer->recv_msg->hdr.nbytes, prte_oob_base.max_msg_size);
-                        peer->state = MCA_OOB_TCP_FAILED;
-                        prte_oob_tcp_peer_close(peer);
-                        return;
-                    }
-                    /* allocate the data region */
-                    peer->recv_msg->data = (char *) malloc(peer->recv_msg->hdr.nbytes);
-                    /* point to it */
-                    peer->recv_msg->rdptr = peer->recv_msg->data;
-                    peer->recv_msg->rdbytes = peer->recv_msg->hdr.nbytes;
-                }
-                /* fall thru and attempt to read the data */
+                /* set up to read the nspace that trails it.  nslen is a
+                 * single byte and PMIX_MAX_NSLEN is 255, so it cannot name
+                 * more characters than the field can hold */
+                peer->recv_msg->rdptr = peer->recv_msg->hdr.nspace;
+                peer->recv_msg->rdbytes = peer->recv_msg->hdr.nslen;
+                /* fall thru and attempt to read it */
             } else if (PRTE_ERR_RESOURCE_BUSY == rc || PRTE_ERR_WOULD_BLOCK == rc) {
                 /* exit this event and let the event lib progress */
                 return;
@@ -543,7 +522,65 @@ void prte_oob_tcp_recv_handler(int sd, short flags, void *cbdata)
             }
         }
 
-        if (peer->recv_msg->hdr_recvd) {
+        /* the names in this header are a rank plus the nspace that follows the
+         * fixed part, so nothing may read one until those characters are in */
+        if (peer->recv_msg->hdr_recvd && !peer->recv_msg->nspace_recvd) {
+            if (0 < peer->recv_msg->hdr.nslen) {
+                rc = read_bytes(peer);
+                if (PRTE_ERR_RESOURCE_BUSY == rc || PRTE_ERR_WOULD_BLOCK == rc) {
+                    /* exit this event and let the event lib progress */
+                    return;
+                }
+                if (PRTE_SUCCESS != rc) {
+                    pmix_output_verbose(OOB_TCP_DEBUG_CONNECT, prte_oob_base.output,
+                                        "%s:tcp:recv:handler error reading nspace - closing connection",
+                                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
+                    prte_oob_tcp_peer_close(peer);
+                    return;
+                }
+            }
+            /* the terminator is not sent - we supply it */
+            PRTE_OOB_TCP_HDR_END_NSPACE(&peer->recv_msg->hdr);
+            peer->recv_msg->nspace_recvd = true;
+
+            /* if this is a zero-byte message, then we are done */
+            if (0 == peer->recv_msg->hdr.nbytes) {
+                pmix_output_verbose(OOB_TCP_DEBUG_CONNECT,
+                                    prte_oob_base.output,
+                                    "%s RECVD ZERO-BYTE MESSAGE FROM %s for tag %d",
+                                    PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                    PRTE_NAME_PRINT(&peer->name), peer->recv_msg->hdr.tag);
+                peer->recv_msg->data = NULL; // make sure
+            } else {
+                pmix_output_verbose(OOB_TCP_DEBUG_CONNECT,
+                                    prte_oob_base.output,
+                                    "%s:tcp:recv:handler allocate data region of size %lu",
+                                    PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                    (unsigned long) peer->recv_msg->hdr.nbytes);
+                if (peer->recv_msg->hdr.nbytes > (uint32_t)(prte_oob_base.max_msg_size * 1024 * 1024)) {
+                    prte_show_help("help-oob-tcp.txt", "msg-too-big", true,
+                                    PRTE_NAME_PRINT(&peer->name), PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                    peer->recv_msg->hdr.nbytes, prte_oob_base.max_msg_size);
+                    peer->state = MCA_OOB_TCP_FAILED;
+                    prte_oob_tcp_peer_close(peer);
+                    return;
+                }
+                /* allocate the data region */
+                peer->recv_msg->data = (char *) malloc(peer->recv_msg->hdr.nbytes);
+                /* point to it */
+                peer->recv_msg->rdptr = peer->recv_msg->data;
+                peer->recv_msg->rdbytes = peer->recv_msg->hdr.nbytes;
+            }
+            /* fall thru and attempt to read the data */
+        }
+
+        if (peer->recv_msg->nspace_recvd) {
+            pmix_proc_t origin, dest;
+
+            /* the header carries the two ranks and the nspace they share */
+            PRTE_OOB_TCP_HDR_PROC(&peer->recv_msg->hdr, peer->recv_msg->hdr.origin, &origin);
+            PRTE_OOB_TCP_HDR_PROC(&peer->recv_msg->hdr, peer->recv_msg->hdr.dst, &dest);
+
             /* continue to read the data block - we start from
              * wherever we left off, which could be at the
              * beginning or somewhere in the message
@@ -554,8 +591,8 @@ void prte_oob_tcp_recv_handler(int sd, short flags, void *cbdata)
                     OOB_TCP_DEBUG_CONNECT, prte_oob_base.output,
                     "%s RECVD COMPLETE MESSAGE FROM %s (ORIGIN %s) OF %d BYTES FOR DEST %s TAG %d",
                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&peer->name),
-                    PRTE_NAME_PRINT(&peer->recv_msg->hdr.origin), (int) peer->recv_msg->hdr.nbytes,
-                    PRTE_NAME_PRINT(&peer->recv_msg->hdr.dst), peer->recv_msg->hdr.tag);
+                    PRTE_NAME_PRINT(&origin), (int) peer->recv_msg->hdr.nbytes,
+                    PRTE_NAME_PRINT(&dest), peer->recv_msg->hdr.tag);
 
                 /* Incarnation guard (bootstrap only): a departed daemon can
                  * reboot into the same rank and return with a strictly-greater
@@ -566,14 +603,12 @@ void prte_oob_tcp_recv_handler(int sd, short flags, void *cbdata)
                  * message has already been read off the socket, so dropping
                  * here leaves the byte stream correctly framed. */
                 if (prte_bootstrap_setup &&
-                    PMIX_CHECK_NSPACE(peer->recv_msg->hdr.origin.nspace,
-                                      PRTE_PROC_MY_NAME->nspace) &&
-                    !prte_rml_epoch_ok(peer->recv_msg->hdr.origin.rank,
-                                       peer->recv_msg->hdr.epoch)) {
+                    PMIX_CHECK_NSPACE(origin.nspace, PRTE_PROC_MY_NAME->nspace) &&
+                    !prte_rml_epoch_ok(origin.rank, peer->recv_msg->hdr.epoch)) {
                     pmix_output_verbose(OOB_TCP_DEBUG_CONNECT, prte_oob_base.output,
                                         "%s DROPPING STALE-INCARNATION MSG FROM %s epoch %lu",
                                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                                        PRTE_NAME_PRINT(&peer->recv_msg->hdr.origin),
+                                        PRTE_NAME_PRINT(&origin),
                                         (unsigned long) peer->recv_msg->hdr.epoch);
                     PMIX_RELEASE(peer->recv_msg);
                     peer->recv_msg = NULL;
@@ -581,14 +616,14 @@ void prte_oob_tcp_recv_handler(int sd, short flags, void *cbdata)
                 }
 
                 /* am I the intended recipient (header was already converted back to host order)? */
-                if (PMIX_CHECK_PROCID(&peer->recv_msg->hdr.dst, PRTE_PROC_MY_NAME)) {
+                if (PMIX_CHECK_PROCID(&dest, PRTE_PROC_MY_NAME)) {
                     /* yes - post it to the RML for delivery */
                     pmix_output_verbose(OOB_TCP_DEBUG_CONNECT,
                                         prte_oob_base.output,
                                         "%s DELIVERING TO RML tag = %d seq_num = %d",
                                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), peer->recv_msg->hdr.tag,
                                         peer->recv_msg->hdr.seq_num);
-                    PRTE_RML_POST_MESSAGE(&peer->recv_msg->hdr.origin, peer->recv_msg->hdr.tag,
+                    PRTE_RML_POST_MESSAGE(&origin, peer->recv_msg->hdr.tag,
                                           peer->recv_msg->hdr.seq_num, peer->recv_msg->data,
                                           peer->recv_msg->hdr.nbytes);
                     /* PMIx_Data_load took ownership of the payload */
@@ -603,10 +638,10 @@ void prte_oob_tcp_recv_handler(int sd, short flags, void *cbdata)
                                         prte_oob_base.output,
                                         "%s TCP RELAYING ROUTED MESSAGE FOR %s",
                                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                                        PRTE_NAME_PRINT(&peer->recv_msg->hdr.dst));
+                                        PRTE_NAME_PRINT(&dest));
                     snd = PMIX_NEW(prte_rml_send_t);
-                    snd->dst = peer->recv_msg->hdr.dst;
-                    PMIX_XFER_PROCID(&snd->origin, &peer->recv_msg->hdr.origin);
+                    PMIX_XFER_PROCID(&snd->dst, &dest);
+                    PMIX_XFER_PROCID(&snd->origin, &origin);
                     /* preserve the origin's epoch across the relay (the
                      * constructor defaulted it to our own epoch) */
                     snd->epoch = peer->recv_msg->hdr.epoch;
@@ -679,6 +714,7 @@ static void rcv_cons(prte_oob_tcp_recv_t *ptr)
 {
     memset(&ptr->hdr, 0, sizeof(prte_oob_tcp_hdr_t));
     ptr->hdr_recvd = false;
+    ptr->nspace_recvd = false;
     ptr->data = NULL;
     ptr->rdptr = NULL;
     ptr->rdbytes = 0;

--- a/src/rml/oob/oob_tcp_sendrecv.h
+++ b/src/rml/oob/oob_tcp_sendrecv.h
@@ -28,6 +28,8 @@
 
 #include "prte_config.h"
 
+#include <assert.h>
+
 #include "src/class/pmix_list.h"
 #include "src/util/pmix_string_copy.h"
 
@@ -60,6 +62,9 @@ typedef struct {
     pmix_list_item_t super;
     prte_oob_tcp_hdr_t hdr;
     bool hdr_recvd;
+    /* the nspace trails the fixed part of the header and is read separately,
+     * so "we have the header" is two steps, not one */
+    bool nspace_recvd;
     char *data;
     char *rdptr;
     size_t rdbytes;
@@ -103,13 +108,15 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_recv_t);
 #define MCA_OOB_TCP_QUEUE_SEND(m, p)                                                           \
     do {                                                                                       \
         prte_oob_tcp_send_t *_s;                                                               \
-        pmix_output_verbose(5, prte_oob_base.output,                       \
+        pmix_output_verbose(5, prte_oob_base.output,                                           \
                             "%s:[%s:%d] queue send to %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), \
                             __FILE__, __LINE__, PRTE_NAME_PRINT(&((m)->dst)));                 \
         _s = PMIX_NEW(prte_oob_tcp_send_t);                                                    \
-        /* setup the header */                                                                 \
-        PMIX_XFER_PROCID(&_s->hdr.origin, &(m)->origin);                                       \
-        PMIX_XFER_PROCID(&_s->hdr.dst, &(m)->dst);                                             \
+        /* one nspace covers both ends - see oob_tcp_hdr.h */                                  \
+        assert(PMIX_CHECK_NSPACE((m)->origin.nspace, (m)->dst.nspace));                        \
+        _s->hdr.origin = (m)->origin.rank;                                                     \
+        _s->hdr.dst = (m)->dst.rank;                                                           \
+        PRTE_OOB_TCP_HDR_LOAD_NSPACE(&_s->hdr, (m)->origin.nspace);                            \
         _s->hdr.type = MCA_OOB_TCP_USER;                                                       \
         _s->hdr.tag = (m)->tag;                                                                \
         _s->hdr.seq_num = (m)->seq_num;                                                        \
@@ -117,12 +124,12 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_recv_t);
         /* point to the actual message */                                                      \
         _s->msg = (m);                                                                         \
         /* set the total number of bytes to be sent */                                         \
-        _s->hdr.nbytes = (m)->dbuf->bytes_used;                                                 \
+        _s->hdr.nbytes = (m)->dbuf->bytes_used;                                                \
         /* prep header for xmission */                                                         \
         MCA_OOB_TCP_HDR_HTON(&_s->hdr);                                                        \
         /* start the send with the header */                                                   \
         _s->sdptr = (char *) &_s->hdr;                                                         \
-        _s->sdbytes = sizeof(prte_oob_tcp_hdr_t);                                              \
+        _s->sdbytes = PRTE_OOB_TCP_HDR_LEN(&_s->hdr);                                          \
         /* add to the msg queue for this peer */                                               \
         MCA_OOB_TCP_QUEUE_MSG((p), _s, true);                                                  \
     } while (0)
@@ -136,13 +143,15 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_recv_t);
 #define MCA_OOB_TCP_QUEUE_PENDING(m, p)                                                           \
     do {                                                                                          \
         prte_oob_tcp_send_t *_s;                                                                  \
-        pmix_output_verbose(5, prte_oob_base.output,                          \
+        pmix_output_verbose(5, prte_oob_base.output,                                              \
                             "%s:[%s:%d] queue pending to %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), \
                             __FILE__, __LINE__, PRTE_NAME_PRINT(&((m)->dst)));                    \
         _s = PMIX_NEW(prte_oob_tcp_send_t);                                                       \
-        /* setup the header */                                                                    \
-        PMIX_XFER_PROCID(&_s->hdr.origin, &(m)->origin);                                          \
-        PMIX_XFER_PROCID(&_s->hdr.dst, &(m)->dst);                                                \
+        /* one nspace covers both ends - see oob_tcp_hdr.h */                                     \
+        assert(PMIX_CHECK_NSPACE((m)->origin.nspace, (m)->dst.nspace));                           \
+        _s->hdr.origin = (m)->origin.rank;                                                        \
+        _s->hdr.dst = (m)->dst.rank;                                                              \
+        PRTE_OOB_TCP_HDR_LOAD_NSPACE(&_s->hdr, (m)->origin.nspace);                               \
         _s->hdr.type = MCA_OOB_TCP_USER;                                                          \
         _s->hdr.tag = (m)->tag;                                                                   \
         _s->hdr.seq_num = (m)->seq_num;                                                           \
@@ -150,12 +159,12 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_recv_t);
         /* point to the actual message */                                                         \
         _s->msg = (m);                                                                            \
         /* set the total number of bytes to be sent */                                            \
-        _s->hdr.nbytes = (m)->dbuf->bytes_used;                                                    \
+        _s->hdr.nbytes = (m)->dbuf->bytes_used;                                                   \
         /* prep header for xmission */                                                            \
         MCA_OOB_TCP_HDR_HTON(&_s->hdr);                                                           \
         /* start the send with the header */                                                      \
         _s->sdptr = (char *) &_s->hdr;                                                            \
-        _s->sdbytes = sizeof(prte_oob_tcp_hdr_t);                                                 \
+        _s->sdbytes = PRTE_OOB_TCP_HDR_LEN(&_s->hdr);                                             \
         /* add to the msg queue for this peer */                                                  \
         MCA_OOB_TCP_QUEUE_MSG((p), _s, false);                                                    \
     } while (0)

--- a/test/unit/rml/test_rml.c
+++ b/test/unit/rml/test_rml.c
@@ -70,6 +70,7 @@
 #include "src/rml/rml.h"
 #include "src/rml/oob/oob.h"
 #include "src/rml/oob/oob_tcp.h"
+#include "src/rml/oob/oob_tcp_hdr.h"
 #include "src/rml/oob/oob_tcp_peer.h"
 
 #define CHECK(label, cond)                                    \
@@ -508,6 +509,89 @@ static int test_progress_thread_pool(void)
     return failures;
 }
 
+
+/* The wire header is a fixed part followed by only the characters of the
+ * nspace it names.  Nothing here needs a socket: the properties that matter
+ * are how long a header is on the wire, that the receiver's two-step read
+ * reconstructs exactly the names the sender put in, and that the byte-order
+ * conversion is a round trip.  Those are what a reader of oob_tcp_sendrecv.c
+ * has to take on trust, and getting any of them wrong delivers a message
+ * under the wrong identity rather than failing.
+ */
+static int test_wire_header(void)
+{
+    int failures = 0;
+    prte_oob_tcp_hdr_t snd, rcv;
+    pmix_proc_t origin, dest;
+    char wire[sizeof(prte_oob_tcp_hdr_t)];
+    size_t len;
+    const char *ns = "prterun-somenode-12345@0";
+
+    /* what a sender builds */
+    memset(&snd, 0, sizeof(snd));
+    snd.epoch = 7;
+    snd.origin = 3;
+    snd.dst = 11;
+    snd.tag = PRTE_RML_TAG_DAEMON;
+    snd.seq_num = 42;
+    snd.nbytes = 4096;
+    snd.type = MCA_OOB_TCP_USER;
+    PRTE_OOB_TCP_HDR_LOAD_NSPACE(&snd, ns);
+
+    CHECK("hdr nslen excludes the terminator", strlen(ns) == snd.nslen);
+    len = PRTE_OOB_TCP_HDR_LEN(&snd);
+    CHECK("hdr wire length is the fixed part plus the nspace",
+          len == PRTE_OOB_TCP_HDR_FIXED + strlen(ns));
+    /* the point of the exercise: the struct is much larger than the message */
+    CHECK("hdr on the wire is far smaller than the struct", len < sizeof(snd) / 4);
+
+    /* what goes out: only the used prefix, in network order */
+    MCA_OOB_TCP_HDR_HTON(&snd);
+    memcpy(wire, &snd, len);
+
+    /* what a receiver does: the fixed part first, then nslen characters,
+     * then supply the terminator the sender did not send */
+    memset(&rcv, 0xff, sizeof(rcv));
+    memcpy(&rcv, wire, PRTE_OOB_TCP_HDR_FIXED);
+    CHECK("nslen needs no byte-order conversion to be usable",
+          PRTE_OOB_TCP_HDR_LEN(&rcv) == len);
+    memcpy(rcv.nspace, wire + PRTE_OOB_TCP_HDR_FIXED, rcv.nslen);
+    PRTE_OOB_TCP_HDR_END_NSPACE(&rcv);
+    MCA_OOB_TCP_HDR_NTOH(&rcv);
+
+    CHECK("epoch survives the round trip", 7 == rcv.epoch);
+    CHECK("tag survives the round trip", PRTE_RML_TAG_DAEMON == rcv.tag);
+    CHECK("seq_num survives the round trip", 42 == rcv.seq_num);
+    CHECK("nbytes survives the round trip", 4096 == rcv.nbytes);
+    CHECK("type survives the round trip", MCA_OOB_TCP_USER == rcv.type);
+    CHECK("the nspace arrives terminated and intact", 0 == strcmp(rcv.nspace, ns));
+
+    /* and the two names the header no longer carries whole come back */
+    PRTE_OOB_TCP_HDR_PROC(&rcv, rcv.origin, &origin);
+    PRTE_OOB_TCP_HDR_PROC(&rcv, rcv.dst, &dest);
+    CHECK("origin rank rebuilt", 3 == origin.rank);
+    CHECK("dst rank rebuilt", 11 == dest.rank);
+    CHECK("origin nspace rebuilt", PMIX_CHECK_NSPACE(origin.nspace, ns));
+    CHECK("dst carries the same nspace", PMIX_CHECK_NSPACE(dest.nspace, ns));
+
+    /* a maximum-length nspace still fits the single-byte length field */
+    memset(&snd, 0, sizeof(snd));
+    {
+        char big[PMIX_MAX_NSLEN + 1];
+        memset(big, 'x', PMIX_MAX_NSLEN);
+        big[PMIX_MAX_NSLEN] = '\0';
+        PRTE_OOB_TCP_HDR_LOAD_NSPACE(&snd, big);
+        CHECK("a full-length nspace is carried whole", PMIX_MAX_NSLEN == snd.nslen);
+        PRTE_OOB_TCP_HDR_END_NSPACE(&snd);
+        CHECK("a full-length nspace round trips", 0 == strcmp(snd.nspace, big));
+    }
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_wire_header\n");
+    }
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0;
@@ -528,6 +612,7 @@ int main(void)
     failures += test_subnet_resolves_and_dedupes();
     failures += test_payload_outlives_sends();
     failures += test_progress_thread_pool();
+    failures += test_wire_header();
 
     prte_finalize();
 


### PR DESCRIPTION
Three commits: one code change and two documentation decisions that came out of measuring the work the code change replaces.

## Carry one nspace in the OOB header, not two whole procids

`prte_oob_tcp_hdr_t` is written raw onto the socket ahead of every RML payload. It named the origin and the final destination as two `pmix_proc_t` — a rank plus a fixed 256-byte nspace array each — so the header was **552 bytes, 512 of them two copies of the same short string**.

On a large message that is noise. On a small one it is the message: a launch-message cpuset slice for an eight-process node carries 101 bytes of payload behind those 552. And nothing about it is particular to slices — the header rides every daemon-to-daemon message PRRTE sends.

The two names have never differed on a message that carries data: every send entry point takes a rank rather than a procid, so a message is always addressed to a peer of the sender's own job, and the relay copies both fields through. The header now carries the two ranks and one nspace, the queueing macros assert the equality they rely on, and the nspace goes last so that only the characters it uses are sent. A typical DVM nspace is about twenty characters, so **552 bytes becomes about fifty**.

Consequences worth reviewing:

- Anything that sends or reads a header sizes it with `PRTE_OOB_TCP_HDR_FIXED` / `PRTE_OOB_TCP_HDR_LEN()`, never `sizeof()` — the struct is deliberately larger than the message.
- The receive side gains a step: `hdr_recvd` no longer means the names are readable, `nspace_recvd` does. Both the socket recv handler and the blocking reads of the connect handshake read in that order.
- `nslen` is a `uint8_t` and `PMIX_MAX_NSLEN` is 255, so no length that fits the field can overrun it and none needs byte-order conversion.
- This is a wire-format change, which the header is explicitly allowed to be: it is exchanged only among daemons of the same DVM, all running the same build. Both ends change here together.

## docs: close two deferred-work entries

`docs/todo.rst` gains a "Decided against" section, for work that was investigated and deliberately not done, so the next person does not spend the effort again.

**Lazy proc-data registration.** The commit that landed the derivation never touched `pmix_server_register_fns.c`, so the withholding half was never done. Measured on the swarm, it should not be: PMIx's own `store_map` already materializes hostname, nodeid, local rank and node rank per rank for the whole job out of the maps PRRTE registers, so withholding the proc arrays cannot remove the job-sized table — and it would trade an authoritative node rank for one PMIx derives assuming a single job per node. The open question the entry posed (is a partial proc-data entry usable?) is answered in passing: it is, and the cpuset scatter has been relying on it since it landed.

**Aggregating the cpuset slices per next hop.** The payload does not change either way; what aggregation removes is a message header per saved crossing — half a megabyte at 1000 x 128 against a launch broadcast that moves ~240 MB. The master-side pack loop is per process, not per buffer, so bucketing into fewer buffers takes just as long. What the measurement did turn up is the header, which is what the first commit fixes.

## Testing

- `make check`: 21 tests pass, including a new `test/unit/rml/test_rml.c` case pinning the header framing — wire length, the two-step read reconstructing the names the sender put in, the byte-order round trip, and a maximum-length nspace.
- Clean build in both a release configuration and `--enable-debug` (warnings as errors).
- `contrib/dockerswarm` full suite, ten nodes: **554 passed, 2 failed, 2 skipped**. Both failures are pre-existing and unrelated — the `--map-by device=network` cases ask for 64 processes against an 8-slot DVM, so the slot error fires before the device rule and the case's skip guard (which greps for the device message) never matches. This diff touches only the OOB transport, docs, and a unit test.
- The rml phase is the one that exercises the new framing directly, and passes: relaying through an interior tree at radix 2, every daemon agreeing on the tree shape, and 3.5 MB relayed intact through partial reads and writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)