### PR TITLE
Append job-level envar directives instead of overwriting

### DIFF
--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -682,37 +682,40 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
             prte_set_attribute(&jdata->attributes, PRTE_JOB_DEBUG_DAEMONS_PER_PROC,
                                PRTE_ATTR_GLOBAL, &info->value.data.uint16, PMIX_UINT16);
 
-            /* there can be multiple of these, so we add them to the attribute list */
         } else if (PMIX_CHECK_KEY(info, PMIX_ENVARS_HARVESTED)) {
             prte_set_attribute(&jdata->attributes, PRTE_JOB_ENVARS_HARVESTED,
                                PRTE_ATTR_GLOBAL, NULL, PMIX_BOOL);
+
+            /* envar directives are multi-valued, so append: prte_pmix_xfer_app()
+             * has already put app_idx 0's directives on this list under these
+             * keys, and prte_set_attribute() would overwrite the first one */
         } else if (PMIX_CHECK_KEY(info, PMIX_SET_ENVAR)) {
             envar.envar = info->value.data.envar.envar;
             envar.value = info->value.data.envar.value;
             envar.separator = info->value.data.envar.separator;
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_SET_ENVAR,
-                               PRTE_ATTR_GLOBAL, &envar, PMIX_ENVAR);
+            prte_append_attribute(&jdata->attributes, PRTE_JOB_SET_ENVAR,
+                                  PRTE_ATTR_GLOBAL, &envar, PMIX_ENVAR);
         } else if (PMIX_CHECK_KEY(info, PMIX_ADD_ENVAR)) {
             envar.envar = info->value.data.envar.envar;
             envar.value = info->value.data.envar.value;
             envar.separator = info->value.data.envar.separator;
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_ADD_ENVAR,
-                               PRTE_ATTR_GLOBAL, &envar, PMIX_ENVAR);
+            prte_append_attribute(&jdata->attributes, PRTE_JOB_ADD_ENVAR,
+                                  PRTE_ATTR_GLOBAL, &envar, PMIX_ENVAR);
         } else if (PMIX_CHECK_KEY(info, PMIX_UNSET_ENVAR)) {
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_UNSET_ENVAR,
-                               PRTE_ATTR_GLOBAL, info->value.data.string, PMIX_STRING);
+            prte_append_attribute(&jdata->attributes, PRTE_JOB_UNSET_ENVAR,
+                                  PRTE_ATTR_GLOBAL, info->value.data.string, PMIX_STRING);
         } else if (PMIX_CHECK_KEY(info, PMIX_PREPEND_ENVAR)) {
             envar.envar = info->value.data.envar.envar;
             envar.value = info->value.data.envar.value;
             envar.separator = info->value.data.envar.separator;
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_PREPEND_ENVAR,
-                               PRTE_ATTR_GLOBAL, &envar, PMIX_ENVAR);
+            prte_append_attribute(&jdata->attributes, PRTE_JOB_PREPEND_ENVAR,
+                                  PRTE_ATTR_GLOBAL, &envar, PMIX_ENVAR);
         } else if (PMIX_CHECK_KEY(info, PMIX_APPEND_ENVAR)) {
             envar.envar = info->value.data.envar.envar;
             envar.value = info->value.data.envar.value;
             envar.separator = info->value.data.envar.separator;
-            prte_set_attribute(&jdata->attributes, PRTE_JOB_APPEND_ENVAR,
-                               PRTE_ATTR_GLOBAL, &envar, PMIX_ENVAR);
+            prte_append_attribute(&jdata->attributes, PRTE_JOB_APPEND_ENVAR,
+                                  PRTE_ATTR_GLOBAL, &envar, PMIX_ENVAR);
 
         } else if (PMIX_CHECK_KEY(info, PMIX_SPAWN_TOOL)) {
             PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_TOOL);

--- a/test/unit/prted/test_prted.c
+++ b/test/unit/prted/test_prted.c
@@ -200,6 +200,10 @@ static int test_xfer_job_info(void)
     pmix_info_t info[3];
     char *str;
     uint32_t u32, *u32ptr;
+    pmix_envar_t envt;
+    prte_attribute_t *attr;
+    size_t nenvars;
+    bool found_app;
 
     /* a boolean directive lands as a job attribute */
     jdata = fresh_job();
@@ -275,6 +279,38 @@ static int test_xfer_job_info(void)
     CHECK("xfer/unknown-cached",
           prte_get_attribute(&jdata->attributes, PRTE_JOB_INFO_CACHE, NULL, PMIX_POINTER));
     PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_RELEASE(jdata);
+
+    /* envar directives are multi-valued: each must land on the list, and none
+     * may displace one already there under the same key - prte_pmix_xfer_app()
+     * runs first and puts app_idx 0's directives on this same list */
+    jdata = fresh_job();
+    PMIX_ENVAR_CONSTRUCT(&envt);
+    envt.envar = (char *) "APP_LEVEL";
+    envt.value = (char *) "1";
+    prte_append_attribute(&jdata->attributes, PRTE_JOB_SET_ENVAR, PRTE_ATTR_GLOBAL,
+                          &envt, PMIX_ENVAR);
+    envt.envar = (char *) "JOB_LEVEL";
+    envt.value = (char *) "2";
+    PMIX_INFO_LOAD(&info[0], PMIX_SET_ENVAR, &envt, PMIX_ENVAR);
+    envt.envar = (char *) "JOB_LEVEL_2";
+    envt.value = (char *) "3";
+    PMIX_INFO_LOAD(&info[1], PMIX_SET_ENVAR, &envt, PMIX_ENVAR);
+    CHECK("xfer/envar-rc", PRTE_SUCCESS == prte_pmix_xfer_job_info(jdata, info, 2));
+    nenvars = 0;
+    found_app = false;
+    PMIX_LIST_FOREACH(attr, &jdata->attributes, prte_attribute_t) {
+        if (PRTE_JOB_SET_ENVAR == attr->key) {
+            ++nenvars;
+            if (0 == strcmp(attr->data.data.envar.envar, "APP_LEVEL")) {
+                found_app = true;
+            }
+        }
+    }
+    CHECK("xfer/envar-count", 3 == nenvars);
+    CHECK("xfer/envar-preexisting-kept", found_app);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
     PMIX_RELEASE(jdata);
 
     /* an empty directive array is a no-op, not a fault */


### PR DESCRIPTION
`prun` into a persistent DVM drops the first `-x` / `--set-env` of every launch.
`prterun` and `mpirun` are unaffected.

```sh
prte --daemonize --no-ready-msg --report-uri /tmp/uri
prun --dvm-uri file:/tmp/uri -x AAA=1 -x BBB=2 -x CCC=3 -np 1 /usr/bin/env
# BBB=2 and CCC=3 are set; AAA is missing
```

`prte_pmix_xfer_job_info()` recorded the five envar directives with
`prte_set_attribute()`, which overwrites the first attribute already carrying
the key rather than adding another. `prte_pmix_xfer_app()` runs first and, for
`app_idx 0`, appends the app's directives to the same `jdata->attributes` list
under the same `PRTE_JOB_*_ENVAR` keys, so the job-level directive landed on top
of the user's first one.

Only `prun` sends a job-level `PMIX_SET_ENVAR`: it calls
`PMIx_server_setup_application()` itself and forwards the harvested
`PMIX_PARAM_FILE_PASSED=1`. `prterun` and `mpirun` send none, so nothing
overwrote. `--unset-env` appeared to work for the same reason: the harvest emits
no job-level `UNSET_ENVAR`.

Use `prte_append_attribute()` for all five keys. Append rather than prepend
keeps the relative order of multiple job-level directives, which
`PREPEND_ENVAR`/`APPEND_ENVAR` depend on.

Testing: 21/21 unit suites pass, and the new case in `test_xfer_job_info()`
fails without the change. Checked against a persistent DVM: `-x`, `--set-env`,
multiple `-x`, `-x VAR` forwarding, `--unset-env`, `--set-env` +
`--prepend-env` ordering, MPMD, plus `prterun` and `mpirun`.

Credits: AccelCom @ Barcelona Supercomputing Center