### PR TITLE
Terminate the procs on a node released by an elastic shrink

### DIFF
--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -6154,6 +6154,67 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     [ "$out" = node1 ] && ok "prun works post-shrink" || bad "prun broken post-shrink"
     RUN 'pterm' >/dev/null 2>&1; cleanup_swarm
 
+    banner "elastic DVM: a shrink accounts for the procs on the node it releases"
+    # Every shrink above releases an IDLE node.  This one releases a node
+    # carrying a live proc: without the release sweep in
+    # shrink_campaign_complete() nothing marks that proc terminated, its job
+    # never reaches PRTE_JOB_STATE_TERMINATED, and prun never returns.
+    #
+    # The job must SPAN the shrunk node -- one entirely on it dies with it
+    # either way, one that avoids it has nothing to account for.
+    #
+    # Every tool names the DVM by URI: the long-running prun leaves a
+    # rendezvous handle of its own, and bare discovery refuses to choose.
+    cleanup_swarm
+    RUN 'rm -f /tmp/dvm.uri; nohup prte --daemonize --report-uri /tmp/dvm.uri --prtemca prte_elastic_mode 1 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    duri=$(RUN 'head -1 /tmp/dvm.uri' 2>/dev/null | tr -d '\r')
+    if [ -z "$duri" ]; then
+        bad "could not start an elastic DVM for the release-accounting test"
+    else
+        out=$(RUN "PRTE_DVM_URI='$duri' timeout 90 elastic grow node2:2,node3:2" 2>&1)
+        if ! echo "$out" | grep -q PMIX_DVM_IS_READY; then
+            bad "grow did not complete -- cannot test the release accounting: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        else
+            # faulty rather than sleep: its ranks register with PMIx and name
+            # their host on startup, which is how the case knows it spanned
+            # node3.
+            RUN 'rm -f /tmp/shrink-live.out' >/dev/null 2>&1
+            RUN_BG /tmp/shrink-live.out "timeout 180 prun --dvm-uri file:/tmp/dvm.uri -n 3 --map-by ppr:1:node $FLT clean 25"
+            sleep 8
+            if ! RUN 'grep -q " HOST node3" /tmp/shrink-live.out'; then
+                bad "no rank landed on node3: $(RUN 'tr "\n" " " < /tmp/shrink-live.out' | tail -c 200)"
+            else
+                ok "a registered proc is running on the node about to be released"
+                out=$(RUN "PRTE_DVM_URI='$duri' timeout 90 elastic shrink node3" 2>&1)
+                echo "$out" | grep -q PMIX_DVM_IS_READY \
+                    && ok "shrink node3 completed under a live job" \
+                    || bad "shrink did not complete under a live job: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+                # survivors finish at ~25s.  Shorter than prun's own 180s
+                # cap, so a hang cannot be mistaken for a return.
+                n=0
+                while [ "$n" -lt 60 ]; do
+                    RUN 'pgrep -x prun' >/dev/null 2>&1 || break
+                    sleep 1; n=$((n+1))
+                done
+                [ "$n" -lt 60 ] \
+                    && ok "the job completed after its node was released" \
+                    || bad "prun never returned -- the released node's proc was never accounted for"
+                n=$(RUN 'grep -c " DONE " /tmp/shrink-live.out' | tr -d ' \r')
+                [ "${n:-0}" -ge 2 ] \
+                    && ok "...and the survivors finished normally" \
+                    || bad "$n/2 survivors finished: $(RUN 'tr "\n" " " < /tmp/shrink-live.out' | tail -c 200)"
+                RUN 'pgrep -x prte >/dev/null' && ok "...and the HNP survived" \
+                                               || bad "the HNP died on the shrink"
+                out=$(RUN 'timeout 60 prun --dvm-uri file:/tmp/dvm.uri -n 2 --map-by ppr:1:node hostname' 2>&1)
+                [ "$(echo "$out" | grep -cE '^node[12]$')" = 2 ] \
+                    && ok "...and the reduced DVM still runs a job" \
+                    || bad "the reduced DVM could not run a job: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+            fi
+        fi
+        RUN 'timeout -k 5 30 pterm --dvm-uri file:/tmp/dvm.uri' >/dev/null 2>&1
+    fi
+    cleanup_swarm
+
     banner "elastic DVM: a departing tool releases the allocation it reserved"
     # A grow creates a RESERVATION owned by the namespace that asked for it,
     # and every reservation carries a disposition saying what becomes of it

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -811,6 +811,44 @@ void prte_ras_base_shrink_complete(prte_shrink_campaign_t *campaign)
     }
 }
 
+/* Mark the application procs on a released node as terminated.  Nothing else
+ * does: the target daemon's proc-state updates race the routing teardown its
+ * departure starts, and its later comm failure is ignored (errmgr_dvm.c), so
+ * the errmgr's lost-daemon sweep never runs either.  An unaccounted proc holds
+ * its job below PRTE_JOB_STATE_TERMINATED and prterun never shuts the DVM down.
+ *
+ * TERMINATED, not TERM_WO_SYNC: the release is planned.  track_procs() skips a
+ * proc already flagged RECORDED, so a real report is not counted twice.  Runs
+ * before prte_plm_base_reset_dvm_node(), which can drop the map's last
+ * reference to the node. */
+static void release_node_procs(prte_node_t *node)
+{
+    prte_proc_t *proc;
+    int i;
+
+    if (NULL == node || NULL == node->procs) {
+        return;
+    }
+
+    for (i = 0; i < node->procs->size; i++) {
+        proc = (prte_proc_t *) pmix_pointer_array_get_item(node->procs, i);
+        if (NULL == proc) {
+            continue;
+        }
+        /* defensive: only application procs are recorded on a node, but the
+         * daemon job is not ours to account for -- the per-target block owns
+         * the target daemon's teardown */
+        if (PMIX_CHECK_NSPACE(proc->name.nspace, PRTE_PROC_MY_NAME->nspace)) {
+            continue;
+        }
+        PMIX_OUTPUT_VERBOSE((2, prte_ras_base_framework.framework_output,
+                             "%s ras:base:shrink releasing proc %s with node %s",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                             PRTE_NAME_PRINT(&proc->name), node->name));
+        PRTE_ACTIVATE_PROC_STATE(&proc->name, PRTE_PROC_STATE_TERMINATED);
+    }
+}
+
 /* Thread-shift target: collectively complete a DVM shrink campaign.  Runs once
  * per campaign on the DVM master, on a fresh event (posted from the grpcomm
  * xcast-completion callback below) so it never executes nested inside the xcast
@@ -862,6 +900,7 @@ static void shrink_campaign_complete(int sd, short args, void *cbdata)
                 continue;
             }
             node = dproc->node;
+            release_node_procs(node);
             if (PRTE_FLAG_TEST(dproc, PRTE_PROC_FLAG_ALIVE)) {
                 PRTE_FLAG_UNSET(dproc, PRTE_PROC_FLAG_ALIVE);
                 dproc->state = PRTE_PROC_STATE_TERMINATED;


### PR DESCRIPTION
shrink_campaign_complete() removes each target daemon and its node from the
DVM but leaves the application procs on that node unaccounted for. The
departing daemon kills them as it finalizes and nothing reports it: a
proc-state update it might still send races the routing teardown its own
departure starts, and its later comm failure is deliberately ignored for an
already-departed daemon (errmgr_dvm.c:369), so the errmgr's lost-daemon sweep
never runs either. Those procs hold their job below
PRTE_JOB_STATE_TERMINATED, which check_complete_resume() requires of every job
before shutting the DVM down, so an elastic run whose generations are each
followed by a shrink prints its output and then hangs.

Sweep each target node's procs to PRTE_PROC_STATE_TERMINATED before the node
is detached.

- TERMINATED, not TERM_WO_SYNC: the release is planned, and TERM_WO_SYNC
  reports the procs as having exited improperly.
- Ordering: before prte_plm_base_reset_dvm_node(), which can drop the map's
  last reference to the node.
- track_procs() guards the terminal count with PRTE_PROC_FLAG_RECORDED, so a
  real report on either side of the sweep is not counted twice.

The procs being swept are alive when the release lands, not already gone with
their reports lost: instrumenting the departing daemon showed the proc still
registered and running until the daemon finalized, stuck in MPI_Finalize's
closing fence, which cannot complete because the campaign has just cut its
daemon out of the routing tree. So this accounts for a planned kill.

## Testing

- contrib/dockerswarm gains "elastic DVM: a shrink accounts for the procs on
  the node it releases": a job spanning node3, node3 shrunk out from under it,
  prun required to return. The suite runs 566 passed / 8 failed / 4 skipped,
  with every elastic case green.

The eight failures are unrelated to this change and unreachable from it:
release_node_procs() runs only from shrink_campaign_complete(), which is
posted only for an elastic shrink campaign, and none of those cases starts
one. Six are binding assertions meeting the host's topology (procs bound to
hwthread sibling pairs where the checks expect a single cpu, plus a container
that cannot set memory binding), one is --display cpus:parseable emitting two
<processors> documents, and one is --report-child-jobs-separately withholding
a child's status without ever reporting it.

Credits: AccelCom @ Barcelona Supercomputing Center