### PR TITLE
Accept nic, fabric and openfabrics as spellings of --map-by device=network

### DIFF
--- a/docs/plans/per_device_mapping/impl-plan.rst
+++ b/docs/plans/per_device_mapping/impl-plan.rst
@@ -935,12 +935,87 @@ UUIDs are order-independent, naming a subset composes correctly with a set
 a resource manager has already filtered (Slurm's ``--gpus-per-task``
 leaves ``CUDA_VISIBLE_DEVICES`` set); an index-based value would not.
 
+H4 — the same for network devices
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The GPU work left the network classes half-finished in two ways, and this
+phase closed both.
+
+**The vocabulary was split where users expect one word.**
+``device=network`` meant ``PMIX_DEVTYPE_NETWORK``, ``device=openfabrics``
+meant ``PMIX_DEVTYPE_OPENFABRICS``, and ``device=nic`` meant the union.
+But one HCA presents itself as *both* — an OpenFabrics OS device
+(``mlx5_0``) and a network interface (``ib0``) on one PCI function — so
+the two narrow spellings returned the same hardware under different names
+and different counts, and whichever the user did not type looked like a
+wrong answer.  ``network``, ``nic``, ``fabric`` and ``openfabrics`` are
+now synonyms for the union, which the PCI-function dedup collapses to one
+entry per card.  The cost is that there is no longer a spelling for
+"ethernet only"; naming the interface (``device=eno6``) answers that
+question exactly, and it is a narrower question than the directive is for.
+
+**A NIC assignment could not be acted on.**  The GPU path ends by naming
+the device to the vendor's runtime; the network path ended at
+``PMIX_DEVICE_ID`` and nothing else.  PMIx's ``pnet`` framework now
+mirrors ``pgpu``: a module-level ``setup_fork``, base fan-out after the
+namespace envar cache is replayed, and
+``pmix_pnet_base_get_assigned_devices()`` / ``_set_assigned_devices()``
+as the shared implementation.  Two things were needed underneath it.
+
+A NIC's **selector** is its OS device name — that is what every fabric
+library's variable accepts, and unlike a GPU's vendor identity it can
+never be missing.  Which of a function's two OS devices supplies that
+name therefore stopped being a coin flip: ``osdev_preferred()`` now takes
+the OpenFabrics device over the network interface, because ``ib0`` is
+accepted by none of those variables.
+
+And a NIC has **no vendor attribute** to filter on the way a GPU does, so
+``pmix_hwloc_device_t`` now carries the PCI ``vendor``/``class`` ids and a
+component selects with the same pair it hands ``pmix_hwloc_check_vendor()``
+in its own ``component_open``.  On a node with two fabrics, naming
+somebody else's NIC in your variable is worse than naming none.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 30 50
+
+   * - Fabric
+     - Variable
+     - Form
+   * - Mellanox / NVIDIA
+     - ``NCCL_IB_HCA``
+     - The device name (``mlx5_0``); NCCL matches an HCA by name.
+   * - Mellanox / NVIDIA
+     - ``UCX_NET_DEVICES``
+     - ``mlx5_0:*`` — UCX names a device *port* and matches each entry as
+       a glob, so this is "this card, whatever ports it has".  The ``:``
+       is load-bearing: ``mlx5_1*`` would also match ``mlx5_10``.
+   * - Intel Omni-Path
+     - ``PSM3_NIC``
+     - The device name; PSM3 selects by NIC name.
+   * - Intel Omni-Path
+     - ``HFI_UNIT``, ``FI_OPX_HFI_SELECT``
+     - **Deliberately not set.**  Both take a unit *ordinal*, which is
+       meaningful only against the driver's enumeration rather than one
+       PMIx performed.  ``hfi1_0``'s trailing digit looks like it and
+       usually is, but a wrong value here does not fail — it quietly puts
+       the process on another adapter.
+
+The ``nvd`` and ``opa`` components also lost their ``configure.m4``
+files, for the reason ``pgpu``'s vendor components did: ``nvd`` was
+hardwired off ("no real NVIDIA-transport detection exists yet") and
+``opa``'s said "always succeed".  Neither links anything, and whether a
+component has work to do is a property of the machine the *daemon* runs
+on — which only ``component_open`` is in a position to know.
+
 Build order
 ~~~~~~~~~~~
 
 H1 first and alone: it is a live defect and needs none of the rest.  Then
 H2, so per-node identity is real.  Then H3, which is only worth doing once
-the identity it would publish is correct.
+the identity it would publish is correct.  H4 last: it is the same shape
+as H3 applied to a second framework, and it reuses the ``setup_fork``
+plumbing H3 proved.
 
 
 Phases as landed

--- a/docs/plans/per_device_mapping/impl-plan.rst
+++ b/docs/plans/per_device_mapping/impl-plan.rst
@@ -923,8 +923,13 @@ Vendors, and what each one can be told
      - Same shape, from ``AMDUUID`` (RSMI backend).
    * - Intel
      - ``ZE_AFFINITY_MASK``
-     - Index-based, no uuid form.  Keeps the ordering problem and needs
-       its own decision; do not guess one.
+     - Index-based, no uuid form — but the index is *read*, not guessed:
+       hwloc's Level Zero backend records the driver and device index
+       ``zeDeviceGet`` returned.  Needs ``ZE_FLAT_DEVICE_HIERARCHY``
+       stated with it, since the same ordinals name a card under
+       ``COMPOSITE`` and a tile under ``FLAT``.  (Written here as "needs
+       its own decision; do not guess one" — the decision is recorded in
+       `Phases as landed`_.)
 
 Two properties of the values are worth stating because they decide the
 failure behaviour.  A wrong ``CUDA_VISIBLE_DEVICES`` does not error — "if
@@ -1043,6 +1048,20 @@ pays nothing.  The attribute stays ``PRTE_ATTR_LOCAL``.
 That guard is worth knowing about before adding anything to a proc: it only
 fires in a debug build, and its output goes to stdout, so on a release build
 the attribute would simply never arrive and the daemon would read a default.
+
+**Intel GPUs are told after all.**  The vendor table above says
+``ZE_AFFINITY_MASK`` "needs its own decision; do not guess one", on the
+premise that PMIx would have to reproduce the Level Zero runtime's device
+ordering.  That premise was wrong in one specific way: PMIx does not have
+to reproduce the ordering, because hwloc's Level Zero backend *recorded*
+it — each root device carries the driver and device index ``zeDeviceGet``
+handed back for it.  So the ordinal is read from the enumeration rather
+than predicted, and read on the node that will fork the process.  What the
+topology cannot record is the model that enumeration ran under, so
+``ZE_FLAT_DEVICE_HIERARCHY`` is written alongside the mask when the child's
+environment does not already name a model, and the assignment is dropped
+with a message when it names a conflicting one.  Nothing here is guessed;
+the rule the table was protecting is intact.
 
 
 Verification checklist

--- a/docs/plans/per_device_mapping/per-device-mapping.rst
+++ b/docs/plans/per_device_mapping/per-device-mapping.rst
@@ -255,12 +255,13 @@ Add one mapping directive::
    * - ``gpu``
      - every compute GPU on the node (``PMIX_DEVTYPE_GPU`` ∪
        ``PMIX_DEVTYPE_COPROC``, filtered — see below)
-   * - ``network``
-     - every network interface (``PMIX_DEVTYPE_NETWORK``)
-   * - ``openfabrics`` (``hca``, ``ofa``)
-     - every OpenFabrics device (``PMIX_DEVTYPE_OPENFABRICS``)
-   * - ``nic``
-     - ``network`` ∪ ``openfabrics``, deduped by PCI function
+   * - ``network`` (``nic``, ``fabric``, ``openfabrics``)
+     - every network interface (``PMIX_DEVTYPE_NETWORK`` ∪
+       ``PMIX_DEVTYPE_OPENFABRICS``, deduped by PCI function).  The four
+       spellings are synonyms: the split they originally had made
+       ``network`` and ``openfabrics`` name the same card differently,
+       and whichever the user did not type looked like a wrong answer.
+       A single interface is still reachable by naming it.
    * - ``block``
      - every block device (``PMIX_DEVTYPE_BLOCK``)
    * - anything else
@@ -460,8 +461,11 @@ is "a pure function of a topology plus a string", which this is):
 3. Otherwise, no GPUs on this node.  That is a hard error for a job that
    asked to map by one — see `Placement`_.
 
-For ``network``/``openfabrics``/``block`` no filtering beyond the type and
-the PCI-function dedup is needed.
+For ``network``/``block`` no filtering beyond the type and the
+PCI-function dedup is needed.  The dedup is what makes the network
+spellings synonyms rather than merely overlapping: one HCA's OpenFabrics
+device and network interface share a PCI function and collapse to one
+entry.
 
 Ordering
 ~~~~~~~~

--- a/src/docs/prrte-rst-content/cli-map-by.rst
+++ b/src/docs/prrte-rst-content/cli-map-by.rst
@@ -83,9 +83,12 @@ applied at the job level:
 * ``DEVICE=<class|name>`` assigns one proc to each device in the node's
   topology, in PCI bus order, placing it on the CPUs local to that
   device. The value is either a class of device -- ``gpu``, ``network``,
-  ``openfabrics``, ``nic`` (network and openfabrics together), or
-  ``block`` -- or the name or UUID of one particular device such as
+  or ``block`` -- or the name or UUID of one particular device such as
   ``mlx5_0``, in which case every proc is placed near that one device.
+  ``nic``, ``fabric`` and ``openfabrics`` are accepted as spellings of
+  ``network`` and mean exactly the same set: one entry per card, whether
+  the node presents it as an OpenFabrics device (``mlx5_0``), a network
+  interface (``ib0``), or both.
 
   Note there is no bare ``--mapby gpu``: the class is the *value* of the
   ``device`` directive, which is what allows other classes of device to

--- a/src/docs/prrte-rst-content/cli-map-by.rst
+++ b/src/docs/prrte-rst-content/cli-map-by.rst
@@ -135,10 +135,22 @@ applied at the job level:
   vendor's device *ordering* variable (``CUDA_DEVICE_ORDER`` and its
   equivalents): the identifiers do not depend on the ordering, which is
   the reason for using them, and changing it would renumber devices for
-  the rest of the process's life. Intel GPUs are deliberately not given a
-  variable: ``ZE_AFFINITY_MASK`` takes device indices, in an order PRRTE
-  has no way to reproduce, and a wrong value there silently hides devices
-  rather than failing.
+  the rest of the process's life.
+
+  Intel is the exception to "named by identity rather than by index".
+  ``ZE_AFFINITY_MASK`` has no identifier form -- it takes Level Zero
+  device ordinals -- but the ordinals are not guessed: hwloc's Level Zero
+  backend records the driver and device index ``zeDeviceGet`` returned for
+  each device, so the value is *read* from that enumeration rather than
+  predicted, on the node that will run the process. Because a Level Zero
+  driver reads ``ZE_FLAT_DEVICE_HIERARCHY`` first and interprets the mask
+  against the devices that model exposes -- the same ordinals name a card
+  under ``COMPOSITE`` and a tile under ``FLAT`` -- the model is stated
+  alongside the mask whenever the process's environment does not already
+  name one. If it names one and it disagrees, nothing is set and a message
+  says so: overriding a deliberate choice would change how many devices
+  the program sees, and writing a mask that will be read under a different
+  model would silently hand it half the hardware it was assigned.
 
   A process mapped against a **network** device is handed it the same
   way, in the variables the fabric libraries read: ``NCCL_IB_HCA`` and

--- a/src/docs/prrte-rst-content/cli-map-by.rst
+++ b/src/docs/prrte-rst-content/cli-map-by.rst
@@ -140,7 +140,19 @@ applied at the job level:
   has no way to reproduce, and a wrong value there silently hides devices
   rather than failing.
 
-  The assignment is also readable directly, whether or not the vendor's
+  A process mapped against a **network** device is handed it the same
+  way, in the variables the fabric libraries read: ``NCCL_IB_HCA`` and
+  ``UCX_NET_DEVICES`` for a Mellanox or NVIDIA InfiniBand adapter, and
+  ``PSM3_NIC`` for an Intel Omni-Path adapter. The device is named by the
+  name those libraries accept -- ``mlx5_0`` -- which is the name hwloc
+  gave it, so unlike the GPU case there is no identity that can be
+  missing. Nothing is set for an adapter whose fabric has no component
+  behind it, and no variable that takes a device *unit number* is set at
+  all (``HFI_UNIT``, ``FI_OPX_HFI_SELECT``): a unit number is meaningful
+  only against the enumeration it came from, and a wrong one there does
+  not fail, it quietly puts the process on another adapter.
+
+  The assignment is also readable directly, whether or not a device
   variable was set, as the ``PMIX_DEVICE_ID`` key of the process's own
   job data.
 

--- a/src/docs/prrte-rst-content/detail-placement-examples.rst
+++ b/src/docs/prrte-rst-content/detail-placement-examples.rst
@@ -395,9 +395,11 @@ particular fabric interface:
 
    $ prun -n 8 --mapby device=mlx5_0 --bindto core ./a.out
 
-Other classes are selected the same way: ``device=openfabrics`` for
-fabric interfaces, ``device=network`` for network interfaces,
-``device=nic`` for both, and ``device=block`` for block devices.
+Other classes are selected the same way: ``device=network`` for the
+node's network interfaces and ``device=block`` for block devices.
+``device=nic``, ``device=fabric`` and ``device=openfabrics`` all mean
+``device=network``: a card that presents both an OpenFabrics device and
+a network interface is one device under any of them.
 
 
 Mapping Processes to Nodes Using Policies

--- a/src/mca/rmaps/base/help-mapby.txt
+++ b/src/mca/rmaps/base/help-mapby.txt
@@ -120,8 +120,12 @@ applied at the job level:
   ROCR_VISIBLE_DEVICES for AMD - named by the vendor's own identifier.
   Only processes mapped against a device get it, and an existing value
   is replaced. PRRTE never sets the vendor's device ORDERING variable.
-  Intel GPUs get none: ZE_AFFINITY_MASK takes indices in an order PRRTE
-  cannot reproduce, and a wrong value there hides devices silently.
+  Intel GPUs get ZE_AFFINITY_MASK, which has no identifier form and takes
+  Level Zero device ordinals - read from the enumeration hwloc's Level
+  Zero backend recorded, not guessed. ZE_FLAT_DEVICE_HIERARCHY is stated
+  alongside it, since a driver interprets the mask against whichever
+  model that names; if the process already names a different model,
+  nothing is set and a message says so.
   A process mapped against a network device is handed it the same way,
   in the variables the fabric libraries read - NCCL_IB_HCA and
   UCX_NET_DEVICES for a Mellanox/NVIDIA adapter, PSM3_NIC for an Intel

--- a/src/mca/rmaps/base/help-mapby.txt
+++ b/src/mca/rmaps/base/help-mapby.txt
@@ -83,10 +83,13 @@ applied at the job level:
 
 * "DEVICE=<class|name>" assigns one proc to each device in the node's
   topology, in PCI bus order, placing it on the CPUs local to that
-  device. The value is either a class of device - "gpu", "network",
-  "openfabrics", "nic" (network and openfabrics together), or "block" -
-  or the name or UUID of one particular device, such as "mlx5_0", in
-  which case every proc is placed near that one device.
+  device. The value is either a class of device - "gpu", "network", or
+  "block" - or the name or UUID of one particular device, such as
+  "mlx5_0", in which case every proc is placed near that one device.
+  "nic", "fabric" and "openfabrics" are accepted as spellings of
+  "network" and mean exactly the same set: one entry per card, whether
+  the node presents it as an OpenFabrics device (mlx5_0), a network
+  interface (ib0), or both.
   Note there is no bare "--mapby gpu": the class is the value of the
   "device" directive, which is what allows other classes of device to
   be supported later without adding a directive for each.

--- a/src/mca/rmaps/base/help-mapby.txt
+++ b/src/mca/rmaps/base/help-mapby.txt
@@ -122,6 +122,12 @@ applied at the job level:
   is replaced. PRRTE never sets the vendor's device ORDERING variable.
   Intel GPUs get none: ZE_AFFINITY_MASK takes indices in an order PRRTE
   cannot reproduce, and a wrong value there hides devices silently.
+  A process mapped against a network device is handed it the same way,
+  in the variables the fabric libraries read - NCCL_IB_HCA and
+  UCX_NET_DEVICES for a Mellanox/NVIDIA adapter, PSM3_NIC for an Intel
+  Omni-Path one - named as those libraries name it ("mlx5_0"). No
+  variable that takes a unit NUMBER is set (HFI_UNIT, FI_OPX_HFI_SELECT):
+  a wrong unit number does not fail, it silently selects another adapter.
 
 * "PE-LIST=a,b" assigns procs to each node in the allocation based on
   the ORDERED qualifier. The list is comprised of comma-delimited

--- a/src/mca/rmaps/base/help-placement.txt
+++ b/src/mca/rmaps/base/help-placement.txt
@@ -762,9 +762,11 @@ on one particular fabric interface:
 
    $ prun -n 8 --mapby device=mlx5_0 --bindto core ./a.out
 
-Other classes are selected the same way - "device=openfabrics" for
-fabric interfaces, "device=network" for network interfaces,
-"device=nic" for both, and "device=block" for block devices.
+Other classes are selected the same way - "device=network" for the
+node's network interfaces and "device=block" for block devices.
+"device=nic", "device=fabric" and "device=openfabrics" all mean
+"device=network": a card that presents both an OpenFabrics device
+and a network interface is one device under any of them.
 
 
 Per-App-Context Mapping Example

--- a/src/mca/rmaps/base/help-placement.txt
+++ b/src/mca/rmaps/base/help-placement.txt
@@ -725,23 +725,36 @@ the environment variable its vendor's runtime reads:
 
    CUDA_VISIBLE_DEVICES   NVIDIA
    ROCR_VISIBLE_DEVICES   AMD
+   ZE_AFFINITY_MASK       Intel
 
-named by the vendor's own identifier rather than by an index. Only
-processes actually mapped against a device are given one, and a value
-already in the environment is replaced - "--map-by device=" is the more
-specific request, and because the identifiers name devices absolutely
-they compose correctly with a set a resource manager has already
-narrowed.
+named, for NVIDIA and AMD, by the vendor's own identifier rather than by
+an index; Intel is the exception, and is described below. Only processes
+actually mapped against a device are given one, and a value already in
+the environment is replaced - "--map-by device=" is the more specific
+request, and because the identifiers name devices absolutely they compose
+correctly with a set a resource manager has already narrowed.
 
 PRRTE never sets the vendor's device ORDERING variable
 (CUDA_DEVICE_ORDER and its equivalents). The identifiers do not depend
 on it, which is precisely why they are used, and changing it would
 renumber every device for the rest of the process's life.
 
-Intel GPUs are deliberately given no variable. ZE_AFFINITY_MASK takes
-device indices in an ordering PRRTE has no way to reproduce, and a wrong
-value in these variables does not fail - it silently reduces the set of
-devices the process can see, which is worse than setting nothing.
+Intel is the exception to "identity rather than index". ZE_AFFINITY_MASK
+has no identifier form - it takes Level Zero device ordinals - but the
+ordinals are not guessed. hwloc's Level Zero backend records the driver
+and device index that zeDeviceGet returned for each device, so the value
+is read from that enumeration rather than predicted, and it is read on
+the node that will run the process.
+
+An ordinal is not a complete statement on its own: a Level Zero driver
+reads ZE_FLAT_DEVICE_HIERARCHY first and then interprets the mask against
+the devices that model exposes, so the same ordinals name a card under
+COMPOSITE and a tile under FLAT. The model is therefore stated alongside
+the mask whenever the process's environment does not already name one.
+If it does name one and it disagrees, nothing is set and a message says
+so - overriding a deliberate choice would change how many devices the
+program sees, and writing a mask that will be read under a different
+model would silently hand it half the hardware it was assigned.
 
 A process mapped against a network device is handed it the same way, in
 the environment variables the fabric libraries read:

--- a/src/mca/rmaps/base/help-placement.txt
+++ b/src/mca/rmaps/base/help-placement.txt
@@ -743,7 +743,26 @@ device indices in an ordering PRRTE has no way to reproduce, and a wrong
 value in these variables does not fail - it silently reduces the set of
 devices the process can see, which is worse than setting nothing.
 
-The assignment can also be read directly, whether or not a vendor
+A process mapped against a network device is handed it the same way, in
+the environment variables the fabric libraries read:
+
+   NCCL_IB_HCA          Mellanox / NVIDIA InfiniBand adapters
+   UCX_NET_DEVICES      Mellanox / NVIDIA InfiniBand adapters
+   PSM3_NIC             Intel Omni-Path adapters
+
+named as those libraries name the device - "mlx5_0" - which is the name
+hwloc gave it. Unlike a GPU's vendor identity that name is always there,
+so the identity check above does not apply to this class.
+
+No variable that names an adapter by its unit NUMBER is set - HFI_UNIT
+and FI_OPX_HFI_SELECT among them. A unit number is meaningful only
+against the enumeration it came from, which is the driver's rather than
+one PRRTE performed, and a wrong number in these variables does not fail
+- it quietly puts the process on a different adapter. Nothing is set at
+all for an adapter whose fabric has no support behind it, rather than
+guessing at a variable it might read.
+
+The assignment can also be read directly, whether or not a device
 variable was set, from the process's own job data under PMIX_DEVICE_ID.
 
 The reverse ratio - several processes on each device rather than several

--- a/src/mca/rmaps/base/rmaps_base_devices.c
+++ b/src/mca/rmaps/base/rmaps_base_devices.c
@@ -89,13 +89,24 @@ static pmix_device_type_t device_class(const char *spec)
          * a vendor backend rather than through DRM */
         return PMIX_DEVTYPE_GPU | PMIX_DEVTYPE_COPROC;
     }
-    if (PMIX_CHECK_CLI_OPTION(s, "openfabrics")) {
-        return PMIX_DEVTYPE_OPENFABRICS;
-    }
-    if (PMIX_CHECK_CLI_OPTION(s, "network")) {
-        return PMIX_DEVTYPE_NETWORK;
-    }
-    if (PMIX_CHECK_CLI_OPTION(s, "nic")) {
+    /* Every spelling of "the thing this node talks to the network with"
+     * means the same set, deliberately.  One HCA presents itself twice -
+     * an OpenFabrics OS device (mlx5_0) and a network one (ib0) on the same
+     * PCI function - and a user asking for a NIC wants the card, not one of
+     * hwloc's two views of it.  Splitting the spellings, as this once did,
+     * made "network" and "openfabrics" return the same hardware under
+     * different names and gave whichever the user did not type an answer
+     * that looked wrong.  The enumeration dedupes by PCI function, so the
+     * union is one entry per card; a particular interface is still
+     * reachable by naming it (device=eno6).
+     *
+     * The cost is that there is no longer a spelling for "ethernet only".
+     * That is a narrower question than the directive is for, and naming the
+     * interface answers it exactly. */
+    if (PMIX_CHECK_CLI_OPTION(s, "network")
+        || PMIX_CHECK_CLI_OPTION(s, "openfabrics")
+        || PMIX_CHECK_CLI_OPTION(s, "fabric")
+        || PMIX_CHECK_CLI_OPTION(s, "nic")) {
         return PMIX_DEVTYPE_NETWORK | PMIX_DEVTYPE_OPENFABRICS;
     }
     if (PMIX_CHECK_CLI_OPTION(s, "block")) {

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -84,8 +84,8 @@ static int prte_rmaps_base_register(pmix_mca_base_register_flag_t flags)
     ret = pmix_mca_base_var_register("prte", NULL, NULL, "mapby",
                                      "Default mapping Policy [slot | hwthread | core | l1cache | "
                                       "l2cache | l3cache | numa | package | node | seq | ppr | "
-                                      "device=<class|name> (gpu, network, openfabrics, nic, block, or a\n"
-                                      " device name such as mlx5_0) | "
+                                      "device=<class|name> (gpu, network (aka nic, fabric,\n"
+                                      " openfabrics), block, or a device name such as mlx5_0) | "
                                       "rankfile | pe-list=a,b (comma-delimited ranges of cpus to use for this job)],"
                                       " with supported colon-delimited modifiers: PE=y (for multiple cpus/proc), "
                                       "SPAN, OVERSUBSCRIBE, NOOVERSUBSCRIBE, NOLOCAL, HWTCPUS, CORECPUS, "

--- a/test/offline/golden/test-topo/group.test-topo.multiapp.map
+++ b/test/offline/golden/test-topo/group.test-topo.multiapp.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo/group.test-topo.ppr.map
+++ b/test/offline/golden/test-topo/group.test-topo.ppr.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo/matrix.test-topo.even.m-core.r-fill.b-core.n7.map
+++ b/test/offline/golden/test-topo/matrix.test-topo.even.m-core.r-fill.b-core.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo/matrix.test-topo.even.m-core.r-node.b-core.n7.map
+++ b/test/offline/golden/test-topo/matrix.test-topo.even.m-core.r-node.b-core.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo/matrix.test-topo.even.m-core.r-slot.b-core.n7.map
+++ b/test/offline/golden/test-topo/matrix.test-topo.even.m-core.r-slot.b-core.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo/matrix.test-topo.even.m-core.r-slot.b-none.n7.map
+++ b/test/offline/golden/test-topo/matrix.test-topo.even.m-core.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo/matrix.test-topo.even.m-core.r-span.b-core.n7.map
+++ b/test/offline/golden/test-topo/matrix.test-topo.even.m-core.r-span.b-core.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo/matrix.test-topo.even.m-hwthread.r-slot.b-none.n7.map
+++ b/test/offline/golden/test-topo/matrix.test-topo.even.m-hwthread.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo/matrix.test-topo.even.m-l1cache.r-slot.b-none.n7.map
+++ b/test/offline/golden/test-topo/matrix.test-topo.even.m-l1cache.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo/matrix.test-topo.even.m-l2cache.r-slot.b-none.n7.map
+++ b/test/offline/golden/test-topo/matrix.test-topo.even.m-l2cache.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo/matrix.test-topo.even.m-l3cache.r-slot.b-none.n7.map
+++ b/test/offline/golden/test-topo/matrix.test-topo.even.m-l3cache.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo/matrix.test-topo.even.m-node.r-slot.b-none.n7.map
+++ b/test/offline/golden/test-topo/matrix.test-topo.even.m-node.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo/matrix.test-topo.even.m-numa.r-slot.b-none.n7.map
+++ b/test/offline/golden/test-topo/matrix.test-topo.even.m-numa.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo/matrix.test-topo.even.m-package.r-slot.b-none.n7.map
+++ b/test/offline/golden/test-topo/matrix.test-topo.even.m-package.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo/matrix.test-topo.even.m-slot.r-slot.b-none.n7.map
+++ b/test/offline/golden/test-topo/matrix.test-topo.even.m-slot.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo/perapp.test-topo.bind.numa-core.map
+++ b/test/offline/golden/test-topo/perapp.test-topo.bind.numa-core.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo/perapp.test-topo.jobqual.map
+++ b/test/offline/golden/test-topo/perapp.test-topo.jobqual.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo/perapp.test-topo.map.node-slot.map
+++ b/test/offline/golden/test-topo/perapp.test-topo.map.node-slot.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo/perapp.test-topo.map.pelist.map
+++ b/test/offline/golden/test-topo/perapp.test-topo.map.pelist.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo/perapp.test-topo.map.three.map
+++ b/test/offline/golden/test-topo/perapp.test-topo.map.three.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo/perapp.test-topo.rank.node-slot.map
+++ b/test/offline/golden/test-topo/perapp.test-topo.rank.node-slot.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo2/group.test-topo2.multiapp.map
+++ b/test/offline/golden/test-topo2/group.test-topo2.multiapp.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo2/group.test-topo2.ppr.map
+++ b/test/offline/golden/test-topo2/group.test-topo2.ppr.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo2/matrix.test-topo2.even.m-core.r-fill.b-core.n7.map
+++ b/test/offline/golden/test-topo2/matrix.test-topo2.even.m-core.r-fill.b-core.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo2/matrix.test-topo2.even.m-core.r-node.b-core.n7.map
+++ b/test/offline/golden/test-topo2/matrix.test-topo2.even.m-core.r-node.b-core.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo2/matrix.test-topo2.even.m-core.r-slot.b-core.n7.map
+++ b/test/offline/golden/test-topo2/matrix.test-topo2.even.m-core.r-slot.b-core.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo2/matrix.test-topo2.even.m-core.r-slot.b-none.n7.map
+++ b/test/offline/golden/test-topo2/matrix.test-topo2.even.m-core.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo2/matrix.test-topo2.even.m-core.r-span.b-core.n7.map
+++ b/test/offline/golden/test-topo2/matrix.test-topo2.even.m-core.r-span.b-core.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo2/matrix.test-topo2.even.m-hwthread.r-slot.b-none.n7.map
+++ b/test/offline/golden/test-topo2/matrix.test-topo2.even.m-hwthread.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo2/matrix.test-topo2.even.m-l1cache.r-slot.b-none.n7.map
+++ b/test/offline/golden/test-topo2/matrix.test-topo2.even.m-l1cache.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo2/matrix.test-topo2.even.m-l2cache.r-slot.b-none.n7.map
+++ b/test/offline/golden/test-topo2/matrix.test-topo2.even.m-l2cache.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo2/matrix.test-topo2.even.m-l3cache.r-slot.b-none.n7.map
+++ b/test/offline/golden/test-topo2/matrix.test-topo2.even.m-l3cache.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo2/matrix.test-topo2.even.m-node.r-slot.b-none.n7.map
+++ b/test/offline/golden/test-topo2/matrix.test-topo2.even.m-node.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo2/matrix.test-topo2.even.m-numa.r-slot.b-none.n7.map
+++ b/test/offline/golden/test-topo2/matrix.test-topo2.even.m-numa.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo2/matrix.test-topo2.even.m-package.r-slot.b-none.n7.map
+++ b/test/offline/golden/test-topo2/matrix.test-topo2.even.m-package.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo2/matrix.test-topo2.even.m-slot.r-slot.b-none.n7.map
+++ b/test/offline/golden/test-topo2/matrix.test-topo2.even.m-slot.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo2/perapp.test-topo2.bind.numa-core.map
+++ b/test/offline/golden/test-topo2/perapp.test-topo2.bind.numa-core.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo2/perapp.test-topo2.jobqual.map
+++ b/test/offline/golden/test-topo2/perapp.test-topo2.jobqual.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo2/perapp.test-topo2.map.node-slot.map
+++ b/test/offline/golden/test-topo2/perapp.test-topo2.map.node-slot.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo2/perapp.test-topo2.map.pelist.map
+++ b/test/offline/golden/test-topo2/perapp.test-topo2.map.pelist.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo2/perapp.test-topo2.map.three.map
+++ b/test/offline/golden/test-topo2/perapp.test-topo2.map.three.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/test-topo2/perapp.test-topo2.rank.node-slot.map
+++ b/test/offline/golden/test-topo2/perapp.test-topo2.rank.node-slot.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/device.turin-4gpu-nvml.gpu-half-interleave.map
+++ b/test/offline/golden/turin-4gpu-nvml/device.turin-4gpu-nvml.gpu-half-interleave.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/device.turin-4gpu-nvml.gpu-half.map
+++ b/test/offline/golden/turin-4gpu-nvml/device.turin-4gpu-nvml.gpu-half.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/device.turin-4gpu-nvml.gpu-interleave.map
+++ b/test/offline/golden/turin-4gpu-nvml/device.turin-4gpu-nvml.gpu-interleave.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/device.turin-4gpu-nvml.gpu-ndev2.map
+++ b/test/offline/golden/turin-4gpu-nvml/device.turin-4gpu-nvml.gpu-ndev2.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/device.turin-4gpu-nvml.gpu-shared.map
+++ b/test/offline/golden/turin-4gpu-nvml/device.turin-4gpu-nvml.gpu-shared.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/device.turin-4gpu-nvml.gpu.map
+++ b/test/offline/golden/turin-4gpu-nvml/device.turin-4gpu-nvml.gpu.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/device.turin-4gpu-nvml.ppr2.map
+++ b/test/offline/golden/turin-4gpu-nvml/device.turin-4gpu-nvml.ppr2.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/group.turin-4gpu-nvml.multiapp.map
+++ b/test/offline/golden/turin-4gpu-nvml/group.turin-4gpu-nvml.multiapp.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/group.turin-4gpu-nvml.ppr.map
+++ b/test/offline/golden/turin-4gpu-nvml/group.turin-4gpu-nvml.ppr.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-core.r-fill.b-core.n7.map
+++ b/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-core.r-fill.b-core.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-core.r-node.b-core.n7.map
+++ b/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-core.r-node.b-core.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-core.r-slot.b-core.n7.map
+++ b/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-core.r-slot.b-core.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-core.r-slot.b-none.n7.map
+++ b/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-core.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-core.r-span.b-core.n7.map
+++ b/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-core.r-span.b-core.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-hwthread.r-slot.b-none.n7.map
+++ b/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-hwthread.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-l1cache.r-slot.b-none.n7.map
+++ b/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-l1cache.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-l2cache.r-slot.b-none.n7.map
+++ b/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-l2cache.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-l3cache.r-slot.b-none.n7.map
+++ b/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-l3cache.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-node.r-slot.b-none.n7.map
+++ b/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-node.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-numa.r-slot.b-none.n7.map
+++ b/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-numa.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-package.r-slot.b-none.n7.map
+++ b/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-package.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-slot.r-slot.b-none.n7.map
+++ b/test/offline/golden/turin-4gpu-nvml/matrix.turin-4gpu-nvml.even.m-slot.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/perapp.turin-4gpu-nvml.bind.numa-core.map
+++ b/test/offline/golden/turin-4gpu-nvml/perapp.turin-4gpu-nvml.bind.numa-core.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/perapp.turin-4gpu-nvml.jobqual.map
+++ b/test/offline/golden/turin-4gpu-nvml/perapp.turin-4gpu-nvml.jobqual.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/perapp.turin-4gpu-nvml.map.node-slot.map
+++ b/test/offline/golden/turin-4gpu-nvml/perapp.turin-4gpu-nvml.map.node-slot.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/perapp.turin-4gpu-nvml.map.pelist.map
+++ b/test/offline/golden/turin-4gpu-nvml/perapp.turin-4gpu-nvml.map.pelist.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/perapp.turin-4gpu-nvml.map.three.map
+++ b/test/offline/golden/turin-4gpu-nvml/perapp.turin-4gpu-nvml.map.three.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu-nvml/perapp.turin-4gpu-nvml.rank.node-slot.map
+++ b/test/offline/golden/turin-4gpu-nvml/perapp.turin-4gpu-nvml.rank.node-slot.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu/group.turin-4gpu.multiapp.map
+++ b/test/offline/golden/turin-4gpu/group.turin-4gpu.multiapp.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu/group.turin-4gpu.ppr.map
+++ b/test/offline/golden/turin-4gpu/group.turin-4gpu.ppr.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-core.r-fill.b-core.n7.map
+++ b/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-core.r-fill.b-core.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-core.r-node.b-core.n7.map
+++ b/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-core.r-node.b-core.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-core.r-slot.b-core.n7.map
+++ b/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-core.r-slot.b-core.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-core.r-slot.b-none.n7.map
+++ b/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-core.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-core.r-span.b-core.n7.map
+++ b/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-core.r-span.b-core.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-hwthread.r-slot.b-none.n7.map
+++ b/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-hwthread.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-l1cache.r-slot.b-none.n7.map
+++ b/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-l1cache.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-l2cache.r-slot.b-none.n7.map
+++ b/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-l2cache.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-l3cache.r-slot.b-none.n7.map
+++ b/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-l3cache.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-node.r-slot.b-none.n7.map
+++ b/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-node.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-numa.r-slot.b-none.n7.map
+++ b/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-numa.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-package.r-slot.b-none.n7.map
+++ b/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-package.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-slot.r-slot.b-none.n7.map
+++ b/test/offline/golden/turin-4gpu/matrix.turin-4gpu.even.m-slot.r-slot.b-none.n7.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu/perapp.turin-4gpu.bind.numa-core.map
+++ b/test/offline/golden/turin-4gpu/perapp.turin-4gpu.bind.numa-core.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu/perapp.turin-4gpu.jobqual.map
+++ b/test/offline/golden/turin-4gpu/perapp.turin-4gpu.jobqual.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu/perapp.turin-4gpu.map.node-slot.map
+++ b/test/offline/golden/turin-4gpu/perapp.turin-4gpu.map.node-slot.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu/perapp.turin-4gpu.map.pelist.map
+++ b/test/offline/golden/turin-4gpu/perapp.turin-4gpu.map.pelist.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu/perapp.turin-4gpu.map.three.map
+++ b/test/offline/golden/turin-4gpu/perapp.turin-4gpu.map.three.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/golden/turin-4gpu/perapp.turin-4gpu.rank.node-slot.map
+++ b/test/offline/golden/turin-4gpu/perapp.turin-4gpu.rank.node-slot.map
@@ -1,11 +1,3 @@
---------------------------------------------------------------------------
-A deprecated MCA variable value was specified in the environment or
-on the command line.  Deprecated MCA variables should be avoided;
-they may disappear in future releases.
-
-Deprecated variable: rmaps_default_mapping_policy
-New variable:        mapby
---------------------------------------------------------------------------
 
 ========================   JOB MAP   ========================
 Data for JOB prterun-JOBID@N offset 0 Total slots allocated N

--- a/test/offline/run_offline_maps.py
+++ b/test/offline/run_offline_maps.py
@@ -476,10 +476,19 @@ def locate_prterun(top_builddir):
 def build_argv(prterun_argv0, topo_path, case):
     argv = [prterun_argv0, "--rtos", "donotlaunch", "--display", "map",
             # pin the mapping-policy baseline so the harness is hermetic: do not
-            # inherit any rmaps_default_mapping_policy a developer may have set
-            # (e.g. in ~/.prte/mca-params.conf). Defaults to the no-directive
-            # "" baseline; cases needing oversubscription pin ":oversubscribe".
-            "--prtemca", "rmaps_default_mapping_policy", case.default_map_policy,
+            # inherit a default mapping policy a developer may have set (e.g. in
+            # ~/.prte/mca-params.conf). Defaults to the no-directive "" baseline;
+            # cases needing oversubscription pin ":oversubscribe".
+            #
+            # Spelled "mapby", the variable's own name, rather than one of its
+            # deprecated synonyms ("map_by", "rmaps_default_mapping_policy").
+            # A synonym still pins the value, but PRRTE prints a deprecation
+            # banner for it, and that banner then lands in every captured
+            # golden - noise in the snapshots, and a spurious diff for anyone
+            # who regenerates only some of them. A command-line setting beats
+            # a file setting whichever spelling the file used, so nothing is
+            # lost by using the current one.
+            "--prtemca", "mapby", case.default_map_policy,
             "--prtemca", "hwloc_use_topo_file", topo_path,
             "-H", case.hostspec]
     if case.map_by is not None:
@@ -580,7 +589,7 @@ class Case:
     extra_args: tuple = ()
     expect: str = "map"          # "map" | "reject"
     expect_banner: str = None    # substring expected on reject
-    # value pinned for rmaps_default_mapping_policy; "" = the no-directive
+    # value pinned for the "mapby" MCA variable; "" = the no-directive
     # baseline. A case that wants oversubscription to come from the DVM
     # default rather than from the command line sets ":oversubscribe" here.
     default_map_policy: str = ""

--- a/test/unit/rmaps/test_devices.c
+++ b/test/unit/rmaps/test_devices.c
@@ -195,6 +195,69 @@ static void check_unnameable_refused(void)
     PMIX_RELEASE(t);
 }
 
+/* Every spelling of the network class names the same set.
+ *
+ * The four are synonyms because one card is routinely two OS devices - an
+ * OpenFabrics one and a network one on the same PCI function - and the
+ * enumeration dedupes by function, so the union is one entry per card.
+ * When the spellings meant different types, "network" and "openfabrics"
+ * returned the same hardware under different names and different counts,
+ * and whichever the user did not type looked like a wrong answer.
+ *
+ * The topology is the reporter's machine: six Mellanox functions carrying
+ * both views, plus a management NIC that has only the network view - so a
+ * naive union would have counted the six cards twice and the answer here
+ * (seven) is the one the dedup produces.
+ */
+static void check_network_synonyms(void)
+{
+    static const char *spellings[] = {"network", "nic", "fabric",
+                                      "openfabrics", NULL};
+    prte_rmaps_options_t opts;
+    prte_topology_t *t;
+    prte_node_t *node;
+    void *ctx = NULL;
+    unsigned count[4];
+    int n;
+
+    t = load_topo(TOPO_FILE);
+    if (NULL == t) {
+        fprintf(stdout, "  SKIP test_devices network synonyms (no %s)\n", TOPO_FILE);
+        return;
+    }
+    node = build_node("node-delta", t);
+
+    for (n = 0; NULL != spellings[n]; n++) {
+        memset(&opts, 0, sizeof(opts));
+        opts.app_idx = -1;
+        opts.map_device = (char *) spellings[n];
+        opts.bind = PRTE_BIND_TO_NONE;
+        ctx = NULL;
+        CHECK(spellings[n], PRTE_SUCCESS == prte_rmaps_base_devices_begin(node, &opts, &ctx));
+        count[n] = prte_rmaps_base_devices_count(node, &opts, ctx);
+        prte_rmaps_base_devices_end(ctx);
+    }
+
+    CHECK("network finds the cards", 7 == count[0]);
+    CHECK("nic means network", count[1] == count[0]);
+    CHECK("fabric means network", count[2] == count[0]);
+    CHECK("openfabrics means network", count[3] == count[0]);
+
+    /* and it is a different set from the GPUs on the same node, which is
+     * the check that would catch a class collapsing into "everything" */
+    memset(&opts, 0, sizeof(opts));
+    opts.app_idx = -1;
+    opts.map_device = "gpu";
+    opts.bind = PRTE_BIND_TO_NONE;
+    ctx = NULL;
+    CHECK("gpu", PRTE_SUCCESS == prte_rmaps_base_devices_begin(node, &opts, &ctx));
+    CHECK("gpu is its own class", 4 == prte_rmaps_base_devices_count(node, &opts, ctx));
+    prte_rmaps_base_devices_end(ctx);
+
+    PMIX_RELEASE(node);
+    PMIX_RELEASE(t);
+}
+
 int test_devices(bool pmix_up)
 {
     prte_topology_t *t;
@@ -254,6 +317,7 @@ int test_devices(bool pmix_up)
     PMIX_RELEASE(t);
 
     check_unnameable_refused();
+    check_network_synonyms();
 
     if (0 == failures) {
         fprintf(stdout, "  PASS test_devices\n");

--- a/test/unit/rmaps/test_policy_parse.c
+++ b/test/unit/rmaps/test_policy_parse.c
@@ -295,6 +295,36 @@ int test_policy_parse(void)
     free(sval);
     PMIX_RELEASE(app);
 
+    /* Every class is carried the same way, so a new one costs a value and
+     * not a code path.  The parser stores the spelling verbatim; which
+     * devices it names is the enumerator's question, and the qualifiers
+     * below apply to whatever the value turned out to be. */
+    app = PMIX_NEW(prte_app_context_t);
+    rc = prte_rmaps_base_set_app_mapping_policy(app, "device=nic:ndev=2:shared");
+    CHECK("mapby device=nic: rc", PRTE_SUCCESS == rc);
+    u16 = get_u16(&app->attributes, PRTE_APP_MAPBY);
+    CHECK("mapby device=nic: policy", PRTE_MAPPING_BYDEVICE == PRTE_GET_MAPPING_POLICY(u16));
+    sval = get_str(&app->attributes, PRTE_APP_MAP_DEVICE);
+    CHECK("mapby device=nic: spec", NULL != sval && 0 == strcmp(sval, "nic"));
+    free(sval);
+    CHECK("mapby device=nic: ndev qualifier",
+          2 == get_u16(&app->attributes, PRTE_APP_MAP_NDEV));
+    CHECK("mapby device=nic: shared qualifier",
+          prte_get_attribute(&app->attributes, PRTE_APP_MAP_SHARED, NULL, PMIX_BOOL));
+    PMIX_RELEASE(app);
+
+    app = PMIX_NEW(prte_app_context_t);
+    rc = prte_rmaps_base_set_app_mapping_policy(app, "device=fabric:interleave=numa");
+    CHECK("mapby device=fabric: rc", PRTE_SUCCESS == rc);
+    sval = get_str(&app->attributes, PRTE_APP_MAP_DEVICE);
+    CHECK("mapby device=fabric: spec", NULL != sval && 0 == strcmp(sval, "fabric"));
+    free(sval);
+    sval = get_str(&app->attributes, PRTE_APP_MAP_INTERLEAVE);
+    CHECK("mapby device=fabric: interleave qualifier",
+          NULL != sval && 0 == strcmp(sval, "numa"));
+    free(sval);
+    PMIX_RELEASE(app);
+
     /* the value is read after the "=", not at a fixed offset past the full
      * spelling - the directive may be abbreviated to any unambiguous prefix */
     app = PMIX_NEW(prte_app_context_t);


### PR DESCRIPTION
Depends on openpmix/openpmix#4169 for the environment half; the mapping half stands alone.

## The vocabulary

`--map-by device=network` meant `PMIX_DEVTYPE_NETWORK`, `device=openfabrics` meant `PMIX_DEVTYPE_OPENFABRICS`, and `device=nic` meant the union. That looks like a useful distinction and is not one.

An HCA presents itself twice — as an OpenFabrics OS device (`mlx5_0`) and as a network interface (`ib0`), on the same PCI function. A user asking to map by a NIC wants the card, not one of hwloc's two views of it, so the narrow spellings returned the same hardware under different names and different counts, and whichever the user did not type looked like a wrong answer. Which name came back for a given card was not something the directive let them control.

All four spellings now mean the union. The enumeration already dedupes by PCI function, so the result is one entry per card however the node presents it, and every qualifier — `ndev=`, `shared`, `interleave=` — applies unchanged, because none of them was ever class-specific:

```
$ prterun --map-by device=nic --bind-to numa -n 4 ...
    rank 0 … Device: mlx5_0      rank 1 … Device: mlx5_3
    rank 2 … Device: eno6        rank 3 … Device: mlx5_1
```

`network`, `fabric` and `openfabrics` give the identical map; `gpu` is untouched. `--map-by device=nic:ndev=2` gives `mlx5_0,mlx5_3` to rank 0, and `:shared` and `:interleave=numa` behave as they do for GPUs.

The cost is that there is no longer a spelling for "ethernet only". That is a narrower question than the directive is for, and naming the interface (`device=eno6`) answers it exactly.

## Two documentation fixes carried alongside

**What a network assignment sets in the environment.** With openpmix#4169 a process mapped against a NIC is handed it in `NCCL_IB_HCA` / `UCX_NET_DEVICES` / `PSM3_NIC`. The placement docs say so, along with the two properties that are decisions rather than consequences: a NIC's name is always available, so the identity check that can refuse a *GPU* mapping does not apply here; and no variable naming an adapter by its unit *number* is set at all, because a unit number is meaningful only against the enumeration it came from.

**Intel GPUs are named to their runtime after all.** The docs still said `ZE_AFFINITY_MASK` is deliberately never set because it takes indices in an ordering PRRTE cannot reproduce. PMIx's `pgpu/intel` now sets it: the premise was wrong in one specific way, since PMIx does not have to *reproduce* the ordering — hwloc's Level Zero backend recorded it. Corrected in all three places that carried it, with a note under "Phases as landed" in the plan saying what changed and why the no-guessing rule it was protecting is intact.

## Offline harness fix

Independent of the above, and its own commit. The harness pins a mapping-policy baseline on every case so a developer's `~/.prte/mca-params.conf` cannot change what it measures — but it spelled that pin `rmaps_default_mapping_policy`, a deprecated synonym for `mapby`. Every run therefore printed PRRTE's deprecation banner, and the banner was captured into **91 of the 95** golden snapshots. The four that lack it then fail against any tree that produces it, so the harness reported a mapping regression where there was none.

A command-line setting beats a file setting whichever spelling the file used, so the pin loses nothing by naming the variable properly. Goldens regenerated in the same commit: **728 deleted lines, zero added**, all of them the banner — no placement changed.

## Testing

- Warning-free `--enable-debug` build; `make check` 20/20 suites.
- `make -C test/offline check-offline`: **2369 pass, 0 fail** (was 2365/4 before the harness fix).
- `prte --daemonize` → `prun -n 4 hostname` → `pterm`.
- `prte-convert-help.py --check-only` clean after regenerating the show-help content.
- New unit coverage: the four spellings agree and GPU stays its own class (`test_devices.c`); `device=nic` and `device=fabric` parse with qualifiers attached (`test_policy_parse.c`).

## Commits

1. Pin the offline harness to the mapping variable's own name
2. Accept nic, fabric and openfabrics as spellings of device=network
3. Say what mapping by a network device sets in the environment
4. Say that Intel GPUs are named to their runtime after all

🤖 Generated with [Claude Code](https://claude.com/claude-code)