### PR TITLE
Reach an external data server as a PMIx tool, and drop the OOB header's namespace

### DIFF
--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -1390,6 +1390,29 @@ prted_dvm_start_mca() {
     sleep 4
     RUN "test -s $PRTED_URI"
 }
+# Start an ADDITIONAL persistent DVM, reporting its URI to a file of its own.
+# The cross-DVM data-server cases need three DVMs up at once, and a single
+# PRTED_URI cannot name three of them.  $1 = uri file, $2 = --host spec,
+# $3 = extra options spliced in ahead of --host (may be empty).
+#
+# Every one of these HNPs runs on node1 -- that is where prte is invoked --
+# so give each its own set of compute nodes.  They are separate DVMs, in
+# separate namespaces, with separate session directories.
+dvm_start_uri() {
+    RUN "rm -f $1" >/dev/null 2>&1
+    RUN "timeout -k 5 60 prte --daemonize --report-uri $1 $3 --host $2" >/dev/null 2>&1
+    sleep 4
+    RUN "test -s $1"
+}
+# ...and the tool forms against a named URI file
+PRUN_URI() { local uri=$1; shift; RUN "timeout -k 5 60 prun --dvm-uri file:$uri $*"; }
+PRUN_URI_BG() {
+    local uri=$1 outf=$2; shift 2
+    docker exec -d -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+        "${NODE}1" bash -lc ". /opt/prte/env.sh;
+            prun --dvm-uri file:$uri $* > $outf 2>&1"
+}
+
 # run a tool against that DVM, from the head node ($@ = argv after "prun")
 PRUN() { RUN "timeout -k 5 60 prun --dvm-uri file:$PRTED_URI $*"; }
 # ...and in the background, with its output captured on node1
@@ -1585,6 +1608,136 @@ test_runtime() {
                 || ok "a client on another node cannot see it, as LOCAL range requires"
         fi
         RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    fi
+    cleanup_swarm
+
+    ####################################################################
+    # An EXTERNAL data server -- one DVM keeping the data for others.
+    #
+    # This is what prte_pmix_server_uri (the old "ompi-server") is for: two
+    # jobs launched by different invocations, in different DVMs, finding
+    # each other through a third DVM that holds the store.  It is what
+    # MPI_Publish_name / MPI_Comm_accept across mpiruns runs on.
+    #
+    # It cannot be reached over the RML: every send entry point takes a rank
+    # and stamps the sender's OWN namespace on it, so a daemon of another
+    # DVM is not nameable at all.  The master therefore attaches to the
+    # server DVM as a PMIx TOOL and reissues the request there
+    # (src/runtime/data_server/ds_relay.c), carrying the asking process's
+    # identity in PMIX_REQUESTOR so the far end attributes it correctly.
+    #
+    # Nothing about that exists on one DVM, which is why it lives here and
+    # not in test/unit/runtime: the whole point is a namespace boundary.
+    ####################################################################
+    banner "runtime/data_server: two DVMs share a third DVM's data server"
+    cleanup_swarm
+    if ! RUN "test -x $DS"; then
+        skp "dataserver client not installed -- re-run ./build.sh"
+    elif ! dvm_start_uri /tmp/ds-server.uri 'node2:2' ''; then
+        bad "could not start the data-server DVM"
+    elif ! dvm_start_uri /tmp/ds-a.uri 'node3:2,node4:2' \
+                         '--prtemca pmix_server_uri file:/tmp/ds-server.uri'; then
+        bad "could not start the first client DVM"
+        RUN "timeout -k 5 30 pterm --dvm-uri file:/tmp/ds-server.uri" >/dev/null 2>&1
+    elif ! dvm_start_uri /tmp/ds-b.uri 'node5:2,node6:2' \
+                         '--prtemca pmix_server_uri file:/tmp/ds-server.uri'; then
+        bad "could not start the second client DVM"
+        RUN "timeout -k 5 30 pterm --dvm-uri file:/tmp/ds-a.uri" >/dev/null 2>&1
+        RUN "timeout -k 5 30 pterm --dvm-uri file:/tmp/ds-server.uri" >/dev/null 2>&1
+    else
+        ok "three DVMs are up: a data server and two clients pointed at it"
+        PRUN_URI_BG /tmp/ds-a.uri /tmp/ds-x1.out \
+            "--host node3:1 -n 1 $DS publish prte.test.cross across-dvms session 90"
+        sleep 8
+        if ! RUN 'grep -q "^PUBLISHED prte.test.cross" /tmp/ds-x1.out'; then
+            bad "the cross-DVM publish never happened: $(RUN 'cat /tmp/ds-x1.out' 2>&1 | tr '\n' ' ' | tail -c 250)"
+        else
+            ok "a proc in DVM A published through the external server"
+
+            out=$(PRUN_URI /tmp/ds-b.uri "--host node5:1 -n 1 $DS lookup prte.test.cross 25" 2>&1)
+            echo "$out" | grep -q '^FOUND prte.test.cross across-dvms' \
+                && ok "a proc in DVM B found it -- the data crossed the DVM boundary" \
+                || bad "a cross-DVM lookup failed: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+
+            # The owner the answer names is the PUBLISHING PROCESS, not the
+            # daemon that relayed for it.  Without the PMIX_REQUESTOR
+            # substitution every item would be owned by DVM A's master
+            # wearing its tool identity, and every ownership rule at the far
+            # end - who may unpublish, what NAMESPACE range admits - would
+            # be answered about the wrong process.  DVM A's namespace is in
+            # its URI file, so this can assert on the identity and not just
+            # on "something was named".
+            n=$(RUN 'cut -d";" -f1 /tmp/ds-a.uri' 2>/dev/null | tr -d '\r' | cut -d. -f1)
+            echo "$out" | grep -q "from $n" \
+                && bad "the published data was owned by DVM A's master, not by the publisher"
+            echo "$out" | grep -qE 'from [^ ]+:0\)' \
+                && ok "...and the answer names the publishing process, not the relay" \
+                || bad "the answer did not name a publisher: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+
+            banner "runtime/data_server: a DVM with no server URI shares nothing"
+            # The control.  A DVM that was not pointed at the server keeps
+            # its own store, so the same key must NOT be visible there -
+            # otherwise the case above proves only that a lookup succeeds
+            # somewhere, not that it crossed anything.
+            if ! prted_dvm_start 'node7:2'; then
+                skp "could not start an unconnected DVM; the control is missing"
+            else
+                out=$(PRUN "--host node7:1 -n 1 $DS lookup prte.test.cross 15" 2>&1)
+                echo "$out" | grep -q '^FOUND prte.test.cross' \
+                    && bad "a DVM with no server URI saw another DVM's data" \
+                    || ok "a DVM with no server URI cannot see it, as it must not"
+                RUN "timeout -k 5 30 pterm --dvm-uri file:$PRTED_URI" >/dev/null 2>&1
+            fi
+
+            banner "runtime/data_server: a waiting lookup crosses DVMs too"
+            # The parked-request path, but with the park in one DVM and the
+            # publish in another.  Both legs are relays, and the wake-up has
+            # to travel back out through the tool connection that asked.
+            PRUN_URI_BG /tmp/ds-b.uri /tmp/ds-x2.out \
+                "--host node5:1 -n 1 $DS lookupwait prte.test.xlater 60"
+            sleep 8
+            if ! RUN 'grep -q "^WAITING" /tmp/ds-x2.out'; then
+                skp "the cross-DVM waiting lookup never started"
+            else
+                ok "a lookup in DVM B is parked in the external server"
+                PRUN_URI_BG /tmp/ds-a.uri /tmp/ds-x3.out \
+                    "--host node4:1 -n 1 $DS publish prte.test.xlater eventually session 40"
+                sleep 12
+                RUN 'grep -q "^FOUND prte.test.xlater eventually" /tmp/ds-x2.out' \
+                    && ok "a publish in DVM A satisfied the lookup parked from DVM B" \
+                    || bad "a parked cross-DVM lookup was never satisfied: $(RUN 'cat /tmp/ds-x2.out' 2>&1 | tr '\n' ' ' | tail -c 250)"
+            fi
+
+            banner "runtime/data_server: an ended job's data is purged from the external server"
+            # When a job finishes, its DVM tells the data server to drop
+            # what that job published (state_dvm.c).  Relayed, that is an
+            # unpublish naming no keys, and the process it names has to be
+            # the departed one - PMIX_REQUESTOR again.  Get that wrong and
+            # the purge either does nothing or takes everything the relaying
+            # tool ever published, including the OTHER client DVM's data.
+            out=$(PRUN_URI /tmp/ds-a.uri "--host node3:1 -n 1 $DS publish prte.test.transient gone session 2" 2>&1)
+            echo "$out" | grep -q '^PUBLISHED prte.test.transient' \
+                && ok "a short-lived job in DVM A published a key" \
+                || bad "the short-lived publish failed: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+            sleep 8
+            # Two single-key lookups rather than one lookup2: a partial
+            # result is only carried back by a PMIx new enough to keep the
+            # payload on a non-SUCCESS status (see the partial-lookup case
+            # above), and this case is not about that.
+            out=$(PRUN_URI /tmp/ds-b.uri "--host node5:1 -n 1 $DS lookup prte.test.transient 20" 2>&1)
+            echo "$out" | grep -q '^FOUND prte.test.transient' \
+                && bad "an ended job's data survived in the external server" \
+                || ok "the ended job's key was purged from the external server"
+            # ...and the purge took ONLY that job's data.  prte.test.cross
+            # belongs to a job that is still running.
+            out=$(PRUN_URI /tmp/ds-b.uri "--host node5:1 -n 1 $DS lookup prte.test.cross 20" 2>&1)
+            echo "$out" | grep -q '^FOUND prte.test.cross across-dvms' \
+                && ok "...and it took only that job's data, not the whole store" \
+                || bad "the purge removed data belonging to a job that is still alive: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        fi
+        for u in /tmp/ds-b.uri /tmp/ds-a.uri /tmp/ds-server.uri; do
+            RUN "timeout -k 5 30 pterm --dvm-uri file:$u" >/dev/null 2>&1
+        done
     fi
     cleanup_swarm
 

--- a/docs/how-things-work/rml/oob.rst
+++ b/docs/how-things-work/rml/oob.rst
@@ -48,6 +48,15 @@ number, the payload length, and a message ``type``:
 * ``IDENT`` / ``PROBE`` — the connection handshake, and
 * ``USER`` — a normal message.
 
+``origin`` and ``dst`` are **ranks**, not full process identifiers, and a data
+message carries no namespace at all — 30 bytes in total.  There is only ever
+one namespace to name: an OOB endpoint belongs to a daemon of this DVM and to
+nothing else, and every send entry point takes a rank that is resolved in the
+sender's own namespace, so the receiver rebuilds both identifiers with its
+own.  The connection handshake is the exception, and the reason the rest can
+be silent: it does carry a namespace, and a peer presenting any namespace but
+ours is refused rather than adopted.
+
 The header is exchanged **only** among daemons of the same DVM, all running the
 same build, so it is **not** a stable ABI.  Its layout may change freely, but
 every daemon in a build must agree; there is no versioning.

--- a/docs/plans/cross_dvm_data_server/cross-dvm-data-server.rst
+++ b/docs/plans/cross_dvm_data_server/cross-dvm-data-server.rst
@@ -1,0 +1,156 @@
+Reaching a data server in another DVM
+=====================================
+
+What this is for
+----------------
+
+PRRTE's data server backs PMIx's publish/lookup service.  Normally the store
+lives on this DVM's own master and every participant reaches it over the RML
+— see `src/runtime/data_server/AGENTS.md
+<https://github.com/openpmix/prrte/blob/master/src/runtime/data_server/AGENTS.md>`_.
+
+``prte_pmix_server_uri`` asks for something else: that the store live in a
+**different DVM**, so that jobs launched by *different invocations* can find
+each other's data.  That is what an MPI application is doing when one
+``mpirun`` calls ``MPI_Publish_name`` and another calls ``MPI_Comm_accept``,
+and it is why ``pmix_server_register_fns.c`` publishes a job's info whenever
+an external server is configured: any subsequent connect has to be able to
+retrieve it.
+
+
+Why it could not work over the RML
+----------------------------------
+
+The RML addresses a peer **by rank**, and stamps the sender's own namespace
+on it.  Every send entry point takes a ``pmix_rank_t``
+(``prte_rml_send_buffer_nb`` and its variants), ``send_buffer()`` builds the
+destination as ``PMIX_LOAD_PROCID(&snd->dst, PRTE_PROC_MY_NAME->nspace,
+rank)``, and ``prte_oob_base_send_nb`` resolves the next hop the same way.  A
+daemon of another DVM is therefore not nameable: the namespace parsed out of
+the server's URI was discarded and the request went to *this* DVM's rank 0.
+
+That has been so since the March 2022 RML rework
+(``17368b1b60``), which rewrote the one line that mattered::
+
+    -    PRTE_RML_SEND(rc, target, xfer, PRTE_RML_TAG_DATA_SERVER);
+    +    PRTE_RML_SEND(rc, target->rank, xfer, PRTE_RML_TAG_DATA_SERVER);
+
+It is not something the transport can be talked into.  Below the API,
+everything is indexed by rank within this DVM — ``prte_rml_is_node_up()``,
+``prte_rml_get_route()``, the boot-epoch table — so a foreign rank collides
+with a local one at every layer, not just in the wire header.  Two further
+gaps made the feature unreachable even in principle: the reply was addressed
+with ``sender->rank`` in the *server's* namespace, and nothing published a
+URI in the form the OOB parses (``--report-uri`` emits the **PMIx** server
+URI, ``nspace.rank;tcp4://host:port``, while ``process_uri`` wants PRRTE's
+own ``tcp://ip:port:ifmask``).
+
+
+The approach: a PMIx tool connection
+------------------------------------
+
+Rather than teach the RML to carry a second namespace, the crossing is made
+where PMIx already supports one.  **The DVM master attaches to the remote
+DVM's PMIx server as a tool** and reissues the operation as an ordinary
+``PMIx_Publish``/``Lookup``/``Unpublish``.  The remote DVM's own upcalls then
+reach its data server exactly as a local client's would.
+
+This is not a new mechanism in PRRTE: ``prte_pmix_set_scheduler()`` already
+attaches the master to a scheduler the same way.
+
+Consequences, all of them wanted:
+
+* **The RML and the wire header stay as they are.**  Nothing has to name a
+  foreign process, so the OOB header can go on carrying one namespace — see
+  the entry in :doc:`../../todo`.
+* **The URI problem disappears.**  What ``PMIx_tool_attach_to_server`` wants
+  under ``PMIX_SERVER_URI`` is exactly what ``prte --report-uri`` writes.
+* **One connection per DVM.**  Only the master attaches; every other daemon
+  relays to it over the RML, as it already does for a locally-hosted data
+  server.
+
+::
+
+    app proc ──PMIx──▶ its prted ──RML(DATA_SERVER)──▶ this DVM's master
+                                                              │
+                                                     prte_ds_relay()
+                                                              │
+                                             PMIx tool connection
+                                                              ▼
+                                              the server DVM's master
+                                                              │
+                                            its own publish/lookup upcall
+                                                              ▼
+                                                   its data server
+
+
+Two things the design has to get right
+--------------------------------------
+
+**Whose request is it.**  A relayed publish arrives at the far end as an
+operation by *this daemon's tool identity*, so every item would be owned by
+the relay rather than by the process that asked.  Ownership is not cosmetic:
+it decides who may unpublish an item, what ``PMIX_RANGE_NAMESPACE`` admits,
+and which items a purge takes when a job ends.  The requesting process is
+therefore carried in ``PMIX_REQUESTOR``, which the PMIx Standard defines for
+precisely this — *"used when relaying a request to the PMIx library on
+behalf of someone else where the API doesn't include a requestor
+parameter"*.
+
+The far end honors it **only from a tool** (``prte_ds_check_requestor()``).
+Relaying is what a tool does; an application process claiming to act for
+another has no such standing, and allowing it would let any process publish —
+and unpublish — under a peer's identity.
+
+**Which server is primary.**  PMIx directs a tool's client-side calls at
+whichever attached server is currently *primary*, and only one may be primary
+at a time.  A master can hold two connections — a scheduler and a data server
+— so an operation may not assume the primary is whatever the last operation
+left in place.  ``prte_pmix_set_primary_server()`` is the single point that
+designates one, and both the data-server relay and
+``prte_pmix_set_scheduler()`` call it before every operation.  It is a no-op
+when the named server is already primary, and it is race-free because the
+PMIx client calls pack and send synchronously, on the same thread, before
+returning.
+
+That replaces the sticky ``scheduler_set_as_server`` flag, which recorded
+"the scheduler has been made primary" once and would have been wrong the
+moment a second connection existed.
+
+
+What changed
+------------
+
+============================================  =====================================================
+file                                          change
+============================================  =====================================================
+``src/prted/pmix/pmix_server_pub.c``          ``init_server()`` attaches as a tool instead of
+                                              parsing an RML URI; only the master attaches;
+                                              ``execute()`` sends to the master when a server is
+                                              external; the purge command packs its directives
+``src/runtime/data_server/ds_relay.c``        new — the relay itself
+``src/runtime/data_server/ds_main.c``         dispatch to the relay; ``prte_ds_check_requestor()``
+``src/runtime/data_server/ds_*.c``            honor ``PMIX_REQUESTOR`` in the directive scan
+``src/prted/pmix/pmix_server_allocate.c``     ``prte_pmix_set_primary_server()``
+``src/mca/state/{dvm,base}``                  purge senders match the new packing, and address
+                                              the master when the server is external
+============================================  =====================================================
+
+The purge command's wire format gained a directive array.  That is allowed
+without ceremony — the message is exchanged inside one DVM, whose processes
+all come from one build — but both ends change in the same commit: three
+senders (``pmix_server_unpublish_fn``, ``state_dvm.c``,
+``state_base_fns.c``) and one reader (``ds_purge.c``).
+
+
+How it is tested
+----------------
+
+Nothing about this exists on a single DVM, so the coverage is in
+``contrib/dockerswarm``'s ``test_runtime`` phase: three DVMs at once — a
+server and two clients pointed at it — asserting that a key published in one
+client DVM is found in the other, that the answer names the **publishing
+process** and not the relay, that a ``PMIX_WAIT`` lookup parked from one DVM
+is woken by a publish from the other, that an ended job's data is purged from
+the external server, that the purge takes **only** that job's data, and — the
+control — that a DVM which was not given the URI sees none of it.

--- a/docs/plans/cross_dvm_data_server/index.rst
+++ b/docs/plans/cross_dvm_data_server/index.rst
@@ -1,0 +1,12 @@
+Cross-DVM Data Server Plans
+===========================
+
+Design and implementation record for reaching a data server that lives in
+*another* DVM — what ``prte_pmix_server_uri`` (historically ``ompi-server``)
+names, and what MPI's ``MPI_Publish_name`` / ``MPI_Comm_accept`` between
+separately-launched jobs runs on.
+
+.. toctree::
+   :maxdepth: 2
+
+   cross-dvm-data-server.rst

--- a/docs/plans/index.rst
+++ b/docs/plans/index.rst
@@ -13,3 +13,4 @@ Detailed implementation plans for in-progress and upcoming features.
    bootstrap/index.rst
    ft_group/index.rst
    scalable_collectives/index.rst
+   cross_dvm_data_server/index.rst

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -143,29 +143,41 @@ would otherwise leave every step passing while testing nothing.
 the ``2(xN)`` form that a multi-node allocation produces; the ``2(x1)`` form
 goes through the same parser and is not separately covered.
 
-Performance work not landed
----------------------------
+Performance work: what the measurements settled
+-----------------------------------------------
 
-**Take the nspace out of the OOB header entirely.**  ``prte_oob_tcp_hdr_t``
+Nothing in this section is outstanding work.  What is here is the evidence
+behind the message-size changes that have landed, and the traps that made
+each of them expensive to get to — kept so the next person can extend the
+work without re-deriving the ground, or re-proposing something already
+measured and answered.
+
+**Judge a header change on what a small message costs.**  ``prte_oob_tcp_hdr_t``
 rides every RML message, and it used to carry the origin and the destination
 as two ``pmix_proc_t`` — 552 bytes, of which 512 were two fixed 256-byte
 nspace arrays holding the same short string.  On small messages that was most
 of the traffic: a launch-message cpuset slice for an eight-process node is
-101 bytes of payload, so the header was 85% of it.  The header now carries
-the two ranks and one length-prefixed nspace, and only the characters the
-nspace uses go on the wire — about 50 bytes for a typical DVM.
+101 bytes of payload, so the header was 85% of it.  It is now **30 bytes,
+fixed**: two ranks and no namespace at all.
 
-The ~22 bytes that remain are still per *message* for something that is a
-property of the *DVM*: every daemon in it shares one nspace for the whole of
-its life.  It could be dropped altogether, because a receiver can reconstruct
-it — every send entry point takes a rank, so a message is always addressed
-within the sender's own job, and a relay only ever forwards traffic of its
-own job — which makes the origin's nspace always the connection peer's, and
-that is known from the IDENT handshake.  What stopped it here is that this is
-an *invariant*, not a field: nothing enforces it, and the failure mode if it
-is ever broken is a message delivered under the wrong sender identity rather
-than an error.  Doing it means first making the invariant something the code
-states and checks, not something a reader has to derive.
+The namespace came out in two steps, and the second one is the useful lesson.
+Collapsing the two ``pmix_proc_t`` to two ranks plus one length-prefixed
+nspace took it to ~50 bytes and was easy, because the two names had never
+differed.  Removing the last ~20 was not a matter of trimming further: what
+stood in the way was that "both ends are always this daemon's namespace" was
+an *invariant nobody enforced*, and the failure mode if it were ever broken is
+a message delivered under the wrong sender identity rather than an error.
+Two things settled that.  A **data server hosted by another DVM**
+(``prte_pmix_server_uri``, historically ``ompi-server``) was the one feature
+that ever wanted to address a foreign namespace, and it turned out never to
+have worked over the RML — every send entry point has taken a rank in the
+sender's own namespace since the 2022 rework, so the server's namespace was
+silently discarded — so it now crosses on a PMIx **tool** connection instead
+(:doc:`plans/cross_dvm_data_server/cross-dvm-data-server`).  And the invariant
+became a **check**: only daemons open an OOB endpoint, the connect handshake
+still carries a namespace, and ``tcp_peer_recv_connect_ack`` refuses a peer
+whose namespace is not ours.  Verified once per connection is what lets every
+message omit the field.
 
 **Judge this kind of change on wire bytes, not on the raw message size.**
 A launch-message size is usually quoted raw, which is the right unit for "how

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -376,6 +376,7 @@ void prte_state_base_notify_data_server(pmix_proc_t *target)
     pmix_data_buffer_t *buf;
     int rc, room = -1;
     uint8_t cmd = PRTE_PMIX_PURGE_PROC_CMD;
+    size_t ninfo;
 
     /* if nobody local to us published anything, then we can ignore this */
     if (PMIX_NSPACE_INVALID(prte_pmix_server_globals.server.nspace)) {
@@ -408,8 +409,22 @@ void prte_state_base_notify_data_server(pmix_proc_t *target)
         return;
     }
 
-    /* send the request to the server */
-    PRTE_RML_RELIABLE_SEND(rc, prte_pmix_server_globals.server.rank,
+    /* no directives of our own - the count still has to be there, as the
+     * command carries one and the reader unpacks it unconditionally */
+    ninfo = 0;
+    rc = PMIx_Data_pack(NULL, buf, &ninfo, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        return;
+    }
+
+    /* Send the request to the server.  An external data server is not
+     * addressable over the RML - only the master holds the PMIx connection
+     * to it - so the request goes to the master, which relays it. */
+    PRTE_RML_RELIABLE_SEND(rc, (NULL == prte_data_server_uri)
+                                   ? prte_pmix_server_globals.server.rank
+                                   : PRTE_PROC_MY_HNP->rank,
                   buf, PRTE_RML_TAG_DATA_SERVER);
     if (PRTE_SUCCESS != rc) {
         PMIX_DATA_BUFFER_RELEASE(buf);

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -747,6 +747,7 @@ static void check_complete_resume(int fd, short args, void *cbdata)
     int32_t index;
     pmix_proc_t pname;
     uint8_t command = PRTE_PMIX_PURGE_PROC_CMD;
+    size_t ninfo;
     pmix_data_buffer_t *buf;
     pmix_pointer_array_t procs;
     prte_app_context_t *app;
@@ -862,6 +863,16 @@ static void check_complete_resume(int fd, short args, void *cbdata)
         /* pack the nspace to be purged */
         pname.rank = PMIX_RANK_WILDCARD;
         rc = PMIx_Data_pack(NULL, buf, &pname, 1, PMIX_PROC);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(buf);
+            goto release;
+        }
+        /* no directives of our own - the count still has to be there, as
+         * the command carries one and the reader unpacks it
+         * unconditionally */
+        ninfo = 0;
+        rc = PMIx_Data_pack(NULL, buf, &ninfo, 1, PMIX_SIZE);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_RELEASE(buf);

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -42,7 +42,7 @@ upcall; each file below implements a related group of them.
 | `pmix_server_queries.c` | `query` — namespaces, proc tables, psets, groups, allocations. |
 | `pmix_server_gen.c` | `abort`, `client_finalized`, `client_connected2`, `tool_connected`, `iof_pull`, `push_stdin`, `log`. `client_finalized` is how a **tool**'s departure is learned as well — see below. |
 | `pmix_server_fence.c` | `fence_nb` and `direct_modex`. |
-| `pmix_server_pub.c` | `publish`/`lookup`/`unpublish` (relayed to the data server). |
+| `pmix_server_pub.c` | `publish`/`lookup`/`unpublish` (relayed to the data server; `init_server()` attaches the master to an **external** one). |
 | `pmix_server_notify.c` | `notify_event` (up), and the RML receive that fans a peer's event out to local clients (down). |
 | `pmix_server_group.c` | `group` — a thin pass-through to grpcomm. |
 | `pmix_server_job_ctrl.c` | `job_control` — kill/terminate/signal/define-pset, as daemon commands. |
@@ -450,6 +450,35 @@ The parts that matter when editing this file:
   must carry every job's termination status, and the job objects do not survive
   to the end of the session — so each one is recorded on `session->results` as
   it retires.
+
+---
+
+## Servers we are a client OF, and which one is primary
+
+A daemon is a PMIx server, but the master is also a PMIx **tool** of anything
+it has to reach outside this DVM. There are two such things, and they are
+reached the same way — `PMIx_tool_attach_to_server()`:
+
+- a **scheduler**, in `prte_pmix_set_scheduler()` (`pmix_server_alloc*.c`);
+- an **external data server**, in `init_server()` (`pmix_server_pub.c`) — a
+  data server living in another DVM, which the RML cannot address at all
+  because it names a peer by rank in the sender's own namespace. See
+  [`../../runtime/data_server/AGENTS.md`](../../runtime/data_server/AGENTS.md).
+
+**PMIx sends a client-side call to whichever attached server is currently
+primary, and only one may be primary at a time.** So *every* operation that
+uses one of these connections must name its own server first:
+`prte_pmix_set_primary_server()` is the single point that does it, it is a
+no-op when the named server is already primary, and it must not be treated as
+a once-at-startup step. This is race-free because the PMIx client calls pack
+and send synchronously before returning, on the thread that just designated
+the primary — so nothing can switch it out from under an in-flight request.
+`PMIx_tool_set_server()` blocks until the PMIx progress thread completes it,
+which is fine from the PRRTE progress thread and fatal from the PMIx one.
+
+The flag this replaced (`scheduler_set_as_server`) recorded "the scheduler has
+been made primary" once and never reconsidered — correct only for as long as
+the scheduler was the sole connection.
 
 ---
 

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -814,7 +814,8 @@ int pmix_server_init(void)
     prte_pmix_server_globals.server = *PRTE_NAME_INVALID;
     prte_pmix_server_globals.scheduler_connected = false;
     prte_pmix_server_globals.scheduler_lookup_done = false;
-    prte_pmix_server_globals.scheduler_set_as_server = false;
+    prte_pmix_server_globals.primary_server = *PRTE_NAME_INVALID;
+    prte_pmix_server_globals.primary_server_set = false;
 
     PMIX_INFO_LIST_START(ilist);
 

--- a/src/prted/pmix/pmix_server_allocate.c
+++ b/src/prted/pmix/pmix_server_allocate.c
@@ -157,15 +157,35 @@ pmix_status_t prte_pmix_set_scheduler(void)
         prte_pmix_server_globals.scheduler_connected = true;
     }
 
-    /* if we have not yet set the scheduler as our server, do so */
-    if (!prte_pmix_server_globals.scheduler_set_as_server) {
-        rc = PMIx_tool_set_server(&prte_pmix_server_globals.scheduler, NULL, 0);
-        if (PMIX_SUCCESS != rc) {
-            return rc;
-        }
-        prte_pmix_server_globals.scheduler_set_as_server = true;
+    /* direct our client-side calls at the scheduler.  This is not a
+     * once-only step: an external data server is a second connection we may
+     * hold, and whichever of the two was used last is the one PMIx would
+     * otherwise send this request to. */
+    return prte_pmix_set_primary_server(&prte_pmix_server_globals.scheduler);
+}
+
+pmix_status_t prte_pmix_set_primary_server(const pmix_proc_t *target)
+{
+    pmix_status_t rc;
+
+    /* PMIX_CHECK_PROCID answers "true" for an empty nspace, so the flag -
+     * not the identity - is what says we have ever designated one */
+    if (prte_pmix_server_globals.primary_server_set &&
+        PMIX_CHECK_PROCID(&prte_pmix_server_globals.primary_server, target)) {
+        return PMIX_SUCCESS;
     }
 
+    rc = PMIx_tool_set_server(target, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+    PMIX_XFER_PROCID(&prte_pmix_server_globals.primary_server, target);
+    prte_pmix_server_globals.primary_server_set = true;
+
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s primary server is now %s",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                        PRTE_NAME_PRINT(target));
     return PMIX_SUCCESS;
 }
 

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -631,7 +631,9 @@ static void _toolconn(int sd, short args, void *cbdata)
                 goto complete;
             }
             // it has been recorded in the library, so record it here
-            prte_pmix_server_globals.scheduler_set_as_server = true;
+            PMIX_XFER_PROCID(&prte_pmix_server_globals.primary_server,
+                             &prte_pmix_server_globals.scheduler);
+            prte_pmix_server_globals.primary_server_set = true;
             goto complete;
         }
     }

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -413,6 +413,15 @@ PRTE_EXPORT extern void pmix_server_alloc_request_resp(int status, pmix_proc_t *
 
 PRTE_EXPORT extern pmix_status_t prte_pmix_set_scheduler(void);
 
+/* Designate an attached server as the primary one, so that the client-side
+ * PMIx calls that follow go to it.  Only one server can be primary at a
+ * time, so any operation that uses one of our tool connections must call
+ * this first rather than assume the primary is still whatever the last
+ * operation left in place.  Cheap when it is: a no-op if the named server
+ * is already primary.  Blocks briefly - PMIx_tool_set_server completes on
+ * the PMIx progress thread - so it must not be called from that thread. */
+PRTE_EXPORT extern pmix_status_t prte_pmix_set_primary_server(const pmix_proc_t *target);
+
 PRTE_EXPORT extern pmix_status_t prte_server_send_request(uint8_t cmd, prte_pmix_server_req_t *req);
 
 PRTE_EXPORT extern void prte_server_lost_connection(size_t evhdlr_registration_id,
@@ -494,7 +503,14 @@ typedef struct {
     bool require_pid_match;
     bool allow_client_clones;
     pmix_proc_t scheduler;
-    bool scheduler_set_as_server;
+    /* PMIx directs a tool's client-side operations at whichever attached
+     * server is currently PRIMARY, and only one server may be primary at a
+     * time.  A daemon can be attached to more than one - a scheduler and an
+     * external data server - so the primary in force is tracked here and
+     * every operation that goes out over one of those connections names its
+     * own server first.  See prte_pmix_set_primary_server(). */
+    pmix_proc_t primary_server;
+    bool primary_server_set;
     char *report_uri;
     char *singleton;
     pmix_device_type_t generate_dist;

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -38,7 +38,6 @@
 #include "src/util/pmix_output.h"
 
 #include "src/mca/errmgr/errmgr.h"
-#include "src/rml/rml_contact.h"
 #include "src/rml/rml.h"
 #include "src/runtime/data_server/prte_data_server.h"
 #include "src/runtime/prte_globals.h"
@@ -49,14 +48,27 @@
 
 #include "src/prted/pmix/pmix_server_internal.h"
 
+/* Attach to the data server named by prte_data_server_uri.
+ *
+ * The server is a DVM of its own, so it is reached as a PMIx *tool
+ * connection* and not over the RML: the RML addresses a peer by rank within
+ * the sender's own namespace and cannot name a process of another DVM at
+ * all (see src/rml/AGENTS.md).  What crosses the boundary is therefore an
+ * ordinary PMIx publish/lookup/unpublish issued by this daemon acting as a
+ * tool of the remote DVM, and the URI this wants is that DVM's PMIx server
+ * URI - what `prte --report-uri` writes out.
+ *
+ * Only the DVM master attaches.  Every other daemon relays to it over the
+ * RML exactly as it does for a data server hosted here, so a DVM holds one
+ * connection to the external server however many daemons it has.
+ */
 static int init_server(void)
 {
     char *server;
-    pmix_value_t val;
     char input[1024], *filename;
     FILE *fp;
-    int rc;
     pmix_status_t ret;
+    pmix_info_t info[2];
 
     /* only do this once */
     prte_pmix_server_globals.pubsub_init = true;
@@ -64,6 +76,10 @@ static int init_server(void)
     /* if the universal server wasn't specified, then we use
      * our own HNP for that purpose */
     if (NULL == prte_data_server_uri) {
+        prte_pmix_server_globals.server = *PRTE_PROC_MY_HNP;
+    } else if (!PRTE_PROC_IS_MASTER) {
+        /* our master holds the connection - everything we cannot serve
+         * ourselves goes to it */
         prte_pmix_server_globals.server = *PRTE_PROC_MY_HNP;
     } else {
         if (0 == strncmp(prte_data_server_uri, "file", strlen("file")) ||
@@ -105,33 +121,41 @@ static int init_server(void)
         } else {
             server = strdup(prte_data_server_uri);
         }
-        /* parse the URI to get the server's name */
-        rc = prte_rml_parse_uris(server, &prte_pmix_server_globals.server, NULL);
-        if (PRTE_SUCCESS != rc) {
-            PRTE_ERROR_LOG(rc);
-            free(server);
-            return rc;
-        }
-        /* setup our route to the server */
-        PMIX_VALUE_LOAD(&val, server, PMIX_STRING);
-        ret = PMIx_Store_internal(&prte_pmix_server_globals.server, PMIX_PROC_URI, &val);
-        if (PMIX_SUCCESS != ret) {
-            PMIX_ERROR_LOG(ret);
-            PMIX_VALUE_DESTRUCT(&val);
-            return rc;
-        }
-        PMIX_VALUE_DESTRUCT(&val);
-
         /* check if we are to wait for the server to start - resolves
          * a race condition that can occur when the server is run
          * as a background job - e.g., in scripts
          */
         if (prte_pmix_server_globals.wait_for_server) {
-            /* ping the server */
-            struct timespec timeout = {prte_pmix_server_globals.timeout, 0};
             /* just hang loose */
+            struct timespec timeout = {prte_pmix_server_globals.timeout, 0};
             nanosleep(&timeout, NULL);
         }
+
+        /* attach to it.  PMIX_WAIT_FOR_CONNECTION is deliberately not set:
+         * the wait above is what the user asked for, and a server that is
+         * not there is an error we want reported now rather than a hang. */
+        PMIX_INFO_LOAD(&info[0], PMIX_SERVER_URI, server, PMIX_STRING);
+        PMIX_INFO_LOAD(&info[1], PMIX_PRIMARY_SERVER, NULL, PMIX_BOOL);
+        ret = PMIx_tool_attach_to_server(NULL, &prte_pmix_server_globals.server,
+                                         info, 2);
+        PMIX_INFO_DESTRUCT(&info[0]);
+        PMIX_INFO_DESTRUCT(&info[1]);
+        free(server);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            return prte_pmix_convert_status(ret);
+        }
+        /* the attach asked for it to be made primary, so the library has
+         * already done what prte_pmix_set_primary_server would - record
+         * that, or the tracker's next comparison is against nothing */
+        PMIX_XFER_PROCID(&prte_pmix_server_globals.primary_server,
+                         &prte_pmix_server_globals.server);
+        prte_pmix_server_globals.primary_server_set = true;
+
+        pmix_output_verbose(1, prte_pmix_server_globals.output,
+                            "%s attached to external data server %s",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                            PRTE_NAME_PRINT(&prte_pmix_server_globals.server));
     }
 
     return PRTE_SUCCESS;
@@ -178,12 +202,18 @@ static void execute(int sd, short args, void *cbdata)
         goto callback;
     }
 
-    /* if the range is SESSION, then set the target to the global server */
+    /* if the range is SESSION, then set the target to the global server.
+     * When that server is an external DVM it is not addressable over the
+     * RML at all, and only the master holds the connection to it - so the
+     * request goes to the master either way, and the master relays it from
+     * prte_data_server().  At the master itself that is a send to self,
+     * which the RML posts straight back for receipt. */
     if (PMIX_RANGE_SESSION == req->range) {
         pmix_output_verbose(1, prte_pmix_server_globals.output,
                             "%s orted:pmix:server range SESSION",
                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
-        target = &prte_pmix_server_globals.server;
+        target = (NULL == prte_data_server_uri) ? &prte_pmix_server_globals.server
+                                                : PRTE_PROC_MY_HNP;
     } else if (PMIX_RANGE_LOCAL == req->range) {
         /* if the range is local, send it to myself */
         pmix_output_verbose(1, prte_pmix_server_globals.output, "%s orted:pmix:server range LOCAL",
@@ -398,6 +428,25 @@ pmix_status_t pmix_server_unpublish_fn(const pmix_proc_t *proc, char **keys,
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(req);
             return rc;
+        }
+
+        /* pack the directives.  A purge takes none of its own, but a
+         * relayed one carries PMIX_REQUESTOR naming the process whose data
+         * is actually to go - without it the data server would purge
+         * everything owned by the relaying tool. */
+        if (PMIX_SUCCESS != (rc = PMIx_Data_pack(NULL, &req->msg, &ninfo, 1, PMIX_SIZE))) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(req);
+            return rc;
+        }
+        if (0 < ninfo) {
+            if (PMIX_SUCCESS
+                != (rc = PMIx_Data_pack(NULL, &req->msg, (pmix_info_t *) info, ninfo,
+                                        PMIX_INFO))) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(req);
+                return rc;
+            }
         }
 
         /* thread-shift so we can store the tracker */

--- a/src/rml/AGENTS.md
+++ b/src/rml/AGENTS.md
@@ -383,9 +383,24 @@ worth stating rather than re-deriving:
   byte-order converted, though, so keep `MCA_OOB_TCP_HDR_HTON`/`_NTOH` covering
   every multi-byte field you add, and zero a header before filling it — the
   fixed part goes on the wire whole, padding included. Note that the struct is
-  **not** the message: it ends in a variable-length nspace, so a send or a read
-  is sized by `PRTE_OOB_TCP_HDR_FIXED`/`PRTE_OOB_TCP_HDR_LEN()` and never by
-  `sizeof`. See [`oob/AGENTS.md`](oob/AGENTS.md), *The wire header*.
+  **not** the message: it ends in an nspace that only the connect handshake
+  sends, so a send or a read is sized by
+  `PRTE_OOB_TCP_HDR_FIXED`/`PRTE_OOB_TCP_HDR_LEN()` and never by `sizeof`
+  (288 bytes of struct, 30 on the wire for a data message). See
+  [`oob/AGENTS.md`](oob/AGENTS.md), *The wire header*.
+- **The RML cannot address another DVM, and is not meant to.** Every send
+  entry point takes a `pmix_rank_t`, and `send_buffer()` builds the
+  destination as that rank in `PRTE_PROC_MY_NAME->nspace`; `prte_oob_base_send_nb`
+  resolves the next hop the same way. So a `pmix_proc_t` naming a foreign
+  daemon loses its namespace here, silently, and the message goes to the local
+  daemon of that rank. The one feature that wanted to cross — a data server
+  hosted by another DVM (`prte_pmix_server_uri`) — reaches it over a PMIx
+  **tool** connection instead; see
+  [`../runtime/data_server/AGENTS.md`](../runtime/data_server/AGENTS.md). Do
+  not add a foreign-namespace send without dealing with the rest: the routing
+  tree, `prte_rml_is_node_up()` and the boot-epoch table are all indexed by
+  rank within *this* DVM, so a foreign rank collides with a local one at every
+  layer.
 - **One transport, one router.** Do not reintroduce component/module
   abstraction to "make it pluggable" unless there is a real second
   implementation; that abstraction is exactly what was removed.

--- a/src/rml/oob/AGENTS.md
+++ b/src/rml/oob/AGENTS.md
@@ -66,36 +66,41 @@ relaying is just "send again from here."
 
 Every message carries a `prte_oob_tcp_hdr_t` (`oob_tcp_hdr.h`): the origin's
 boot `epoch`, the `origin` and final `dst` **ranks**, the `tag`, a sequence
-number, the payload length, a message `type` (`IDENT`/`PROBE` for the
-handshake, `USER` for a normal message), and the nspace those two ranks belong
-to. It is exchanged **only** among daemons of the same DVM, which all run the
-same build, so it is **not** a stable ABI — you may change its layout, but
-every daemon must agree; there is no versioning.
+number, the payload length, and a message `type` (`IDENT`/`PROBE` for the
+handshake, `USER` for a normal message). It is exchanged **only** among daemons
+of the same DVM, which all run the same build, so it is **not** a stable ABI —
+you may change its layout, but every daemon must agree; there is no versioning.
 
 Five rules that are not obvious from the struct:
 
-- **Only `PRTE_OOB_TCP_HDR_LEN()` bytes of it go on the wire.** The nspace is
-  last and variable: `nslen` characters are sent, without a terminator, and
-  the receiver supplies one (`PRTE_OOB_TCP_HDR_END_NSPACE`). Anything that
-  sends or reads a header uses `PRTE_OOB_TCP_HDR_FIXED` and
-  `PRTE_OOB_TCP_HDR_LEN()`, **never** `sizeof(prte_oob_tcp_hdr_t)` — the
-  struct is bigger than the message, because the nspace array is the
-  receiver's landing space for a string that is usually ~20 bytes. That is
-  not a micro-optimization: holding the two names as `pmix_proc_t` made this
-  header 552 bytes, and it rides *every* RML message. A cpuset slice for an
-  eight-process node carries 101 bytes of payload.
-- **One nspace covers both ends**, because they have never differed on a
-  message that carries data: every send entry point takes a rank
-  (`prte_rml_send_buffer_nb` and friends), so a message is always addressed
-  within the sender's own job, the origin is the sender, and a relay copies
-  both through. The queueing macros assert it. The connect handshake is the
-  one place the two names can differ — there `dst` is the peer being
-  introduced to — and the receiver reads only the origin, so the field carries
-  the origin's nspace there too.
-- **Reading a name out of a header takes two reads off the socket.** The
-  ranks arrive with the fixed part, the nspace after it, so `hdr_recvd` is not
-  enough to build a `pmix_proc_t` — `nspace_recvd` is the flag that says the
-  names are complete. Rebuild a procid with `PRTE_OOB_TCP_HDR_PROC()`.
+- **A data message carries no namespace at all.** Its wire length is exactly
+  `PRTE_OOB_TCP_HDR_FIXED` — 30 bytes — and the receiver rebuilds both procids
+  with *its own* nspace via `PRTE_OOB_TCP_HDR_PROC()`. Three things make that
+  safe rather than merely usually-true: only `ess/hnp` and the prted path open
+  an OOB endpoint (no tool and no application process has one), every send
+  entry point takes a **rank** which `send_buffer()` resolves in
+  `PRTE_PROC_MY_NAME->nspace`, and a relay only forwards traffic of its own
+  job. So a foreign namespace is unrepresentable, not just unused. This is
+  what the header costs now; it began as two whole `pmix_proc_t` at 552 bytes
+  and rides *every* RML message — for a cpuset slice with 101 bytes of
+  payload it was 85% of the message.
+- **The connect handshake does carry one, and that is where it is checked.**
+  `tcp_peer_recv_connect_ack` refuses a peer whose nspace is not ours (and
+  refuses one that gives none, which would otherwise fall back to ours and
+  defeat the check). Once per connection, instead of restated on every
+  message. Do not remove it to "simplify": it is the enforcement that lets
+  every other header omit the field.
+- **`nslen` describes the wire length by itself.** The handshake sets it, a
+  data header sets it to zero, and both are read the same way — fixed part
+  first, then `nslen` characters, then the terminator the receiver supplies
+  (`PRTE_OOB_TCP_HDR_END_NSPACE`). Anything that sends or reads a header uses
+  `PRTE_OOB_TCP_HDR_FIXED` and `PRTE_OOB_TCP_HDR_LEN()`, **never**
+  `sizeof(prte_oob_tcp_hdr_t)` — the struct is 288 bytes, because the nspace
+  array is the receiver's landing space.
+- **Reading a name out of a header takes two reads off the socket**, even
+  though the second is empty for a data message: `hdr_recvd` is not enough to
+  build a `pmix_proc_t`, `nspace_recvd` is the flag that says the names are
+  complete.
 - **Every multi-byte field is byte-order converted**, by
   `MCA_OOB_TCP_HDR_HTON`/`_NTOH`. Add a field, extend both macros — a field
   that is quietly not converted works perfectly until two daemons differ in

--- a/src/rml/oob/oob_tcp_connection.c
+++ b/src/rml/oob/oob_tcp_connection.c
@@ -1007,6 +1007,33 @@ int prte_oob_tcp_peer_recv_connect_ack(prte_oob_tcp_peer_t *pr, int sd, prte_oob
 
     /* convert the header */
     MCA_OOB_TCP_HDR_NTOH(&hdr);
+
+    /* A handshake is the one header that carries a namespace, and this is
+     * the one place it is checked - which is what lets every message that
+     * follows leave it out and be reconstructed with our own (see
+     * oob_tcp_hdr.h).  Only daemons of this DVM have an OOB endpoint, so a
+     * peer naming any other namespace is not a peer of ours: a daemon of a
+     * different DVM belonging to the same user, or a process claiming to be
+     * one.  Refuse it rather than adopt it as the local daemon of that rank.
+     * An absent namespace is refused for the same reason - it would fall
+     * back to ours and defeat the check. */
+    if (0 == hdr.nslen
+        || !PMIX_CHECK_NSPACE(hdr.nspace, PRTE_PROC_MY_NAME->nspace)) {
+        pmix_output(0,
+                    "%s tcp_peer_recv_connect_ack: refusing a connection from "
+                    "namespace \"%s\" - this daemon serves \"%s\"",
+                    PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                    (0 == hdr.nslen) ? "(none given)" : hdr.nspace,
+                    PRTE_PROC_MY_NAME->nspace);
+        if (NULL != peer) {
+            peer->state = MCA_OOB_TCP_FAILED;
+            prte_oob_tcp_peer_close(peer);
+        } else {
+            CLOSE_THE_SOCKET(sd);
+        }
+        return PRTE_ERR_CONNECTION_REFUSED;
+    }
+
     /* rebuild the sender's identity, which the header carries as a rank
      * plus the nspace read above */
     PRTE_OOB_TCP_HDR_PROC(&hdr, hdr.origin, &sender);

--- a/src/rml/oob/oob_tcp_hdr.h
+++ b/src/rml/oob/oob_tcp_hdr.h
@@ -46,23 +46,40 @@ typedef uint8_t prte_oob_tcp_msg_type_t;
 
 /* header for tcp msgs
  *
- * Only the first PRTE_OOB_TCP_HDR_LEN() bytes of this struct go on the wire.
- * The nspace is last, and only the characters it actually uses are sent - the
- * rest of the array is scratch space for the receiver to land them in.  That
- * is the whole reason for the layout: this header rides *every* RML message,
- * and holding the names as two `pmix_proc_t` made it 552 bytes, of which 512
- * were two fixed 256-byte nspace arrays holding the same short string.  On a
- * launch-message cpuset slice for an eight-process node - 101 bytes of
- * payload - that header was 85% of the message.
+ * Only the first PRTE_OOB_TCP_HDR_LEN() bytes of this struct go on the wire,
+ * and for a data message that is just the fixed part: **the nspace is sent
+ * only by the connect handshake**.  This header rides *every* RML message, so
+ * what it does not carry matters.  It began as two whole `pmix_proc_t` - 552
+ * bytes, of which 512 were two fixed 256-byte nspace arrays holding the same
+ * short string - which on a launch-message cpuset slice for an eight-process
+ * node was 85% of a 101-byte message.
  *
- * One nspace covers both ends, because they have never differed on a message
- * that carries data: every send entry point takes a *rank*
- * (prte_rml_send_buffer_nb and friends), so the destination is always a peer
- * of the sender's own job, the origin is the sender itself, and a relay
- * copies both through unchanged.  The connect handshake is the one place the
- * two names can differ - there `dst` is the peer being introduced to - and
- * the receiver there reads only the origin, so the field carries the origin's
- * nspace in that case too.
+ * A data message needs no nspace at all, because there is only ever one:
+ *
+ *  - **Every OOB endpoint belongs to a daemon of this DVM.**  The transport is
+ *    opened by `ess/hnp` and by the standard prted path, and by nothing else -
+ *    no tool and no application process has one.  So a peer is always a daemon
+ *    of our own job.
+ *  - **Every send entry point takes a rank**, and `send_buffer()` builds the
+ *    destination as that rank in `PRTE_PROC_MY_NAME->nspace`
+ *    (`prte_oob_base_send_nb` stamps the hop the same way).  A foreign
+ *    namespace is not merely unused, it is unrepresentable.
+ *  - A **relay** forwards traffic of its own job, so both names stay ours.
+ *
+ * The receiver therefore reconstructs both procids with its own namespace, and
+ * the handshake is what makes that safe rather than merely true: an IDENT
+ * carries the connecting daemon's nspace and `tcp_peer_recv_connect_ack`
+ * **refuses a peer whose nspace is not ours**.  The invariant is checked once
+ * per connection instead of being restated on every message - and instead of
+ * being left for a reader to derive.
+ *
+ * That leaves `nslen` describing the wire length by itself: a handshake header
+ * sets it, a data header sets it to zero, and both are read the same way.
+ *
+ * (One thing that historically wanted to cross a namespace here was a data
+ * server hosted by another DVM.  It never worked over the RML - the namespace
+ * was silently discarded - and it now uses a PMIx tool connection instead.  See
+ * `src/runtime/data_server/AGENTS.md`.)
  */
 typedef struct {
     /* boot epoch (incarnation) of the origin. A daemon that departs and reboots
@@ -87,11 +104,13 @@ typedef struct {
     /* type of message */
     prte_oob_tcp_msg_type_t type;
     /* characters of nspace that follow, NOT counting a terminator - none is
-     * sent.  A uint8_t holds every legal length because PMIX_MAX_NSLEN is
-     * 255, which is also why no bound check is needed on the receiving side. */
+     * sent.  ZERO on a data message, which carries no nspace at all; non-zero
+     * only on the handshake.  A uint8_t holds every legal length because
+     * PMIX_MAX_NSLEN is 255, which is also why no bound check is needed on
+     * the receiving side. */
     uint8_t nslen;
-    /* the nspace both ranks above belong to.  Sent as nslen characters; the
-     * receiver terminates it itself. */
+    /* the nspace the two ranks above belong to, sent by the handshake alone.
+     * Sent as nslen characters; the receiver terminates it itself. */
     char nspace[PMIX_MAX_NSLEN + 1];
 } prte_oob_tcp_hdr_t;
 
@@ -114,11 +133,21 @@ typedef struct {
     } while (0)
 
 /* terminate the nspace a peer just handed us.  Called once the nslen
- * characters have been read, and before anything reads the field. */
+ * characters have been read, and before anything reads the field.  With no
+ * nspace on the wire this makes the field an empty string, which is what the
+ * accessor below tests for by way of nslen. */
 #define PRTE_OOB_TCP_HDR_END_NSPACE(h)  ((h)->nspace[(h)->nslen] = '\0')
 
+/* The namespace the header's ranks belong to: the one the handshake sent, or
+ * - for a data message, which sends none - our own.  Those are the same
+ * namespace; see the note above for why that is guaranteed rather than
+ * assumed. */
+#define PRTE_OOB_TCP_HDR_NSPACE(h) \
+    ((0 == (h)->nslen) ? PRTE_PROC_MY_NAME->nspace : (h)->nspace)
+
 /* rebuild one of the two procids the header no longer carries whole */
-#define PRTE_OOB_TCP_HDR_PROC(h, r, p)  PMIX_LOAD_PROCID((p), (h)->nspace, (r))
+#define PRTE_OOB_TCP_HDR_PROC(h, r, p) \
+    PMIX_LOAD_PROCID((p), PRTE_OOB_TCP_HDR_NSPACE(h), (r))
 
 /**
  * Convert the message header to host byte order

--- a/src/rml/oob/oob_tcp_sendrecv.h
+++ b/src/rml/oob/oob_tcp_sendrecv.h
@@ -112,11 +112,14 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_recv_t);
                             "%s:[%s:%d] queue send to %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), \
                             __FILE__, __LINE__, PRTE_NAME_PRINT(&((m)->dst)));                 \
         _s = PMIX_NEW(prte_oob_tcp_send_t);                                                    \
-        /* one nspace covers both ends - see oob_tcp_hdr.h */                                  \
-        assert(PMIX_CHECK_NSPACE((m)->origin.nspace, (m)->dst.nspace));                        \
+        /* Both ends are this daemon's own namespace, so none goes on the    \
+         * wire - see oob_tcp_hdr.h.  Asserted rather than derived: it is     \
+         * what the receiver reconstructs the two procids from. */            \
+        assert(PMIX_CHECK_NSPACE((m)->origin.nspace, PRTE_PROC_MY_NAME->nspace)                \
+               && PMIX_CHECK_NSPACE((m)->dst.nspace, PRTE_PROC_MY_NAME->nspace));              \
         _s->hdr.origin = (m)->origin.rank;                                                     \
         _s->hdr.dst = (m)->dst.rank;                                                           \
-        PRTE_OOB_TCP_HDR_LOAD_NSPACE(&_s->hdr, (m)->origin.nspace);                            \
+        _s->hdr.nslen = 0;                                                                     \
         _s->hdr.type = MCA_OOB_TCP_USER;                                                       \
         _s->hdr.tag = (m)->tag;                                                                \
         _s->hdr.seq_num = (m)->seq_num;                                                        \
@@ -147,11 +150,12 @@ PMIX_CLASS_DECLARATION(prte_oob_tcp_recv_t);
                             "%s:[%s:%d] queue pending to %s", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), \
                             __FILE__, __LINE__, PRTE_NAME_PRINT(&((m)->dst)));                    \
         _s = PMIX_NEW(prte_oob_tcp_send_t);                                                       \
-        /* one nspace covers both ends - see oob_tcp_hdr.h */                                     \
-        assert(PMIX_CHECK_NSPACE((m)->origin.nspace, (m)->dst.nspace));                           \
+        /* both ends are our own namespace - see MCA_OOB_TCP_QUEUE_SEND */                        \
+        assert(PMIX_CHECK_NSPACE((m)->origin.nspace, PRTE_PROC_MY_NAME->nspace)                   \
+               && PMIX_CHECK_NSPACE((m)->dst.nspace, PRTE_PROC_MY_NAME->nspace));                 \
         _s->hdr.origin = (m)->origin.rank;                                                        \
         _s->hdr.dst = (m)->dst.rank;                                                              \
-        PRTE_OOB_TCP_HDR_LOAD_NSPACE(&_s->hdr, (m)->origin.nspace);                               \
+        _s->hdr.nslen = 0;                                                                        \
         _s->hdr.type = MCA_OOB_TCP_USER;                                                          \
         _s->hdr.tag = (m)->tag;                                                                   \
         _s->hdr.seq_num = (m)->seq_num;                                                           \

--- a/src/runtime/data_server/AGENTS.md
+++ b/src/runtime/data_server/AGENTS.md
@@ -34,6 +34,7 @@ app proc ◀─PMIx── its prted ◀──RML(PRTE_RML_TAG_DATA_CLIENT)──
 | `ds_lookup.c` | Answer from the store, or park the request if the caller asked to wait. |
 | `ds_unpublish.c` | Remove the caller's own items by key. |
 | `ds_purge.c` | Remove everything a (departing) process owns. |
+| `ds_relay.c` | Reissue a request to an **external** data server — one living in another DVM — over a PMIx tool connection, and answer the requesting daemon when it replies. |
 
 State is `prte_data_store`: a `pmix_pointer_array_t` of published objects
 plus a `pmix_list_t` of parked requests. There is no locking — everything
@@ -67,6 +68,49 @@ A related trap, seen in three of these files: `PMIx_Data_pack(NULL, buf,
 &rc, 1, PMIX_STATUS)` assigned back to `rc` packs the right value but then
 discards it, so the error being reported is replaced by the pack's own
 status. Keep the two in separate variables.
+
+---
+
+## An external data server — the store in another DVM
+
+`prte_pmix_server_uri` names a data server living in a **different DVM**, so
+that jobs launched by different invocations can find each other's data
+(`MPI_Publish_name` / `MPI_Comm_accept` across `mpirun`s). When it is set,
+this DVM stores nothing of its own: `prte_data_server()` hands every request
+straight to `prte_ds_relay()`.
+
+**It is not reachable over the RML, and no amount of work here would make it
+so.** The RML addresses a peer by *rank*, stamping the sender's own namespace
+on it (`rml_send.c`, `oob_base_stubs.c`), so a daemon of another DVM cannot be
+named at all — the namespace parsed out of the server's URI was simply
+discarded and the request went to the local master. The crossing is therefore
+a PMIx **tool** connection: the DVM master attaches to the remote DVM's PMIx
+server (`init_server()` in `../../prted/pmix/pmix_server_pub.c`) and reissues
+the operation as an ordinary `PMIx_Publish`/`Lookup`/`Unpublish`, which the
+remote DVM's own upcalls deliver to its data server.
+
+Three things follow, and each is load-bearing:
+
+- **Only the master attaches.** Every other daemon relays to it over the RML
+  exactly as it does for a local store, so a DVM holds one connection however
+  many daemons it has. At the master itself the RML send is a send to self.
+- **The requesting process is carried in `PMIX_REQUESTOR`.** Otherwise the far
+  end attributes the operation to the relaying daemon's *tool* identity, and
+  every ownership rule — who may unpublish, what `PMIX_RANGE_NAMESPACE`
+  admits, what a job-end purge takes — is answered about the wrong process.
+  `prte_ds_check_requestor()` honors the claim **only from a tool**; an
+  application process making one is trying to act under a peer's identity, and
+  the claim is dropped.
+- **The primary server must be named per operation.** PMIx sends a tool's
+  client-side call to whichever attached server is currently primary, and a
+  master may also be attached to a scheduler. `prte_pmix_set_primary_server()`
+  is the one place that designates one; call it immediately before the PMIx
+  call, never once at startup.
+
+The purge command carries a directive array for this reason — it is the only
+way `PMIX_REQUESTOR` can reach `ds_purge`. Three senders pack it
+(`pmix_server_unpublish_fn`, `state_dvm.c`, `state_base_fns.c`) and one reader
+unpacks it; they change together.
 
 ---
 
@@ -151,6 +195,15 @@ is on the HNP and the clients are elsewhere, so the interesting paths only
 exist with real daemons: a publish on one node found by a lookup on another,
 the range and userid rules between real processes, unpublish, and the
 `PMIX_WAIT` path where a lookup parks until a later publish satisfies it.
+
+The **external** data server is multi-node coverage by construction — the
+whole point is a namespace boundary, and one DVM has none. `test_runtime`
+stands up three DVMs at once (a server and two clients pointed at it) and
+asserts that data crosses, that the answer names the publishing process
+rather than the relay, that a parked `PMIX_WAIT` lookup in one client is woken
+by a publish in the other, that an ended job's data is purged from the server
+and that the purge takes *only* that job's data — plus the control, that a
+DVM which was not given the URI sees none of it.
 
 **Not covered:** `PMIX_RANGE_CUSTOM` (no accessor list exists to test),
 `PMIX_PERSIST_FIRST_READ` end-to-end, and `ds_purge` (which is driven by

--- a/src/runtime/data_server/Makefile.am
+++ b/src/runtime/data_server/Makefile.am
@@ -31,4 +31,5 @@ libprrte_la_SOURCES += \
         runtime/data_server/ds_publish.c \
         runtime/data_server/ds_lookup.c \
         runtime/data_server/ds_unpublish.c \
-        runtime/data_server/ds_purge.c
+        runtime/data_server/ds_purge.c \
+        runtime/data_server/ds_relay.c

--- a/src/runtime/data_server/ds.h
+++ b/src/runtime/data_server/ds.h
@@ -119,6 +119,24 @@ PRTE_EXPORT void prte_ds_purge(pmix_proc_t *sender,
 PRTE_EXPORT pmix_status_t prte_data_server_check_range(prte_data_req_t *req,
                                                        prte_data_object_t *data);
 
+/* Relay a request to the external data server named by
+ * prte_data_server_uri, and answer the requesting daemon when it replies.
+ * Returns PMIX_SUCCESS once it owns the request - including when the
+ * request failed and it has already sent the failure - so the caller must
+ * not answer one it handed over.  See ds_relay.c. */
+PRTE_EXPORT pmix_status_t prte_ds_relay(pmix_proc_t *sender, int room_number,
+                                        uint8_t command,
+                                        pmix_data_buffer_t *buffer);
+
+/* Honor a PMIX_REQUESTOR directive, which names the process a relayed
+ * request is being made on behalf of.  Only a TOOL may claim it: a daemon
+ * of another DVM attaches to us as a tool and reissues what its own client
+ * asked for, whereas an application process has no such standing and
+ * allowing it would let any process publish - and unpublish - under
+ * another's identity.  Overwrites *owner when the claim is allowed. */
+PRTE_EXPORT void prte_ds_check_requestor(pmix_proc_t *owner,
+                                         const pmix_info_t *info);
+
 END_C_DECLS
 
 #endif /* PRTE_DS_INTERNAL_H */

--- a/src/runtime/data_server/ds_lookup.c
+++ b/src/runtime/data_server/ds_lookup.c
@@ -135,6 +135,9 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
                 wait = true;
             } else if (PMIx_Check_key(info[n].key, PMIX_RANGE)) {
                 range = info[n].value.data.range;
+            } else if (PMIx_Check_key(info[n].key, PMIX_REQUESTOR)) {
+                /* a relay looking up on behalf of a process in its own DVM */
+                prte_ds_check_requestor(&requestor, &info[n]);
             }
         }
         /* ignore anything else for now */

--- a/src/runtime/data_server/ds_main.c
+++ b/src/runtime/data_server/ds_main.c
@@ -148,6 +148,19 @@ void prte_data_server(int status, pmix_proc_t *sender,
         return;
     }
 
+    /* When an external data server is configured, this DVM stores nothing:
+     * the request is reissued to that server over our PMIx tool connection
+     * to it, and the relay answers this sender when it replies.  Only the
+     * master holds that connection, which is why every daemon addressed
+     * its request here (pmix_server_pub.c, execute). */
+    if (NULL != prte_data_server_uri) {
+        rc = prte_ds_relay(sender, room_number, command, buffer);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+        }
+        return;
+    }
+
     PMIX_DATA_BUFFER_CREATE(answer);
     /* pack the room number as this must lead any response */
     rc = PMIx_Data_pack(NULL, answer, &room_number, 1, PMIX_INT);
@@ -218,6 +231,39 @@ void prte_data_server(int status, pmix_proc_t *sender,
         }
     }
 
+}
+
+void prte_ds_check_requestor(pmix_proc_t *owner, const pmix_info_t *info)
+{
+    prte_job_t *jdata;
+
+    if (PMIX_PROC != info->value.type || NULL == info->value.data.proc) {
+        return;
+    }
+
+    /* Acting for another process is what a RELAY does, and only a tool
+     * relays: a daemon of another DVM attaches to us as a tool and
+     * reissues the operation its own client asked for.  Anything else
+     * claiming it is a process trying to publish - or unpublish - under
+     * somebody else's name, so the claim is simply dropped and the
+     * operation proceeds under the caller's own identity. */
+    jdata = prte_get_job_data_object(owner->nspace);
+    if (NULL == jdata || !PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL)) {
+        pmix_output_verbose(1, prte_data_store.output,
+                            "%s data server: %s is not a tool - ignoring its "
+                            "claim to act for %s",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                            PRTE_NAME_PRINT(owner),
+                            PMIX_NAME_PRINT(info->value.data.proc));
+        return;
+    }
+
+    pmix_output_verbose(1, prte_data_store.output,
+                        "%s data server: %s is acting for %s",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                        PRTE_NAME_PRINT(owner),
+                        PMIX_NAME_PRINT(info->value.data.proc));
+    PMIX_XFER_PROCID(owner, info->value.data.proc);
 }
 
 pmix_status_t prte_data_server_check_range(prte_data_req_t *req,

--- a/src/runtime/data_server/ds_publish.c
+++ b/src/runtime/data_server/ds_publish.c
@@ -127,6 +127,9 @@ pmix_status_t prte_ds_publish(pmix_proc_t *sender,
             data->persistence = info[n].value.data.persist;
         } else if (PMIx_Check_key(info[n].key, PMIX_USERID)) {
             data->uid = info[n].value.data.uint32;
+        } else if (PMIx_Check_key(info[n].key, PMIX_REQUESTOR)) {
+            /* a relay publishing on behalf of a process in its own DVM */
+            prte_ds_check_requestor(&data->owner, &info[n]);
         } else {
             /* add it to the list of data */
             ds1 = PMIX_NEW(prte_info_item_t);

--- a/src/runtime/data_server/ds_purge.c
+++ b/src/runtime/data_server/ds_purge.c
@@ -59,6 +59,8 @@ void prte_ds_purge(pmix_proc_t *sender,
     pmix_status_t rc, ret;
     pmix_proc_t requestor;
     prte_data_req_t *req, *rqnext;
+    pmix_info_t *info;
+    size_t n, ninfo;
 
     /* unpack the proc whose data is to be purged - session
      * data is purged by providing a requestor whose rank
@@ -68,6 +70,33 @@ void prte_ds_purge(pmix_proc_t *sender,
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         goto done;
+    }
+
+    /* unpack the directives, if any */
+    count = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &ninfo, &count, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto done;
+    }
+    if (0 < ninfo) {
+        PMIX_INFO_CREATE(info, ninfo);
+        count = (int32_t) ninfo;
+        rc = PMIx_Data_unpack(NULL, buffer, info, &count, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_INFO_FREE(info, ninfo);
+            goto done;
+        }
+        for (n = 0; n < ninfo; n++) {
+            if (PMIx_Check_key(info[n].key, PMIX_REQUESTOR)) {
+                /* a relay purging on behalf of a process in its own DVM.
+                 * Without this the purge would take everything the relay
+                 * itself owns - which is everything it ever published. */
+                prte_ds_check_requestor(&requestor, &info[n]);
+            }
+        }
+        PMIX_INFO_FREE(info, ninfo);
     }
 
     pmix_output_verbose(1, prte_data_store.output,

--- a/src/runtime/data_server/ds_relay.c
+++ b/src/runtime/data_server/ds_relay.c
@@ -1,0 +1,446 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/**
+ * @file
+ *
+ * Relay a data-server request to an EXTERNAL data server.
+ *
+ * When prte_data_server_uri names a server, this DVM does not store
+ * published data at all - the named DVM does, so that jobs launched by
+ * different invocations can find each other's data (what an MPI
+ * application reaches through MPI_Publish_name / MPI_Comm_accept).
+ *
+ * That server is a DVM of its own, and its daemons are in a different
+ * namespace, which the RML cannot address: every send entry point takes a
+ * rank and stamps this daemon's own namespace on it, so a foreign daemon is
+ * simply not nameable (see src/rml/AGENTS.md).  The crossing is therefore a
+ * PMIx TOOL connection - this daemon attaches to the remote DVM's PMIx
+ * server (pmix_server_pub.c, init_server) and reissues the request as an
+ * ordinary PMIx_Publish/Lookup/Unpublish.  The remote DVM's own
+ * publish/lookup upcalls then reach its data server exactly as a local
+ * client's would.
+ *
+ * Only the DVM master attaches, so every request arrives here over the RML -
+ * from another daemon, or from the master itself as a send to self - and
+ * every answer goes back the same way, in the format
+ * pmix_server_keyval_client() expects.  Nothing above this file knows
+ * whether the data server was local or remote.
+ *
+ * The requesting process's identity is carried across in PMIX_REQUESTOR,
+ * which the Standard defines for exactly this: "used when relaying a
+ * request to the PMIx library on behalf of someone else where the API
+ * doesn't include a requestor parameter".  Without it every item published
+ * through the relay would be owned by this daemon's tool identity, and the
+ * ownership rules at the far end - who may unpublish, what
+ * PMIX_RANGE_NAMESPACE admits - would all be answered about the wrong
+ * process.
+ */
+
+#include "prte_config.h"
+#include "constants.h"
+#include "types.h"
+
+#include "src/pmix/pmix-internal.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_output.h"
+
+#include "src/mca/errmgr/errmgr.h"
+#include "src/prted/pmix/pmix_server_internal.h"
+#include "src/rml/rml.h"
+#include "src/runtime/prte_globals.h"
+#include "src/util/name_fns.h"
+
+#include "src/runtime/data_server/prte_data_server.h"
+#include "src/runtime/data_server/ds.h"
+
+/* one relayed request in flight */
+typedef struct {
+    pmix_object_t super;
+    pmix_event_t ev;
+    /* the daemon that asked us, and the room number it is waiting on */
+    pmix_proc_t sender;
+    int room_number;
+    uint8_t command;
+    /* what we tell it when the far end answers */
+    pmix_status_t status;
+    /* the directive array handed to PMIx - ours to free */
+    pmix_info_t *info;
+    size_t ninfo;
+    char **keys;
+    /* a lookup's results, copied out of the PMIx callback */
+    pmix_pdata_t *pdata;
+    size_t npdata;
+} prte_ds_relay_t;
+
+static void rlcon(prte_ds_relay_t *p)
+{
+    PMIX_PROC_CONSTRUCT(&p->sender);
+    p->room_number = -1;
+    p->command = 0;
+    p->status = PMIX_SUCCESS;
+    p->info = NULL;
+    p->ninfo = 0;
+    p->keys = NULL;
+    p->pdata = NULL;
+    p->npdata = 0;
+}
+static void rldes(prte_ds_relay_t *p)
+{
+    if (NULL != p->info) {
+        PMIX_INFO_FREE(p->info, p->ninfo);
+    }
+    if (NULL != p->keys) {
+        PMIx_Argv_free(p->keys);
+    }
+    if (NULL != p->pdata) {
+        PMIX_PDATA_FREE(p->pdata, p->npdata);
+    }
+}
+static PMIX_CLASS_INSTANCE(prte_ds_relay_t, pmix_object_t, rlcon, rldes);
+
+/* Send the answer the requesting daemon is parked on.
+ *
+ * The format is the one every handler in this directory produces and
+ * pmix_server_keyval_client() unpacks: the room number, the command, the
+ * status, and - for a lookup that found something - a byte object holding
+ * the count and then a (proc, info) pair per item.
+ */
+static void answer(prte_ds_relay_t *cd)
+{
+    pmix_data_buffer_t *reply, pbkt;
+    pmix_byte_object_t pbo;
+    pmix_status_t rc;
+    size_t n;
+    int ret;
+
+    PMIX_DATA_BUFFER_CREATE(reply);
+
+    rc = PMIx_Data_pack(NULL, reply, &cd->room_number, 1, PMIX_INT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(reply);
+        return;
+    }
+    rc = PMIx_Data_pack(NULL, reply, &cd->command, 1, PMIX_UINT8);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(reply);
+        return;
+    }
+    rc = PMIx_Data_pack(NULL, reply, &cd->status, 1, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(reply);
+        return;
+    }
+
+    if (PRTE_PMIX_LOOKUP_CMD == cd->command && 0 < cd->npdata) {
+        PMIX_DATA_BUFFER_CONSTRUCT(&pbkt);
+        rc = PMIx_Data_pack(NULL, &pbkt, &cd->npdata, 1, PMIX_SIZE);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+            PMIX_DATA_BUFFER_RELEASE(reply);
+            return;
+        }
+        for (n = 0; n < cd->npdata; n++) {
+            pmix_info_t item;
+
+            rc = PMIx_Data_pack(NULL, &pbkt, &cd->pdata[n].proc, 1, PMIX_PROC);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+                PMIX_DATA_BUFFER_RELEASE(reply);
+                return;
+            }
+            /* the wire carries a pmix_info_t per item, not a pdata - the
+             * owner was packed above and the key/value is what remains */
+            PMIX_INFO_CONSTRUCT(&item);
+            PMIX_LOAD_KEY(item.key, cd->pdata[n].key);
+            PMIX_VALUE_XFER_DIRECT(rc, &item.value, &cd->pdata[n].value);
+            if (PMIX_SUCCESS == rc) {
+                rc = PMIx_Data_pack(NULL, &pbkt, &item, 1, PMIX_INFO);
+            }
+            PMIX_INFO_DESTRUCT(&item);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+                PMIX_DATA_BUFFER_RELEASE(reply);
+                return;
+            }
+        }
+        rc = PMIx_Data_unload(&pbkt, &pbo);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+            PMIX_DATA_BUFFER_RELEASE(reply);
+            return;
+        }
+        rc = PMIx_Data_pack(NULL, reply, &pbo, 1, PMIX_BYTE_OBJECT);
+        PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(reply);
+            return;
+        }
+    }
+
+    PRTE_RML_RELIABLE_SEND(ret, cd->sender.rank, reply, PRTE_RML_TAG_DATA_CLIENT);
+    if (PRTE_SUCCESS != ret) {
+        PRTE_ERROR_LOG(ret);
+        PMIX_DATA_BUFFER_RELEASE(reply);
+    }
+}
+
+/* completion, on the PRRTE progress thread */
+static void relay_complete(int sd, short args, void *cbdata)
+{
+    prte_ds_relay_t *cd = (prte_ds_relay_t *) cbdata;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(cd);
+
+    pmix_output_verbose(1, prte_data_store.output,
+                        "%s data server relay: %s answered %s",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                        PRTE_NAME_PRINT(&prte_pmix_server_globals.server),
+                        PMIx_Error_string(cd->status));
+
+    answer(cd);
+    PMIX_RELEASE(cd);
+}
+
+/* PMIx completion for publish/unpublish/purge - runs on the PMIx progress
+ * thread, so it captures the status and shifts */
+static void opcb(pmix_status_t status, void *cbdata)
+{
+    prte_ds_relay_t *cd = (prte_ds_relay_t *) cbdata;
+
+    cd->status = status;
+    PRTE_PMIX_THREADSHIFT(cd, prte_event_base, relay_complete);
+}
+
+/* PMIx completion for a lookup.  The pdata array belongs to PMIx and is
+ * gone once this returns, so it is copied here rather than carried. */
+static void lkcb(pmix_status_t status, pmix_pdata_t data[], size_t ndata,
+                 void *cbdata)
+{
+    prte_ds_relay_t *cd = (prte_ds_relay_t *) cbdata;
+    size_t n;
+
+    cd->status = status;
+    if (0 < ndata && NULL != data) {
+        PMIX_PDATA_CREATE(cd->pdata, ndata);
+        cd->npdata = ndata;
+        for (n = 0; n < ndata; n++) {
+            PMIX_PDATA_XFER(&cd->pdata[n], &data[n]);
+        }
+    }
+    PRTE_PMIX_THREADSHIFT(cd, prte_event_base, relay_complete);
+}
+
+/* Build the directive array we hand to PMIx: whatever the requester sent,
+ * plus the requestor identity the far end needs to attribute the operation
+ * correctly.  See the note at the head of this file. */
+static pmix_status_t load_directives(prte_ds_relay_t *cd,
+                                     pmix_info_t *info, size_t ninfo,
+                                     pmix_proc_t *requestor)
+{
+    size_t n;
+
+    cd->ninfo = ninfo + 1;
+    PMIX_INFO_CREATE(cd->info, cd->ninfo);
+    if (NULL == cd->info) {
+        cd->ninfo = 0;
+        return PMIX_ERR_NOMEM;
+    }
+    for (n = 0; n < ninfo; n++) {
+        PMIX_INFO_XFER(&cd->info[n], &info[n]);
+    }
+    PMIX_INFO_LOAD(&cd->info[ninfo], PMIX_REQUESTOR, requestor, PMIX_PROC);
+    return PMIX_SUCCESS;
+}
+
+/* unpack the trailing directive array, if the command carries one */
+static pmix_status_t unpack_directives(pmix_data_buffer_t *buffer,
+                                       pmix_info_t **info, size_t *ninfo)
+{
+    pmix_status_t rc;
+    int32_t count;
+
+    *info = NULL;
+    *ninfo = 0;
+
+    count = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, ninfo, &count, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        *ninfo = 0;
+        return rc;
+    }
+    if (0 == *ninfo) {
+        return PMIX_SUCCESS;
+    }
+    PMIX_INFO_CREATE(*info, *ninfo);
+    count = (int32_t) *ninfo;
+    rc = PMIx_Data_unpack(NULL, buffer, *info, &count, PMIX_INFO);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_INFO_FREE(*info, *ninfo);
+        *info = NULL;
+        *ninfo = 0;
+        return rc;
+    }
+    return PMIX_SUCCESS;
+}
+
+/* unpack a key array of the form the data-server commands use: a count
+ * followed by that many strings */
+static pmix_status_t unpack_keys(pmix_data_buffer_t *buffer, char ***keys)
+{
+    pmix_status_t rc;
+    int32_t count;
+    size_t n, nkeys;
+    char *str;
+
+    count = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &nkeys, &count, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+    for (n = 0; n < nkeys; n++) {
+        count = 1;
+        rc = PMIx_Data_unpack(NULL, buffer, &str, &count, PMIX_STRING);
+        if (PMIX_SUCCESS != rc) {
+            PMIx_Argv_free(*keys);
+            *keys = NULL;
+            return rc;
+        }
+        PMIx_Argv_append_nosize(keys, str);
+        free(str);
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t prte_ds_relay(pmix_proc_t *sender, int room_number,
+                            uint8_t command, pmix_data_buffer_t *buffer)
+{
+    prte_ds_relay_t *cd;
+    pmix_proc_t requestor;
+    pmix_info_t *info = NULL;
+    size_t ninfo = 0;
+    pmix_status_t rc;
+    int32_t count;
+
+    /* the requestor leads every one of these commands */
+    count = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &requestor, &count, PMIX_PROC);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+
+    cd = PMIX_NEW(prte_ds_relay_t);
+    PMIX_XFER_PROCID(&cd->sender, sender);
+    cd->room_number = room_number;
+    cd->command = command;
+
+    switch (command) {
+    case PRTE_PMIX_PUBLISH_CMD:
+        rc = unpack_directives(buffer, &info, &ninfo);
+        break;
+
+    case PRTE_PMIX_LOOKUP_CMD:
+    case PRTE_PMIX_UNPUBLISH_CMD:
+        rc = unpack_keys(buffer, &cd->keys);
+        if (PMIX_SUCCESS == rc) {
+            rc = unpack_directives(buffer, &info, &ninfo);
+        }
+        break;
+
+    case PRTE_PMIX_PURGE_PROC_CMD:
+        /* no keys - a purge names only the process whose data is to go,
+         * and the directives that came with it */
+        rc = unpack_directives(buffer, &info, &ninfo);
+        break;
+
+    default:
+        rc = PMIX_ERR_BAD_PARAM;
+        break;
+    }
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(cd);
+        return rc;
+    }
+
+    rc = load_directives(cd, info, ninfo, &requestor);
+    if (NULL != info) {
+        PMIX_INFO_FREE(info, ninfo);
+    }
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(cd);
+        return rc;
+    }
+
+    /* Point our client-side calls at the data server.  We may hold more
+     * than one server connection - a scheduler is the other - and PMIx
+     * sends a client operation to whichever one is currently primary, so
+     * this is done per request and not once at startup. */
+    rc = prte_pmix_set_primary_server(&prte_pmix_server_globals.server);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(cd);
+        return rc;
+    }
+
+    pmix_output_verbose(1, prte_data_store.output,
+                        "%s data server relay: cmd %u for %s to %s",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (unsigned) command,
+                        PRTE_NAME_PRINT(&requestor),
+                        PRTE_NAME_PRINT(&prte_pmix_server_globals.server));
+
+    switch (command) {
+    case PRTE_PMIX_PUBLISH_CMD:
+        rc = PMIx_Publish_nb(cd->info, cd->ninfo, opcb, cd);
+        break;
+
+    case PRTE_PMIX_LOOKUP_CMD:
+        rc = PMIx_Lookup_nb(cd->keys, cd->info, cd->ninfo, lkcb, cd);
+        break;
+
+    case PRTE_PMIX_UNPUBLISH_CMD:
+        rc = PMIx_Unpublish_nb(cd->keys, cd->info, cd->ninfo, opcb, cd);
+        break;
+
+    case PRTE_PMIX_PURGE_PROC_CMD:
+        /* a purge is an unpublish of everything the process owns, which
+         * PMIx spells as an unpublish naming no keys */
+        rc = PMIx_Unpublish_nb(NULL, cd->info, cd->ninfo, opcb, cd);
+        break;
+
+    default:
+        rc = PMIX_ERR_BAD_PARAM;
+        break;
+    }
+
+    if (PMIX_SUCCESS != rc) {
+        /* the callback will not fire, so answer from here - the requester
+         * is parked on this room number and nothing else will release it */
+        PMIX_ERROR_LOG(rc);
+        cd->status = rc;
+        answer(cd);
+        PMIX_RELEASE(cd);
+        /* the request has been answered - our caller must not answer it
+         * again */
+        return PMIX_SUCCESS;
+    }
+
+    return PMIX_SUCCESS;
+}

--- a/src/runtime/data_server/ds_unpublish.c
+++ b/src/runtime/data_server/ds_unpublish.c
@@ -138,6 +138,12 @@ pmix_status_t prte_ds_unpublish(pmix_proc_t *sender,
                 rq.uid = info[n].value.data.uint32;
             } else if (PMIx_Check_key(info[n].key, PMIX_RANGE)) {
                 rq.range = info[n].value.data.range;
+            } else if (PMIx_Check_key(info[n].key, PMIX_REQUESTOR)) {
+                /* a relay unpublishing on behalf of a process in its own
+                 * DVM.  This must be honored before the ownership test
+                 * below, which is what says only the publisher may remove
+                 * an item. */
+                prte_ds_check_requestor(&rq.requestor, &info[n]);
             }
         }
         /* ignore anything else for now */

--- a/test/unit/rml/test_rml.c
+++ b/test/unit/rml/test_rml.c
@@ -62,6 +62,7 @@
 #    include <net/if.h>
 #endif
 
+#include "src/runtime/prte_globals.h"
 #include "src/runtime/runtime.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_if.h"
@@ -510,13 +511,17 @@ static int test_progress_thread_pool(void)
 }
 
 
-/* The wire header is a fixed part followed by only the characters of the
- * nspace it names.  Nothing here needs a socket: the properties that matter
- * are how long a header is on the wire, that the receiver's two-step read
- * reconstructs exactly the names the sender put in, and that the byte-order
- * conversion is a round trip.  Those are what a reader of oob_tcp_sendrecv.c
- * has to take on trust, and getting any of them wrong delivers a message
- * under the wrong identity rather than failing.
+/* The wire header.
+ *
+ * A DATA message carries no namespace at all: every OOB peer is a daemon of
+ * this DVM, so the receiver rebuilds both procids with its own.  The connect
+ * HANDSHAKE does carry one, because that is where the claim is checked.
+ * Nothing here needs a socket - what matters is how long each of the two is
+ * on the wire, that the receiver's read reconstructs exactly the names the
+ * sender put in, and that the byte-order conversion is a round trip.  Those
+ * are what a reader of oob_tcp_sendrecv.c has to take on trust, and getting
+ * any of them wrong delivers a message under the wrong identity rather than
+ * failing.
  */
 static int test_wire_header(void)
 {
@@ -527,7 +532,10 @@ static int test_wire_header(void)
     size_t len;
     const char *ns = "prterun-somenode-12345@0";
 
-    /* what a sender builds */
+    /* this process stands in for the receiving daemon */
+    PMIX_LOAD_NSPACE(PRTE_PROC_MY_NAME->nspace, ns);
+
+    /* --- a data message ------------------------------------------------ */
     memset(&snd, 0, sizeof(snd));
     snd.epoch = 7;
     snd.origin = 3;
@@ -536,26 +544,21 @@ static int test_wire_header(void)
     snd.seq_num = 42;
     snd.nbytes = 4096;
     snd.type = MCA_OOB_TCP_USER;
-    PRTE_OOB_TCP_HDR_LOAD_NSPACE(&snd, ns);
+    snd.nslen = 0;      /* what the queueing macros do */
 
-    CHECK("hdr nslen excludes the terminator", strlen(ns) == snd.nslen);
     len = PRTE_OOB_TCP_HDR_LEN(&snd);
-    CHECK("hdr wire length is the fixed part plus the nspace",
-          len == PRTE_OOB_TCP_HDR_FIXED + strlen(ns));
+    CHECK("a data header is exactly the fixed part",
+          len == PRTE_OOB_TCP_HDR_FIXED);
     /* the point of the exercise: the struct is much larger than the message */
     CHECK("hdr on the wire is far smaller than the struct", len < sizeof(snd) / 4);
 
-    /* what goes out: only the used prefix, in network order */
     MCA_OOB_TCP_HDR_HTON(&snd);
     memcpy(wire, &snd, len);
 
-    /* what a receiver does: the fixed part first, then nslen characters,
-     * then supply the terminator the sender did not send */
     memset(&rcv, 0xff, sizeof(rcv));
     memcpy(&rcv, wire, PRTE_OOB_TCP_HDR_FIXED);
     CHECK("nslen needs no byte-order conversion to be usable",
           PRTE_OOB_TCP_HDR_LEN(&rcv) == len);
-    memcpy(rcv.nspace, wire + PRTE_OOB_TCP_HDR_FIXED, rcv.nslen);
     PRTE_OOB_TCP_HDR_END_NSPACE(&rcv);
     MCA_OOB_TCP_HDR_NTOH(&rcv);
 
@@ -564,15 +567,49 @@ static int test_wire_header(void)
     CHECK("seq_num survives the round trip", 42 == rcv.seq_num);
     CHECK("nbytes survives the round trip", 4096 == rcv.nbytes);
     CHECK("type survives the round trip", MCA_OOB_TCP_USER == rcv.type);
-    CHECK("the nspace arrives terminated and intact", 0 == strcmp(rcv.nspace, ns));
 
-    /* and the two names the header no longer carries whole come back */
+    /* both names come back in OUR namespace, which is the whole point of
+     * leaving it off the wire */
     PRTE_OOB_TCP_HDR_PROC(&rcv, rcv.origin, &origin);
     PRTE_OOB_TCP_HDR_PROC(&rcv, rcv.dst, &dest);
     CHECK("origin rank rebuilt", 3 == origin.rank);
     CHECK("dst rank rebuilt", 11 == dest.rank);
-    CHECK("origin nspace rebuilt", PMIX_CHECK_NSPACE(origin.nspace, ns));
+    CHECK("origin nspace is the receiver's own", PMIX_CHECK_NSPACE(origin.nspace, ns));
     CHECK("dst carries the same nspace", PMIX_CHECK_NSPACE(dest.nspace, ns));
+
+    /* --- a handshake --------------------------------------------------- */
+    memset(&snd, 0, sizeof(snd));
+    snd.origin = 5;
+    snd.dst = 0;
+    snd.type = MCA_OOB_TCP_IDENT;
+    PRTE_OOB_TCP_HDR_LOAD_NSPACE(&snd, ns);
+
+    CHECK("hdr nslen excludes the terminator", strlen(ns) == snd.nslen);
+    len = PRTE_OOB_TCP_HDR_LEN(&snd);
+    CHECK("a handshake header is the fixed part plus the nspace",
+          len == PRTE_OOB_TCP_HDR_FIXED + strlen(ns));
+
+    MCA_OOB_TCP_HDR_HTON(&snd);
+    memcpy(wire, &snd, len);
+
+    /* what a receiver does: the fixed part first, then nslen characters,
+     * then supply the terminator the sender did not send */
+    memset(&rcv, 0xff, sizeof(rcv));
+    memcpy(&rcv, wire, PRTE_OOB_TCP_HDR_FIXED);
+    CHECK("the handshake's nspace length arrives with the fixed part",
+          PRTE_OOB_TCP_HDR_LEN(&rcv) == len);
+    memcpy(rcv.nspace, wire + PRTE_OOB_TCP_HDR_FIXED, rcv.nslen);
+    PRTE_OOB_TCP_HDR_END_NSPACE(&rcv);
+    MCA_OOB_TCP_HDR_NTOH(&rcv);
+    CHECK("the nspace arrives terminated and intact", 0 == strcmp(rcv.nspace, ns));
+    CHECK("a matching handshake nspace is what the peer check compares",
+          PMIX_CHECK_NSPACE(rcv.nspace, PRTE_PROC_MY_NAME->nspace));
+
+    /* a stranger's handshake is distinguishable - this is the comparison
+     * tcp_peer_recv_connect_ack makes before adopting a peer */
+    PMIX_LOAD_NSPACE(rcv.nspace, "prterun-othernode-999@0");
+    CHECK("another DVM's handshake nspace does not match",
+          !PMIX_CHECK_NSPACE(rcv.nspace, PRTE_PROC_MY_NAME->nspace));
 
     /* a maximum-length nspace still fits the single-byte length field */
     memset(&snd, 0, sizeof(snd));

--- a/test/unit/runtime/test_runtime.c
+++ b/test/unit/runtime/test_runtime.c
@@ -1238,6 +1238,64 @@ static int test_data_server_range(void)
     return failures;
 }
 
+/* A relayed request names the process it is acting for in PMIX_REQUESTOR,
+ * and only a TOOL is allowed to make that claim.  The relay is a daemon of
+ * another DVM attached to us as a tool (see ds_relay.c); an application
+ * process making the same claim is trying to publish - or unpublish - under
+ * a peer's identity, so the claim has to be dropped rather than honored. */
+static int test_data_server_requestor(void)
+{
+    int failures = 0;
+    prte_job_t *toolj, *appj;
+    pmix_proc_t owner, behalf;
+    pmix_info_t info;
+
+    reset_globals();
+
+    toolj = make_job("relay.tool");
+    PRTE_FLAG_SET(toolj, PRTE_JOB_FLAG_TOOL);
+    CHECK("requestor: tool job registered", PRTE_SUCCESS == prte_set_job_data_object(toolj));
+    appj = make_job("some.app");
+    CHECK("requestor: app job registered", PRTE_SUCCESS == prte_set_job_data_object(appj));
+
+    PMIX_LOAD_PROCID(&behalf, "far.away.job", 3);
+
+    /* a tool may act for somebody else */
+    PMIX_LOAD_PROCID(&owner, "relay.tool", 0);
+    PMIX_INFO_LOAD(&info, PMIX_REQUESTOR, &behalf, PMIX_PROC);
+    prte_ds_check_requestor(&owner, &info);
+    CHECK("requestor: a tool's claim is honored", PMIX_CHECK_PROCID(&owner, &behalf));
+    PMIX_INFO_DESTRUCT(&info);
+
+    /* an application process may not */
+    PMIX_LOAD_PROCID(&owner, "some.app", 1);
+    PMIX_INFO_LOAD(&info, PMIX_REQUESTOR, &behalf, PMIX_PROC);
+    prte_ds_check_requestor(&owner, &info);
+    CHECK("requestor: an application's claim is refused",
+          PMIX_CHECK_NSPACE(owner.nspace, "some.app") && 1 == owner.rank);
+    PMIX_INFO_DESTRUCT(&info);
+
+    /* neither may a namespace we have never heard of - a job object is what
+     * says what the caller is, and without one there is nothing to trust */
+    PMIX_LOAD_PROCID(&owner, "unknown.job", 4);
+    PMIX_INFO_LOAD(&info, PMIX_REQUESTOR, &behalf, PMIX_PROC);
+    prte_ds_check_requestor(&owner, &info);
+    CHECK("requestor: an unknown namespace's claim is refused",
+          PMIX_CHECK_NSPACE(owner.nspace, "unknown.job"));
+    PMIX_INFO_DESTRUCT(&info);
+
+    /* a directive of the wrong type is ignored rather than dereferenced */
+    PMIX_LOAD_PROCID(&owner, "relay.tool", 0);
+    PMIX_INFO_LOAD(&info, PMIX_REQUESTOR, "not-a-procid", PMIX_STRING);
+    prte_ds_check_requestor(&owner, &info);
+    CHECK("requestor: a mistyped directive is ignored",
+          PMIX_CHECK_NSPACE(owner.nspace, "relay.tool"));
+    PMIX_INFO_DESTRUCT(&info);
+
+    reset_globals();
+    return failures;
+}
+
 /* ------------------------------------------------------------------ */
 /* progress threads                                                   */
 /* ------------------------------------------------------------------ */
@@ -1458,6 +1516,7 @@ int main(void)
     failures += test_exit_status();
     failures += test_data_server_objects();
     failures += test_data_server_range();
+    failures += test_data_server_requestor();
     failures += test_progress_thread_cpus();
     failures += test_progress_thread_lifecycle();
     failures += test_paramfile_ordering();


### PR DESCRIPTION
### The problem

A DVM can be told to keep its published data in **another DVM** — `prte_pmix_server_uri`, historically `ompi-server` — so that jobs launched by separate invocations can find each other. That is what `MPI_Publish_name` / `MPI_Comm_accept` between two `mpirun`s runs on.

It has not worked since March 2022.

The RML addresses a peer **by rank**, stamping the sender's own namespace on it: every send entry point takes a `pmix_rank_t`, `send_buffer()` builds the destination as that rank in `PRTE_PROC_MY_NAME->nspace`, and `prte_oob_base_send_nb` resolves the next hop the same way. So the namespace parsed out of the server's URI was discarded and the request went to the **local** master. `17368b1b60` ("RML Rework: Stage 3") converted the one call that mattered:

```diff
-    PRTE_RML_SEND(rc, target, xfer, PRTE_RML_TAG_DATA_SERVER);
+    PRTE_RML_SEND(rc, target->rank, xfer, PRTE_RML_TAG_DATA_SERVER);
```

Nothing noticed, because with no external server configured the target *is* the local master. Two further gaps made it unreachable in principle anyway: the reply was addressed with `sender->rank` in the server's namespace, and nothing published a URI in the form the OOB parses — `--report-uri` emits the PMIx server URI, while `process_uri` wants PRRTE's own `tcp://ip:port:ifmask`.

Nor is this something the transport can be talked into. Below the API everything is indexed by rank within this DVM — the routing tree, `prte_rml_is_node_up()`, the incarnation table — so a foreign rank collides with a local one at every layer.

### What this does

**Moves the crossing to a PMIx tool connection.** The DVM master attaches to the remote DVM's PMIx server and reissues the operation as an ordinary `PMIx_Publish`/`Lookup`/`Unpublish`; the remote DVM's own upcalls deliver it to its data server. This is not a new mechanism here — `prte_pmix_set_scheduler()` already attaches the master to a scheduler the same way — and it settles the URI question, since what `PMIx_tool_attach_to_server` wants is exactly what `prte --report-uri` writes.

Only the master attaches; every other daemon relays to it over the RML as it already does for a locally-hosted store, so a DVM holds one connection however many daemons it has.

Two things the relay has to get right:

- **`PMIX_REQUESTOR` carries the asking process.** Otherwise every item is owned by the relaying daemon's *tool* identity, and every ownership rule at the far end — who may unpublish, what `PMIX_RANGE_NAMESPACE` admits, which items a job-end purge takes — is answered about the wrong process. The far end honors the claim **only from a tool**; an application process making it is trying to act under a peer's identity.
- **The primary server is named per operation.** PMIx directs a tool's client-side calls at whichever attached server is primary, and only one may be primary at a time. A master can now hold two connections, so `prte_pmix_set_primary_server()` is the single point that designates one, and the scheduler path uses it too. It replaces `scheduler_set_as_server`, which recorded "the scheduler has been made primary" once and would have been wrong the moment a second connection existed.

**And then takes the namespace off the OOB header.** With nothing left that wants to address a foreign namespace on the RML, `prte_oob_tcp_hdr_t` — which precedes *every* RML message — drops it. The header went 552 bytes (two whole `pmix_proc_t`) → ~50 (two ranks + one namespace) → **30, fixed**. For a launch-message cpuset slice with 101 bytes of payload, it has gone from 85% of the message to 23%.

The receiver rebuilds both identifiers with its own namespace. That is sound because only `ess/hnp` and the prted path open an OOB endpoint — no tool, no application process — so a peer is always a daemon of our own job, and a foreign namespace is unrepresentable rather than merely unused.

What had blocked this previously was that those are an invariant nobody enforced, whose failure mode is a message delivered under the wrong sender identity rather than an error. So it is now **checked**: the connect handshake still carries a namespace, and `tcp_peer_recv_connect_ack` refuses a peer whose namespace is not ours (including one that offers none, which would otherwise fall back to ours and defeat the check). That catches something the boot-epoch stamp cannot — it orders incarnations *within* one DVM, so a daemon of a different DVM belonging to the same user passes it.

### Wire-format changes

Both are internal to a single DVM, and each changes every end in the same commit:

- the purge command gains a directive array (three senders, one reader) — the only way `PMIX_REQUESTOR` can reach `ds_purge`;
- a data message's header no longer carries a namespace.

### Testing

Nothing about the cross-DVM path exists on one DVM, so it lives in `contrib/dockerswarm`: **three DVMs at once** — a server and two clients pointed at it — asserting that data crosses, that the answer names the *publishing process* rather than the relay, that a `PMIX_WAIT` lookup parked from one client is woken by a publish from the other, that an ended job's data is purged from the server, that the purge takes **only** that job's data, and — the control — that a DVM not given the URI sees none of it.

- Swarm: **105 passed, 0 failed, 0 skipped** across `test_rml`, `test_runtime`, `test_grpcomm`, `test_prted` — including radix-2 relaying through an interior daemon, 3.5 MB through partial reads and writes, the max-message guard, and daemon loss under a live DVM.
- `make check`: 21/21. New unit coverage for the requestor gate (`test_runtime`) and for both header shapes (`test_rml`).
- Clean `--enable-debug` build, docs build warning-free, and each commit builds and tests on its own.
