### PR TITLE
Let --stop-in-app name the breakpoint to stop at

### DIFF
--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -977,6 +977,30 @@ test_schizo() {
         && ok "both --set-env directives reached the remote process" \
         || bad "a repeated --set-env was dropped: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
 
+    banner "schizo: --stop-in-app names a breakpoint the REMOTE processes see"
+    # "--stop-in-app=<name>" says WHERE the application is to stop.  The tool
+    # records the name as a job attribute and nothing turns it into an envar
+    # until setup_fork runs - on whichever daemon forks the process.  So only
+    # a remote node can show that the attribute travelled: recorded local to
+    # the HNP it would still read correctly on the head node while every
+    # process elsewhere stopped at a place nobody asked for.
+    out=$(RUN 'prterun --host node2:1,node3:1 -np 2 --map-by node \
+                 --rtos stop-in-app=sz-breakpoint \
+                 bash -c "echo SZBP \$(hostname) \${PMIX_BREAKPOINT:-unset}"' 2>&1); rc=$?
+    n=$(echo "$out" | grep -cE '^SZBP node[23] sz-breakpoint$')
+    [ "$rc" = 0 ] && [ "$n" = 2 ] \
+        && ok "the breakpoint name reached both remote processes" \
+        || bad "breakpoint name missing on a remote node (rc=$rc, matched=$n): $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+
+    # ...and asking to stop with no name in particular sets no envar at all,
+    # so an application that filters on the name stops wherever it likes
+    # rather than nowhere.
+    out=$(RUN 'prterun --host node2:1 -np 1 --rtos stop-in-app \
+                 bash -c "echo SZBP2 \${PMIX_BREAKPOINT:-unset}"' 2>&1)
+    echo "$out" | grep -q '^SZBP2 unset$' \
+        && ok "an unnamed stop-in-app leaves PMIX_BREAKPOINT unset" \
+        || bad "an unnamed stop-in-app set a breakpoint: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+
     banner "schizo: --merge-stderr-to-stdout is honored, not silently dropped"
     # The deprecated spelling is in the prterun/prun option tables.  With no
     # conversion behind it, it parsed cleanly and then did nothing at all -

--- a/examples/client.c
+++ b/examples/client.c
@@ -28,6 +28,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <strings.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -35,6 +36,10 @@
 #include <pmix.h>
 
 static pmix_proc_t myproc;
+
+/* the string ID of the one place this example stops at when asked to stop
+ * somewhere of its own choosing - see "prterun --help stop-in-app" */
+#define EXAMPLE_BREAKPOINT "example-app"
 
 /* this is the event notification function we pass down below
  * when registering for general events - i.e.,, the default
@@ -158,6 +163,7 @@ int main(int argc, char **argv)
     bool local, all_local = false;
     char **peers;
     pmix_rank_t *locals = NULL;
+    char *bkpt;
 
     pid = getpid();
     fprintf(stderr, "Client %lu: Running\n", (unsigned long) pid);
@@ -203,6 +209,18 @@ int main(int argc, char **argv)
      * debugger */
     PMIX_INFO_LOAD(&i2, PMIX_OPTIONAL, NULL, PMIX_BOOL);
     if (PMIX_SUCCESS == (rc = PMIx_Get(&proc, PMIX_DEBUG_STOP_IN_APP, &i2, 1, &val))) {
+        /* the launcher may have named the ONE place it wants us to stop at -
+         * "prterun --stop-in-app=<name>" passes that name down in the
+         * PMIX_BREAKPOINT envar.  This example has exactly one such place,
+         * right here, so a request for any other name is a request not to
+         * stop at all.  An unnamed request stops us wherever we get to
+         * first, which is also here. */
+        bkpt = getenv("PMIX_BREAKPOINT");
+        if (NULL != bkpt && 0 != strcasecmp(bkpt, EXAMPLE_BREAKPOINT)) {
+            fprintf(stderr, "[%s:%d] not stopping at %s - %s was requested\n", myproc.nspace,
+                    myproc.rank, EXAMPLE_BREAKPOINT, bkpt);
+            goto nostop;
+        }
         /* register for debugger release */
         DEBUG_CONSTRUCT_LOCK(&mylock);
         PMIX_INFO_CREATE(info, 1);
@@ -220,10 +238,21 @@ int main(int argc, char **argv)
                     myproc.rank);
             goto done;
         }
+        /* Tell the host we have arrived and are waiting.  Only the
+         * application knows where its own breakpoints are, so nobody else
+         * can say this - and a process that waits without saying it waits
+         * forever: the runtime never reports the job ready for debug, and
+         * no debugger is ever told to attach. */
+        PMIX_INFO_CREATE(info, 2);
+        PMIX_INFO_LOAD(&info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+        PMIX_INFO_LOAD(&info[1], PMIX_BREAKPOINT, EXAMPLE_BREAKPOINT, PMIX_STRING);
+        PMIx_Notify_event(PMIX_READY_FOR_DEBUG, &myproc, PMIX_RANGE_RM, info, 2, NULL, NULL);
+        PMIX_INFO_FREE(info, 2);
         /* wait for debugger release */
         DEBUG_WAIT_THREAD(&myrel.lock);
         DEBUG_DESTRUCT_MYREL(&myrel);
     }
+nostop:
 
     /* get our universe size */
     if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, NULL, 0, &val))) {

--- a/src/docs/prrte-rst-content/cli-runtime-options.rst
+++ b/src/docs/prrte-rst-content/cli-runtime-options.rst
@@ -120,10 +120,20 @@ Supported values include:
   application process(es) to stop in ``PMIx_Init()``. The directive
   will apply to all processes in the job.
 
-* ``STOP-IN-APP``: indicates that the runtime should direct
-  application processes to stop at some application-defined place and
-  notify they are ready-to-debug. The directive will apply to all
-  processes in the job.
+* ``STOP-IN-APP[=<breakpoint>]``: indicates that the runtime should
+  direct application processes to stop at some application-defined
+  place and notify they are ready-to-debug. The directive will apply
+  to all processes in the job. Given without a value, the processes
+  stop at whichever such place they reach first. Given a value, that
+  string is the identifier of the one breakpoint at which they are to
+  stop: the runtime passes it to the application in the
+  ``PMIX_BREAKPOINT`` environment variable and then waits for the
+  application to report itself ready for debug, so it is up to the
+  application to recognize the name and stop in the corresponding
+  place. This is the one directive whose value may be something other
+  than a truth value, and it is read as a truth value whenever it
+  spells one |mdash| so a breakpoint cannot be named ``true``,
+  ``false``, or any other spelling of a boolean.
 
 * ``TIMEOUT=<string>``: directs the runtime to terminate the job after
   it has executed for the specified time. Time is specified in

--- a/src/mca/schizo/base/help-schizo-rtos.txt
+++ b/src/mca/schizo/base/help-schizo-rtos.txt
@@ -116,10 +116,20 @@ Supported values include:
   application process(es) to stop in "PMIx_Init()". The directive will
   apply to all processes in the job.
 
-* "STOP-IN-APP": indicates that the runtime should direct application
-  processes to stop at some application-defined place and notify they
-  are ready-to-debug. The directive will apply to all processes in the
-  job.
+* "STOP-IN-APP[=<breakpoint>]": indicates that the runtime should
+  direct application processes to stop at some application-defined
+  place and notify they are ready-to-debug. The directive will apply
+  to all processes in the job. Given without a value, the processes
+  stop at whichever such place they reach first. Given a value, that
+  string is the identifier of the one breakpoint at which they are to
+  stop: the runtime passes it to the application in the
+  "PMIX_BREAKPOINT" environment variable and then waits for the
+  application to report itself ready for debug, so it is up to the
+  application to recognize the name and stop in the corresponding
+  place. This is the one directive whose value may be something other
+  than a truth value, and it is read as a truth value whenever it
+  spells one — so a breakpoint cannot be named "true", "false", or any
+  other spelling of a boolean.
 
 * "TIMEOUT=<string>": directs the runtime to terminate the job after
   it has executed for the specified time. Time is specified in colon-

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -570,16 +570,25 @@ int prte_schizo_base_setup_fork(prte_job_t *jdata, prte_app_context_t *app)
 {
     prte_attribute_t *attr;
     bool exists, prefix_defined = false;
-    char *param, *p2, *saveptr, *p, *defprefix;
+    char *param, *p2, *saveptr, *p, *defprefix, *bkpt;
     int i;
     prte_job_t *daemons;
-    /* the job is part of the hook's contract, but the only prefix this
-     * function consults is the app's own and the DVM-wide default carried
-     * on the daemon job */
-    PRTE_HIDE_UNUSED_PARAMS(jdata);
 
     /* flag that we started this job */
     PMIx_Setenv("PRTE_LAUNCHED", "1", true, &app->env);
+
+    /* if the user named the place they want the application to stop at,
+     * hand that name down to the application.  The runtime cannot know
+     * where any given breakpoint lives - only the application can - so all
+     * we can do is tell it which one was asked for and then wait for the
+     * "ready for debug" event it fires when it gets there.  An application
+     * that stops at a breakpoint of its own choosing (STOP-IN-APP with no
+     * name) sees no envar and stops at the first one it comes to. */
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_BREAKPOINT,
+                           (void **) &bkpt, PMIX_STRING)) {
+        PMIx_Setenv("PMIX_BREAKPOINT", bkpt, true, &app->env);
+        free(bkpt);
+    }
 
     /* NOTE: the generic envar directives (SET/ADD/UNSET/PREPEND/APPEND, at
      * both job and app level) are NOT applied here.  odls' process_envars()

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -126,7 +126,7 @@ static struct option ompioptions[] = {
     PMIX_OPTION_DEFINE(PRTE_CLI_XTERM, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PRTE_CLI_STOP_ON_EXEC, PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE(PRTE_CLI_STOP_IN_INIT, PMIX_ARG_NONE),
-    PMIX_OPTION_DEFINE(PRTE_CLI_STOP_IN_APP, PMIX_ARG_NONE),
+    PMIX_OPTION_DEFINE(PRTE_CLI_STOP_IN_APP, PMIX_ARG_OPTIONAL),
     PMIX_OPTION_DEFINE(PRTE_CLI_TIMEOUT, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PRTE_CLI_REPORT_STATE, PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE(PRTE_CLI_STACK_TRACES, PMIX_ARG_NONE),
@@ -775,11 +775,22 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
 
-        /* --stop-in-app  ->  --runtime-options stop-in-app */
+        /* --stop-in-app[=<breakpoint>]  ->  --runtime-options stop-in-app[=<breakpoint>]
+         *
+         * The optional value names the place the application is to stop at,
+         * so it has to survive the conversion - dropping it would silently
+         * turn a request to stop at one named breakpoint into a request to
+         * stop at whichever one the application reaches first. */
         else if (0 == strcmp(option, PRTE_CLI_STOP_IN_APP)) {
+            if (NULL != opt->values && NULL != opt->values[0]) {
+                pmix_asprintf(&p2, "%s=%s", PRTE_CLI_STOP_IN_APP, opt->values[0]);
+            } else {
+                p2 = strdup(PRTE_CLI_STOP_IN_APP);
+            }
             rc = prte_schizo_base_add_directive(results, option,
-                                                PRTE_CLI_RTOS, PRTE_CLI_STOP_IN_APP,
+                                                PRTE_CLI_RTOS, p2,
                                                 warn);
+            free(p2);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
 

--- a/src/mca/schizo/prte/help-prterun.txt
+++ b/src/mca/schizo/prte/help-prterun.txt
@@ -79,8 +79,9 @@ option to the help request as "--help <option>".
 | "--stop-in-init"     | Direct the specified processes to stop in     |
 |                      | "PMIx_Init"                                   |
 +----------------------+-----------------------------------------------+
-| "--stop-in-app"      | Direct the specified processes to stop at an  |
-|                      | application-controlled location               |
+| "--stop-in-app"      | Direct the processes to stop at an            |
+|      [=breakpoint]   | application-controlled location, optionally   |
+|                      | naming the breakpoint at which to stop        |
 +----------------------+-----------------------------------------------+
 | "--do-not-launch"    | Perform all necessary operations to prepare   |
 |                      | to launch the application, but do not         |
@@ -694,9 +695,22 @@ e.g., "1,3-6,9", or as "all".
 [stop-in-app]
 
 Include the "PMIX_DEBUG_STOP_IN_APP" attribute in the application's
-job info directing that the specified ranks stop at an application-
-determined point pending release. Ranks are specified as a comma-
-delimited list of ranges — e.g., "1,3-6,9", or as "all".
+job info directing that the processes stop at an application-
+determined point pending release. The directive applies to all
+processes in the job.
+
+An optional argument names the one breakpoint at which they are to
+stop — e.g., "--stop-in-app=mpi-init". PRRTE cannot know where any
+given breakpoint lives; all it can do is pass the name to the
+application in the "PMIX_BREAKPOINT" environment variable and then
+wait for the "ready for debug" event the application generates when it
+gets there. It is therefore up to the application to recognize the
+name and stop in the corresponding place. Given without an argument,
+the processes stop at whichever such place they reach first.
+
+Since the argument is read as a boolean when it spells one, a
+breakpoint cannot be named "true", "false", or any other spelling of a
+truth value.
 #
 [x]
 

--- a/src/mca/schizo/prte/help-prterun.txt
+++ b/src/mca/schizo/prte/help-prterun.txt
@@ -688,9 +688,8 @@ If supported, stop each process at start of execution
 [stop-in-init]
 
 Include the "PMIX_DEBUG_STOP_IN_INIT" attribute in the application's
-job info directing that the specified ranks stop in PMIx_Init pending
-release. Ranks are specified as a comma-delimited list of ranges —
-e.g., "1,3-6,9", or as "all".
+job info directing that the processes stop in PMIx_Init pending
+release. The directive applies to all processes in the job.
 #
 [stop-in-app]
 

--- a/src/mca/schizo/prte/help-prun.txt
+++ b/src/mca/schizo/prte/help-prun.txt
@@ -70,8 +70,9 @@ option to the help request as "--help <option>".
 | "--stop-in-init"     | Direct the specified processes to stop in     |
 |                      | "PMIx_Init"                                   |
 +----------------------+-----------------------------------------------+
-| "--stop-in-app"      | Direct the specified processes to stop at an  |
-|                      | application-controlled location               |
+| "--stop-in-app"      | Direct the processes to stop at an            |
+|      [=breakpoint]   | application-controlled location, optionally   |
+|                      | naming the breakpoint at which to stop        |
 +----------------------+-----------------------------------------------+
 | "--no-aggregate-     | Do not aggregate help messages issued by      |
 | help"                | multiple processes - report each one as it is |

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -186,7 +186,7 @@ static struct option prterunoptions[] = {
     PMIX_OPTION_DEFINE(PRTE_CLI_XTERM, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PRTE_CLI_STOP_ON_EXEC, PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE(PRTE_CLI_STOP_IN_INIT, PMIX_ARG_NONE),
-    PMIX_OPTION_DEFINE(PRTE_CLI_STOP_IN_APP, PMIX_ARG_NONE),
+    PMIX_OPTION_DEFINE(PRTE_CLI_STOP_IN_APP, PMIX_ARG_OPTIONAL),
     PMIX_OPTION_SHORT_DEFINE(PRTE_CLI_FWD_ENVAR, PMIX_ARG_REQD, 'x'),
     PMIX_OPTION_DEFINE(PMIX_CLI_SET_ENVAR, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PMIX_CLI_PREPEND_ENVAR, PMIX_ARG_REQD),
@@ -315,7 +315,7 @@ static struct option prunoptions[] = {
     PMIX_OPTION_DEFINE(PRTE_CLI_XTERM, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PRTE_CLI_STOP_ON_EXEC, PMIX_ARG_NONE),
     PMIX_OPTION_DEFINE(PRTE_CLI_STOP_IN_INIT, PMIX_ARG_NONE),
-    PMIX_OPTION_DEFINE(PRTE_CLI_STOP_IN_APP, PMIX_ARG_NONE),
+    PMIX_OPTION_DEFINE(PRTE_CLI_STOP_IN_APP, PMIX_ARG_OPTIONAL),
     PMIX_OPTION_SHORT_DEFINE(PRTE_CLI_FWD_ENVAR, PMIX_ARG_REQD, 'x'),
     PMIX_OPTION_DEFINE(PMIX_CLI_SET_ENVAR, PMIX_ARG_REQD),
     PMIX_OPTION_DEFINE(PMIX_CLI_PREPEND_ENVAR, PMIX_ARG_REQD),
@@ -902,11 +902,22 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
 
-        /* --stop-in-app  ->  --runtime-options stop-in-app */
+        /* --stop-in-app[=<breakpoint>]  ->  --runtime-options stop-in-app[=<breakpoint>]
+         *
+         * The optional value names the place the application is to stop at,
+         * so it has to survive the conversion - dropping it would silently
+         * turn a request to stop at one named breakpoint into a request to
+         * stop at whichever one the application reaches first. */
         else if (0 == strcmp(option, PRTE_CLI_STOP_IN_APP)) {
+            if (NULL != opt->values && NULL != opt->values[0]) {
+                pmix_asprintf(&p2, "%s=%s", PRTE_CLI_STOP_IN_APP, opt->values[0]);
+            } else {
+                p2 = strdup(PRTE_CLI_STOP_IN_APP);
+            }
             rc = prte_schizo_base_add_directive(results, option,
-                                                PRTE_CLI_RTOS, PRTE_CLI_STOP_IN_APP,
+                                                PRTE_CLI_RTOS, p2,
                                                 warn);
+            free(p2);
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
 

--- a/src/mca/state/base/state_base_options.c
+++ b/src/mca/state/base/state_base_options.c
@@ -76,7 +76,7 @@ static void set_bool_option(prte_job_t *jdata, prte_attribute_key_t key, bool fl
  * PMIX_RUNTIME_OPTIONS info struct */
 int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
 {
-    char **options, *ptr;
+    char **options, *ptr, *bkpt;
     int n, k, tm;
     bool flag, *fptr = &flag;
     int32_t i32;
@@ -250,6 +250,7 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
              * here instead, where it is still the user's command line and
              * not a policy nobody asked for. */
             if (NULL != ptr && !prte_schizo_base_directive_is_valued(options[n]) &&
+                !PMIX_CHECK_CLI_OPTION(options[n], PRTE_CLI_STOP_IN_APP) &&
                 PRTE_SUCCESS != prte_cli_bool_value(ptr, &flag)) {
                 prte_show_help("help-schizo-base.txt", "non-boolean-value", true,
                                PRTE_CLI_RTOS, options[n], ptr);
@@ -355,15 +356,44 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
                 }
 
             } else if (PMIX_CHECK_CLI_OPTION(options[n], PRTE_CLI_STOP_IN_APP)) {
-                flag = PMIX_CHECK_TRUE(&value);
+                /* this is the one hybrid directive: written bare or with a
+                 * truth value it asserts the boolean "stop wherever the
+                 * application chooses to stop", and written with anything
+                 * else that text is the string ID of the ONE breakpoint the
+                 * application is to stop at.  This is why the strict-boolean
+                 * refusal above steps around this directive.  A breakpoint
+                 * therefore cannot be named with any spelling of a truth
+                 * value - "true" and "false" mean what they always mean. */
+                if (PRTE_SUCCESS == prte_cli_bool_value(ptr, &flag)) {
+                    bkpt = NULL;
+                } else {
+                    flag = true;
+                    bkpt = ptr;
+                }
                 if (flag) {
                     prte_set_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_APP,
                                        PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
                     /* also must add to job-level cache */
                     PMIX_INFO_LOAD(&info, PMIX_DEBUG_STOP_IN_APP, NULL, PMIX_BOOL);
                     pmix_server_cache_job_info(jdata, &info);
+                    if (NULL == bkpt) {
+                        /* no particular place was named, so any prior
+                         * request for one no longer applies */
+                        prte_remove_attribute(&jdata->attributes, PRTE_JOB_BREAKPOINT);
+                    } else {
+                        prte_set_attribute(&jdata->attributes, PRTE_JOB_BREAKPOINT,
+                                           PRTE_ATTR_GLOBAL, bkpt, PMIX_STRING);
+                        /* the daemons turn this into an envar for the app to
+                         * read, but cache it as well so anything holding a
+                         * PMIx handle on the job - a debugger tool, or the
+                         * application itself - can simply ask for it */
+                        PMIX_INFO_LOAD(&info, PMIX_BREAKPOINT, bkpt, PMIX_STRING);
+                        pmix_server_cache_job_info(jdata, &info);
+                        PMIX_INFO_DESTRUCT(&info);
+                    }
                 } else {
                     prte_remove_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_APP);
+                    prte_remove_attribute(&jdata->attributes, PRTE_JOB_BREAKPOINT);
                 }
 
             } else if (PMIX_CHECK_CLI_OPTION(options[n], PRTE_CLI_TIMEOUT)) {

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -518,7 +518,7 @@ static void ready_for_debug(int fd, short args, void *cbdata)
     void *tinfo;
     pmix_status_t rc;
     int n;
-    char *name;
+    char *name, *bkpt;
     prte_app_context_t *app;
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
@@ -537,6 +537,17 @@ static void ready_for_debug(int fd, short args, void *cbdata)
     PMIX_PROC_RELEASE(nptr);
     /* pass the nspace of the job */
     PMIX_INFO_LIST_ADD(rc, tinfo, PMIX_NSPACE, jdata->nspace, PMIX_STRING);
+    /* a READY_FOR_DEBUG event is supposed to say WHERE the processes are
+     * waiting.  If the user named the breakpoint, that is the answer - the
+     * procs cannot have reported ready anywhere else.  We have nothing to
+     * say when they did not: a process that stops at a place of its own
+     * choosing reports the name to its local daemon, and that name does not
+     * travel with the daemon's aggregated report to us. */
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_BREAKPOINT,
+                           (void **) &bkpt, PMIX_STRING)) {
+        PMIX_INFO_LIST_ADD(rc, tinfo, PMIX_BREAKPOINT, bkpt, PMIX_STRING);
+        free(bkpt);
+    }
     for (n=0; n < jdata->apps->size; n++) {
         app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, n);
         if (NULL == app) {

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -522,6 +522,8 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "STOP-IN-INIT";
         case PRTE_JOB_STOP_IN_APP:
             return "STOP-IN-APP";
+        case PRTE_JOB_BREAKPOINT:
+            return "BREAKPOINT";
         case PRTE_JOB_ENVARS_HARVESTED:
             return "ENVARS-HARVESTED";
         case PRTE_JOB_OUTPUT_NOCOPY:

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -235,6 +235,7 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_DEBUG_DAEMONS_PER_PROC     (PRTE_JOB_START_KEY +  87) // uint16_t - Number of debug daemons per application proc
 #define PRTE_JOB_STOP_IN_INIT               (PRTE_JOB_START_KEY +  88) // bool - stop in PMIx_Init
 #define PRTE_JOB_STOP_IN_APP                (PRTE_JOB_START_KEY +  89) // bool - stop at app-determined location
+#define PRTE_JOB_BREAKPOINT                 (PRTE_JOB_START_KEY + 131) // char* - string ID of the app-determined location at which to stop
 #define PRTE_JOB_ENVARS_HARVESTED           (PRTE_JOB_START_KEY +  90) // envars have already been harvested
 #define PRTE_JOB_OUTPUT_NOCOPY              (PRTE_JOB_START_KEY +  91) // bool - do not copy output to stdout/err
 #define PRTE_JOB_RANK_OUTPUT                (PRTE_JOB_START_KEY +  92) // bool - tag stdout/stderr with rank

--- a/test/unit/state/test_state.c
+++ b/test/unit/state/test_state.c
@@ -544,6 +544,93 @@ static int test_runtime_options(void)
 }
 
 /*
+ * "stop-in-app" is the one runtime option whose value is not a truth value.
+ * Written bare or with a boolean it asserts "stop wherever the application
+ * chooses"; written with anything else, that text is the string ID of the
+ * breakpoint the application is to stop at, which the daemons hand to the
+ * process in the PMIX_BREAKPOINT envar.  Two things can go wrong quietly
+ * here: the strict-boolean refusal that guards every other directive would
+ * reject a breakpoint name outright, and a name left behind by an earlier
+ * directive would send the job to a breakpoint nobody asked for.
+ */
+static int test_stop_in_app(void)
+{
+    int failures = 0;
+    prte_job_t *jdata;
+    char *spec, *bkpt;
+
+    /* bare: stop somewhere, no particular place */
+    jdata = PMIX_NEW(prte_job_t);
+    PMIX_LOAD_NSPACE(jdata->nspace, "unit-test-sia1");
+    spec = strdup("stop-in-app");
+    CHECK("bare directive accepted",
+          PRTE_SUCCESS == prte_state_base_set_runtime_options(jdata, spec));
+    free(spec);
+    CHECK("bare sets stop-in-app",
+          prte_get_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_APP, NULL, PMIX_BOOL));
+    CHECK("bare names no breakpoint",
+          !prte_get_attribute(&jdata->attributes, PRTE_JOB_BREAKPOINT, NULL, PMIX_STRING));
+
+    /* a name: not a truth value, so it must not be refused as one, and the
+     * directive after it must still be applied */
+    spec = strdup("stop-in-app=mpi-init,recoverable=true");
+    CHECK("named breakpoint accepted",
+          PRTE_SUCCESS == prte_state_base_set_runtime_options(jdata, spec));
+    free(spec);
+    CHECK("name sets stop-in-app",
+          prte_get_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_APP, NULL, PMIX_BOOL));
+    bkpt = NULL;
+    CHECK("name recorded",
+          prte_get_attribute(&jdata->attributes, PRTE_JOB_BREAKPOINT, (void **) &bkpt,
+                             PMIX_STRING));
+    CHECK("name value", NULL != bkpt && 0 == strcmp(bkpt, "mpi-init"));
+    if (NULL != bkpt) {
+        free(bkpt);
+    }
+    CHECK("directive after the name applied",
+          prte_get_attribute(&jdata->attributes, PRTE_JOB_RECOVERABLE, NULL, PMIX_BOOL));
+
+    /* asserting the boolean afterwards drops the name: the job is no longer
+     * to stop at that one place */
+    spec = strdup("stop-in-app=true");
+    CHECK("truth value accepted",
+          PRTE_SUCCESS == prte_state_base_set_runtime_options(jdata, spec));
+    free(spec);
+    CHECK("true keeps stop-in-app",
+          prte_get_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_APP, NULL, PMIX_BOOL));
+    CHECK("true clears the name",
+          !prte_get_attribute(&jdata->attributes, PRTE_JOB_BREAKPOINT, NULL, PMIX_STRING));
+
+    /* and turning it off clears both */
+    spec = strdup("stop-in-app=mpi-init");
+    CHECK("name re-applied", PRTE_SUCCESS == prte_state_base_set_runtime_options(jdata, spec));
+    free(spec);
+    spec = strdup("stop-in-app=false");
+    CHECK("false accepted", PRTE_SUCCESS == prte_state_base_set_runtime_options(jdata, spec));
+    free(spec);
+    CHECK("false clears stop-in-app",
+          !prte_get_attribute(&jdata->attributes, PRTE_JOB_STOP_IN_APP, NULL, PMIX_BOOL));
+    CHECK("false clears the name",
+          !prte_get_attribute(&jdata->attributes, PRTE_JOB_BREAKPOINT, NULL, PMIX_STRING));
+    PMIX_RELEASE(jdata);
+
+    /* the exemption is confined to this directive - its neighbors still
+     * refuse a value that is neither true nor false */
+    jdata = PMIX_NEW(prte_job_t);
+    PMIX_LOAD_NSPACE(jdata->nspace, "unit-test-sia2");
+    spec = strdup("stop-in-init=mpi-init");
+    CHECK("stop-in-init still refuses a non-boolean",
+          PRTE_ERR_SILENT == prte_state_base_set_runtime_options(jdata, spec));
+    free(spec);
+    PMIX_RELEASE(jdata);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_stop_in_app\n");
+    }
+    return failures;
+}
+
+/*
  * Component selection is role-driven: dvm answers only for the DVM master,
  * prted only for a daemon, both at priority 100.  Exactly one applies to
  * any given process, which is what makes a "pick one" framework safe here.
@@ -648,6 +735,7 @@ int main(void)
     failures += test_proc_dispatch();
     failures += test_caddy_contract();
     failures += test_runtime_options();
+    failures += test_stop_in_app();
     failures += test_component_selection();
 
     (void) pmix_mca_base_framework_close(&prte_state_base_framework);


### PR DESCRIPTION
### Problem

`--stop-in-app` has always been an all-or-nothing request. The job was marked as stopping somewhere the application chooses, and the application had no way to learn *which* place was wanted. A library with more than one such point — and Open MPI has several — could therefore only stop at the first one it reached, which is rarely the one the user wanted to look at.

The option has advertised "stop at an application-controlled location" for years with no way to say which location.

### What this does

Gives the directive an optional value naming the breakpoint: `--stop-in-app=mpi-init`, or `--rtos stop-in-app=mpi-init`.

PRRTE cannot know where any given breakpoint lives; only the application can. So all the runtime does is carry the name:

- it records it on the job as `PRTE_JOB_BREAKPOINT`;
- the daemon that forks each process turns it into the `PMIX_BREAKPOINT` envar in `setup_fork`;
- the application compares that against its own breakpoint names, stops at the matching one, and generates `PMIX_READY_FOR_DEBUG`.

That last half is the part PRRTE already implemented — proc state → job state → notify the launch proxy — and it needed no change. The name is additionally cached in the job info so anything holding a PMIx handle on the job can ask for it, and it is reported back in the ready-for-debug event PRRTE sends the launch proxy, which until now said nothing at all about where the processes were waiting.

### The value is a hybrid

Written bare or with a truth value the directive means what it always meant; written with anything else, that text is a breakpoint name. This is why the strict-boolean refusal that guards every other runtime option has to step around this one. The cost is that a breakpoint cannot be named `true`, `false`, or any other spelling of a boolean — which the help text says.

`PMIX_BREAKPOINT` is deliberately **not** added as a `PMIx_Spawn` info key: the PMIx docs describe it as an OUT attribute on `PMIX_READY_FOR_DEBUG`, explicitly not passed to `PMIx_Spawn`. A tool gets the same result today through `PMIX_RUNTIME_OPTIONS="stop-in-app=<name>"`, which reaches the same parser.

### Two incidental commits

- `examples/client.c` honored `PMIX_DEBUG_STOP_IN_APP` by waiting for a debugger release it never announced itself ready for. Nothing else can announce it — only the application knows where its own breakpoints are — so run under `--stop-in-app` the example waited forever. It now generates the event and honors the breakpoint name, which makes it a working reference for the application side.
- `--stop-in-init`'s help told the user to name the ranks that are to stop, as a comma-delimited list of ranges. Nothing anywhere reads one; the option sets a single job-level attribute and every process stops.

### Testing

- Clean `--enable-debug` build; `make check` (21 pass); `make -C test/offline check-offline` (2369 pass); the `prte-convert-help.py` cross-check.
- New unit test `test_stop_in_app` in `test/unit/state/test_state.c`: bare, named, `=true` clearing a prior name, `=false` clearing both, a directive after a name still applied, and the exemption confined to this directive (`stop-in-init=mpi-init` still refused).
- New `test_schizo` case in `contrib/dockerswarm/run-tests.sh`, and run against the swarm: the name reaches both remote processes on node2/node3, and the unnamed form leaves `PMIX_BREAKPOINT` unset. Only a remote node can show that the attribute travelled — recorded local to the HNP it would still read correctly on the head node while every process elsewhere stopped at a place nobody asked for.
- End to end with a test client implementing `ompi_rte_breakpoint`'s shape: a matching name stops the procs and drives the job to `READY_FOR_DEBUG`; a non-matching name runs straight through.

### Note for the Open MPI side

`ompi_rte_breakpoint()` currently reads `OMPI_BREAKPOINT`, not `PMIX_BREAKPOINT`, so named breakpoints will not take effect with today's OMPI until that side is updated. PRRTE deliberately does not also set `OMPI_BREAKPOINT`.