### PR TITLE
Decide access to published data by permissions, then range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,9 @@ cov-int
 # Out-of-tree (VPATH) build dirs.  vpath-linux/vpath-macos are the ones
 # contrib/dockerswarm/build.sh creates; build/ is the conventional name
 # for your own, which AGENTS.md tells you to use rather than configuring
-# in the source tree.
-/vpath-linux/
-/vpath-macos/
+# in the source tree.  Any other vpath-* is a build against some other
+# dependency - a PMIx from a topic branch, say - and is equally yours.
+/vpath-*/
 /build/
 
 .hgrc

--- a/contrib/dockerswarm/dataserver.c
+++ b/contrib/dockerswarm/dataserver.c
@@ -32,7 +32,9 @@
  *   dataserver lookupwait <key> [seconds] [range]
  *       PMIx_Lookup with PMIX_WAIT, which parks the request in the data
  *       server until somebody publishes the key.  Prints "WAITING" first so
- *       the harness can tell it got that far.
+ *       the harness can tell it got that far.  It also carries PMIX_TIMEOUT
+ *       = <seconds>, so a key nobody ever publishes ends in
+ *       "STATUS PMIX_ERR_TIMEOUT" rather than hanging.
  *
  *   dataserver lookup2 <key1> <key2> [seconds]
  *       Look both keys up in one call.  With only one of them published

--- a/contrib/dockerswarm/dataserver.c
+++ b/contrib/dockerswarm/dataserver.c
@@ -11,10 +11,19 @@
  * dataserver -- a minimal PMIx client for exercising PRRTE's publish/lookup
  * data server (src/runtime/data_server/) across nodes.
  *
- *   dataserver publish <key> <value> [range] [seconds]
+ *   dataserver publish <key> <value> [range] [seconds] [access]
  *       PMIx_Publish the key, print "PUBLISHED <key>", then stay alive for
  *       <seconds> (the data lives as long as the publisher does, and a
  *       lookup has to find it while it is there).
+ *
+ *       <access> names an access-permission list to publish with:
+ *         self-uid / other-uid   PMIX_ACCESS_USERIDS holding our own
+ *                                effective uid, or one that is not ours,
+ *                                inside a PMIX_ACCESS_PERMISSIONS array
+ *         self-gid / other-gid   PMIX_ACCESS_GRPIDS at the top level,
+ *                                holding our own effective gid or another
+ *       Absent a list, published data is readable only by its publisher's
+ *       own uid and gid, which is the default the data server applies.
  *
  *   dataserver lookup <key> [seconds] [range]
  *       PMIx_Lookup with no wait.  Prints one "FOUND <key> <value>" line per
@@ -34,10 +43,15 @@
  * instance rather than to the HNP (see pmix_server_pub.c), so it is only
  * reachable by a lookup carrying the same range.
  *
- *   dataserver unpublish <key> [seconds]
+ *   dataserver unpublish <key> [seconds] [pubrange] [unpubrange]
  *       Publish, then unpublish, then look up - all from one process, since
  *       only the publisher may unpublish its own data.  Prints
  *       "UNPUBLISHED" and then the lookup outcome.
+ *
+ *       The two ranges are separate on purpose.  Duplicate keys are allowed
+ *       on different ranges, so an unpublish removes only what was published
+ *       to the range IT names (PMIX_RANGE_SESSION when it names none) - give
+ *       the two arguments different values and the item must survive.
  *
  * <range> is one of session (default), namespace, local, proc-local, global.
  *
@@ -80,11 +94,60 @@ static pmix_data_range_t parse_range(const char *s)
     return PMIX_RANGE_SESSION;
 }
 
+/* Load the access-permission directive named by <access> into *info.
+ * Returns the number of directives loaded (0 or 1).  The uid form is
+ * nested inside PMIX_ACCESS_PERMISSIONS and the gid form is given at the
+ * top level, so the two spellings the data server accepts both get
+ * exercised. */
+static size_t load_access(const char *access, pmix_info_t *info)
+{
+    pmix_data_array_t *ids, *perms;
+    uint32_t *idp;
+    pmix_info_t *ip;
+
+    if (NULL == access) {
+        return 0;
+    }
+
+    PMIX_DATA_ARRAY_CREATE(ids, 1, PMIX_UINT32);
+    idp = (uint32_t *) ids->array;
+
+    if (0 == strcmp(access, "self-uid") || 0 == strcmp(access, "other-uid")) {
+        idp[0] = (uint32_t) geteuid();
+        if ('o' == access[0]) {
+            idp[0] += 1;
+        }
+        /* wrap it in a PMIX_ACCESS_PERMISSIONS array */
+        PMIX_DATA_ARRAY_CREATE(perms, 1, PMIX_INFO);
+        ip = (pmix_info_t *) perms->array;
+        PMIX_INFO_LOAD(&ip[0], PMIX_ACCESS_USERIDS, ids, PMIX_DATA_ARRAY);
+        PMIX_DATA_ARRAY_FREE(ids);
+        PMIX_INFO_LOAD(info, PMIX_ACCESS_PERMISSIONS, perms, PMIX_DATA_ARRAY);
+        PMIX_DATA_ARRAY_FREE(perms);
+        return 1;
+    }
+
+    if (0 == strcmp(access, "self-gid") || 0 == strcmp(access, "other-gid")) {
+        idp[0] = (uint32_t) getegid();
+        if ('o' == access[0]) {
+            idp[0] += 1;
+        }
+        PMIX_INFO_LOAD(info, PMIX_ACCESS_GRPIDS, ids, PMIX_DATA_ARRAY);
+        PMIX_DATA_ARRAY_FREE(ids);
+        return 1;
+    }
+
+    PMIX_DATA_ARRAY_FREE(ids);
+    fprintf(stderr, "ERROR unknown access spec: %s\n", access);
+    return 0;
+}
+
 static int do_publish(const char *key, const char *value,
-                      const char *rangestr, int seconds)
+                      const char *rangestr, int seconds, const char *access)
 {
     pmix_status_t rc;
-    pmix_info_t info[2];
+    pmix_info_t info[3];
+    size_t n, ninfo = 2;
     pmix_data_range_t range = parse_range(rangestr);
 
     rc = PMIx_Init(&myproc, NULL, 0);
@@ -97,10 +160,12 @@ static int do_publish(const char *key, const char *value,
 
     PMIX_INFO_LOAD(&info[0], key, value, PMIX_STRING);
     PMIX_INFO_LOAD(&info[1], PMIX_RANGE, &range, PMIX_DATA_RANGE);
+    ninfo += load_access(access, &info[2]);
 
-    rc = PMIx_Publish(info, 2);
-    PMIX_INFO_DESTRUCT(&info[0]);
-    PMIX_INFO_DESTRUCT(&info[1]);
+    rc = PMIx_Publish(info, ninfo);
+    for (n = 0; n < ninfo; n++) {
+        PMIX_INFO_DESTRUCT(&info[n]);
+    }
     if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "ERROR PMIx_Publish(%s): %s\n", key, PMIx_Error_string(rc));
         PMIx_Finalize(NULL, 0);
@@ -184,10 +249,13 @@ static int do_lookup(char **keys, size_t nkeys, int seconds, bool wait,
     return ret;
 }
 
-static int do_unpublish(const char *key, int seconds)
+static int do_unpublish(const char *key, int seconds, const char *pubrange,
+                        const char *unpubrange)
 {
     pmix_status_t rc;
-    pmix_info_t info;
+    pmix_info_t info[2];
+    pmix_data_range_t range = parse_range(pubrange);
+    pmix_data_range_t urange = parse_range(unpubrange);
     /* PMIx_Unpublish takes a NULL-terminated key array */
     char *keys[2] = {NULL, NULL};
 
@@ -197,9 +265,11 @@ static int do_unpublish(const char *key, int seconds)
         return 1;
     }
 
-    PMIX_INFO_LOAD(&info, key, "unpublish-me", PMIX_STRING);
-    rc = PMIx_Publish(&info, 1);
-    PMIX_INFO_DESTRUCT(&info);
+    PMIX_INFO_LOAD(&info[0], key, "unpublish-me", PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_RANGE, &range, PMIX_DATA_RANGE);
+    rc = PMIx_Publish(info, 2);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
     if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "ERROR PMIx_Publish: %s\n", PMIx_Error_string(rc));
         PMIx_Finalize(NULL, 0);
@@ -211,11 +281,19 @@ static int do_unpublish(const char *key, int seconds)
     /* confirm it is really there before we take it away, so a later
      * NOTFOUND cannot be blamed on the publish */
     keys[0] = (char *) key;
-    (void) lookup_keys(keys, 1, seconds, false, NULL);
+    (void) lookup_keys(keys, 1, seconds, false, pubrange);
 
     keys[0] = (char *) key;
     keys[1] = NULL;
-    rc = PMIx_Unpublish(keys, NULL, 0);
+    if (NULL == unpubrange) {
+        /* say nothing about the range, which is the common case and the
+         * one that leans on the default matching the publish default */
+        rc = PMIx_Unpublish(keys, NULL, 0);
+    } else {
+        PMIX_INFO_LOAD(&info[0], PMIX_RANGE, &urange, PMIX_DATA_RANGE);
+        rc = PMIx_Unpublish(keys, info, 1);
+        PMIX_INFO_DESTRUCT(&info[0]);
+    }
     if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "ERROR PMIx_Unpublish: %s\n", PMIx_Error_string(rc));
         PMIx_Finalize(NULL, 0);
@@ -225,7 +303,7 @@ static int do_unpublish(const char *key, int seconds)
     fflush(stdout);
 
     keys[0] = (char *) key;
-    (void) lookup_keys(keys, 1, seconds, false, NULL);
+    (void) lookup_keys(keys, 1, seconds, false, pubrange);
 
     PMIx_Finalize(NULL, 0);
     return 0;
@@ -237,11 +315,11 @@ int main(int argc, char **argv)
 
     if (2 > argc) {
         fprintf(stderr,
-                "usage: %s publish <key> <value> [range] [secs]\n"
+                "usage: %s publish <key> <value> [range] [secs] [access]\n"
                 "       %s lookup <key> [secs] [range]\n"
                 "       %s lookupwait <key> [secs] [range]\n"
                 "       %s lookup2 <key1> <key2> [secs]\n"
-                "       %s unpublish <key> [secs]\n",
+                "       %s unpublish <key> [secs] [pubrange] [unpubrange]\n",
                 argv[0], argv[0], argv[0], argv[0], argv[0]);
         return 2;
     }
@@ -252,7 +330,8 @@ int main(int argc, char **argv)
             return 2;
         }
         return do_publish(argv[2], argv[3], (5 > argc) ? NULL : argv[4],
-                          (6 > argc) ? 120 : atoi(argv[5]));
+                          (6 > argc) ? 120 : atoi(argv[5]),
+                          (7 > argc) ? NULL : argv[6]);
     }
     if (0 == strcmp(argv[1], "lookup") || 0 == strcmp(argv[1], "lookupwait")) {
         if (3 > argc) {
@@ -278,7 +357,9 @@ int main(int argc, char **argv)
             fprintf(stderr, "unpublish needs a key\n");
             return 2;
         }
-        return do_unpublish(argv[2], (4 > argc) ? 20 : atoi(argv[3]));
+        return do_unpublish(argv[2], (4 > argc) ? 20 : atoi(argv[3]),
+                            (5 > argc) ? NULL : argv[4],
+                            (6 > argc) ? NULL : argv[5]);
     }
 
     fprintf(stderr, "unknown mode: %s\n", argv[1]);

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -1612,6 +1612,21 @@ test_runtime() {
                 && ok "...and the reply carried the publisher's identity" \
                 || bad "the reply did not name the data owner: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
 
+            banner "runtime/data_server: a lookup's own range constrains the search"
+            # The PMIx retrieval rules apply the range TWICE: the publisher's
+            # says who may see the item, and the requester's says whose items
+            # it is willing to see.  ds_lookup used to unpack the requester's
+            # range and put it only on a PARKED request, where nothing ever
+            # read it - so an immediate lookup searched everything the
+            # publishers would let it see, whatever it had asked for.
+            #
+            # Each prun gets its own namespace, so a NAMESPACE-range lookup
+            # from a different job must not reach this SESSION-range item.
+            out=$(PRUN "--host node3:1 -n 1 $DS lookup prte.test.k1 15 namespace" 2>&1)
+            echo "$out" | grep -q '^FOUND prte.test.k1' \
+                && bad "a namespace-scoped lookup reached another namespace's data" \
+                || ok "a namespace-scoped lookup did not reach another namespace's data"
+
             banner "runtime/data_server: a key nobody published is NOT_FOUND, not a hang"
             # A miss travels the same path and has to come back as a status.
             # ds_lookup used to have exits that returned without sending
@@ -1710,6 +1725,53 @@ test_runtime() {
         [ "$n" = 1 ] \
             && ok "...and the key was gone afterwards" \
             || bad "the key survived the unpublish (FOUND $n times)"
+
+        banner "runtime/data_server: an owner may unpublish on any range"
+        # Removal is a question of OWNERSHIP, not of access: the publisher
+        # may take back what it published whatever range it went out on, and
+        # whatever range the unpublish itself names.  This used to be gated
+        # on the read rule, so an owner could not remove data published to a
+        # range it does not itself fall within (PMIX_RANGE_RM admits only the
+        # host's namespace, PMIX_RANGE_CUSTOM only the accessors it named) --
+        # and was told SUCCESS while the item stayed in the store.
+        out=$(PRUN "--host node2:1 -n 1 $DS unpublish prte.test.rng 15 global session" 2>&1)
+        n=$(echo "$out" | grep -c '^FOUND prte.test.rng')
+        [ "$n" = 1 ] \
+            && ok "an owner unpublished its GLOBAL-range data naming SESSION" \
+            || bad "an owner could not remove its own data (FOUND $n times): $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+
+        banner "runtime/data_server: access permissions decide who may read"
+        # Absent an accessor list, published data belongs to its publisher:
+        # only the publisher's own uid and gid may read it.  A list -- given
+        # here as PMIX_ACCESS_USERIDS inside a PMIX_ACCESS_PERMISSIONS array,
+        # or PMIX_ACCESS_GRPIDS at the top level -- replaces that default with
+        # a requirement, and a requestor that fails it is told
+        # PMIX_ERR_NO_PERMISSIONS rather than "not found".
+        #
+        # Every container here runs as the same user, so the discriminating
+        # case is a list naming somebody else: what it proves is that the
+        # publisher's list is read and enforced, not merely stored.
+        for spec in self-uid other-uid self-gid other-gid; do
+            PRUN_BG /tmp/ds-acc-$spec.out \
+                "--host node2:1 -n 1 $DS publish prte.test.acc.$spec val session 60 $spec"
+        done
+        sleep 8
+        for spec in self-uid self-gid; do
+            out=$(PRUN "--host node3:1 -n 1 $DS lookup prte.test.acc.$spec 15" 2>&1)
+            echo "$out" | grep -q "^FOUND prte.test.acc.$spec" \
+                && ok "a list naming our own identity ($spec) admits the reader" \
+                || bad "a permitted reader was refused ($spec): $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        done
+        for spec in other-uid other-gid; do
+            out=$(PRUN "--host node3:1 -n 1 $DS lookup prte.test.acc.$spec 15" 2>&1)
+            echo "$out" | grep -q "^FOUND prte.test.acc.$spec" \
+                && bad "a list naming somebody else ($spec) did not keep us out" \
+                || ok "a list naming somebody else ($spec) refused the reader"
+            echo "$out" | grep -q 'STATUS PMIX_ERR_NO_PERMISSIONS' \
+                && ok "...and said so with NO_PERMISSIONS, not NOT_FOUND" \
+                || bad "a refusal was not reported as NO_PERMISSIONS ($spec): $(echo "$out" | grep '^STATUS' | tr -d '\r')"
+        done
+
         RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     fi
     cleanup_swarm

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -1772,6 +1772,16 @@ test_runtime() {
                 || bad "a refusal was not reported as NO_PERMISSIONS ($spec): $(echo "$out" | grep '^STATUS' | tr -d '\r')"
         done
 
+        banner "runtime/data_server: a parked lookup honors PMIX_TIMEOUT"
+        # PMIX_WAIT parks the request until somebody publishes the key.  With
+        # a PMIX_TIMEOUT the wait is bounded: the data server arms a timer on
+        # the parked request and answers PMIX_ERR_TIMEOUT if nothing satisfies
+        # it first.  Without that timer the caller waited forever -- the
+        # timeout reached the daemon's caddy and went no further.
+        out=$(PRUN "--host node3:1 -n 1 $DS lookupwait prte.test.nobodypublishes 15" 2>&1)
+        echo "$out" | grep -q 'STATUS PMIX_ERR_TIMEOUT' \
+            && ok "a wait for a key nobody publishes ended in TIMEOUT" \
+            || bad "a parked lookup did not time out: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
         RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     fi
     cleanup_swarm

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -32,12 +32,6 @@ Runtime behavior
 surface exists for SLURM only.  Everything above the component is
 RM-agnostic; what is missing is the Flux-side conversation.
 
-**``PMIX_RANGE_CUSTOM`` denies everyone.**  The data server's ``check_range``
-has no accessor-list implementation and falls through to ``PMIX_ERROR``
-(``src/runtime/data_server/``).  Denying is the safe direction for an
-unimplemented rule, and it is the reason a publisher cannot express "these
-specific processes may read this".
-
 **``filem/raw`` does not survive losing a daemon mid-staging.**  Its fault
 handler is deliberately minimal (``src/mca/filem/raw/filem_raw_module.c``);
 the note in place observes that the real thing should be straightforward,
@@ -219,11 +213,10 @@ Every marker in the code
 
 The list above is meant to be the whole of it: a ``TODO``, ``FIXME`` or
 ``XXX`` left in PRRTE's own sources should have an entry here in prose — and
-so should an arm deliberately left empty, like the data server's
-``PMIX_RANGE_CUSTOM`` case, which carries no keyword at all — and this table
-is what makes that checkable.  If you leave a marker, add the entry; if you
-find a marker this table does not name, either the entry or the marker is
-stale.
+so should an arm deliberately left empty, which carries no keyword at all —
+and this table is what makes that checkable.  If you leave a marker, add the
+entry; if you find a marker this table does not name, either the entry or
+the marker is stale.
 
 .. list-table::
    :header-rows: 1
@@ -266,9 +259,6 @@ stale.
      - nothing records who is "connected"
    * - ``mca/ras/flux/ras_flux_module.c``, ``modify``
      - ``ras/flux`` has no ``modify()``
-   * - ``runtime/data_server/ds_main.c``,
-       ``prte_data_server_check_range``
-     - ``PMIX_RANGE_CUSTOM`` denies everyone
 
 Two families of marker are **not** ours, and are deliberately absent from
 that table: the ``TODO`` comments in ``hostfile_lex.c`` and

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -577,10 +577,11 @@ void pmix_server_keyval_client(int status, pmix_proc_t *sender,
     }
 
     /* these answers carry no payload: nothing was found, nothing could be
-     * shown to this requestor, or the command is one that returns only a
-     * status */
+     * shown to this requestor, the wait ran out, or the command is one that
+     * returns only a status */
     if (PMIX_ERR_NOT_FOUND == ret ||
         PMIX_ERR_NO_PERMISSIONS == ret ||
+        PMIX_ERR_TIMEOUT == ret ||
         PRTE_PMIX_UNPUBLISH_CMD == command ||
         PRTE_PMIX_PUBLISH_CMD == command) {
         goto release;

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -576,7 +576,11 @@ void pmix_server_keyval_client(int status, pmix_proc_t *sender,
         goto release;
     }
 
+    /* these answers carry no payload: nothing was found, nothing could be
+     * shown to this requestor, or the command is one that returns only a
+     * status */
     if (PMIX_ERR_NOT_FOUND == ret ||
+        PMIX_ERR_NO_PERMISSIONS == ret ||
         PRTE_PMIX_UNPUBLISH_CMD == command ||
         PRTE_PMIX_PUBLISH_CMD == command) {
         goto release;

--- a/src/runtime/data_server/AGENTS.md
+++ b/src/runtime/data_server/AGENTS.md
@@ -218,6 +218,15 @@ later publish resolves the rest, `complete_resolved` is what says the
 request is finished — do not re-derive it by counting `req->keys`, because
 that array has already been swapped for the unresolved remainder.
 
+A `PMIX_TIMEOUT` given with the wait bounds it: the parked request carries
+an event armed for that many seconds (`lookup_timeout` in `ds_lookup.c`),
+which takes it off `pending` and answers `PMIX_ERR_TIMEOUT` with no payload.
+Anything that disposes of the request earlier — a satisfying publish, a
+purge, finalize — releases it, and the destructor is what disarms the
+timer, so every path is covered by `PMIX_RELEASE`. Without the timer a wait
+for a key nobody publishes never returned: the timeout reached the daemon's
+caddy (`req->timeout` in `pmix_server_pub.c`) and went no further.
+
 `ds_purge` drops both the departing process's published items *and* any
 lookup it left parked; a request that outlives its requestor would otherwise
 have a later publish trying to reply to a process that no longer exists.
@@ -240,6 +249,9 @@ have a later publish trying to reply to a process that no longer exists.
 - **An access rule is not an ownership rule.** See the section above: what
   may be read and what may be removed are different questions, and the
   answer to the first one refused owners their own data.
+- **A parked request can own an armed timer.** Remove it from `pending` and
+  `PMIX_RELEASE` it; never `free` around it, and never leave the list
+  holding one you have released.
 - **No locking, and none is wanted.** Everything here runs inside the RML
   receive on the progress thread.
 - **`prte_data_store.output` is `-1` until a verbosity is registered**, so
@@ -264,10 +276,10 @@ the range and access rules between real processes, a namespace-scoped lookup
 that must *not* reach another job's data, an accessor list that admits or
 refuses a real reader (and is answered with `PMIX_ERR_NO_PERMISSIONS`),
 unpublish — including an owner removing data published on a range it does
-not itself fall within — and the `PMIX_WAIT` path where a lookup parks
-until a later publish satisfies it. The `dataserver` helper takes the
-publish range, the unpublish range and an access spec as separate arguments
-for those cases.
+not itself fall within — and the `PMIX_WAIT` path, both where a later
+publish satisfies it and where `PMIX_TIMEOUT` ends it. The `dataserver`
+helper takes the publish range, the unpublish range and an access spec as
+separate arguments for those cases.
 
 The **external** data server is multi-node coverage by construction — the
 whole point is a namespace boundary, and one DVM has none. `test_runtime`

--- a/src/runtime/data_server/AGENTS.md
+++ b/src/runtime/data_server/AGENTS.md
@@ -29,7 +29,7 @@ app proc ◀─PMIx── its prted ◀──RML(PRTE_RML_TAG_DATA_CLIENT)──
 |------|------|
 | `prte_data_server.h` | The public surface: init/finalize, the RML receive callback, and the four command codes. |
 | `ds.h` | The internal objects — `prte_data_object_t` (one published item), `prte_data_req_t` (one parked lookup), `prte_ds_info_t`, and the `prte_data_store` singleton. |
-| `ds_main.c` | `prte_data_server()` — the RML receive that unpacks the room number and command and dispatches; `prte_data_server_check_range()`; all the class instances. |
+| `ds_main.c` | `prte_data_server()` — the RML receive that unpacks the room number and command and dispatches; the access check and the two range checks; all the class instances. |
 | `ds_publish.c` | Store an item, then satisfy any parked lookups it answers. |
 | `ds_lookup.c` | Answer from the store, or park the request if the caller asked to wait. |
 | `ds_unpublish.c` | Remove the caller's own items by key. |
@@ -114,28 +114,89 @@ unpacks it; they change together.
 
 ---
 
-## Ranges — the access-control rules
+## Who may read, and who may remove
 
-`prte_data_server_check_range()` decides whether a requestor may see a
-published item. It is the only access control here, so it is worth reading
-before changing:
+Two different questions, and conflating them is what went wrong here
+before. **Reading** is decided by the publisher's access permissions and
+then by the range. **Removal** is decided by ownership alone.
 
-| `data->range` | Admits |
-|---------------|--------|
-| `SESSION`, `GLOBAL`, `UNDEF` | anyone |
-| `NAMESPACE` | any rank of the publisher's namespace |
-| `LOCAL` | requestors behind the same daemon (`req->proxy` vs `data->proxy`) |
-| `PROC_LOCAL` | the publishing process itself |
-| `RM` | our own (the host server's) namespace |
-| `CUSTOM` | **nobody** — the accessor list is not implemented |
+### Retrieval: permissions first, then range
 
-`CUSTOM` denying is deliberate, not an oversight in the tests: the function
-falls through to `return PMIX_ERROR`, which is the safe direction for an
-unimplemented rule.
+`prte_data_server_check_access()` is the first gate. Absent an accessor
+list, published data belongs to its publisher: the requestor must present
+the publisher's own uid **and** gid. A publisher that names a list —
+`PMIX_ACCESS_USERIDS`, `PMIX_ACCESS_GRPIDS`, either inside a
+`PMIX_ACCESS_PERMISSIONS` array or at the top level — replaces that
+default, and each list it gives is a **requirement**, not a grant: a
+requestor must satisfy every list present. (So a publisher whose own uid is
+absent from its own `PMIX_ACCESS_USERIDS` cannot look its own data up
+either. It can still unpublish it — see below.) A refusal is
+`PMIX_ERR_NO_PERMISSIONS`, and `ds_lookup` reports that status rather than
+`NOT_FOUND` when the key existed and only permission was lacking.
 
-Separately from the range, both publish and lookup compare `uid` — data is
-only visible to the user that posted it. That check is in the callers, not
-in `check_range`.
+A restriction the publisher gave and we cannot parse **fails the publish**.
+Storing it anyway would store the data unrestricted, which is the one
+outcome nobody asked for.
+
+This depends on PMIx handing us both ids. The library appends `PMIX_USERID`
+and `PMIX_GRPID` to the info array of every publish, lookup and unpublish —
+the gid took an openpmix change to be handed over at all (it comes from the
+peer's connection record, not from the message), and where it is missing
+both sides read `UINT32_MAX` and the rule degrades to uid-only rather than
+locking everyone out.
+
+### Then the range, in both directions
+
+The PMIx retrieval rules apply the range test twice: the requestor must
+fall within the range the *publisher* named, and the publisher must fall
+within the range the *requester* named. One predicate answers both —
+`range_admits()` in `ds_main.c`, "does `subject` fall within `range` as seen
+from `anchor`" — and the two entry points differ only in which process
+plays which role:
+
+| Entry point | Range applied | Anchor → subject |
+|-------------|---------------|------------------|
+| `prte_data_server_check_range()` | `data->range` | publisher → requestor |
+| `prte_data_server_check_search_range()` | `req->range` | requestor → publisher |
+
+| range | Admits the subject when |
+|-------|-------------------------|
+| `SESSION`, `GLOBAL`, `UNDEF` | always |
+| `NAMESPACE` | it shares the anchor's namespace |
+| `LOCAL` | it sits behind the anchor's daemon (`req->proxy` vs `data->proxy`) |
+| `PROC_LOCAL` | it *is* the anchor |
+| `RM` | it is the host environment — our own namespace |
+| `CUSTOM` | the publisher's accessor list admits it |
+
+`CUSTOM` is the one range that is not a relation between two processes: the
+accessor list *is* the range, so `check_range` answers it directly — admit
+when a list was given (the access check has already applied it), refuse when
+the publisher named nobody, since there is no other reading of a custom
+range with no custom in it. In the requester's direction there is no list to
+consult and `range_admits` refuses it.
+
+The requester's half used to be missing entirely: `ds_lookup` unpacked
+`PMIX_RANGE` and put it only on a *parked* request, where nothing read it,
+so a lookup that asked to search its own namespace searched everything its
+publishers would let it see. Both checks now run in `ds_lookup` and in
+`ds_publish`'s pending-request loop, and the default on both sides is
+`PMIX_RANGE_SESSION` — the constructors say so, which is why `rqcon` sets a
+range at all.
+
+### Removal: ownership, and nothing else
+
+`ds_unpublish` applies neither rule. **An owner may unpublish what it
+published on any range**, and the range the unpublish itself names does not
+narrow that. The test is that the requesting process *is* the owner — a
+stronger check than comparing uids, because a process identity is stamped by
+its own PMIx server rather than asserted by the caller (or, for a relay,
+claimed in `PMIX_REQUESTOR` and honored only from a tool).
+
+Gating removal on the read rule is exactly the confusion this section
+exists to prevent: it left a `PMIX_RANGE_RM` or `PMIX_RANGE_CUSTOM` item
+impossible to remove — the owner falls outside its own item's range — while
+still answering `PMIX_SUCCESS`, so the item sat in the store until its job
+ended.
 
 `data->proxy` and `req->proxy` are what the `LOCAL` rule compares, and
 `PMIX_NEW` does not zero its allocation, so both constructors have to
@@ -176,6 +237,9 @@ have a later publish trying to reply to a process that no longer exists.
 - **A stack `PMIX_CONSTRUCT`ed object needs `PMIX_DESTRUCT` on *every*
   return.** `ds_lookup` and `ds_unpublish` both build a `prte_data_req_t` on
   the stack to carry the requestor into `check_range`.
+- **An access rule is not an ownership rule.** See the section above: what
+  may be read and what may be removed are different questions, and the
+  answer to the first one refused owners their own data.
 - **No locking, and none is wanted.** Everything here runs inside the RML
   receive on the progress thread.
 - **`prte_data_store.output` is `-1` until a verbosity is registered**, so
@@ -186,15 +250,24 @@ have a later publish trying to reply to a process that no longer exists.
 
 ## Testing
 
-**Unit — `test/unit/runtime/test_runtime.c`.** `prte_data_server_check_range`
-against every range value in both directions, and the object constructors'
-initialization contract. Neither needs the RML.
+**Unit — `test/unit/runtime/test_runtime.c`.** Both range checks against
+every range value in both directions — `prte_data_server_check_range` from
+the publisher's side and `prte_data_server_check_search_range` from the
+requester's — and the object constructors' initialization contract,
+including the `PMIX_RANGE_SESSION` default a request carries. Neither needs
+the RML.
 
 **Multi-node — `contrib/dockerswarm`, the `test_runtime` phase.** The store
 is on the HNP and the clients are elsewhere, so the interesting paths only
 exist with real daemons: a publish on one node found by a lookup on another,
-the range and userid rules between real processes, unpublish, and the
-`PMIX_WAIT` path where a lookup parks until a later publish satisfies it.
+the range and access rules between real processes, a namespace-scoped lookup
+that must *not* reach another job's data, an accessor list that admits or
+refuses a real reader (and is answered with `PMIX_ERR_NO_PERMISSIONS`),
+unpublish — including an owner removing data published on a range it does
+not itself fall within — and the `PMIX_WAIT` path where a lookup parks
+until a later publish satisfies it. The `dataserver` helper takes the
+publish range, the unpublish range and an access spec as separate arguments
+for those cases.
 
 The **external** data server is multi-node coverage by construction — the
 whole point is a namespace boundary, and one DVM has none. `test_runtime`
@@ -205,9 +278,11 @@ by a publish in the other, that an ended job's data is purged from the server
 and that the purge takes *only* that job's data — plus the control, that a
 DVM which was not given the URI sees none of it.
 
-**Not covered:** `PMIX_RANGE_CUSTOM` (no accessor list exists to test),
-`PMIX_PERSIST_FIRST_READ` end-to-end, and `ds_purge` (which is driven by
-process termination rather than by a client call).
+**Not covered:** `PMIX_PERSIST_FIRST_READ` end-to-end, and `ds_purge` (which
+is driven by process termination rather than by a client call). Access
+permissions are covered only with the harness running as a single user, so
+what the swarm proves is that a list naming *somebody else* keeps us out —
+not that a genuinely different uid gets in.
 
 A note on the partial-lookup case, because it took both code bases to make
 it work. PRRTE returning the status *and* the values it found is only half

--- a/src/runtime/data_server/ds.h
+++ b/src/runtime/data_server/ds.h
@@ -73,6 +73,10 @@ PMIX_CLASS_DECLARATION(prte_data_object_t);
 /* define a request object for delayed answers */
 typedef struct {
     pmix_list_item_t super;
+    /* the timeout event, armed only for a parked request that was given a
+     * PMIX_TIMEOUT.  Named "ev" by the caddy convention */
+    prte_event_t ev;
+    bool timer_active;
     pmix_proc_t proxy;
     pmix_proc_t requestor;
     int room_number;

--- a/src/runtime/data_server/ds.h
+++ b/src/runtime/data_server/ds.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2007-2020 Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2015-2020 Intel, Inc.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -47,9 +47,18 @@ typedef struct {
      * owner can remove it
      */
     pmix_proc_t owner;
-    /* uid of the owner - helps control
-     * access rights */
+    /* effective uid and gid of the owner - absent an accessor list,
+     * these ARE the access rule: the data belongs to its publisher */
     uint32_t uid;
+    uint32_t gid;
+    /* the accessor lists the publisher gave, if any
+     * (PMIX_ACCESS_USERIDS / PMIX_ACCESS_GRPIDS, either at the top level
+     * or inside a PMIX_ACCESS_PERMISSIONS array).  Each list that is
+     * present is a requirement the requestor must meet. */
+    uint32_t *auids;
+    size_t nauids;
+    uint32_t *agids;
+    size_t nagids;
     /* characteristics */
     pmix_data_range_t range;
     pmix_persistence_t persistence;
@@ -67,7 +76,10 @@ typedef struct {
     pmix_proc_t proxy;
     pmix_proc_t requestor;
     int room_number;
+    /* effective uid and gid of the requestor - what an accessor list, or
+     * the publisher's own identity, is checked against */
     uint32_t uid;
+    uint32_t gid;
     pmix_data_range_t range;
     char **keys;
 } prte_data_req_t;
@@ -116,8 +128,29 @@ PRTE_EXPORT void prte_ds_purge(pmix_proc_t *sender,
                                pmix_data_buffer_t *buffer,
                                pmix_data_buffer_t *answer);
 
+/* Apply the PUBLISHER's range: may this requestor see this item?  This is
+ * an access rule, so it governs lookup - not removal, which is a question
+ * of ownership (see ds_unpublish.c). */
 PRTE_EXPORT pmix_status_t prte_data_server_check_range(prte_data_req_t *req,
                                                        prte_data_object_t *data);
+
+/* Apply the publisher's ACCESS PERMISSIONS: may this requestor's uid and
+ * gid see this item?  A publisher that named no accessors keeps the data to
+ * itself - the requestor must present the publisher's own uid and gid - and
+ * each list it did name (PMIX_ACCESS_USERIDS, PMIX_ACCESS_GRPIDS) is a
+ * requirement rather than a grant, so a requestor must satisfy every list
+ * that is present.  Returns PMIX_ERR_NO_PERMISSIONS when refused, which is
+ * the status the retrieval rules ask for. */
+PRTE_EXPORT pmix_status_t prte_data_server_check_access(prte_data_req_t *req,
+                                                        prte_data_object_t *data);
+
+/* Apply the REQUESTER's range: is this publisher one the lookup asked to
+ * search?  The PMIx retrieval rules constrain a lookup to data whose
+ * publisher falls within the range the requester gave (the default being
+ * PMIX_RANGE_SESSION), which is what keeps duplicate keys published on
+ * different ranges apart.  Both checks have to pass. */
+PRTE_EXPORT pmix_status_t prte_data_server_check_search_range(prte_data_req_t *req,
+                                                              prte_data_object_t *data);
 
 /* Relay a request to the external data server named by
  * prte_data_server_uri, and answer the requesting daemon when it replies.

--- a/src/runtime/data_server/ds_lookup.c
+++ b/src/runtime/data_server/ds_lookup.c
@@ -64,8 +64,12 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
     pmix_info_t *info;
     pmix_data_buffer_t pbkt;
     uint32_t uid = UINT32_MAX;
+    uint32_t gid = UINT32_MAX;
     bool wait = false;
-    pmix_data_range_t range=PMIX_RANGE_UNDEF;
+    bool denied = false;
+    /* the default range for a lookup is SESSION - see the PMIx
+     * retrieval rules for published data */
+    pmix_data_range_t range = PMIX_RANGE_SESSION;
     prte_data_object_t *data;
     prte_ds_info_t *rinfo;
     prte_info_item_t *ds1, *ds2;
@@ -130,6 +134,8 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
         for (n = 0; n < ninfo; n++) {
             if (PMIx_Check_key(info[n].key, PMIX_USERID)) {
                 uid = info[n].value.data.uint32;
+            } else if (PMIx_Check_key(info[n].key, PMIX_GRPID)) {
+                gid = info[n].value.data.uint32;
             } else if (PMIx_Check_key(info[n].key, PMIX_WAIT)) {
                 /* flag that we wait until the data is present */
                 wait = true;
@@ -150,6 +156,13 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
     PMIX_CONSTRUCT(&rq, prte_data_req_t);
     memcpy(&rq.requestor, &requestor, sizeof(pmix_proc_t));
     memcpy(&rq.proxy, sender, sizeof(pmix_proc_t));
+    /* the range the requestor gave constrains the search, so it has to be
+     * on the request we hand to the range checks - it used to be unpacked
+     * and then only ever reach a PARKED request, which meant an immediate
+     * lookup searched everything the publishers would let it see */
+    rq.range = range;
+    rq.uid = uid;
+    rq.gid = gid;
 
     for (i = 0; NULL != keys[i]; i++) {
         pmix_output_verbose(10, prte_data_store.output,
@@ -162,17 +175,27 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
             if (NULL == data) {
                 continue;
             }
-            /* for security reasons, can only access data posted by the same user id */
-            if (uid != data->uid) {
-                pmix_output_verbose(10, prte_data_store.output,
-                                    "%s\tMISMATCH UID %u %u",
-                                    PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (unsigned) uid,
-                                    (unsigned) data->uid);
+            /* Access is decided in two steps, in this order: the
+             * requestor must first satisfy the publisher's access
+             * permissions, and then meet its range constraint. */
+            if (PMIX_SUCCESS != prte_data_server_check_access(&rq, data)) {
+                /* if this item holds the key, the answer is "you may not
+                 * have it" rather than "there is no such thing", and the
+                 * retrieval rules ask us to say so */
+                PMIX_LIST_FOREACH(ds1, &data->info, prte_info_item_t) {
+                    if (PMIx_Check_key(ds1->info.key, keys[i])) {
+                        denied = true;
+                        break;
+                    }
+                }
                 continue;
             }
-
-            /* check the range */
             if (PMIX_SUCCESS != prte_data_server_check_range(&rq, data)) {
+                continue;
+            }
+            /* ...and the requestor's own range constrains which publishers
+             * it asked us to search at all */
+            if (PMIX_SUCCESS != prte_data_server_check_search_range(&rq, data)) {
                 continue;
             }
             /* see if we have this key */
@@ -266,6 +289,7 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
             req->proxy = *sender;
             memcpy(&req->requestor, &requestor, sizeof(pmix_proc_t));
             req->uid = uid;
+            req->gid = gid;
             req->range = range;
             req->keys = cache;
             cache = NULL;
@@ -284,8 +308,11 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
             PMIx_Argv_free(cache);
             cache = NULL;
             if (0 == nanswers) {
-                /* nothing was found - indicate that situation */
-                rc = PMIX_ERR_NOT_FOUND;
+                /* nothing was found - indicate that situation.  If the
+                 * data was there and we refused it, say which: the
+                 * retrieval rules reserve PMIX_ERR_NO_PERMISSIONS for
+                 * exactly this case */
+                rc = denied ? PMIX_ERR_NO_PERMISSIONS : PMIX_ERR_NOT_FOUND;
                 PMIx_Argv_free(keys);
                 PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
                 PMIX_DESTRUCT(&rq);

--- a/src/runtime/data_server/ds_lookup.c
+++ b/src/runtime/data_server/ds_lookup.c
@@ -49,6 +49,65 @@
 #include "src/runtime/data_server/prte_data_server.h"
 #include "src/runtime/data_server/ds.h"
 
+/* A parked lookup that was given a PMIX_TIMEOUT gets an event that fires if
+ * nothing satisfies it first.  Without one, a PMIX_WAIT lookup for a key
+ * nobody ever publishes waits forever: the timeout the caller gave reached
+ * the daemon's caddy and went no further, and the request left the pending
+ * list only when a publish matched it or its requestor died. */
+static void lookup_timeout(int sd, short args, void *cbdata)
+{
+    prte_data_req_t *req = (prte_data_req_t *) cbdata;
+    pmix_data_buffer_t *reply;
+    pmix_status_t ret = PMIX_ERR_TIMEOUT;
+    uint8_t command = PRTE_PMIX_LOOKUP_CMD;
+    int rc;
+
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+    PMIX_ACQUIRE_OBJECT(req);
+
+    /* the event has fired, so there is nothing left to disarm */
+    req->timer_active = false;
+
+    pmix_output_verbose(1, prte_data_store.output,
+                        "%s data server: parked lookup from %s timed out",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                        PMIX_NAME_PRINT(&req->requestor));
+
+    /* it is waiting for nothing now */
+    pmix_list_remove_item(&prte_data_store.pending, &req->super);
+
+    /* answer it: room number, the command it is an answer to, and the
+     * status.  A timeout carries no payload, and the daemon-side receiver
+     * knows not to look for one */
+    PMIX_DATA_BUFFER_CREATE(reply);
+    rc = PMIx_Data_pack(NULL, reply, &req->room_number, 1, PMIX_INT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto done;
+    }
+    rc = PMIx_Data_pack(NULL, reply, &command, 1, PMIX_UINT8);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto done;
+    }
+    rc = PMIx_Data_pack(NULL, reply, &ret, 1, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto done;
+    }
+    PRTE_RML_RELIABLE_SEND(rc, req->proxy.rank, reply, PRTE_RML_TAG_DATA_CLIENT);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        goto done;
+    }
+    PMIX_RELEASE(req);
+    return;
+
+done:
+    PMIX_DATA_BUFFER_RELEASE(reply);
+    PMIX_RELEASE(req);
+}
+
 pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
                              pmix_data_buffer_t *buffer,
                              pmix_data_buffer_t *answer)
@@ -65,6 +124,7 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
     pmix_data_buffer_t pbkt;
     uint32_t uid = UINT32_MAX;
     uint32_t gid = UINT32_MAX;
+    int timeout = 0;
     bool wait = false;
     bool denied = false;
     /* the default range for a lookup is SESSION - see the PMIx
@@ -77,6 +137,7 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
     bool found;
     prte_data_req_t *req, rq;
     pmix_byte_object_t pbo;
+    struct timeval tv;
 
     /* unpack the requestor */
     count = 1;
@@ -136,6 +197,8 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
                 uid = info[n].value.data.uint32;
             } else if (PMIx_Check_key(info[n].key, PMIX_GRPID)) {
                 gid = info[n].value.data.uint32;
+            } else if (PMIx_Check_key(info[n].key, PMIX_TIMEOUT)) {
+                timeout = info[n].value.data.integer;
             } else if (PMIx_Check_key(info[n].key, PMIX_WAIT)) {
                 /* flag that we wait until the data is present */
                 wait = true;
@@ -294,6 +357,16 @@ pmix_status_t prte_ds_lookup(pmix_proc_t *sender, int room_number,
             req->keys = cache;
             cache = NULL;
             pmix_list_append(&prte_data_store.pending, &req->super);
+            if (0 < timeout) {
+                /* the caller said how long it is prepared to wait */
+                tv.tv_sec = timeout;
+                tv.tv_usec = 0;
+                prte_event_evtimer_set(prte_event_base, &req->ev,
+                                       lookup_timeout, req);
+                req->timer_active = true;
+                PMIX_POST_OBJECT(req);
+                prte_event_evtimer_add(&req->ev, &tv);
+            }
             PMIx_Argv_free(keys);
             PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
             PMIX_DESTRUCT(&rq);

--- a/src/runtime/data_server/ds_main.c
+++ b/src/runtime/data_server/ds_main.c
@@ -472,12 +472,20 @@ static void rqcon(prte_data_req_t *p)
     p->keys = NULL;
     p->uid = UINT32_MAX;
     p->gid = UINT32_MAX;
+    p->timer_active = false;
     /* the default range for a lookup or an unpublish is SESSION - the
      * same default the publish side carries */
     p->range = PMIX_RANGE_SESSION;
 }
 static void rqdes(prte_data_req_t *p)
 {
+    /* a parked request that is answered - or purged - before its timeout
+     * fires still owns an armed event, and libevent must not be left
+     * holding a pointer into freed storage */
+    if (p->timer_active) {
+        prte_event_evtimer_del(&p->ev);
+        p->timer_active = false;
+    }
     PMIx_Argv_free(p->keys);
 }
 PMIX_CLASS_INSTANCE(prte_data_req_t,

--- a/src/runtime/data_server/ds_main.c
+++ b/src/runtime/data_server/ds_main.c
@@ -266,71 +266,165 @@ void prte_ds_check_requestor(pmix_proc_t *owner, const pmix_info_t *info)
     PMIX_XFER_PROCID(owner, info->value.data.proc);
 }
 
+/* One range rule, applied in both directions.
+ *
+ * The PMIx retrieval rules for published data impose the range test
+ * twice: the publisher's range says who may see the item, and the
+ * requester's range says whose items it is willing to see.  Both ask the
+ * same question - does "subject" fall within "range" as seen from
+ * "anchor" - so both are answered here, with the caller deciding which
+ * process plays which role.
+ *
+ * This is an ACCESS rule: it says who may read an item.  It is therefore
+ * the wrong test for who may REMOVE one, which is a question of
+ * ownership - see ds_unpublish.c. */
+static pmix_status_t range_admits(pmix_data_range_t range,
+                                  const pmix_proc_t *anchor,
+                                  const pmix_proc_t *anchor_proxy,
+                                  const pmix_proc_t *subject,
+                                  const pmix_proc_t *subject_proxy)
+{
+    bool match;
+
+    switch (range) {
+    case PMIX_RANGE_UNDEF:
+    case PMIX_RANGE_SESSION:
+    case PMIX_RANGE_GLOBAL:
+        // open to everyone
+        match = true;
+        break;
+
+    case PMIX_RANGE_NAMESPACE:
+        match = PMIX_CHECK_NSPACE(anchor->nspace, subject->nspace);
+        break;
+
+    case PMIX_RANGE_LOCAL:
+        // the two must sit behind the same daemon
+        match = PMIX_CHECK_PROCID(anchor_proxy, subject_proxy);
+        break;
+
+    case PMIX_RANGE_PROC_LOCAL:
+        match = PMIX_CHECK_PROCID(anchor, subject);
+        break;
+
+    case PMIX_RANGE_RM:
+        /* the subject must be the host environment - which means its
+         * nspace must match that of the host's server, which is my own */
+        match = PMIX_CHECK_NSPACE(subject->nspace, PRTE_PROC_MY_NAME->nspace);
+        break;
+
+    case PMIX_RANGE_CUSTOM:
+        /* a CUSTOM range is the publisher's accessor list, and only a
+         * publisher has one - see prte_data_server_check_range(), which
+         * answers this case before we are reached.  In the other
+         * direction, where the anchor is a requestor asking us to search,
+         * there is no list to consult and nothing it could mean */
+        match = false;
+        break;
+
+    default:
+        match = false;
+        break;
+    }
+
+    pmix_output_verbose(10, prte_data_store.output,
+                        "%s\tRANGE %s ANCHOR %s SUBJECT %s: %s",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                        PMIx_Data_range_string(range),
+                        PMIX_NAME_PRINT(anchor),
+                        PMIX_NAME_PRINT(subject),
+                        match ? "ADMIT" : "DENY");
+
+    return match ? PMIX_SUCCESS : PMIX_ERROR;
+}
+
+/* the publisher's range: may this requestor see this item? */
 pmix_status_t prte_data_server_check_range(prte_data_req_t *req,
                                            prte_data_object_t *data)
 {
-    // we automatically accept session and global ranges
-    if (PMIX_RANGE_SESSION == data->range ||
-        PMIX_RANGE_GLOBAL == data->range ||
-        PMIX_RANGE_UNDEF == data->range) {
+    if (PMIX_RANGE_CUSTOM == data->range) {
+        /* for CUSTOM the accessor list IS the range - "available only to
+         * processes as specified in the pmix_info_t associated with this
+         * call".  So admit whoever the list admits, which
+         * prte_data_server_check_access() decides, and refuse everyone
+         * when the publisher named nobody: there is no other reading of a
+         * custom range with no custom in it. */
+        if (0 == data->nauids && 0 == data->nagids) {
+            return PMIX_ERROR;
+        }
         return PMIX_SUCCESS;
     }
+    return range_admits(data->range, &data->owner, &data->proxy,
+                        &req->requestor, &req->proxy);
+}
 
-    if (PMIX_RANGE_NAMESPACE == data->range) {
-        if (PMIX_CHECK_NSPACE(req->requestor.nspace, data->owner.nspace)) {
-            pmix_output_verbose(10, prte_data_store.output,
-                                "%s\tMATCH NSPACES %s %s",
-                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                                req->requestor.nspace,
-                                data->owner.nspace);
+/* the publisher's access permissions: may this requestor's uid and gid see
+ * this item?  See the header for the rule; note that a list the publisher
+ * gave is a REQUIREMENT, so a publisher whose own uid is not on its own
+ * PMIX_ACCESS_USERIDS list cannot look its own data up either.  Removing it
+ * is a separate question, answered by ownership - see ds_unpublish.c. */
+pmix_status_t prte_data_server_check_access(prte_data_req_t *req,
+                                            prte_data_object_t *data)
+{
+    size_t n;
+    bool found;
+
+    if (0 == data->nauids && 0 == data->nagids) {
+        /* no accessors named: the data belongs to whoever published it */
+        if (req->uid == data->uid && req->gid == data->gid) {
             return PMIX_SUCCESS;
         }
+        pmix_output_verbose(10, prte_data_store.output,
+                            "%s\tACCESS DENY owner %u/%u requestor %u/%u",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                            (unsigned) data->uid, (unsigned) data->gid,
+                            (unsigned) req->uid, (unsigned) req->gid);
+        return PMIX_ERR_NO_PERMISSIONS;
     }
-    if (PMIX_RANGE_LOCAL == data->range) {
-        // the sender is the requestor's daemon, so see if
-        // that matches the published data's proxy
-        if (PMIX_CHECK_PROCID(&data->proxy, &req->proxy)) {
-            pmix_output_verbose(10, prte_data_store.output,
-                                "%s\tMATCH LOCATION %s %s",
-                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                                PMIX_NAME_PRINT(&data->proxy),
-                                PMIX_NAME_PRINT(&req->proxy));
-            return PMIX_SUCCESS;
+
+    if (0 < data->nauids) {
+        found = false;
+        for (n = 0; n < data->nauids; n++) {
+            if (data->auids[n] == req->uid) {
+                found = true;
+                break;
+            }
         }
-    }
-    if (PMIX_RANGE_PROC_LOCAL == data->range) {
-        // the requestor must be the same as the owner
-        if (PMIX_CHECK_PROCID(&data->owner, &req->requestor)) {
+        if (!found) {
             pmix_output_verbose(10, prte_data_store.output,
-                                "%s\tMATCH LOCAL %s %s",
+                                "%s\tACCESS DENY uid %u not permitted",
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                                PMIX_NAME_PRINT(&data->owner),
-                                PMIX_NAME_PRINT(&req->requestor));
-            return PMIX_SUCCESS;
-        }
-    }
-
-    if (PMIX_RANGE_CUSTOM == data->range) {
-        // requestor must be on the list of allowed accessors
-
-    }
-
-    if (PMIX_RANGE_RM == data->range) {
-        // the requestor must be from the host - which means
-        // the nspace of the requestor must match that of
-        // the host's server, which is my own
-        if (PMIX_CHECK_NSPACE(req->requestor.nspace, PRTE_PROC_MY_NAME->nspace)) {
-            pmix_output_verbose(10, prte_data_store.output,
-                                "%s\tMATCH RM %s %s",
-                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                                req->requestor.nspace,
-                                PRTE_PROC_MY_NAME->nspace);
-            return PMIX_SUCCESS;
+                                (unsigned) req->uid);
+            return PMIX_ERR_NO_PERMISSIONS;
         }
     }
 
-    // no matches
-    return PMIX_ERROR;
+    if (0 < data->nagids) {
+        found = false;
+        for (n = 0; n < data->nagids; n++) {
+            if (data->agids[n] == req->gid) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            pmix_output_verbose(10, prte_data_store.output,
+                                "%s\tACCESS DENY gid %u not permitted",
+                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                (unsigned) req->gid);
+            return PMIX_ERR_NO_PERMISSIONS;
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+/* the requester's range: is this publisher one it asked to search? */
+pmix_status_t prte_data_server_check_search_range(prte_data_req_t *req,
+                                                  prte_data_object_t *data)
+{
+    return range_admits(req->range, &req->requestor, &req->proxy,
+                        &data->owner, &data->proxy);
 }
 
 // CLASS INSTANCE
@@ -344,6 +438,11 @@ static void construct(prte_data_object_t *ptr)
     PMIX_PROC_CONSTRUCT(&ptr->proxy);
     PMIX_PROC_CONSTRUCT(&ptr->owner);
     ptr->uid = UINT32_MAX;
+    ptr->gid = UINT32_MAX;
+    ptr->auids = NULL;
+    ptr->nauids = 0;
+    ptr->agids = NULL;
+    ptr->nagids = 0;
     ptr->range = PMIX_RANGE_SESSION;
     ptr->persistence = PMIX_PERSIST_SESSION;
     PMIX_CONSTRUCT(&ptr->info, pmix_list_t);
@@ -351,6 +450,12 @@ static void construct(prte_data_object_t *ptr)
 
 static void destruct(prte_data_object_t *ptr)
 {
+    if (NULL != ptr->auids) {
+        free(ptr->auids);
+    }
+    if (NULL != ptr->agids) {
+        free(ptr->agids);
+    }
     PMIX_LIST_DESTRUCT(&ptr->info);
 }
 
@@ -366,7 +471,10 @@ static void rqcon(prte_data_req_t *p)
     p->room_number = -1;
     p->keys = NULL;
     p->uid = UINT32_MAX;
-    p->range = PMIX_RANGE_UNDEF;
+    p->gid = UINT32_MAX;
+    /* the default range for a lookup or an unpublish is SESSION - the
+     * same default the publish side carries */
+    p->range = PMIX_RANGE_SESSION;
 }
 static void rqdes(prte_data_req_t *p)
 {

--- a/src/runtime/data_server/ds_publish.c
+++ b/src/runtime/data_server/ds_publish.c
@@ -49,6 +49,88 @@
 #include "src/runtime/data_server/prte_data_server.h"
 #include "src/runtime/data_server/ds.h"
 
+/* Load a uid/gid list out of an access-permission directive.  The Standard
+ * types these as a pmix_data_array_t of the ids; a single id given as a
+ * plain PMIX_UINT32 is accepted too, since refusing it would only push
+ * publishers into building a one-element array.  Anything else is a
+ * restriction we cannot read, and a restriction we cannot read has to fail
+ * the publish - never be silently dropped, which would store the data with
+ * no restriction at all. */
+static pmix_status_t load_ids(const pmix_value_t *val, uint32_t **ids, size_t *nids)
+{
+    pmix_data_array_t *array;
+    uint32_t *dst;
+
+    if (PMIX_UINT32 == val->type) {
+        dst = (uint32_t *) malloc(sizeof(uint32_t));
+        if (NULL == dst) {
+            return PMIX_ERR_NOMEM;
+        }
+        dst[0] = val->data.uint32;
+        if (NULL != *ids) {
+            free(*ids);
+        }
+        *ids = dst;
+        *nids = 1;
+        return PMIX_SUCCESS;
+    }
+
+    if (PMIX_DATA_ARRAY != val->type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    array = val->data.darray;
+    if (NULL == array || NULL == array->array || 0 == array->size ||
+        PMIX_UINT32 != array->type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    dst = (uint32_t *) malloc(array->size * sizeof(uint32_t));
+    if (NULL == dst) {
+        return PMIX_ERR_NOMEM;
+    }
+    memcpy(dst, array->array, array->size * sizeof(uint32_t));
+    if (NULL != *ids) {
+        free(*ids);
+    }
+    *ids = dst;
+    *nids = array->size;
+    return PMIX_SUCCESS;
+}
+
+/* Unpack a PMIX_ACCESS_PERMISSIONS directive - an array of pmix_info_t
+ * naming the permissions - onto the data object. */
+static pmix_status_t load_permissions(const pmix_value_t *val,
+                                      prte_data_object_t *data)
+{
+    pmix_data_array_t *array;
+    pmix_info_t *iptr;
+    pmix_status_t rc;
+    size_t n;
+
+    if (PMIX_DATA_ARRAY != val->type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    array = val->data.darray;
+    if (NULL == array || NULL == array->array || 0 == array->size ||
+        PMIX_INFO != array->type) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    iptr = (pmix_info_t *) array->array;
+    for (n = 0; n < array->size; n++) {
+        if (PMIx_Check_key(iptr[n].key, PMIX_ACCESS_USERIDS)) {
+            rc = load_ids(&iptr[n].value, &data->auids, &data->nauids);
+        } else if (PMIx_Check_key(iptr[n].key, PMIX_ACCESS_GRPIDS)) {
+            rc = load_ids(&iptr[n].value, &data->agids, &data->nagids);
+        } else {
+            /* a permission we do not know how to enforce */
+            rc = PMIX_ERR_BAD_PARAM;
+        }
+        if (PMIX_SUCCESS != rc) {
+            return rc;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
 pmix_status_t prte_ds_publish(pmix_proc_t *sender,
                               pmix_data_buffer_t *buffer,
                               pmix_data_buffer_t *answer)
@@ -120,6 +202,7 @@ pmix_status_t prte_ds_publish(pmix_proc_t *sender,
     }
 
     /* check for directives */
+    ret = PMIX_SUCCESS;
     for (n = 0; n < ninfo; n++) {
         if (PMIx_Check_key(info[n].key, PMIX_RANGE)) {
             data->range = info[n].value.data.range;
@@ -127,6 +210,16 @@ pmix_status_t prte_ds_publish(pmix_proc_t *sender,
             data->persistence = info[n].value.data.persist;
         } else if (PMIx_Check_key(info[n].key, PMIX_USERID)) {
             data->uid = info[n].value.data.uint32;
+        } else if (PMIx_Check_key(info[n].key, PMIX_GRPID)) {
+            data->gid = info[n].value.data.uint32;
+        } else if (PMIx_Check_key(info[n].key, PMIX_ACCESS_PERMISSIONS)) {
+            ret = load_permissions(&info[n].value, data);
+        } else if (PMIx_Check_key(info[n].key, PMIX_ACCESS_USERIDS)) {
+            /* the Standard puts these inside PMIX_ACCESS_PERMISSIONS, but
+             * they are self-describing enough to honor at the top level */
+            ret = load_ids(&info[n].value, &data->auids, &data->nauids);
+        } else if (PMIx_Check_key(info[n].key, PMIX_ACCESS_GRPIDS)) {
+            ret = load_ids(&info[n].value, &data->agids, &data->nagids);
         } else if (PMIx_Check_key(info[n].key, PMIX_REQUESTOR)) {
             /* a relay publishing on behalf of a process in its own DVM */
             prte_ds_check_requestor(&data->owner, &info[n]);
@@ -135,6 +228,14 @@ pmix_status_t prte_ds_publish(pmix_proc_t *sender,
             ds1 = PMIX_NEW(prte_info_item_t);
             PMIX_INFO_XFER(&ds1->info, &info[n]);
             pmix_list_append(&data->info, &ds1->super);
+        }
+        if (PMIX_SUCCESS != ret) {
+            /* an access restriction we could not read.  Storing the data
+             * anyway would store it unrestricted, so refuse the publish */
+            PMIX_ERROR_LOG(ret);
+            PMIX_INFO_FREE(info, ninfo);
+            PMIX_RELEASE(data);
+            return ret;
         }
     }
     /* the values we keep were copied into the data object above, so the
@@ -154,11 +255,16 @@ pmix_status_t prte_ds_publish(pmix_proc_t *sender,
     rc = PRTE_SUCCESS;
     PMIX_LIST_FOREACH_SAFE(req, rqnext, &prte_data_store.pending, prte_data_req_t)
     {
-        if (req->uid != data->uid) {
+        /* the same three tests an immediate lookup applies, in the same
+         * order: the publisher's access permissions, then its range, then
+         * the range the requestor asked us to search */
+        if (PMIX_SUCCESS != prte_data_server_check_access(req, data)) {
             continue;
         }
-        /* check the range */
         if (PMIX_SUCCESS != prte_data_server_check_range(req, data)) {
+            continue;
+        }
+        if (PMIX_SUCCESS != prte_data_server_check_search_range(req, data)) {
             continue;
         }
 

--- a/src/runtime/data_server/ds_unpublish.c
+++ b/src/runtime/data_server/ds_unpublish.c
@@ -132,13 +132,12 @@ pmix_status_t prte_ds_unpublish(pmix_proc_t *sender,
             PMIX_DESTRUCT(&rq);
             return rc;
         }
-        /* scan the directives for things we care about */
+        /* Scan the directives for things we care about, which for a
+         * removal is only who is asking.  PMIX_RANGE and the caller's
+         * uid/gid say who may READ an item; an owner may take back what it
+         * published on any range, so neither is consulted here. */
         for (n = 0; n < ninfo; n++) {
-            if (PMIx_Check_key(info[n].key, PMIX_USERID)) {
-                rq.uid = info[n].value.data.uint32;
-            } else if (PMIx_Check_key(info[n].key, PMIX_RANGE)) {
-                rq.range = info[n].value.data.range;
-            } else if (PMIx_Check_key(info[n].key, PMIX_REQUESTOR)) {
+            if (PMIx_Check_key(info[n].key, PMIX_REQUESTOR)) {
                 /* a relay unpublishing on behalf of a process in its own
                  * DVM.  This must be honored before the ownership test
                  * below, which is what says only the publisher may remove
@@ -158,19 +157,25 @@ pmix_status_t prte_ds_unpublish(pmix_proc_t *sender,
             if (NULL == data) {
                 continue;
             }
-            /* can only access data posted by the same user id */
-            if (rq.uid != data->uid) {
-                continue;
-            }
-            /* can only access data posted by the same process */
+            /* only the publishing process may remove its own data - a
+             * stronger test than comparing uids, and the one that matters:
+             * a process identity is stamped by its own PMIx server (or, for
+             * a relay, claimed in PMIX_REQUESTOR and honored only from a
+             * tool), not asserted by the caller */
             if (!PMIX_CHECK_NSPACE(rq.requestor.nspace, data->owner.nspace) ||
                 rq.requestor.rank != data->owner.rank) {
                 continue;
             }
-            /* check the range */
-            if (PMIX_SUCCESS != prte_data_server_check_range(&rq, data)) {
-                continue;
-            }
+            /* Ownership is the whole rule for removal, and the test above
+             * has just established it: an owner may unpublish what it
+             * published on ANY range.  Range and access permissions govern
+             * who may READ an item, and neither belongs here - applying
+             * the read rule refused an owner its own data whenever the
+             * range was one the owner does not itself fall within (a
+             * PMIX_RANGE_RM item admits only the host's namespace, a
+             * PMIX_RANGE_CUSTOM one only the accessors it named), while
+             * still answering SUCCESS, and the item then sat in the store
+             * until its job ended. */
             /* see if we have this key */
             PMIX_LIST_FOREACH_SAFE(ds1, ds2, &data->info, prte_info_item_t) {
                 if (PMIx_Check_key(ds1->info.key, rq.keys[i])) {

--- a/test/unit/runtime/test_runtime.c
+++ b/test/unit/runtime/test_runtime.c
@@ -1226,12 +1226,181 @@ static int test_data_server_range(void)
     CHECK("range: RM admits the host's own namespace",
           PMIX_SUCCESS == prte_data_server_check_range(req, data));
 
-    /* CUSTOM has no accessor list implemented, so it must deny rather than
-     * fall through to a permit */
+    /* For CUSTOM the accessor list IS the range, so a publisher that named
+     * nobody admits nobody - including itself */
     data->range = PMIX_RANGE_CUSTOM;
     PMIX_LOAD_PROCID(&req->requestor, "publisher.ns", 2);
-    CHECK("range: CUSTOM denies (no accessor list is implemented)",
+    CHECK("range: CUSTOM denies when the publisher named no accessors",
           PMIX_SUCCESS != prte_data_server_check_range(req, data));
+    /* ...and defers to the list when there is one, which the access check
+     * is what evaluates */
+    data->nauids = 1;
+    data->auids = (uint32_t *) malloc(sizeof(uint32_t));
+    data->auids[0] = 4242;
+    CHECK("range: CUSTOM admits when an accessor list was given",
+          PMIX_SUCCESS == prte_data_server_check_range(req, data));
+
+    PMIX_RELEASE(req);
+    PMIX_RELEASE(data);
+    return failures;
+}
+
+/* Access permissions are the FIRST gate on retrieval - a requestor must
+ * satisfy them before the range constraint is even asked.  Absent a list,
+ * published data belongs to its publisher: only the publisher's own uid and
+ * gid may read it.  Each list the publisher does give is a requirement. */
+static int test_data_server_access(void)
+{
+    int failures = 0;
+    prte_data_object_t *data;
+    prte_data_req_t *req;
+
+    data = PMIX_NEW(prte_data_object_t);
+    CHECK("access: a new object has no owner uid/gid",
+          UINT32_MAX == data->uid && UINT32_MAX == data->gid);
+    CHECK("access: a new object names no accessors",
+          NULL == data->auids && 0 == data->nauids &&
+          NULL == data->agids && 0 == data->nagids);
+    data->uid = 1000;
+    data->gid = 100;
+
+    req = PMIX_NEW(prte_data_req_t);
+    CHECK("access: a new request has no uid/gid",
+          UINT32_MAX == req->uid && UINT32_MAX == req->gid);
+
+    /* no list: the publisher's own identity is the rule */
+    req->uid = 1000;
+    req->gid = 100;
+    CHECK("access: the publisher's own uid and gid are admitted",
+          PMIX_SUCCESS == prte_data_server_check_access(req, data));
+    req->uid = 1001;
+    CHECK("access: another uid is refused",
+          PMIX_ERR_NO_PERMISSIONS == prte_data_server_check_access(req, data));
+    req->uid = 1000;
+    req->gid = 101;
+    CHECK("access: another gid is refused",
+          PMIX_ERR_NO_PERMISSIONS == prte_data_server_check_access(req, data));
+
+    /* a uid list is a requirement, and it is the ONLY one when no gid list
+     * was given - the whole point being to admit somebody else */
+    data->nauids = 2;
+    data->auids = (uint32_t *) malloc(2 * sizeof(uint32_t));
+    data->auids[0] = 1001;
+    data->auids[1] = 1002;
+    req->uid = 1001;
+    req->gid = 999;
+    CHECK("access: a uid on the list is admitted whatever its gid",
+          PMIX_SUCCESS == prte_data_server_check_access(req, data));
+    req->uid = 1003;
+    CHECK("access: a uid not on the list is refused",
+          PMIX_ERR_NO_PERMISSIONS == prte_data_server_check_access(req, data));
+    req->uid = 1000;
+    CHECK("access: the publisher's own uid is refused by a list that omits it",
+          PMIX_ERR_NO_PERMISSIONS == prte_data_server_check_access(req, data));
+
+    /* both lists given: both are requirements */
+    data->nagids = 1;
+    data->agids = (uint32_t *) malloc(sizeof(uint32_t));
+    data->agids[0] = 50;
+    req->uid = 1001;
+    req->gid = 50;
+    CHECK("access: a requestor meeting both lists is admitted",
+          PMIX_SUCCESS == prte_data_server_check_access(req, data));
+    req->gid = 51;
+    CHECK("access: meeting the uid list but not the gid list is refused",
+          PMIX_ERR_NO_PERMISSIONS == prte_data_server_check_access(req, data));
+    req->uid = 1003;
+    req->gid = 50;
+    CHECK("access: meeting the gid list but not the uid list is refused",
+          PMIX_ERR_NO_PERMISSIONS == prte_data_server_check_access(req, data));
+
+    /* a gid list on its own */
+    free(data->auids);
+    data->auids = NULL;
+    data->nauids = 0;
+    req->uid = 1003;
+    req->gid = 50;
+    CHECK("access: a gid on the list is admitted whatever its uid",
+          PMIX_SUCCESS == prte_data_server_check_access(req, data));
+
+    PMIX_RELEASE(req);
+    PMIX_RELEASE(data);
+    return failures;
+}
+
+/* The requester's own range is the OTHER half of the rule: the PMIx
+ * retrieval rules constrain a lookup to data whose publisher falls within
+ * the range the requester asked for, which is what keeps duplicate keys
+ * published on different ranges apart.  It is the same predicate as
+ * above with the two processes swapped, and it used to be unpacked and
+ * then never applied to anything. */
+static int test_data_server_search_range(void)
+{
+    int failures = 0;
+    prte_data_object_t *data;
+    prte_data_req_t *req;
+
+    data = PMIX_NEW(prte_data_object_t);
+    PMIX_LOAD_PROCID(&data->owner, "publisher.ns", 2);
+    PMIX_LOAD_PROCID(&data->proxy, "prte-daemons", 5);
+    /* the publisher's own range admits everyone throughout, so what is
+     * under test is only the requester's */
+    data->range = PMIX_RANGE_GLOBAL;
+
+    req = PMIX_NEW(prte_data_req_t);
+    PMIX_LOAD_PROCID(&req->requestor, "other.ns", 0);
+    PMIX_LOAD_PROCID(&req->proxy, "prte-daemons", 9);
+
+    CHECK("search: a new request defaults to the SESSION range",
+          PMIX_RANGE_SESSION == req->range);
+
+    /* session/global/undef search everything */
+    CHECK("search: SESSION admits any publisher",
+          PMIX_SUCCESS == prte_data_server_check_search_range(req, data));
+    req->range = PMIX_RANGE_GLOBAL;
+    CHECK("search: GLOBAL admits any publisher",
+          PMIX_SUCCESS == prte_data_server_check_search_range(req, data));
+    req->range = PMIX_RANGE_UNDEF;
+    CHECK("search: UNDEF admits any publisher",
+          PMIX_SUCCESS == prte_data_server_check_search_range(req, data));
+
+    /* NAMESPACE searches only publishers in the requester's namespace */
+    req->range = PMIX_RANGE_NAMESPACE;
+    CHECK("search: NAMESPACE refuses a publisher in another namespace",
+          PMIX_SUCCESS != prte_data_server_check_search_range(req, data));
+    PMIX_LOAD_PROCID(&req->requestor, "publisher.ns", 7);
+    CHECK("search: NAMESPACE admits a publisher in the requester's namespace",
+          PMIX_SUCCESS == prte_data_server_check_search_range(req, data));
+
+    /* LOCAL searches only publishers behind the requester's own daemon */
+    req->range = PMIX_RANGE_LOCAL;
+    CHECK("search: LOCAL refuses a publisher behind another daemon",
+          PMIX_SUCCESS != prte_data_server_check_search_range(req, data));
+    PMIX_LOAD_PROCID(&req->proxy, "prte-daemons", 5);
+    CHECK("search: LOCAL admits a publisher behind the same daemon",
+          PMIX_SUCCESS == prte_data_server_check_search_range(req, data));
+
+    /* PROC_LOCAL searches only what the requester published itself */
+    req->range = PMIX_RANGE_PROC_LOCAL;
+    CHECK("search: PROC_LOCAL refuses a peer's data",
+          PMIX_SUCCESS != prte_data_server_check_search_range(req, data));
+    PMIX_LOAD_PROCID(&req->requestor, "publisher.ns", 2);
+    CHECK("search: PROC_LOCAL admits the requester's own data",
+          PMIX_SUCCESS == prte_data_server_check_search_range(req, data));
+
+    /* RM searches only data published by the host environment */
+    req->range = PMIX_RANGE_RM;
+    CHECK("search: RM refuses data published by an application",
+          PMIX_SUCCESS != prte_data_server_check_search_range(req, data));
+    PMIX_LOAD_NSPACE(data->owner.nspace, PRTE_PROC_MY_NAME->nspace);
+    CHECK("search: RM admits data published by the host",
+          PMIX_SUCCESS == prte_data_server_check_search_range(req, data));
+
+    /* and CUSTOM denies here too - a requester has no accessor list to be
+     * on any more than a publisher has one to name */
+    req->range = PMIX_RANGE_CUSTOM;
+    CHECK("search: CUSTOM denies (no accessor list is implemented)",
+          PMIX_SUCCESS != prte_data_server_check_search_range(req, data));
 
     PMIX_RELEASE(req);
     PMIX_RELEASE(data);
@@ -1516,6 +1685,8 @@ int main(void)
     failures += test_exit_status();
     failures += test_data_server_objects();
     failures += test_data_server_range();
+    failures += test_data_server_search_range();
+    failures += test_data_server_access();
     failures += test_data_server_requestor();
     failures += test_progress_thread_cpus();
     failures += test_progress_thread_lifecycle();


### PR DESCRIPTION
## The problem

Two different questions had run together in the data server, and the range was
not the whole of either.

**Reading.** Every retrieval path compared `uid` and refused anything published
by another user, before any range or permission was consulted. That is the one
case a `PMIX_ACCESS_USERIDS` list exists to admit, so the whole
`PMIX_ACCESS_PERMISSIONS` family — defined since PMIx v4.1 — was unreachable.
`PMIX_RANGE_CUSTOM`'s arm in `check_range` had always been empty, so a publisher
asking for a custom range got an item nobody could ever read.

**The requester's own range was ignored.** `ds_lookup` unpacked `PMIX_RANGE` and
stored it on a *parked* request only, where nothing read it, and never set it on
the immediate path at all. The PMIx retrieval rules apply the range in both
directions — the requestor must fall within the publisher's range, and the
publisher within the requester's — and only the first half was enforced. A
lookup that asked to search its own namespace searched everything its publishers
would let it see.

**Removal.** `ds_unpublish` gated removal on the *read* rule. An owner does not
necessarily fall within its own item's range: `PMIX_RANGE_RM` admits only the
host's namespace, `PMIX_RANGE_CUSTOM` admitted nobody. Such an item could not be
unpublished by the process that published it — and the caller was told
`PMIX_SUCCESS` while it stayed in the store until its job ended.

**A parked lookup never timed out.** `PMIX_TIMEOUT` was carried as far as
`req->timeout` in `pmix_server_pub.c` and read by no one, so a `PMIX_WAIT` lookup
for a key nobody publishes — an application that got the key name wrong — hung
forever.

## The change

Three commits.

1. **Access, then range.** A requestor must first satisfy the publisher's access
   permissions: absent a list, published data belongs to its publisher and the
   requestor must present the publisher's own uid *and* gid; a list
   (`PMIX_ACCESS_USERIDS` / `PMIX_ACCESS_GRPIDS`, nested in
   `PMIX_ACCESS_PERMISSIONS` or at the top level) replaces that default with a
   requirement. Refusals report `PMIX_ERR_NO_PERMISSIONS`, which is what the
   retrieval rules reserve it for. A restriction we cannot parse fails the
   publish rather than storing the data unrestricted. Then the range, in both
   directions, as one predicate with the two processes swapping roles — including
   `PMIX_RANGE_CUSTOM`, for which the accessor list *is* the range. Removal is
   ownership and nothing else: an owner may unpublish what it published on any
   range.
2. **The parked-lookup timeout**, armed on the request and disarmed by its
   destructor, so a satisfying publish, a purge or finalize all leave nothing
   behind.
3. A one-line `.gitignore` tidy for out-of-tree `vpath-*` build dirs.

The gid this depends on needs the companion openpmix change (openpmix/openpmix#4170),
which takes it from the peer's connection record rather than the wire — the first
version of that PR added a message field and the cross-version tests were right to
segfault on it. Where the gid is missing, both sides here read `UINT32_MAX` and the
default rule degrades to uid-only rather than locking everyone out — verified against
an unpatched PMIx, not assumed.

## Testing

`--enable-debug` builds warning-free against a PMIx with and without the gid
change; `make check` passes (20/20) in both. New unit coverage for the access
rule (default identity, each list alone, both lists, and a list that locks the
publisher out), for the requester-side range across every range value, and for
`CUSTOM` deferring to the list.

Live DVM, against the patched PMIx:

| case | result |
|---|---|
| publish/lookup, same uid+gid, no list | `SUCCESS` |
| list naming our own uid / our own gid | `SUCCESS` |
| list naming another uid / another gid | `PMIX_ERR_NO_PERMISSIONS` |
| lookup scoped `namespace` / `proc-local` from another job | `NOT_FOUND` |
| owner unpublishes GLOBAL data naming SESSION, or `proc-local` | removed |
| `PMIX_WAIT` for a key nobody publishes, 10s | `PMIX_ERR_TIMEOUT` |
| `PMIX_WAIT` satisfied before the timer | `SUCCESS`, DVM healthy |

`contrib/dockerswarm` gains cases for the four access specs, the
owner-any-range unpublish, a namespace-scoped lookup that must not reach another
job's data, and the timeout — **these have not been run**; the swarm was not up
on the machine this was developed on.

`docs/todo.rst` loses its `PMIX_RANGE_CUSTOM` entry and the data server's
`AGENTS.md` now leads with "who may read, and who may remove", since the
distinction is what the bugs were made of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)