### PR TITLE
Answer a Get about a job that has ended instead of waiting for it

### DIFF
--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -2281,6 +2281,67 @@ test_pmix() {
 test_prted() {
     local out rc ns n bpid
 
+    banner "prted: a Get of a job that has already ENDED is answered, not parked"
+    # dmodex_req looks the target job up in prte_job_data and, finding
+    # nothing, used to park the request on the assumption that this is a
+    # race: the job exists and our record of it is still on its way.  That is
+    # one of two ways to get there.  The other is a job that has already
+    # terminated - its object was released, it is never coming back, and the
+    # request then parks forever.  Nothing drains that array on a timer, and
+    # PMIx deliberately sets no timeout on a host request so as not to race
+    # us, so the caller's PMIx_Get never returns at all.
+    #
+    # PRRTE already kept the answer: a bounded registry of departed jobs,
+    # consulted on the path that serves ANOTHER daemon's request but not on
+    # the one that serves a local client.  This asks on both, because the two
+    # sides record their departures in different places - a daemon when it
+    # releases its copy of the job, the master in its own job lifecycle - and
+    # only the daemon half was wired up.
+    #
+    # Deterministic, with no race to lose: the job is over and reaped before
+    # anything asks about it.  An answer is a pass whichever answer it is;
+    # silence is the bug, and shows up as the full timeout.
+    cleanup_swarm
+    if ! RUN 'command -v jobinfo >/dev/null'; then
+        skp "jobinfo client not installed -- re-run ./build.sh"
+    elif ! prted_dvm_start 'node1:2,node2:2,node3:2,node4:2'; then
+        bad "could not start a DVM for the ended-job Get test"
+    else
+        # a job that runs on node2 and finishes
+        out=$(PRUN '--host node2:1 -n 1 jobinfo publish 3' 2>&1)
+        ns=$(echo "$out" | grep -m1 '^NSPACE ' | awk '{print $2}' | tr -d '\r')
+        if [ -z "$ns" ]; then
+            bad "the short-lived job never reported its nspace: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        else
+            ok "a job ran and ended (nspace $ns)"
+            sleep 5   # let the DVM finish reaping it
+            # ask on the MASTER, whose own job object is gone by now
+            t0=$(date +%s)
+            out=$(PRUN "--host node1:1 -n 1 jobinfo fetch $ns 20" 2>&1)
+            t1=$(date +%s)
+            [ $((t1 - t0)) -lt 20 ] \
+                && ok "the master answered for a job that has ended ($((t1 - t0))s)" \
+                || bad "the master parked a Get of an ended job ($((t1 - t0))s)"
+            echo "$out" | grep -qE 'JOBSIZE |NOT_FOUND' \
+                && ok "...and the answer was an answer" \
+                || bad "the master returned neither a size nor an error: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+
+            # ...and on a DAEMON that never hosted it, which is the other
+            # half: a different lookup, a different departure record
+            t0=$(date +%s)
+            out=$(PRUN "--host node3:1 -n 1 jobinfo fetch $ns 20" 2>&1)
+            t1=$(date +%s)
+            [ $((t1 - t0)) -lt 20 ] \
+                && ok "a daemon answered for a job that has ended ($((t1 - t0))s)" \
+                || bad "a daemon parked a Get of an ended job ($((t1 - t0))s)"
+            echo "$out" | grep -qE 'JOBSIZE |NOT_FOUND' \
+                && ok "...and that answer was an answer too" \
+                || bad "the daemon returned neither a size nor an error: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        fi
+        RUN "timeout -k 5 30 pterm --dvm-uri file:$PRTED_URI" >/dev/null 2>&1
+    fi
+    cleanup_swarm
+
     banner "prted: a job-level Get of ANOTHER job is answered by the daemon"
     # A client asks for the JOB-LEVEL data of a DIFFERENT job, from a node
     # that hosts none of that job's procs.  This is the cross-job job-level
@@ -2857,16 +2918,17 @@ test_tools() {
     #
     # examples/dynamic.c spawns "client" from its cwd, so the child job is
     # whatever we put there: a script that outlives its parent and then exits
-    # 7, while the parent itself exits 0.  Both halves of the defect need that
-    # lifetime -- the status prun reports AND the fact that it was still there
-    # to report it.
+    # 7, while the parent itself exits 0.
     #
-    # The sleep is also what keeps this case off a race that has nothing to do
-    # with what it is testing: dynamic follows its spawn with a PMIx_Get of the
-    # child's job size and a PMIx_Connect to it, and against a child that has
-    # ALREADY exited those occasionally never return, hanging the parent.  A
-    # child that is still running when its parent asks about it is both the
-    # honest shape of this test and the one that does not flake.
+    # The child has to outlive the parent, and that is the whole reason for
+    # the sleep.  Both halves of what is being tested need it -- the status
+    # prun reports, and the fact that prun was still there to report it.  A
+    # child that had already exited by the time its parent finished would
+    # leave the timing assertion below with nothing to measure.
+    #
+    # It used to say here that the sleep also kept this case off an unrelated
+    # hang, which was true and was the wrong reason to write a test: that hang
+    # is the defect this commit fixes, and the case above proves it directly.
     for n in 1 2 3; do
         ON $n 'rm -rf /tmp/dyn && mkdir -p /tmp/dyn &&
                printf "#!/bin/sh\nsleep 15\nexit 7\n" > /tmp/dyn/client && chmod +x /tmp/dyn/client' >/dev/null 2>&1

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -1101,6 +1101,15 @@ static void cleanup_job(int sd, short args, void *cbdata)
             }
             PMIX_PROC_RELEASE(nptr);
         }
+        /* From here on, the answer to a question about this job is "not
+         * found" rather than "wait" - and the difference is a hang.  A
+         * lookup that fails cannot tell a job we have not heard of YET from
+         * one that has been and gone, so it assumes the first and parks the
+         * request; nothing drains that on a timer.  The daemons record their
+         * own departures where they release their copy of the job
+         * (PRTE_DAEMON_CONT_CLEANUP_JOB); this is the master's copy, and its
+         * lifecycle is here. */
+        prte_pmix_server_job_departed(caddy->jdata->nspace);
         PMIX_RELEASE(caddy->jdata);
     }
     PMIX_RELEASE(caddy);

--- a/src/prted/AGENTS.md
+++ b/src/prted/AGENTS.md
@@ -349,6 +349,26 @@ startup, or teardown:
 prte --daemonize && prun -n 4 hostname && pterm
 ```
 
+**A lookup that finds no job must say WHICH kind of nothing it found.**
+`prte_get_job_data_object()` returning `NULL` covers two opposite
+situations: a job whose record has not reached us *yet* — a race worth
+waiting out — and one that has already ended, whose object was released
+and is never coming back. Code that cannot tell them apart assumes the
+first and parks the request, and nothing on either side of that will ever
+release it: PRRTE runs no timer over those arrays, and PMIx deliberately
+sets no timeout on a host request so as not to race the host. The result
+is a permanently wedged `PMIx_Get`.
+
+`prte_pmix_server_job_has_departed()` is the discriminator, backed by a
+bounded registry of the last jobs to go. **Every** path that fails such a
+lookup and would otherwise wait must consult it — `dmodex_req()` (a local
+client's get), `pmix_server_dmdx_recv()` (another daemon's), and the
+retry cycle. Departures are recorded where the job object is released,
+which is in two different places: a daemon does it under
+`PRTE_DAEMON_CONT_CLEANUP_JOB`, and the master in `state_dvm.c`'s
+`cleanup_job()`, because the master runs its own job lifecycle. Adding a
+release site means adding a `prte_pmix_server_job_departed()` beside it.
+
 **Multi-node — `contrib/dockerswarm/`.** Most of what is interesting in
 this directory only exists across nodes: a daemon that hosts none of a
 job's procs, a tool connecting through a non-master daemon, a signal that

--- a/src/prted/pmix/pmix_server_fence.c
+++ b/src/prted/pmix/pmix_server_fence.c
@@ -174,10 +174,35 @@ static void dmodex_req(int sd, short args, void *cbdata)
 
     /* lookup who is hosting this proc */
     if (NULL == (jdata = prte_get_job_data_object(req->tproc.nspace))) {
-        /* if we don't know the job, then it could be a race
-         * condition where we are being asked about a process
-         * that we don't know about yet. In this case, just
-         * record the request and we will process it later */
+        /* Two very different situations bring us here, and only one of them
+         * is worth waiting for.
+         *
+         * A job we have not heard of YET is a race - the requestor got the
+         * namespace from somewhere and our own record of it is still on its
+         * way - so park the request and answer it when the job turns up.
+         *
+         * A job that has already FINISHED is never coming back.  Its object
+         * was released when it terminated, so parking a request on it parks
+         * it forever: nothing drains this array on a timer, and PMIx
+         * deliberately sets no timeout on a host request so as not to race
+         * us.  That is a real hang, and an easy one to hit - a process that
+         * asks about a job it just spawned (PMIx_Get of the child's job
+         * size; examples/dynamic.c does exactly this) wedges permanently if
+         * the child was short-lived enough to be gone before the question
+         * arrived.  The bigger the job, the longer the question takes to
+         * arrive, and the likelier that is.
+         *
+         * So refuse what we can prove is over rather than waiting on it.
+         * PMIX_ERR_NOT_FOUND is the truth and is what the caller's PMIx_Get
+         * returns; what we must not do is leave them holding. */
+        if (prte_pmix_server_job_has_departed(req->tproc.nspace)) {
+            pmix_output_verbose(2, prte_pmix_server_globals.output,
+                                "%s DMODX REQ FOR %s:%u - JOB HAS ENDED",
+                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                req->tproc.nspace, req->tproc.rank);
+            prc = PMIX_ERR_NOT_FOUND;
+            goto callback;
+        }
         req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
         return;
     }

--- a/test/unit/prted/test_prted.c
+++ b/test/unit/prted/test_prted.c
@@ -71,6 +71,7 @@
 #include "src/mca/schizo/base/base.h"
 #include "src/mca/state/base/base.h"
 #include "src/prted/prted.h"
+#include "src/prted/pmix/pmix_server.h"
 #include "src/prted/pmix/pmix_server_internal.h"
 
 #define CHECK(label, cond)                                    \
@@ -1284,6 +1285,65 @@ static int test_session_time(void)
     return failures;
 }
 
+/*
+ * The departed-job registry.  A lookup that cannot find a job has to tell
+ * "we have not heard of it YET" from "it has been and gone": the first is a
+ * race worth waiting out, the second is a request that would wait forever,
+ * because nothing drains those on a timer.  This list is the only thing that
+ * can tell them apart, so the two properties that matter are that it
+ * remembers what it was told and that it stays bounded - a persistent DVM
+ * runs jobs without end.
+ */
+static int test_departed_jobs(void)
+{
+    int failures = 0;
+    /* the helpers take a pmix_nspace_t - a fixed-size array - so hand them
+     * one rather than a string literal the compiler can see is shorter */
+    pmix_nspace_t ns, first, last;
+    int i;
+
+    /* the registry lives in the server globals, which a full
+     * pmix_server_init() would have constructed for us */
+    PMIX_CONSTRUCT(&prte_pmix_server_globals.departed_jobs, pmix_list_t);
+
+    PMIX_LOAD_NSPACE(ns, "unit-test-never-existed");
+    CHECK("an unknown job has not departed", !prte_pmix_server_job_has_departed(ns));
+
+    PMIX_LOAD_NSPACE(first, "unit-test-dep@1");
+    prte_pmix_server_job_departed(first);
+    CHECK("a departed job is remembered", prte_pmix_server_job_has_departed(first));
+    PMIX_LOAD_NSPACE(ns, "unit-test-dep@2");
+    CHECK("...and its neighbours are not", !prte_pmix_server_job_has_departed(ns));
+
+    /* recording the same one twice must not consume a second slot, or a job
+     * whose departure is reported more than once would push out the history
+     * of jobs that really did depart */
+    prte_pmix_server_job_departed(first);
+    CHECK("a repeat does not grow the list",
+          1 == pmix_list_get_size(&prte_pmix_server_globals.departed_jobs));
+
+    /* the bound holds, and it is the OLDEST that is dropped */
+    for (i = 2; i <= 40; i++) {
+        snprintf(ns, sizeof(ns), "unit-test-dep@%d", i);
+        prte_pmix_server_job_departed(ns);
+    }
+    CHECK("the list stays bounded",
+          32 >= pmix_list_get_size(&prte_pmix_server_globals.departed_jobs));
+    PMIX_LOAD_NSPACE(last, "unit-test-dep@40");
+    CHECK("the most recent departure is still known",
+          prte_pmix_server_job_has_departed(last));
+    CHECK("the oldest has aged out", !prte_pmix_server_job_has_departed(first));
+
+    /* LIST_DESTRUCT, not DESTRUCT: the latter only re-initializes the list
+     * and would leak every entry still on it */
+    PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.departed_jobs);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_departed_jobs\n");
+    }
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0, skipped = 0;
@@ -1344,6 +1404,7 @@ int main(void)
         return 1;
     }
 
+    failures += test_departed_jobs();
     failures += test_prefix_normalization();
     failures += test_singleton_id();
     failures += test_xfer_job_info();


### PR DESCRIPTION
### The problem

`prte_get_job_data_object()` returning `NULL` means two opposite things, and `dmodex_req()` could only act on one of them:

* a job whose record has **not reached us yet** — the requestor got the namespace from somewhere and our copy is still in flight. Waiting is right.
* a job that has **already terminated** — its object was released when it ended, and it is never coming back. Waiting is fatal.

It assumed the first and parked the request. Nothing sweeps those arrays on a timer, and PMIx deliberately sets no timeout on a host request so as not to race the host, so the caller's `PMIx_Get` simply never returns. Not even the application's own `PMIX_TIMEOUT` rescues it.

Two ways to reach it, one of them needing no race at all:

```
# run a job, let it finish, then ask about it -- hangs every time
prun --host node2:1 -n 1 jobinfo publish 3     # note its nspace, let it end
prun --host node1:1 -n 1 jobinfo fetch <nspace> 20    # never returns
```

and the one that found it: a process asking about a job **it just spawned**. `examples/dynamic.c` does `PMIx_Get(child, PMIX_JOB_SIZE)` after every spawn, and any application doing the same wedges permanently whenever the child was short-lived enough to be gone before the question arrived. It took about fifteen spawns to hit by accident on a ten-node swarm.

### The change

PRRTE already knew the answer and was not asking. `prte_pmix_server_job_has_departed()` and its bounded registry of recently departed jobs exist for exactly this, and two paths already consult it — the one serving another daemon's request (`pmix_server_dmdx_recv`) and the retry cycle. The path serving a **local client's** get did not, and that is the one an application reaches. One test of it there is the whole fix for the daemon side.

The master needed the other half. It never *recorded* a departure at all: the recording sits under `PRTE_DAEMON_CONT_CLEANUP_JOB`, where a daemon releases its copy of the job, and the comment there says the master is not part of that because it runs its own job lifecycle. So it now records one where that lifecycle actually releases the object, in `state_dvm.c`'s `cleanup_job()`.

Both halves are needed: a client on the master and a client on a daemon hang independently, and the swarm case asks on both.

The 32-entry bound on the registry is not made worse by this. A request can only arrive for a job that ended while it was in flight, and anything older than the last 32 job terminations in the DVM has long since been answered or abandoned.

### Testing

* Warning-free `--enable-debug` build; `make check` 21/21; full swarm suite **584 passed, 0 failed**.
* New unit case (`test/unit/prted/`) for the registry itself: it remembers what it was told, a repeat does not consume a slot, the bound holds, and it is the oldest that ages out.
* New multi-node case (`test_prted`) driving the deterministic shape above on the master *and* on a daemon that never hosted the job. Verified against a build with the fix reverted: all four assertions fail there (60s, no answer) and pass with it (5s, an answer).

A note on the reproducer, since it cost time: the spawn race is narrow and only reproduces on the HNP (60/60 clean with the parent on another node), and it cannot be made deterministic by delaying the get — the parent's own PMIx client caches the child's job info within a second or so and answers locally, so the request never reaches the server at all. `PMIX_GET_REFRESH_CACHE` does not defeat that either. The job-that-has-ended shape above needs no spawn and no race, which is why the test uses it.

Found while adding the swarm coverage for #2685. Independent of that change, but rebased on top of it now that it has merged, because it also corrects a comment #2685 left behind: that case gives its spawned child a lifetime, and the comment claimed one of the reasons was to keep the case clear of "an unrelated hang". That hang is this defect. The reason was a bad one — a fixture should not be shaped around an unexplained failure — and the comment now says only the honest reason (the child has to outlive the parent or the timing assertion has nothing to measure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

