### PR TITLE
Have prun wait for the jobs its job spawned

### DIFF
--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -2718,7 +2718,7 @@ test_session() {
 #   * an appfile spreading its app contexts over different nodes
 #   * a job's exit status coming back from a proc that ran somewhere else
 test_tools() {
-    local out rc n uri1 uri2 pid1 pid2
+    local out rc n uri1 uri2 pid1 pid2 t0 t1
 
     banner "tools: prte-info reports the same build on every node"
     # Cheap, and it catches the single most confusing swarm failure: some
@@ -2838,6 +2838,90 @@ test_tools() {
 
         RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     fi
+    cleanup_swarm
+
+    banner "tools: prun waits for the jobs its job spawned, as prterun does"
+    # prterun runs its own DVM and shuts it down only once EVERY job in it has
+    # terminated, so it forwards the whole spawn tree's output and returns the
+    # tree's status.  prun asked to be told when its own job ended and left at
+    # that -- so a job dynamically spawned by its job lost its output forwarding
+    # and its exit status the moment the parent finished, even though the job
+    # itself ran happily on.  The DVM now stamps each job-end notification with
+    # the spawn tree it came from and how much of that tree is still running, and
+    # prun waits for the tree.
+    #
+    # This belongs on the swarm rather than in a unit test because the spawned
+    # job is mapped onto a DIFFERENT node from its parent: the tree the tool
+    # waits for spans daemons, and the notification has to cross the DVM to
+    # reach it.
+    #
+    # examples/dynamic.c spawns "client" from its cwd, so the child job is
+    # whatever we put there: a script that outlives its parent and then exits
+    # 7, while the parent itself exits 0.  Both halves of the defect need that
+    # lifetime -- the status prun reports AND the fact that it was still there
+    # to report it.
+    #
+    # The sleep is also what keeps this case off a race that has nothing to do
+    # with what it is testing: dynamic follows its spawn with a PMIx_Get of the
+    # child's job size and a PMIx_Connect to it, and against a child that has
+    # ALREADY exited those occasionally never return, hanging the parent.  A
+    # child that is still running when its parent asks about it is both the
+    # honest shape of this test and the one that does not flake.
+    for n in 1 2 3; do
+        ON $n 'rm -rf /tmp/dyn && mkdir -p /tmp/dyn &&
+               printf "#!/bin/sh\nsleep 15\nexit 7\n" > /tmp/dyn/client && chmod +x /tmp/dyn/client' >/dev/null 2>&1
+    done
+    if prted_dvm_start 'node1:2,node2:2,node3:2'; then
+        t0=$(date +%s)
+        out=$(RUN "cd /tmp/dyn && timeout 90 prun --dvm-uri file:$PRTED_URI -np 1 dynamic" 2>&1); rc=$?
+        t1=$(date +%s)
+        if ! echo "$out" | grep -q 'Spawn success'; then
+            bad "prun could not spawn a child job -- the rest of this case is meaningless: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        else
+            ok "prun's job spawned a child job"
+            # THE regression, both halves.  prun used to leave when its own job
+            # ended: it came back in well under the child's lifetime, and with
+            # 0 because it never learned what the child returned.
+            # The threshold is well clear of both sides: prun without the fix
+            # comes back in about 5s -- the parent job's own life -- and with
+            # it in about 20s, the child's.
+            [ $((t1 - t0)) -ge 10 ] \
+                && ok "prun stayed for the spawned job's whole life ($((t1 - t0))s)" \
+                || bad "prun returned in $((t1 - t0))s, before the child it spawned had finished"
+            [ "$rc" = 7 ] \
+                && ok "prun returns the spawned job's status, as prterun does (rc=$rc)" \
+                || bad "prun abandoned the job its job spawned -- expected 7, got rc=$rc"
+
+            # ...and the same directive that governs prterun's answer governs
+            # prun's, which is a decision prun now has to make for itself: the
+            # DVM is persistent, so it cannot make it for everyone.
+            out=$(RUN "cd /tmp/dyn && timeout 90 prun --dvm-uri file:$PRTED_URI --runtime-options report-child-jobs-separately -np 1 dynamic" 2>&1); rc=$?
+            [ "$rc" = 0 ] \
+                && ok "with report-child-jobs-separately prun returns the PRIMARY job's status (rc=0)" \
+                || bad "prun did not withhold the child's status (rc=$rc)"
+            echo "$out" | grep -q 'Child job' \
+                && ok "and prun still reports the child's status to the user" \
+                || bad "prun withheld the child's status AND never reported it: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        fi
+
+        # A tool must wait for ITS OWN tree and nobody else's.  An unfiltered
+        # job-end handler is how prun gets to see its descendants at all, so the
+        # thing to prove is that it does not also make it wait on a stranger:
+        # a 45s job under another prun must not delay this one.
+        PRUN_BG /tmp/otherprun.out '--host node3:1 -np 1 sleep 45'
+        sleep 3
+        t0=$(date +%s)
+        RUN "timeout -k 5 60 prun --dvm-uri file:$PRTED_URI --host node2:1 -np 1 hostname" >/dev/null 2>&1
+        t1=$(date +%s)
+        [ $((t1 - t0)) -lt 25 ] \
+            && ok "a prun is not held up by another user's job on the same DVM ($((t1 - t0))s)" \
+            || bad "prun waited on a job outside its own spawn tree ($((t1 - t0))s)"
+        RUN "timeout -k 5 30 pterm --dvm-uri file:$PRTED_URI" >/dev/null 2>&1
+        sleep 3
+    else
+        bad "could not start a persistent DVM for the prun spawn-tree case"
+    fi
+    for n in 1 2 3; do ON $n 'rm -rf /tmp/dyn' >/dev/null 2>&1; done
     cleanup_swarm
 }
 

--- a/docs/launching-apps/index.rst
+++ b/docs/launching-apps/index.rst
@@ -28,6 +28,17 @@ The rest of this section usually refers only to ``prterun``, even though the
 same discussions also apply to ``prun`` because the command line syntax
 is identical.
 
+.. note:: "Until the application completes" includes anything the application
+          *spawns*. A job started with ``PMIx_Spawn`` (or ``MPI_Comm_spawn``)
+          outlives the job that started it by default, and both commands wait
+          for the whole spawn tree: output from every job in the tree is
+          forwarded, and the exit status reported is the first non-zero status
+          returned by any of them |mdash| the primary job or anything
+          descended from it. Use the ``report-child-jobs-separately`` runtime
+          option (``prterun --help runtime-options``) to have only the primary
+          job's status decide the command's exit status, with a spawned job's
+          non-zero status reported on its own instead.
+
 
 .. toctree::
    :maxdepth: 1

--- a/src/mca/state/AGENTS.md
+++ b/src/mca/state/AGENTS.md
@@ -380,6 +380,16 @@ defaults it reads are this framework's MCA params.
 > param. The `!prte_persistent` gate on that copy matches where it is
 > read: only a one-shot DVM reports an exit status, so a job spawned into
 > a persistent DVM cannot change the policy for everyone else.
+>
+> On a **persistent** DVM the same policy therefore has to be applied by
+> the *tool*, which is the process that has an exit status to report, and
+> `prun` does it with `prte_state_base_report_child_sep()` — the reader
+> that lives beside the walk in `state_base_options.c` so the directive has
+> one spelling and one set of truth rules. The DVM sends `prun` the facts
+> it needs and no policy: `dvm_notify()` stamps every `PMIX_EVENT_JOB_END`
+> with `PMIX_SPAWN_TREE_ROOT` (`prte_job_t::launcher`, or the job itself
+> when nothing spawned it) and `PMIX_SPAWN_TREE_ACTIVE` (how many jobs in
+> that tree have yet to terminate). See `src/prted/AGENTS.md`.
 
 > **Do not use the directive loop's index as a scratch variable.** The
 > walk is `for (n = 0; NULL != options[n]; n++)`. Two branches used to
@@ -494,7 +504,7 @@ states invoke.
 
 | Layer | Where | Covers |
 |-------|-------|--------|
-| Unit | [`test/unit/state/test_state.c`](../../../test/unit/state/test_state.c) (`make check`) | the table API and its return protocol; dispatch incl. the ERROR/ANY fallback ordering and the NULL-cbfunc/NULL-proc guards; the caddy initialization contract (the NULL-job case above); `set_runtime_options` directive parsing — boolean sense, directive ordering, unknown/bad-combination refusals; per-role component selection. |
+| Unit | [`test/unit/state/test_state.c`](../../../test/unit/state/test_state.c) (`make check`) | the table API and its return protocol; dispatch incl. the ERROR/ANY fallback ordering and the NULL-cbfunc/NULL-proc guards; the caddy initialization contract (the NULL-job case above); `set_runtime_options` directive parsing — boolean sense, directive ordering, unknown/bad-combination refusals; `prte_state_base_report_child_sep()` agreeing with that walk on every spelling of the directive; per-role component selection. |
 | Multi-node | `test_state` in [`contrib/dockerswarm/run-tests.sh`](../../../contrib/dockerswarm/run-tests.sh) | the runtime-option directives end-to-end through `prterun` (a real forked child is what makes the boolean sense observable, via `odls`); **`report-child-jobs-separately` against a real parent/child job pair** (see below); a `NULL`-job `NEVER_LAUNCHED` reaching the errmgr fallback and tearing the DVM down promptly instead of hanging; and `check_complete`'s resource accounting, which only shows up as successive jobs re-filling the same allocation on one persistent DVM. |
 
 Testing a policy that discriminates between a **primary** job and one it

--- a/src/mca/state/base/base.h
+++ b/src/mca/state/base/base.h
@@ -59,6 +59,7 @@ PRTE_EXPORT void prte_state_base_print_job_state_machine(void);
 PRTE_EXPORT void prte_state_base_print_proc_state_machine(void);
 
 PRTE_EXPORT int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec);
+PRTE_EXPORT bool prte_state_base_report_child_sep(const char *spec);
 
 /*
  * Base functions

--- a/src/mca/state/base/state_base_options.c
+++ b/src/mca/state/base/state_base_options.c
@@ -72,6 +72,49 @@ static void set_bool_option(prte_job_t *jdata, prte_attribute_key_t key, bool fl
     }
 }
 
+/* Does SPEC - a runtime-option string as it came off a command line - ask
+ * that the exit status of child jobs be reported separately?
+ *
+ * The DVM answers this for itself from the attribute the walk below records,
+ * but a launcher driving a PERSISTENT DVM has to answer it for its own exit
+ * status, in its own process, with no job object anywhere near it.  The
+ * reader lives here beside the writer so that the directive has one spelling
+ * and one set of truth rules; a private copy in the tool would go stale the
+ * first time either changed.
+ *
+ * Anything malformed reads as "no".  This is not where a bad command line is
+ * diagnosed - the DVM does that, with the message and the failure - and
+ * answering twice would only mean saying it twice. */
+bool prte_state_base_report_child_sep(const char *spec)
+{
+    char **options, *ptr;
+    pmix_value_t value;
+    bool flag = false;
+    int n;
+
+    if (NULL == spec) {
+        return false;
+    }
+    options = PMIx_Argv_split(spec, ',');
+    for (n = 0; NULL != options[n]; n++) {
+        ptr = strchr(options[n], '=');
+        if (NULL != ptr) {
+            *ptr = '\0';
+            ++ptr;
+        }
+        if (!PMIX_CHECK_CLI_OPTION(options[n], PRTE_CLI_REPORT_CHILD_SEP)) {
+            continue;
+        }
+        /* the same pair the walk below uses, so a value this says "true" to
+         * is exactly one that sets the attribute there */
+        PMIX_VALUE_LOAD(&value, ptr, PMIX_STRING);
+        flag = PMIX_CHECK_TRUE(&value);
+        PMIX_VALUE_DESTRUCT(&value);
+    }
+    PMIx_Argv_free(options);
+    return flag;
+}
+
 /* this function is called if pmix_server_dyn receives a
  * PMIX_RUNTIME_OPTIONS info struct */
 int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -1106,6 +1106,77 @@ static void cleanup_job(int sd, short args, void *cbdata)
     PMIX_RELEASE(caddy);
 }
 
+#ifdef PMIX_SPAWN_TREE_ROOT
+/* Do these two namespaces name the same thing?
+ *
+ * NOT PMIX_CHECK_NSPACE, which answers "true" the moment either side is
+ * empty - wildcard semantics that are right for a match against a request
+ * and wrong here.  Most jobs in a DVM carry an empty launcher, and reading
+ * every one of them as a member of whatever tree we are asking about would
+ * put a stranger's job in a tool's wait set. */
+static bool same_nspace(const char *a, const char *b)
+{
+    if (PMIX_NSPACE_INVALID(a) || PMIX_NSPACE_INVALID(b)) {
+        return false;
+    }
+    return (0 == strncmp(a, b, PMIX_MAX_NSLEN));
+}
+
+/* The root of the spawn tree JDATA belongs to.  prte_job_t::launcher already
+ * holds it, recorded when the job was created and copied transitively from
+ * the parent, so a grandchild names the same root as its parent does.  It is
+ * empty only for a job nobody spawned - the primary job of a prterun, or of a
+ * prun whose tool namespace never got a job object - and such a job is the
+ * root of its own tree. */
+static const char *spawn_tree_root(prte_job_t *jdata)
+{
+    if (PMIX_NSPACE_INVALID(jdata->launcher)) {
+        return jdata->nspace;
+    }
+    return jdata->launcher;
+}
+
+/* How many jobs in ROOT's spawn tree have yet to terminate, not counting
+ * JDATA, whose termination is being reported.
+ *
+ * A job is in the tree if it names ROOT as its launcher, or if it IS the root
+ * - the latter matters when the root is a job rather than a tool, so that a
+ * child ending while its parent is still alive does not report an empty tree.
+ * Tool job objects are skipped: a tool is a namespace the DVM tracks, not a
+ * job that ever reaches a terminal state, so counting one would leave the
+ * tree permanently non-empty.
+ *
+ * "Not yet terminated" is the same test check_complete() applies when a
+ * non-persistent DVM decides whether it can shut down, and deliberately so:
+ * the whole point is that a tool watching a persistent DVM can now wait for
+ * exactly what prterun waits for. */
+static uint32_t spawn_tree_active(prte_job_t *jdata, const char *root)
+{
+    prte_job_t *jptr;
+    uint32_t count = 0;
+    int i;
+
+    for (i = 0; i < prte_job_data->size; i++) {
+        jptr = (prte_job_t *) pmix_pointer_array_get_item(prte_job_data, i);
+        if (NULL == jptr || jptr == jdata) {
+            continue;
+        }
+        if (PMIX_CHECK_NSPACE(jptr->nspace, PRTE_PROC_MY_NAME->nspace) ||
+            PRTE_FLAG_TEST(jptr, PRTE_JOB_FLAG_TOOL)) {
+            continue;
+        }
+        if (!same_nspace(jptr->launcher, root) &&
+            !same_nspace(jptr->nspace, root)) {
+            continue;
+        }
+        if (jptr->state < PRTE_JOB_STATE_TERMINATED) {
+            ++count;
+        }
+    }
+    return count;
+}
+#endif
+
 static void dvm_notify(int sd, short args, void *cbdata)
 {
     prte_state_caddy_t *caddy = (prte_state_caddy_t *) cbdata;
@@ -1125,6 +1196,10 @@ static void dvm_notify(int sd, short args, void *cbdata)
     pmix_data_range_t range = PMIX_RANGE_SESSION;
     pmix_status_t code, ret;
     char *errmsg = NULL;
+#ifdef PMIX_SPAWN_TREE_ROOT
+    const char *treeroot;
+    uint32_t treeactive;
+#endif
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
     PMIX_OUTPUT_VERBOSE((2, prte_state_base_framework.framework_output,
@@ -1201,6 +1276,18 @@ static void dvm_notify(int sd, short args, void *cbdata)
         if (0 < xcode) {
             ++ninfo;
         }
+#ifdef PMIX_SPAWN_TREE_ROOT
+        /* Which spawn tree this job belonged to, and what is left of it.
+         * A tool that launched the root of the tree cannot work either out
+         * for itself: it is told when a job ends, never when one starts, so
+         * at the moment its own job ends it has no way to know whether
+         * anything it started is still running - nor, when some later job
+         * ends, whether that job descended from it or belongs to another
+         * user of the same persistent DVM. */
+        treeroot = spawn_tree_root(jdata);
+        treeactive = spawn_tree_active(jdata, treeroot);
+        ninfo += 2;
+#endif
         PMIX_INFO_CREATE(info, ninfo);
         n = 0;
         /* ensure this only goes to the job terminated event handler */
@@ -1216,6 +1303,10 @@ static void dvm_notify(int sd, short args, void *cbdata)
             pname.rank = PMIX_RANK_WILDCARD;
         }
         PMIX_INFO_LOAD(&info[n++], PMIX_EVENT_AFFECTED_PROC, &pname, PMIX_PROC);
+#ifdef PMIX_SPAWN_TREE_ROOT
+        PMIX_INFO_LOAD(&info[n++], PMIX_SPAWN_TREE_ROOT, treeroot, PMIX_STRING);
+        PMIX_INFO_LOAD(&info[n++], PMIX_SPAWN_TREE_ACTIVE, &treeactive, PMIX_UINT32);
+#endif
         /* and what the application exited with, when that is a thing */
         if (0 < xcode) {
             PMIX_INFO_LOAD(&info[n++], PMIX_EXIT_CODE, &xcode, PMIX_INT);

--- a/src/prted/AGENTS.md
+++ b/src/prted/AGENTS.md
@@ -279,6 +279,41 @@ report the job's exit status. Signal forwarding is done with
 which is what eventually arrives at `prted_comm.c`'s
 `SIGNAL_LOCAL_PROCS`.
 
+**"The job" means the whole spawn tree, and the `PMIX_EVENT_JOB_END`
+handler is deliberately *not* filtered to our own namespace.** A job
+spawned by ours outlives it by default, so our job's termination is not
+the end of what we launched — and `prterun`, which owns its DVM and shuts
+it down only once every job in it has terminated, waits for the lot and
+returns what the lot came back with. Filtering the handler with
+`PMIX_EVENT_AFFECTED_PROC` hid exactly the events needed to match that:
+the spawned job's termination names the *spawned* job, so `prun` left the
+moment its own job ended, and the spawned job's output and exit status
+went nowhere. So the handler now takes every job end in the session and
+sorts them out itself:
+
+- **Whose is it?** `ours()` accepts our own namespace, plus anything whose
+  `PMIX_SPAWN_TREE_ROOT` is our tool namespace (the DVM builds a job object
+  for a connected tool and roots the tree there) or our job's namespace
+  (where it did not). Everything else is another user's work on a shared
+  persistent DVM and must not make us wait.
+- **Are we done?** `PMIX_SPAWN_TREE_ACTIVE` — how many jobs in that tree
+  have yet to terminate. This is the part a tool cannot compute: it is
+  told when a job *ends*, never when one starts, so at its own job's end it
+  has no way to know whether to keep waiting. Zero is sound as a terminal
+  condition rather than merely likely, because a job can only be spawned by
+  a process that is still running.
+- **What do we exit with?** The first non-zero status from anywhere in the
+  tree, unless `report-child-jobs-separately` is in effect, in which case
+  only the primary job decides and a child's non-zero status is reported on
+  its own. The DVM cannot make that call on a persistent DVM — it is one
+  launcher's policy, not the run's — so `prun` reads the directive off its
+  own command line with `prte_state_base_report_child_sep()`.
+
+Note where the child-status messages are rendered: the handler runs on the
+**PMIx** progress thread, so it only records them, and `prun_common()`
+walks the list and calls `prte_show_help()` after the wait completes and
+the handler has been deregistered.
+
 **It also closes the `ess` framework its caller opened, and the ordering
 is load-bearing: every PRRTE framework must be closed while PMIx is still
 up.** PRRTE has no component repository of its own — its components are
@@ -320,6 +355,14 @@ job's procs, a tool connecting through a non-master daemon, a signal that
 must reach one job and not another, a shrink that has to ACK before it
 departs. `run-tests.sh`'s `test_prted()` covers these; see
 [`contrib/dockerswarm/AGENTS.md`](../../contrib/dockerswarm/AGENTS.md).
+
+`prun`'s spawn-tree wait is here too, under the `src/tools` banner, and
+belongs on the swarm rather than in a unit test for a specific reason: the
+spawned job is mapped onto a *different node* from its parent, so the tree
+the tool waits for spans daemons and the notification has to cross the DVM
+to reach it. The case also proves the other half — that an unfiltered
+job-end handler does **not** make one `prun` wait on another `prun`'s job
+on the same persistent DVM.
 
 ---
 

--- a/src/prted/prun_common.c
+++ b/src/prted/prun_common.c
@@ -114,6 +114,40 @@ static pmix_nspace_t spawnednspace;
  * job used to come back as 71 - the low byte of PRTE_ERROR. */
 static int job_exit_code = -1;
 
+/* Our own job's termination is not the end of the work we started: a job it
+ * spawned outlives it by default, and prterun - which runs its own DVM and
+ * shuts it down only once every job in it has terminated - waits for the
+ * whole tree and returns what the tree came back with.  We are the same
+ * launcher talking to a DVM somebody else owns, so we have to wait for the
+ * same thing by watching for it.  The DVM stamps each PMIX_EVENT_JOB_END
+ * with the root of the spawn tree the job belonged to and the number of jobs
+ * in that tree still running; what follows is what we make of that.
+ *
+ * Whether a child job's status is reported on its own instead of becoming
+ * ours.  Read from our command line before the spawn, on the main thread. */
+static bool report_child_sep = false;
+
+/* The first non-zero termination status seen anywhere in the tree, and the
+ * first message that came with one - what we hand the waiting main thread
+ * once the tree has drained.
+ *
+ * These three, and the list below, are written by the event handler on the
+ * PMIx progress thread and read by the main thread only after the wait that
+ * handler wakes has completed and the handler has been deregistered.  None
+ * of them is a PRRTE object, so nothing here is touched from the wrong
+ * thread. */
+static int status_from_tree = 0;
+static char *tree_msg = NULL;
+
+/* a child job's exit status, held for reporting once we are back on the main
+ * thread - show_help is not ours to call from the PMIx progress thread */
+typedef struct child_status_t {
+    struct child_status_t *next;
+    pmix_nspace_t nspace;
+    int code;
+} child_status_t;
+static child_status_t *child_statuses = NULL;
+
 static size_t evid = INT_MAX;
 static pmix_proc_t myproc;
 static bool verbose = false;
@@ -212,14 +246,40 @@ progress:
     }
 }
 
+/* Is JOBID, whose end the DVM just reported with spawn-tree root ROOT, part
+ * of the tree we launched?
+ *
+ * Our own job is, by name.  Beyond that a descendant is recognized by its
+ * root, which for anything we started is either the namespace we hold as a
+ * tool - the DVM builds a job object for a connected tool and roots the tree
+ * there - or, where it did not, our job's own namespace.  Everything else
+ * belongs to another user of the same persistent DVM and is none of our
+ * business: an unfiltered handler is how we get to see our descendants at
+ * all, and this is what keeps it from making us wait on strangers. */
+static bool in_our_tree(const char *jobid, const char *root)
+{
+    if (0 == strncmp(jobid, spawnednspace, PMIX_MAX_NSLEN)) {
+        return true;
+    }
+    if (NULL == root || '\0' == root[0]) {
+        return false;
+    }
+    return (0 == strncmp(root, myproc.nspace, PMIX_MAX_NSLEN) ||
+            0 == strncmp(root, spawnednspace, PMIX_MAX_NSLEN));
+}
+
 static void evhandler(size_t evhdlr_registration_id, pmix_status_t status,
                       const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
                       pmix_info_t *results, size_t nresults,
                       pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
 {
     prte_pmix_lock_t *lock = NULL;
-    int jobstatus = 0;
+    int jobstatus = 0, xcode = -1;
     pmix_nspace_t jobid = {0};
+    char *root = NULL;
+    uint32_t active = 0;
+    bool primary;
+    child_status_t *cs;
     size_t n;
     char *msg = NULL;
     PRTE_HIDE_UNUSED_PARAMS(evhdlr_registration_id, source, results, nresults);
@@ -237,29 +297,85 @@ static void evhandler(size_t evhdlr_registration_id, pmix_status_t status,
             } else if (0 == strncmp(info[n].key, PMIX_EXIT_CODE, PMIX_MAX_KEYLEN)) {
                 /* the application's own status - preferred over the
                  * termination reason when we come to exit */
-                job_exit_code = info[n].value.data.integer;
+                xcode = info[n].value.data.integer;
             } else if (0 == strncmp(info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN)) {
                 PMIX_LOAD_NSPACE(jobid, info[n].value.data.proc->nspace);
             } else if (0 == strncmp(info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
                 lock = (prte_pmix_lock_t *) info[n].value.data.ptr;
+#ifdef PMIX_SPAWN_TREE_ROOT
+            } else if (0 == strncmp(info[n].key, PMIX_SPAWN_TREE_ROOT, PMIX_MAX_KEYLEN)) {
+                root = info[n].value.data.string;
+            } else if (0 == strncmp(info[n].key, PMIX_SPAWN_TREE_ACTIVE, PMIX_MAX_KEYLEN)) {
+                active = info[n].value.data.uint32;
+#endif
             } else if (0 == strncmp(info[n].key, PMIX_EVENT_TEXT_MESSAGE, PMIX_MAX_KEYLEN)) {
                 msg = info[n].value.data.string;
             }
         }
-        if (verbose && PMIX_CHECK_NSPACE(jobid, spawnednspace)) {
-            pmix_output(0, "JOB %s COMPLETED WITH STATUS %d", PRTE_JOBID_PRINT(jobid), jobstatus);
+    }
+
+    if (!in_our_tree(jobid, root)) {
+        /* somebody else's job on a DVM we share */
+        goto progress;
+    }
+    primary = (0 == strncmp(jobid, spawnednspace, PMIX_MAX_NSLEN));
+
+    if (verbose) {
+        pmix_output(0, "JOB %s COMPLETED WITH STATUS %d, %u LEFT IN TREE",
+                    PRTE_JOBID_PRINT(jobid), jobstatus, active);
+    }
+
+    /* Fold this job's result into what we will exit with.  The rule is
+     * prterun's: the FIRST non-zero status wins, so a job that failed is not
+     * overwritten by one that later succeeded - unless the user asked for
+     * child jobs to be reported separately, in which case only the primary
+     * job decides our status and a child's failure is reported on its own. */
+    if (primary || !report_child_sep) {
+        if (0 >= job_exit_code && 0 < xcode) {
+            job_exit_code = xcode;
         }
+        if (0 == status_from_tree && 0 != jobstatus) {
+            status_from_tree = jobstatus;
+        }
+    } else if (0 < xcode) {
+        /* 0 < , not 0 != : xcode starts at -1 meaning "the DVM reported
+         * none", which is what a job that exited cleanly leaves it at */
+        cs = (child_status_t *) malloc(sizeof(child_status_t));
+        if (NULL != cs) {
+            PMIX_LOAD_NSPACE(cs->nspace, jobid);
+            cs->code = xcode;
+            cs->next = child_statuses;
+            child_statuses = cs;
+        }
+    }
+    if (NULL != msg && NULL == tree_msg) {
+        tree_msg = strdup(msg);
+    }
+
+    /* Wait until the tree is empty.  A job can only be spawned by a process
+     * that is still running, so a tree with nothing left in it cannot
+     * acquire anything more, and this is the last event we will get. */
+    if (0 < active) {
+        goto progress;
+    }
+
+    if (NULL == lock) {
+        /* the event did not carry the object we registered - fall back to
+         * the lock the main thread is actually parked on */
+        lock = release_lock;
     }
     if (NULL != lock) {
         /* save the status */
-        lock->status = jobstatus;
-        if (NULL != msg) {
-            lock->msg = strdup(msg);
+        lock->status = status_from_tree;
+        if (NULL != tree_msg) {
+            lock->msg = tree_msg;
+            tree_msg = NULL;
         }
         /* release the lock */
         PRTE_PMIX_WAKEUP_THREAD(lock);
     }
 
+progress:
     /* we _always_ have to execute the evhandler callback or
      * else the event progress engine will hang */
     if (NULL != cbfunc) {
@@ -774,25 +890,30 @@ int prun_common(pmix_cli_result_t *results,
         PMIX_INFO_FREE(iptr, 1);
     }
 
-    /* register to be notified when
-     * our job completes */
+    /* Register to be notified when the work we started completes.
+     *
+     * NOT filtered to our own namespace with PMIX_EVENT_AFFECTED_PROC, which
+     * is what this used to do and is the whole reason a job dynamically
+     * spawned by ours was abandoned the moment ours ended: the spawned job's
+     * termination names the spawned job, so the filter hid exactly the
+     * events we most needed.  We take every job end the session reports and
+     * sort out which are ours in the handler, where the spawn-tree root the
+     * DVM stamps on each one makes that a string compare. */
     ret = PMIX_EVENT_JOB_END;
     /* setup the info */
-    ninfo = 3;
+    ninfo = 2;
     PMIX_INFO_CREATE(iptr, ninfo);
     /* give the handler a name */
     PMIX_INFO_LOAD(&iptr[0], PMIX_EVENT_HDLR_NAME, "JOB_TERMINATION_EVENT", PMIX_STRING);
-    /* specify we only want to be notified when our
-     * job terminates */
-    PMIX_LOAD_PROCID(&pname, spawnednspace, PMIX_RANK_WILDCARD);
-    PMIX_INFO_LOAD(&iptr[1], PMIX_EVENT_AFFECTED_PROC, &pname, PMIX_PROC);
     /* request that they return our lock object */
-    PMIX_INFO_LOAD(&iptr[2], PMIX_EVENT_RETURN_OBJECT, &rellock, PMIX_POINTER);
+    PMIX_INFO_LOAD(&iptr[1], PMIX_EVENT_RETURN_OBJECT, &rellock, PMIX_POINTER);
     /* do the registration */
     PRTE_PMIX_CONSTRUCT_LOCK(&lock);
     PMIx_Register_event_handler(&ret, 1, iptr, ninfo, evhandler, regcbfunc, &lock);
     PRTE_PMIX_WAIT_THREAD(&lock);
     PRTE_PMIX_DESTRUCT_LOCK(&lock);
+    /* the registration copied these */
+    PMIX_INFO_FREE(iptr, ninfo);
 
     if (verbose) {
         pmix_output(0, "JOB %s EXECUTING", PRTE_JOBID_PRINT(spawnednspace));
@@ -817,6 +938,19 @@ int prun_common(pmix_cli_result_t *results,
     PRTE_PMIX_DESTRUCT_LOCK(&lock);
     PRTE_PMIX_DESTRUCT_LOCK(&rellock);
 
+    /* Report any child job that ended non-zero while "report child jobs
+     * separately" was in effect.  Held until here rather than said as it
+     * happened: the handler that collected these runs on the PMIx progress
+     * thread, and show_help is not ours to call from there.  The handler is
+     * deregistered by now, so nothing is still writing this list. */
+    while (NULL != child_statuses) {
+        child_status_t *cs = child_statuses;
+        child_statuses = cs->next;
+        prte_show_help("help-state-base.txt", "child-job-status", true,
+                       PRTE_LOCAL_JOBID_PRINT(cs->nspace), cs->code);
+        free(cs);
+    }
+
     /* close the push of our stdin */
     PMIX_INFO_LOAD(&info, PMIX_IOF_COMPLETE, NULL, PMIX_BOOL);
     PRTE_PMIX_CONSTRUCT_LOCK(&lock);
@@ -832,6 +966,17 @@ int prun_common(pmix_cli_result_t *results,
 DONE:
     /* the release lock is about to leave scope */
     release_lock = NULL;
+    /* an abort message we never got to hand to a waiter - the DVM went away
+     * before the tree drained */
+    if (NULL != tree_msg) {
+        free(tree_msg);
+        tree_msg = NULL;
+    }
+    while (NULL != child_statuses) {
+        child_status_t *cstmp = child_statuses;
+        child_statuses = cstmp->next;
+        free(cstmp);
+    }
     PMIX_LIST_FOREACH(evitm, &forwarded_signals, prte_event_list_item_t)
     {
         prte_event_signal_del(&evitm->ev);
@@ -945,9 +1090,20 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
     opt = pmix_cmd_line_get_param(results, PRTE_CLI_RTOS);
     if (NULL != opt) {
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_RUNTIME_OPTIONS, opt->values[0], PMIX_STRING);
+        /* one of these is ours to act on as well: it decides whether a child
+         * job's exit status becomes OUR exit status, and we are the process
+         * that has one.  The DVM reads the same directive for its own answer
+         * when it is the launcher; here nobody else can.  The MCA param has
+         * the same standing it has there - set, it wins outright. */
+        report_child_sep = prte_report_child_jobs_separately ||
+                           prte_state_base_report_child_sep(opt->values[0]);
     } else if (NULL != prte_schizo_base.default_runtime_options) {
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_RUNTIME_OPTIONS,
                            prte_schizo_base.default_runtime_options, PMIX_STRING);
+        report_child_sep = prte_report_child_jobs_separately ||
+                           prte_state_base_report_child_sep(prte_schizo_base.default_runtime_options);
+    } else {
+        report_child_sep = prte_report_child_jobs_separately;
     }
 
     /* check what user wants us to do with stdin */

--- a/test/unit/state/test_state.c
+++ b/test/unit/state/test_state.c
@@ -544,6 +544,62 @@ static int test_runtime_options(void)
 }
 
 /*
+ * prte_state_base_report_child_sep() reads the same directive the walk above
+ * records, but for a caller with no job object: a launcher driving a
+ * persistent DVM, deciding whether a child job's exit status becomes its own.
+ *
+ * The one thing that matters about it is that it AGREES with the walk.  Two
+ * readers of one directive that disagree would make "prun --runtime-options
+ * report-child-jobs-separately" and "prterun ..." return different exit
+ * statuses for the same run, which is the failure the directive exists to
+ * prevent.  So every case below is asserted against the attribute the walk
+ * leaves behind, not against a hand-written expectation.
+ */
+static int test_report_child_sep_reader(void)
+{
+    int failures = 0;
+    prte_job_t *jdata;
+    char *spec;
+    bool viawalk;
+    size_t n;
+    /* the spellings a command line can carry, including one that names the
+     * directive alongside others and one that does not name it at all */
+    const char *specs[] = {
+        "report-child-jobs-separately",
+        "report-child-jobs-separately=true",
+        "report-child-jobs-separately=false",
+        "recoverable,report-child-jobs-separately,notifyerrors",
+        "recoverable,report-child-jobs-separately=false",
+        "timeout=60",
+        NULL
+    };
+
+    for (n = 0; NULL != specs[n]; n++) {
+        jdata = PMIX_NEW(prte_job_t);
+        PMIX_LOAD_NSPACE(jdata->nspace, "unit-test-rcsr");
+        /* set_runtime_options edits the string it is given, so each reader
+         * gets its own copy */
+        spec = strdup(specs[n]);
+        CHECK(specs[n], PRTE_SUCCESS == prte_state_base_set_runtime_options(jdata, spec));
+        free(spec);
+        viawalk = prte_get_attribute(&jdata->attributes, PRTE_JOB_REPORT_CHILD_SEP,
+                                     NULL, PMIX_BOOL);
+        spec = strdup(specs[n]);
+        CHECK(specs[n], viawalk == prte_state_base_report_child_sep(spec));
+        free(spec);
+        PMIX_RELEASE(jdata);
+    }
+
+    /* a caller with nothing to read is not asking for it */
+    CHECK("no spec reads as false", !prte_state_base_report_child_sep(NULL));
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_report_child_sep_reader\n");
+    }
+    return failures;
+}
+
+/*
  * "stop-in-app" is the one runtime option whose value is not a truth value.
  * Written bare or with a boolean it asserts "stop wherever the application
  * chooses"; written with anything else, that text is the string ID of the
@@ -735,6 +791,7 @@ int main(void)
     failures += test_proc_dispatch();
     failures += test_caddy_contract();
     failures += test_runtime_options();
+    failures += test_report_child_sep_reader();
     failures += test_stop_in_app();
     failures += test_component_selection();
 


### PR DESCRIPTION
Fixes #2682.

### The problem

`prterun` runs its own DVM and shuts it down only once every job in it has terminated, so a job dynamically spawned with `MPI_Comm_spawn` is waited for: its output is forwarded for as long as it runs, and its exit status comes back as `prterun`'s. `prun` did none of that. It asked to be told when its own job ended and left when it was, so the moment the parent finished, the spawned job's output went nowhere and its status was unreachable — the job itself ran happily on to completion, unaware that nobody was listening any more. Same program, same DVM, two different answers depending on which command started it.

Measured with the issue's reproducer (`examples/dynamic.c`, parent exits 0, child exits 7):

| | before | after | `prterun` |
|---|---|---|---|
| exit status | **0** | **7** | 7 |
| spawned job's output | lost at parent's end | forwarded | forwarded |

**It is two defects, not one.** The issue names the lifetime half. The exit status is a second one that the first was hiding: with the parent made to linger so `prun` stayed connected and saw the child's entire life, output and all, it still exited 0 while the child exited 3. A child's status was never folded in, because `state_dvm.c`'s aggregation is gated on `!prte_persistent` — a persistent DVM computes no tree status for anybody.

### The change

The DVM already tracks what `prun` needs and never told it. `prte_job_t::launcher` has recorded the root of the spawn tree since the job was created, and it is copied transitively, so a grandchild names the same root as its parent. For a `prun` launch that root is **`prun`'s own tool namespace** — the DVM builds a job object for a connected tool (`PRTE_JOB_FLAG_TOOL`) and `prte_plm_base_recv()` roots the tree there — so the tool already holds the identifier it needs.

* **DVM** — `dvm_notify()` stamps every `PMIX_EVENT_JOB_END` with `PMIX_SPAWN_TREE_ROOT` and `PMIX_SPAWN_TREE_ACTIVE` (openpmix/openpmix#4167). The count is a walk of `prte_job_data` applying the same "not yet terminated" test `check_complete()` uses when a one-shot DVM decides it can shut down. The namespace comparison is a strict one rather than `PMIX_CHECK_NSPACE`, whose wildcard reading of an empty namespace would have swept every unspawned job in the DVM into whatever tree was being asked about.
* **prun** — the job-end handler loses its `PMIX_EVENT_AFFECTED_PROC` filter, which was the immediate cause: a spawned job's termination names the *spawned* job, so the filter hid precisely the events that mattered. It now takes every job end the session reports, keeps the ones in its own tree, and waits until that tree is empty. Zero is a sound terminal condition, not merely a likely one — a job can only be spawned by a process still running.
* **Exit status** — `prterun`'s rule (first non-zero from any job in the tree) unless `report-child-jobs-separately` says only the primary job decides. That policy is applied by `prun`, because the DVM cannot: on a persistent DVM one launcher's directive must not decide everyone else's exit status, which is why the DVM's own copy of it is gated on `!prte_persistent`. `prun` reads the directive off its own command line with a new `prte_state_base_report_child_sep()`, which lives beside the walk that records the attribute so the two cannot come to disagree about a spelling.

A job marked `PMIX_SPAWN_CHILD_SEP` is still waited for. That attribute says the child is not to be killed when its parent dies — which is *why* it outlives the parent; `prterun` waits for it too, and parity is the point.

### Testing

* Warning-free `--enable-debug` build; `make check` 21/21; offline mapper harness 2369/2369; docs build clean; live `prte`/`prun`/`pterm` smoke test.
* New unit case in `test/unit/state/` asserts the CLI reader agrees with the attribute walk on every spelling of the directive, so the two readers cannot drift.
* New multi-node case in `contrib/dockerswarm/run-tests.sh` (in `test_tools`): the spawned job is mapped onto a different node from its parent, so the tree spans daemons and the notification has to cross the DVM. It checks both halves — that `prun` stays for the child's whole life and returns its status — plus the `report-child-jobs-separately` behaviour and, importantly, that an unfiltered job-end handler does **not** make one `prun` wait on another `prun`'s job on the same DVM.
* Verified against a pre-fix build of the same swarm: 40/40 return 0 in ~5s there, 40/40 return 7 in ~20s here.
* Full swarm suite green.

### Note for reviewers

The swarm case gives its spawned child a lifetime (`sleep 15; exit 7`) because the child has to outlive its parent — otherwise the "prun stayed for the spawned job's whole life" assertion has nothing to measure.

Full disclosure on how that got there: I first reached for the sleep because the case was failing intermittently and I had not explained why, which is bending a fixture around a bug however well the new shape can be argued for. The bug was real and is now root-caused and fixed separately in #2686 — a `PMIx_Get` about a job that has already ended parked forever instead of being answered. That fix is independent of this PR and lands on its own; this case would be stable either way now, and keeps the sleep on its own merits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

