### PR TITLE
Carry a re-homed daemon's lineage in its failure notice

### DIFF
--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -137,6 +137,12 @@ SWARM_CLEAN='
     # the CPU burners the PMIx-churn phases raise (see load_on): harmless if
     # none are running, and leaving one behind would slow every later phase
     pkill -9 -x yes 2>/dev/null
+    # a bare `sleep` is the stand-in application in several cases. One that
+    # outlives its daemon is exactly what a case checking orphan cleanup looks
+    # for, so a case that legitimately fails leaves strays behind - and without
+    # this they would be counted against the NEXT run, which reports the
+    # failure against innocent code.
+    pkill -9 -x sleep 2>/dev/null
     rm -rf /tmp/prte.* /tmp/prted.* /tmp/prtrn.* /tmp/prun.* /tmp/ompi.* \
            /tmp/pmix.* 2>/dev/null
     find /tmp -maxdepth 2 -name "pmix.*" -prune -exec rm -rf {} + 2>/dev/null
@@ -4591,6 +4597,70 @@ test_errmgr() {
         RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     else
         bad "could not start a radix-2 DVM for the leaf-loss test"
+    fi
+    cleanup_swarm
+
+    banner "errmgr: losing the HNP is the one loss no daemon may survive"
+    # The mirror of the case above, and the reason that one has to be careful
+    # about what it treats as a lifeline.  A daemon that loses a CHILD routes
+    # around it; a daemon that loses the HNP must not, because the root is the
+    # one rank with no inheritor to be routed around -- which is why
+    # prte_rml_update_ancestors starts its walk at index 1, and why
+    # prte_rml_route_lost returns PRTE_ERR_FATAL for the HNP alone instead of
+    # repairing.  The OOB turns that non-SUCCESS return into
+    # PRTE_PROC_STATE_LIFELINE_LOST rather than COMM_FAILED, and errmgr/prted
+    # answers it by killing its local procs and exiting.  Every daemon must
+    # reach that conclusion: anything that "recovers" instead leaves orphaned
+    # prteds -- and orphaned application processes -- running on the cluster
+    # with nothing left to command them.
+    #
+    # radix 2 over seven nodes is what separates the two ways of reaching it.
+    # Only ranks 1 and 2 (node2, node3) are the HNP's children and lose that
+    # socket directly.  Ranks 3-6 lose their PARENT, repair the tree around it
+    # the ordinary way, land on rank 0 as their new lifeline, and discover the
+    # root is gone only when they try to use it.  At the default radix every
+    # daemon is in the first category and the second is never exercised at all.
+    cleanup_swarm
+    if prted_dvm_start_mca 'node1:1,node2:1,node3:1,node4:1,node5:1,node6:1,node7:1' \
+                           '--prtemca rml_base_radix 2'; then
+        # one proc under a direct child of the HNP (node2) and two under
+        # daemons that are two levels down (node4, node7)
+        PRUN_BG /tmp/errmgr-hnp.out '--host node2:1,node4:1,node7:1 -n 3 --map-by node sleep 313'
+        sleep 6
+        c=$(prted_count 2 3 4 5 6 7)
+        if [ "$c" != 6 ]; then
+            bad "the DVM spans $c of 6 compute nodes -- not the tree this case needs"
+        elif ! ON 2 'pgrep -x sleep' >/dev/null 2>&1; then
+            bad "the job never started: $(RUN 'tr -d "\\000" < /tmp/errmgr-hnp.out' 2>&1 | tr '\n' ' ' | tail -c 250)"
+        else
+            ok "a job is running under a seven-node radix-2 DVM"
+            RUN 'pkill -9 -x prte' >/dev/null 2>&1
+            c=$(prted_settle 45 2 3 4 5 6 7)
+            [ "$c" = 0 ] \
+                && ok "every daemon exited when the HNP died" \
+                || bad "$c daemon(s) outlived the HNP -- a lifeline loss was recovered from"
+            # ...and took their local procs with them.  A daemon that exits
+            # without killing what it launched is the same orphan problem one
+            # level down, and the DVM that could clean it up is already gone.
+            n=0
+            for k in 2 4 7; do
+                ON "$k" 'pgrep -x sleep' >/dev/null 2>&1 && n=$((n+1))
+            done
+            [ "$n" = 0 ] \
+                && ok "...having killed the procs they were running" \
+                || bad "$n node(s) left an application proc orphaned"
+            # the tool has nothing left to talk to either
+            i=0
+            while [ "$i" -lt 30 ]; do
+                RUN 'pgrep -x prun' >/dev/null 2>&1 || break
+                sleep 1; i=$((i+1))
+            done
+            [ "$i" -lt 30 ] \
+                && ok "...and the tool did not hang on a DVM that is gone (${i}s)" \
+                || bad "prun is still waiting on an HNP that no longer exists"
+        fi
+    else
+        bad "could not start a radix-2 DVM for the HNP-loss test"
     fi
     cleanup_swarm
 

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -5215,6 +5215,86 @@ test_rml() {
     fi
     cleanup_swarm
 
+    banner "rml: a re-homed daemon reports the lineage that explains the re-home"
+    # Two interior daemons at once, which is the shape that separates a daemon's
+    # new parent from the death that gave it one.  radix 2 over ten nodes is
+    # 0 -> {1,2}, 1 -> {3,5}, 2 -> {4,6}, 3 -> {7}, 4 -> {8}, 5 -> {9}; killing
+    # node2 (rank 1) and node6 (rank 5) together leaves rank 3 (node4) re-homed
+    # onto rank 9 (node10) -- and rank 9 never held a socket to rank 1, so
+    # nothing it can observe tells it that the daemon it now believes is its
+    # own parent is gone.
+    #
+    # Rank 3's failure notice is the one thing that could tell it, and until it
+    # carried an ancestor list it could not: the failure array is filtered to
+    # the sender's own subtree, and the ancestor that moved it is by definition
+    # not in it, so the notice a re-homing daemon sends is EMPTY.  It now
+    # carries the lineage it believes in, ending with the parent it is sending
+    # to, and the receiver reconciles that against its own exactly as it does an
+    # adoption notice coming the other way.
+    #
+    # What this case pins is the wire path and the recovery: the lineage
+    # travels, every parent checks it, and a double interior loss leaves a DVM
+    # that tears down instead of a daemon that decided the tree was
+    # unreconcilable.  What it CANNOT force is the inference itself.  Rank 9
+    # discovers rank 1 by trying to send to it, and in a container the dead
+    # daemon's host is still up, so the connect is refused immediately rather
+    # than hanging the way a vanished node's would -- rank 9 almost always wins
+    # its own race and finds nothing left to learn.  The inference is pinned
+    # instead by test/unit/rml/test_rml_routing.c::test_reconcile_ancestry,
+    # which sets the two views up directly.
+    cleanup_swarm
+    hosts='node1:1,node2:1,node3:1,node4:1,node5:1,node6:1,node7:1,node8:1,node9:1,node10:1'
+    RUN_BG /tmp/rml-2kill.out "timeout -k 5 180 prterun --prtemca rml_base_radix 2 \
+               --prtemca routed_base_verbose 2 --leave-session-attached \
+               --host $hosts -np 10 --map-by node sleep 90"
+    sleep 12
+    if ! RUN 'pgrep -x prterun' >/dev/null 2>&1; then
+        bad "the radix-2 job never started: $(RUN 'tr -d "\\000" < /tmp/rml-2kill.out' 2>&1 | tr '\n' ' ' | tail -c 250)"
+    elif [ "$(prted_count 2 6)" != 2 ]; then
+        bad "node2/node6 have no daemons to kill -- the DVM did not span ten nodes"
+    else
+        ok "a job is running across a ten-node radix-2 tree"
+        # as close to simultaneous as the harness can get: both kills issued
+        # before either is waited on
+        ON 2 'pkill -9 -x prted' >/dev/null 2>&1 &
+        ON 6 'pkill -9 -x prted' >/dev/null 2>&1 &
+        wait
+        n=0
+        while [ "$n" -lt 90 ]; do
+            RUN 'pgrep -x prterun' >/dev/null 2>&1 || break
+            sleep 1; n=$((n+1))
+        done
+        [ "$n" -lt 90 ] \
+            && ok "losing two interior daemons at once did not hang the DVM (${n}s)" \
+            || bad "prterun never returned after a double interior daemon loss"
+        out=$(RUN 'tr -d "\\000" < /tmp/rml-2kill.out' 2>&1)
+        # the scenario actually happened: daemons re-homed onto new parents
+        n=$(echo "$out" | grep -c 'recovering with parent update')
+        [ "$n" -ge 2 ] \
+            && ok "...after $n daemons re-homed onto a new parent" \
+            || bad "no daemon re-homed, so the case asserted nothing: $(echo "$out" | grep -c .) lines captured"
+        # and every one of those re-homings carried a lineage the new parent
+        # checked -- this is the wire field, end to end
+        n=$(echo "$out" | grep -c 'lineage reported by')
+        [ "$n" -ge 1 ] \
+            && ok "...each reporting the lineage that explains it ($n checked)" \
+            || bad "no failure notice carried an ancestor list"
+        # a lineage that cannot be placed is a race to drop going up, and fatal
+        # coming down.  Neither may fire here: both views are reconcilable.
+        echo "$out" | grep -q 'incompatible routing tree state' \
+            && bad "a daemon declared the routing tree unreconcilable" \
+            || ok "...and no daemon found the repaired tree unreconcilable"
+        echo "$out" | grep -q 'cannot be reconciled' \
+            && bad "a reported lineage could not be reconciled" \
+            || ok "...nor rejected a reported one"
+        # and the eight daemons that did not die went with it, rather than one
+        # of them surviving on a lineage nobody else believes in
+        c=$(prted_settle 15 1 3 4 5 7 8 9 10)
+        [ "$c" = 0 ] && ok "...and every surviving daemon went down with it" \
+                     || bad "$c prted still running after the DVM tore down"
+    fi
+    cleanup_swarm
+
     banner "rml/oob: peer sockets serviced by dedicated OOB progress threads"
     # prte_oob_progress_threads (default 0) moves each peer's send/recv socket
     # events off the main progress thread onto one of N worker bases, chosen

--- a/docs/how-things-work/rml/index.rst
+++ b/docs/how-things-work/rml/index.rst
@@ -184,6 +184,17 @@ final."  The recovery status is then delivered to the registered fault handlers:
 the RML's own (``rml_fault_handler.c``, which drives process states and
 death/adoption notices), followed by grpcomm, filem, and relm.
 
+Both of those notices carry the sender's view of the *other* daemon's ancestor
+list, and the receiver reconciles it against its own before acting.  That is
+what lets two daemons agree on the repaired tree in one exchange rather than
+waiting for a message addressed to a dead rank to time out: the failure notice
+a re-homed daemon sends upward reports only the failures inside its own
+subtree, and the ancestor whose death moved it is never in that set, so without
+the lineage a new parent has no way to learn why it suddenly has a child.  A
+report that cannot be reconciled is fatal coming *down* the tree — an adoption
+notice is how a daemon learns its own place — and merely dropped coming up,
+where the same news always arrives by another route.
+
 ``relm`` (the ``src/rml/relm/`` subtree) is the **reliable messaging** layer.
 ``prte_rml_send_buffer_reliable_nb`` routes through it; it drives a small state
 machine that re-sends messages over the repaired tree so that a message in

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -39,12 +39,6 @@ since the transport it stages over (xcast) is already resilient.  Until then,
 a daemon lost while files are in flight fails the staging rather than
 re-driving it.
 
-**A promoted daemon's failure notice does not carry its ancestor list.**  In
-``src/rml/rml_fault_handler.c``, a daemon whose parent changed reports the
-failures in its subtree upward, but not the ancestor chain it now believes
-in — so the new parent cannot confirm that the child agrees with it about the
-shape of the repaired tree.
-
 **Nobody owns marking failed procs ``COMM_FAILED``.**  The recovery
 sequence in ``src/rml/rml_fault_handler.c`` calls each subsystem's
 ``fault_handler`` in turn, and the marked question there is whether that
@@ -234,8 +228,6 @@ the marker is stale.
    * - ``rml/oob/oob_tcp_connection.c``,
        ``prte_oob_tcp_peer_recv_connect_ack``
      - a TCP peer closed rather than retried at its next address
-   * - ``rml/rml_fault_handler.c``, ``send_failures_notice``
-     - a promoted daemon's failure notice carries no ancestor list
    * - ``rml/routed_radix.c``, ``prte_rml_repair_routing_tree``
      - nobody owns marking failed procs ``COMM_FAILED``
    * - ``rml/routed_radix.c``, ``prte_rml_compute_routing_tree``

--- a/src/mca/errmgr/prted/AGENTS.md
+++ b/src/mca/errmgr/prted/AGENTS.md
@@ -109,6 +109,19 @@ order:
 2. **Lifeline lost** (`LIFELINE_LOST`) → set exit status, `killprocs` all
    children, and `prte_quit()`. Our routed children will see us leave and
    die on their own.
+
+   This is the daemon's suicide requirement, and it is the *whole* answer
+   to losing the HNP: the root is the one rank with no inheritor to be
+   routed around, so `prte_rml_route_lost()` returns `PRTE_ERR_FATAL` for
+   it rather than repairing, and the OOB turns that into `LIFELINE_LOST`
+   instead of `COMM_FAILED`. Anything that "recovers" here leaves orphaned
+   daemons — and the application processes under them — running with
+   nothing left to command them. `contrib/dockerswarm/run-tests.sh`
+   ("losing the HNP is the one loss no daemon may survive") kills the HNP
+   under a live job at radix 2, where ranks 1 and 2 lose that socket
+   directly while the ranks below them get here the long way: they lose
+   their own parent, repair the tree, land on rank 0, and only then find
+   the root gone.
 3. **Unreachable peer** (`UNABLE_TO_SEND_MSG`, `NO_PATH_TO_TARGET`,
    `PEER_UNKNOWN`, `FAILED_TO_CONNECT`) → **this is not, by itself, our
    lifeline**, and it must not end the daemon. See the gotcha below;

--- a/src/rml/AGENTS.md
+++ b/src/rml/AGENTS.md
@@ -128,6 +128,106 @@ ranks not already in `failed_dmns` (so the detector's own rank, echoed back by
 the HNP's global broadcast, is skipped), and the errmgr independently ignores a
 comm failure for a daemon it has already torn out.
 
+### Both recovery notices carry a lineage, and both reconcile it the same way
+
+A repair emits two notices, and until recently only one of them said anything
+about the *shape* of the tree:
+
+| | tag | payload | sent when |
+|---|---|---|---|
+| parent → child | `DAEMON_ADOPTED` | the child's new ancestor list (`[my ancestors…, me]`) | our children changed, or we were promoted |
+| child → parent | `DAEMON_DIED` | the failed ranks **in the sender's own subtree**, plus (now) the sender's ancestor list | every repair, to the current lifeline |
+
+The HNP does not send that second one upward — it has nowhere to send it — but
+it reuses the same tag and the same packing routine to broadcast the confirmed
+set downward, which is why the first field on the wire is the `global` flag and
+why the ancestor list rides only the upward leg. A lineage means nothing to a
+daemon receiving a broadcast.
+
+The upward notice's rank array cannot describe a re-home. It is filtered by
+`radix_subtree_contains(&cur_node, …)`, and the ancestor whose death moved the
+sender is by definition *not* in the sender's subtree — so the notice a
+re-homing daemon sends its new parent is, in the ordinary case, **empty**. A
+parent that had not yet detected that death learned nothing from it and went on
+routing the child's traffic through a dead ancestor until one of its own sends
+timed out. That gap is what the ancestor list closes: its last entry is the
+parent it was sent to, so stripping that entry leaves the sender's view of the
+*receiver's* lineage, directly comparable with the receiver's own.
+
+`prte_rml_reconcile_ancestry()` is the single implementation both directions
+use. It applies our own failure knowledge to the report (`update_ancestors`,
+which can only shorten a list), and then walks our list toward the report one
+hypothesised death at a time. Its verdict is one of four:
+
+- **`AGREED`** — nothing to do; the common case, and the only one a test can
+  force (see below).
+- **`INFERRED`** — the peer knows of ancestor deaths we do not, and the array
+  names them. The caller drives `prte_rml_repair_routing_tree()`.
+- **`STALE`** — reconciling would require declaring a **returned** rank dead;
+  see below.
+- **`INCONSISTENT`** — no set of deaths reconciles the two views.
+
+The two directions deliberately differ on that last one. An adoption notice is
+how a daemon learns *its own* lineage, so a report it cannot place means it no
+longer knows where it is: `FORCED_EXIT`. A failure notice is an accelerant —
+everything it can tell us also arrives by a path that does not depend on a
+peer's honesty (our own lost socket, or the HNP's arbitrated broadcast) — so an
+unplaceable report going *up* is logged and dropped. Both directions also
+require the report to name us before any of this runs.
+
+Three things here are load-bearing, and two of them were bugs:
+
+- **Do not pad the report out to our own length.** `update_ancestors` fills an
+  empty slot with "the previous ancestor's next inheritor", which is right for a
+  hole in the middle of a real list and nonsense for a slot invented past its
+  end. The reconciliation used to pad, and a report of `[0]` — all the HNP sends
+  when it adopts a grandchild after losing the daemon between — became `[0,2]` at
+  radix 2, rank 2 being the root's *other* child and no ancestor of the receiver
+  at any point in the DVM's life. That reconciled against nothing, and an
+  unplaceable adoption notice is a `FORCED_EXIT`. The trigger was not exotic: a
+  dead interior daemon whose parent noticed before its grandchild did. A
+  legitimately shorter report is what the tail loop handles.
+
+- **A rank that has RETURNED may not be inferred dead.** `revived_dmns` records
+  them (set by `prte_rml_revive_routing_tree`, cleared when a death is actually
+  recorded). A report is a snapshot of the sender's view when it *sent*, and a
+  revival travels as its own xcast: a notice that crossed with one carries a
+  lineage from before the return, and it reconciles perfectly — by burying a
+  daemon that is alive and talking to us. That is the `STALE` verdict, and it
+  abandons the whole reconciliation rather than skipping the one rank.
+
+- **Nothing may be left marked.** The walk sets bits in `failed_dmns` as it
+  hypothesises, because that is what makes `update_ancestors` step past a rank;
+  every one of them is cleared again before returning, since deciding whether any
+  of it is real is the *caller's* job.
+
+- **`record_inference` is what makes the walk terminate**, and both of its
+  remaining refusals matter. It will not infer a rank that is *already* failed —
+  nothing can be inferred about one, so seeing it means the walk is not
+  converging — which bounds the walk at one accepted inference per daemon. And
+  it will not infer **rank 0**: the root is every ancestor list's first entry
+  and has no inheritor to route around, which is why `update_ancestors` starts
+  at index 1 — so a hypothesised root death is never revisited and the loop
+  spins forever. The unit test for that one *hangs* rather than failing, which
+  is worth knowing before you go looking for it.
+
+`test/unit/rml/test_rml_routing.c::test_reconcile_ancestry` pins all of it,
+including both bugs above, by standing the two views up directly — each report
+is the ancestor list the peer's own `compute_routing_tree()` produces from the
+failures that peer knows about, so a change to the radix math moves both sides.
+
+**What the container harness cannot force.** The swarm case
+(`contrib/dockerswarm/run-tests.sh`, "a re-homed daemon reports the lineage
+that explains the re-home") kills two interior daemons at once, which is the
+shape that separates a daemon's new parent from the death that gave it one. It
+pins the wire path and the recovery — the lineage travels, every parent checks
+it, and the DVM tears down instead of a daemon deciding the tree is
+unreconcilable — but not the *inference*. The new parent discovers the death by
+trying to send to it, and in a container the dead daemon's host is still up, so
+that connect is refused immediately rather than hanging the way a vanished
+node's would; the parent wins its own race and finds nothing left to learn. The
+window this closes is a real cluster's, where a node that goes away sends no RST.
+
 ### The tree layout, precisely
 
 `radix.h` is the whole of the math, and it is worth writing down because the

--- a/src/rml/rml.c
+++ b/src/rml/rml.c
@@ -56,6 +56,7 @@ prte_rml_base_t prte_rml_base = {
     .global_failed_dmns = { .super = PMIX_OBJ_STATIC_INIT(pmix_bitmap_t) },
     .dead_dmns = { .super = PMIX_OBJ_STATIC_INIT(pmix_bitmap_t) },
     .absent_dmns = { .super = PMIX_OBJ_STATIC_INIT(pmix_bitmap_t) },
+    .revived_dmns = { .super = PMIX_OBJ_STATIC_INIT(pmix_bitmap_t) },
     .lateral_links = { .super = PMIX_OBJ_STATIC_INIT(pmix_bitmap_t) },
     .lateral_lost_cb = NULL,
     .peer_epochs = NULL,
@@ -325,6 +326,7 @@ void prte_rml_close(void)
     PMIX_DESTRUCT(&prte_rml_base.global_failed_dmns);
     PMIX_DESTRUCT(&prte_rml_base.dead_dmns);
     PMIX_DESTRUCT(&prte_rml_base.absent_dmns);
+    PMIX_DESTRUCT(&prte_rml_base.revived_dmns);
     PMIX_DESTRUCT(&prte_rml_base.lateral_links);
     if (NULL != prte_rml_base.peer_epochs) {
         free(prte_rml_base.peer_epochs);
@@ -366,6 +368,12 @@ int prte_rml_open(void)
      * comes back (the unheal path). Initialized once here for the same reason. */
     PMIX_CONSTRUCT(&prte_rml_base.absent_dmns, pmix_bitmap_t);
     pmix_bitmap_init(&prte_rml_base.absent_dmns, prte_process_info.num_daemons);
+    /* revived_dmns records the ranks that have come back, so that a peer's
+     * report of our lineage - which may predate the return - can never be the
+     * thing that declares one of them dead again. Constructed once here for
+     * the same reason as the two above. */
+    PMIX_CONSTRUCT(&prte_rml_base.revived_dmns, pmix_bitmap_t);
+    pmix_bitmap_init(&prte_rml_base.revived_dmns, prte_process_info.num_daemons);
     /* lateral_links records the peers we hold a non-tree connection to. Like
      * the two above it is constructed once and never re-initialized by a
      * routing recompute: a grow reshapes the tree but does not dissolve the

--- a/src/rml/rml.h
+++ b/src/rml/rml.h
@@ -326,6 +326,18 @@ typedef struct {
     // the daemon returns (the "unheal" path). Only bootstrap faults populate
     // it -- a launched/elastic departure remains permanent in dead_dmns.
     pmix_bitmap_t absent_dmns;
+    // Ranks that have come back (the unheal path cleared their absent mark)
+    // and have not since been confirmed dead again. Constructed once, like the
+    // two sets above. Its one job is to bound what may be *inferred*: a peer's
+    // report of our lineage is a snapshot of that peer's view when it sent,
+    // and a revival travels as its own xcast, so a notice that crossed with
+    // one carries a lineage predating the return. Acting on it would bury a
+    // daemon that is alive and talking to us, so a rank in this set may only
+    // be declared dead by something that observed it directly - a lost socket,
+    // or the HNP's arbitrated broadcast. Cleared again when such a death is
+    // recorded, so a rank that returns and later really dies is not pinned
+    // alive forever.
+    pmix_bitmap_t revived_dmns;
 
     // Highest boot epoch (incarnation) known for each daemon rank, indexed by
     // rank; 0 means "not yet learned". A rebooted bootstrap daemon returns with
@@ -401,6 +413,18 @@ PRTE_EXPORT void prte_rml_send_callback(int status, pmix_proc_t *peer,
                                         prte_rml_tag_t tag, void *cbdata);
 PRTE_EXPORT void prte_rml_compute_routing_tree(void);
 PRTE_EXPORT void prte_rml_update_ancestors(pmix_data_array_t* ancestors);
+/* Reconcile a peer's report of THIS daemon's ancestor list (root first, not
+ * including us) against prte_rml_base.ancestors.  Both notices that reshape the
+ * tree carry such a list - the adoption notice a parent sends down, and the
+ * failure notice a child sends up - and both reconcile it here.
+ *
+ * `report` is normalized in place against our own failure knowledge; `inferred`
+ * receives the ranks that must have died when the return is
+ * PRTE_RML_ANCESTRY_INFERRED, and is left empty otherwise.  Both arrays belong
+ * to the caller.  Nothing is left marked failed: the caller decides whether to
+ * act on the inference by driving prte_rml_repair_routing_tree(). */
+PRTE_EXPORT prte_rml_ancestry_t prte_rml_reconcile_ancestry(pmix_data_array_t* report,
+                                                            pmix_data_array_t* inferred);
 PRTE_EXPORT void prte_rml_repair_routing_tree(pmix_data_array_t* failed_ranks,
                                               bool global);
 PRTE_EXPORT void prte_rml_revive_routing_tree(pmix_rank_t rank);

--- a/src/rml/rml_fault_handler.c
+++ b/src/rml/rml_fault_handler.c
@@ -54,11 +54,260 @@ static void shrink_ranks(pmix_data_array_t* arr){
     resize_ranks(arr, size);
 }
 
+/* Do two rank arrays hold the same sequence? */
+static bool ranks_differ(const pmix_data_array_t* a, const pmix_data_array_t* b)
+{
+    if (a->size != b->size) {
+        return true;
+    }
+    for (size_t i = 0; i < a->size; i++) {
+        if (((pmix_rank_t*)a->array)[i] != ((pmix_rank_t*)b->array)[i]) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/* Record one inferred ancestor death, marking the rank failed so that the next
+ * pass of prte_rml_update_ancestors walks past it. Returns false, and sets
+ * *why, when this rank must not be inferred dead at all:
+ *
+ *  - An out-of-range rank. PMIX_RANK_INVALID is the value an ancestor slot
+ *    holds when the walk found no living inheritor at all, and setting a bit
+ *    at that index would ask the bitmap to grow to UINT32_MAX bits.
+ *
+ *  - The root. Rank 0 is every daemon's first ancestor and has no inheritor to
+ *    be routed around, which is why update_ancestors starts its walk at index
+ *    1; losing the HNP is fatal by construction, not something to recover from.
+ *    A well-formed report can never ask for it -- every ancestor list begins
+ *    with 0, so index 0 never differs -- but a malformed one that stripped down
+ *    to nothing would fall into the tail loop and, because update_ancestors
+ *    never revisits index 0, hypothesise the root's death over and over: the
+ *    unit test for this hangs rather than failing.
+ *
+ *  - A rank we already believe dead. Nothing can be *inferred* about one --
+ *    update_ancestors would have walked past it before we ever compared -- so
+ *    seeing it here means the walk is not converging. This is what bounds the
+ *    walk: every accepted inference marks a living rank dead, so there can be
+ *    at most one per daemon.
+ *
+ *  - A rank that has RETURNED. A report is a snapshot of the sender's view at
+ *    the moment it sent, and a revival travels as its own xcast, so a notice
+ *    that crossed with one carries a lineage predating the return. Burying a
+ *    daemon that is alive and talking to us is much worse than converging a
+ *    beat later on a death somebody actually observed, so the whole
+ *    reconciliation is abandoned rather than the one rank skipped.
+ */
+static bool record_inference(pmix_data_array_t* inferred, size_t* n,
+                             pmix_rank_t ancestor, prte_rml_ancestry_t* why)
+{
+    if (ancestor >= prte_rml_base.n_dmns || 0 == ancestor) {
+        *why = PRTE_RML_ANCESTRY_INCONSISTENT;
+        return false;
+    }
+    if (pmix_bitmap_is_set_bit(&prte_rml_base.failed_dmns, ancestor)) {
+        *why = PRTE_RML_ANCESTRY_INCONSISTENT;
+        return false;
+    }
+    if (pmix_bitmap_is_set_bit(&prte_rml_base.revived_dmns, ancestor)) {
+        *why = PRTE_RML_ANCESTRY_STALE;
+        return false;
+    }
+
+    // grow only when the next slot is past the end - "<=" also fired while
+    // the array still had room and shrank it back under the entries we had
+    // already recorded
+    if (*n >= inferred->size) {
+        resize_ranks(inferred, (*n+1)*3/2);
+    }
+    ((pmix_rank_t*)inferred->array)[(*n)++] = ancestor;
+    pmix_bitmap_set_bit(&prte_rml_base.failed_dmns, ancestor);
+    return true;
+}
+
+prte_rml_ancestry_t prte_rml_reconcile_ancestry(pmix_data_array_t* report,
+                                                pmix_data_array_t* inferred)
+{
+    // Apply what WE already know to the peer's list first: a difference our own
+    // failure knowledge accounts for is not new information.
+    //
+    // Note what is deliberately NOT done here: the report is not first padded
+    // out to our own length. update_ancestors fills an empty slot with "the
+    // previous ancestor's next inheritor", which is meaningful for a hole in
+    // the middle of a real list and nonsense for a slot invented past its end -
+    // padding a report of [0] (all the HNP sends when it adopts a grandchild
+    // directly) produced [0,2] at radix 2, rank 2 being the root's OTHER child
+    // and no ancestor of ours at all. That reconciled against nothing and took
+    // the DVM down with a FORCED_EXIT, in exactly the race the notice exists to
+    // settle. A legitimately shorter report is what the tail loop below is for.
+    prte_rml_update_ancestors(report);
+
+    if (!ranks_differ(report, &prte_rml_base.ancestors)) {
+        return PRTE_RML_ANCESTRY_AGREED;
+    }
+
+    if (report->size > prte_rml_base.ancestors.size) {
+        // The peer places us deeper than we place ourselves, and our own
+        // failure knowledge did not account for it. An ancestor list only ever
+        // shortens through failures, so no set of deaths reconciles this.
+        return PRTE_RML_ANCESTRY_INCONSISTENT;
+    }
+
+    // Operate on a copy of our ancestors, walking it toward the report one
+    // inferred death at a time. record_inference is what bounds the walk: it
+    // refuses a rank that is already failed, so every pass that is allowed to
+    // proceed marks one more living rank dead.
+    pmix_data_array_t ancestors = PMIX_DATA_ARRAY_STATIC_INIT;
+    resize_ranks(&ancestors, prte_rml_base.ancestors.size);
+    for (size_t i = 0; i < ancestors.size; i++) {
+        ((pmix_rank_t*)ancestors.array)[i] =
+            ((pmix_rank_t*)prte_rml_base.ancestors.array)[i];
+    }
+
+    resize_ranks(inferred, 1);
+    size_t infer_i = 0;
+    prte_rml_ancestry_t verdict = PRTE_RML_ANCESTRY_INFERRED;
+
+    for (size_t i = 0; i < report->size && i < ancestors.size; i++) {
+        pmix_rank_t ancestor = ((pmix_rank_t*)ancestors.array)[i];
+        if (ancestor == ((pmix_rank_t*)report->array)[i]) {
+            continue;
+        }
+
+        if (!record_inference(inferred, &infer_i, ancestor, &verdict)) {
+            break;
+        }
+        prte_rml_update_ancestors(&ancestors);
+
+        i--;
+    }
+    while (PRTE_RML_ANCESTRY_INFERRED == verdict &&
+           ancestors.size > report->size) {
+        pmix_rank_t ancestor = ((pmix_rank_t*)ancestors.array)[report->size];
+
+        if (!record_inference(inferred, &infer_i, ancestor, &verdict)) {
+            break;
+        }
+        prte_rml_update_ancestors(&ancestors);
+    }
+
+    // Undo setting the failed bit for inferred failures, so the caller can do
+    // the full error handling process for them.
+    shrink_ranks(inferred);
+    for (size_t i = 0; i < inferred->size; i++) {
+        pmix_bitmap_clear_bit(
+            &prte_rml_base.failed_dmns, ((pmix_rank_t*)inferred->array)[i]
+        );
+    }
+
+    // If the arrays are still different, one/both of us are in an invalid state
+    if (PRTE_RML_ANCESTRY_INFERRED == verdict &&
+        ranks_differ(report, &ancestors)) {
+        verdict = PRTE_RML_ANCESTRY_INCONSISTENT;
+    }
+    PMIx_Data_array_destruct(&ancestors);
+
+    if (PRTE_RML_ANCESTRY_INFERRED != verdict) {
+        // Nothing may be acted on, so hand back no inferences at all
+        resize_ranks(inferred, 0);
+    } else if (0 == inferred->size) {
+        // The lists differ but no death explains it
+        verdict = PRTE_RML_ANCESTRY_INCONSISTENT;
+    }
+    return verdict;
+}
+
+/* A child's report of its own lineage, riding its failure notice (see
+ * send_failures_notice). Its last entry is the parent it sent to, which is what
+ * makes it checkable: strip that entry and what remains is the child's view of
+ * OUR ancestor list, directly comparable with our own.
+ *
+ * Consumes nothing and repairs only on a clean inference. Where the downward
+ * (adoption) path treats an irreconcilable report as fatal, this one only logs:
+ * that report is how a daemon learns its own lineage, whereas this one is an
+ * accelerant. Everything it can tell us also arrives by a route that does not
+ * depend on a peer's honesty - our own lost socket, or the HNP's arbitrated
+ * broadcast - so a report we cannot place is a race to drop, not a reason to
+ * end the DVM.
+ */
+static void reconcile_child_ancestry(pmix_data_array_t* report,
+                                     pmix_proc_t* sender)
+{
+    /* A repair here would emit adoption and failure notices to daemons that are
+     * already on their way out, where they can be misread as faults - the same
+     * reason prte_rml_route_lost stops short of one while a teardown is under
+     * way. */
+    if (prte_finalizing || prte_prteds_term_ordered ||
+        prte_abnormal_term_ordered || prte_dvm_leaving) {
+        return;
+    }
+
+    if (0 == report->size) {
+        /* only the HNP has an empty ancestor list, and the HNP never sends
+         * this leg of the message */
+        return;
+    }
+
+    pmix_rank_t* ranks = (pmix_rank_t*) report->array;
+    if (ranks[report->size-1] != PRTE_PROC_MY_NAME->rank) {
+        /* Stale: the sender has re-homed since it sent, or we have. Its list
+         * names some other daemon as its parent, so it says nothing about OUR
+         * lineage and must not be reconciled against it. */
+        PMIX_OUTPUT_VERBOSE((
+            1, prte_rml_base.routed_output,
+            "%s routed:radix: failure notice from %s reports parent %s, not us"
+            " - ignoring its ancestry",
+            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(sender),
+            PRTE_VPID_PRINT(ranks[report->size-1])
+        ));
+        return;
+    }
+    resize_ranks(report, report->size-1);
+
+    pmix_data_array_t inferred = PMIX_DATA_ARRAY_STATIC_INIT;
+    prte_rml_ancestry_t verdict = prte_rml_reconcile_ancestry(report, &inferred);
+
+    switch (verdict) {
+    case PRTE_RML_ANCESTRY_AGREED:
+        /* The ordinary outcome, and worth a trace of its own: it is the only
+         * evidence that the lineage travelled and was checked at all, which is
+         * the half of this a test can pin down. Whether it ever carries news
+         * depends on who wins a race with a socket error. */
+        PMIX_OUTPUT_VERBOSE((
+            2, prte_rml_base.routed_output,
+            "%s routed:radix: lineage reported by %s agrees with ours",
+            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(sender)
+        ));
+        break;
+
+    case PRTE_RML_ANCESTRY_INFERRED:
+        PMIX_OUTPUT_VERBOSE((
+            1, prte_rml_base.routed_output,
+            "%s routed:radix: lineage reported by %s implies %lu ancestor"
+            " death(s) we had not recorded", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+            PRTE_NAME_PRINT(sender), (unsigned long) inferred.size
+        ));
+        prte_rml_repair_routing_tree(&inferred, /* global = */ false);
+        break;
+
+    case PRTE_RML_ANCESTRY_STALE:
+    case PRTE_RML_ANCESTRY_INCONSISTENT:
+        PMIX_OUTPUT_VERBOSE((
+            1, prte_rml_base.routed_output,
+            "%s routed:radix: lineage reported by %s cannot be reconciled"
+            " - ignoring it", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+            PRTE_NAME_PRINT(sender)
+        ));
+        break;
+    }
+    PMIx_Data_array_destruct(&inferred);
+}
+
 void prte_rml_recv_failures_notice(
     int status, pmix_proc_t* sender, pmix_data_buffer_t* buf,
     prte_rml_tag_t tag, void* cbdata
 ) {
-    PRTE_HIDE_UNUSED_PARAMS(status,sender,tag,cbdata);
+    PRTE_HIDE_UNUSED_PARAMS(status,tag,cbdata);
 
     int cnt = 1;
 
@@ -132,6 +381,24 @@ void prte_rml_recv_failures_notice(
 
     /* repair takes a copy of what it needs, so the unpacked array is ours */
     PMIx_Data_array_destruct(&failed_ranks);
+
+    /* The sender's own lineage rides the upward leg only. Reconcile it AFTER
+     * the repair above: the ranks it just reported may be exactly what explains
+     * the difference between our two views, in which case there is nothing left
+     * to infer. */
+    if (!global) {
+        pmix_data_array_t report = PMIX_DATA_ARRAY_STATIC_INIT;
+        cnt = 1;
+        ret = PMIx_Data_unpack(NULL, buf, &report, &cnt, PMIX_DATA_ARRAY);
+        if (PMIX_SUCCESS != ret) {
+            /* Advisory payload: losing it costs us the early convergence, not
+             * the DVM, and the failures above have already been applied. */
+            PMIX_ERROR_LOG(ret);
+        } else {
+            reconcile_child_ancestry(&report, sender);
+        }
+        PMIx_Data_array_destruct(&report);
+    }
 }
 
 void prte_rml_recv_adoption_notice(
@@ -155,97 +422,33 @@ void prte_rml_recv_adoption_notice(
     // may just be old. Instead, we use their reported ancestry list to infer
     // any relevant faults that must have happened and use that information to
     // update our state.
-
-    // Update the reported list with any faults we know of. Note the reported
-    // list is deliberately NOT padded out to our own length first:
-    // update_ancestors fills an empty slot with "the previous ancestor's next
-    // inheritor", which is meaningful for a hole in the middle of a real list
-    // and nonsense for a slot invented past its end. A legitimately shorter
-    // report is what the tail loop below is for.
-    prte_rml_update_ancestors(&report);
-
-    // If we match after updating their list, there's no new info for us
-    bool different = report.size != prte_rml_base.ancestors.size;
-    for(size_t i = 0; !different && i < report.size; i++){
-        different = ((pmix_rank_t*)report.array)[i] !=
-            ((pmix_rank_t*)prte_rml_base.ancestors.array)[i];
-    }
-    if(!different){
-        PMIx_Data_array_destruct(&report);
-        return;
-    }
-
-    if(report.size > prte_rml_base.ancestors.size){
-        // This should never happen -- it implies there is some extra failure
-        // that could lead to our depth increasing, which is an invariate
-        // violation. Depth should only ever decrease.
-        PRTE_ERROR_LOG( PRTE_ERR_UNRECOVERABLE );
-        PMIX_OUTPUT_VERBOSE((
-            0, prte_rml_base.routed_output,
-            "%s routed:radix: incompatible routing tree state from %s",
-            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(sender)
-        ));
-        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
-        PMIx_Data_array_destruct(&report);
-        return;
-    }
-
-    // Operate on a copy of our ancestors
-    pmix_data_array_t ancestors = PMIX_DATA_ARRAY_STATIC_INIT;
-    resize_ranks(&ancestors, prte_rml_base.ancestors.size);
-    for(size_t i = 0; i < ancestors.size; i++){
-        ((pmix_rank_t*)ancestors.array)[i] =
-            ((pmix_rank_t*)prte_rml_base.ancestors.array)[i];
-    }
-
-    // Build an array of inferred faults
     pmix_data_array_t inferred = PMIX_DATA_ARRAY_STATIC_INIT;
-    resize_ranks(&inferred, 1);
-    size_t infer_i = 0;
-
-    for(size_t i = 0; i < report.size && i < ancestors.size; i++){
-        pmix_rank_t ancestor = ((pmix_rank_t*)ancestors.array)[i];
-        if(ancestor == ((pmix_rank_t*)report.array)[i]) continue;
-
-        if(infer_i >= inferred.size) resize_ranks(&inferred, (infer_i+1)*1.5);
-        ((pmix_rank_t*)inferred.array)[infer_i++] = ancestor;
-
-        pmix_bitmap_set_bit(&prte_rml_base.failed_dmns, ancestor);
-        prte_rml_update_ancestors(&ancestors);
-
-        i--;
-    }
-    while(ancestors.size > report.size){
-        pmix_rank_t ancestor = ((pmix_rank_t*)ancestors.array)[report.size];
-
-        // grow only when the next slot is past the end - "<=" also fired while
-        // the array still had room and shrank it back under the entries we had
-        // already recorded
-        if(infer_i >= inferred.size) resize_ranks(&inferred, (infer_i+1)*1.5);
-        ((pmix_rank_t*)inferred.array)[infer_i++] = ancestor;
-
-        pmix_bitmap_set_bit(&prte_rml_base.failed_dmns, ancestor);
-        prte_rml_update_ancestors(&ancestors);
-    }
-
-    // Undo setting the failed bit for inferred failures, so we can do the full
-    // error handling process for them.
-    shrink_ranks(&inferred);
-    for(size_t i = 0; i < inferred.size; i++){
-        pmix_bitmap_clear_bit(
-            &prte_rml_base.failed_dmns, ((pmix_rank_t*)inferred.array)[i]
-        );
-    }
-
-    // If the arrays are still different, one/both of us are in an invalid state
-    different = report.size != ancestors.size;
-    for(size_t i = 0; !different && i < report.size; i++){
-        different = ((pmix_rank_t*)report.array)[i] !=
-            ((pmix_rank_t*)ancestors.array)[i];
-    }
+    prte_rml_ancestry_t verdict = prte_rml_reconcile_ancestry(&report, &inferred);
     PMIx_Data_array_destruct(&report);
-    PMIx_Data_array_destruct(&ancestors);
-    if(different){
+
+    switch (verdict) {
+    case PRTE_RML_ANCESTRY_AGREED:
+        break;
+
+    case PRTE_RML_ANCESTRY_INFERRED:
+        // Finally, do a full repair on the inferred faults
+        prte_rml_repair_routing_tree(&inferred, /* global = */ false);
+        break;
+
+    case PRTE_RML_ANCESTRY_STALE:
+        // Our would-be parent's view predates a return we have already applied.
+        // It gets the correction the same way we did, from the revival xcast.
+        PMIX_OUTPUT_VERBOSE((
+            1, prte_rml_base.routed_output,
+            "%s routed:radix: ignoring pre-revival adoption notice from %s",
+            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(sender)
+        ));
+        break;
+
+    case PRTE_RML_ANCESTRY_INCONSISTENT:
+        // This one is fatal in this direction and not in the other: an adoption
+        // notice is how we learn our own lineage, so a report we cannot place
+        // means we no longer know where we are in the tree.
         PRTE_ERROR_LOG( PRTE_ERR_UNRECOVERABLE );
         PMIX_OUTPUT_VERBOSE((
             0, prte_rml_base.routed_output,
@@ -253,13 +456,7 @@ void prte_rml_recv_adoption_notice(
             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(sender)
         ));
         PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
-        PMIx_Data_array_destruct(&inferred);
-        return;
-    }
-
-    // Finally, do a full repair on the inferred faults
-    if(inferred.size > 0){
-        prte_rml_repair_routing_tree(&inferred, /* global = */ false);
+        break;
     }
     PMIx_Data_array_destruct(&inferred);
 }
@@ -329,9 +526,6 @@ static void send_failures_notice(const prte_rml_recovery_status_t* status){
     // Build array of failures to pass up to my parent
     pmix_data_array_t arr = PMIX_DATA_ARRAY_STATIC_INIT;
     if(status->parent_changed){
-        // TODO: Include current ancestor list, to ensure new parent understands
-        // that they are my new parent.
-
         // New parent might not be aware of old failures, report all non-global
         // failures in my subtree
         pmix_bitmap_t local_only;
@@ -384,6 +578,33 @@ static void send_failures_notice(const prte_rml_recovery_status_t* status){
         PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         PMIX_DATA_BUFFER_RELEASE(msg);
         return;
+    }
+
+    // Tell our parent the lineage we now believe in - our ancestor list, whose
+    // last entry is the parent we are sending to. This is the mirror of what an
+    // adoption notice carries the other way, and the receiver reconciles it the
+    // same way, but the two directions were not symmetric until now: a notice
+    // travelling UP reported facts about the sender's subtree and nothing about
+    // why it was talking to this daemon at all. A parent that has not yet
+    // detected the death that re-homed us learns nothing from it, and keeps
+    // routing our traffic through a dead ancestor until one of its own sends
+    // times out. It cannot even reconstruct the death from the failure array:
+    // that array is filtered to the sender's own subtree, and an ancestor is by
+    // definition not in it, so the common re-homing case sends an EMPTY array.
+    //
+    // The list rides only this leg. The HNP's copy of this message is a global
+    // broadcast to daemons whose lineage has nothing to do with ours, which is
+    // why `global` gates it - and why `global` unpacks first, so the same tag
+    // can carry both shapes.
+    if (!global) {
+        ret = PMIx_Data_pack(NULL, msg, &prte_rml_base.ancestors, 1,
+                             PMIX_DATA_ARRAY);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
+            PMIX_DATA_BUFFER_RELEASE(msg);
+            return;
+        }
     }
 
     // HNP broadcasts new failure information down

--- a/src/rml/rml_fault_handler.c
+++ b/src/rml/rml_fault_handler.c
@@ -156,10 +156,12 @@ void prte_rml_recv_adoption_notice(
     // any relevant faults that must have happened and use that information to
     // update our state.
 
-    // Update the reported list with any faults we know of
-    if(report.size < prte_rml_base.ancestors.size){
-        resize_ranks(&report, prte_rml_base.ancestors.size);
-    }
+    // Update the reported list with any faults we know of. Note the reported
+    // list is deliberately NOT padded out to our own length first:
+    // update_ancestors fills an empty slot with "the previous ancestor's next
+    // inheritor", which is meaningful for a hole in the middle of a real list
+    // and nonsense for a slot invented past its end. A legitimately shorter
+    // report is what the tail loop below is for.
     prte_rml_update_ancestors(&report);
 
     // If we match after updating their list, there's no new info for us

--- a/src/rml/rml_types.h
+++ b/src/rml/rml_types.h
@@ -361,6 +361,23 @@ typedef struct {
                        //   up, not necessarily related to failures
 } prte_rml_routed_tree_node_t;
 
+/* Outcome of reconciling a peer's report of THIS daemon's ancestor list
+ * against our own view of it - see prte_rml_reconcile_ancestry(). */
+typedef enum {
+    /* The two views agree once our own failure knowledge has been applied to
+     * the report: the peer told us nothing we did not already know. */
+    PRTE_RML_ANCESTRY_AGREED,
+    /* The peer knows of ancestor deaths we do not.  The inferred array holds
+     * the ranks that must have failed for its view to be the correct one. */
+    PRTE_RML_ANCESTRY_INFERRED,
+    /* Reconciling would require declaring a rank dead that has RETURNED, so
+     * the report necessarily predates the return and says nothing current.
+     * A race to be ignored, not an error. */
+    PRTE_RML_ANCESTRY_STALE,
+    /* No set of ancestor deaths reconciles the two views. */
+    PRTE_RML_ANCESTRY_INCONSISTENT
+} prte_rml_ancestry_t;
+
 /* struct for passing information about a daemon fault to MCA components */
 typedef struct {
     pmix_object_t super;

--- a/src/rml/routed_radix.c
+++ b/src/rml/routed_radix.c
@@ -270,6 +270,10 @@ void prte_rml_repair_routing_tree(pmix_data_array_t* failed_ranks, bool global){
             } else {
                 pmix_bitmap_set_bit(&prte_rml_base.dead_dmns, r);
             }
+            // A rank we are now recording as departed is no longer one whose
+            // return has to be protected from being inferred away, so let the
+            // mark go. It is re-set if the rank returns again.
+            pmix_bitmap_clear_bit(&prte_rml_base.revived_dmns, r);
         }
         ((pmix_rank_t*)status.failed_ranks.array)[j++] = r;
     }
@@ -395,6 +399,10 @@ void prte_rml_revive_routing_tree(pmix_rank_t rank){
     pmix_bitmap_clear_bit(&prte_rml_base.failed_dmns, rank);
     pmix_bitmap_clear_bit(&prte_rml_base.global_failed_dmns, rank);
     pmix_bitmap_clear_bit(&prte_rml_base.absent_dmns, rank);
+    // Remember that it came back. A lineage reported to us by a peer whose
+    // view predates this xcast would otherwise let us infer the rank dead
+    // again - see prte_rml_reconcile_ancestry.
+    pmix_bitmap_set_bit(&prte_rml_base.revived_dmns, rank);
 
     // Rebuild from the base positions with the returned rank now living: it
     // re-takes its slot above us if it was our ancestor (demoting us), or

--- a/test/unit/rml/test_rml_routing.c
+++ b/test/unit/rml/test_rml_routing.c
@@ -71,7 +71,7 @@ static void build_dvm(int radix, pmix_rank_t ndmns, pmix_rank_t myrank)
     prte_rml_compute_routing_tree();
 }
 
-/* construct the four failure bitmaps the way prte_rml_open() does */
+/* construct the failure bitmaps the way prte_rml_open() does */
 static void bitmaps_construct(void)
 {
     PMIX_CONSTRUCT(&prte_rml_base.failed_dmns, pmix_bitmap_t);
@@ -82,6 +82,8 @@ static void bitmaps_construct(void)
     pmix_bitmap_init(&prte_rml_base.absent_dmns, 64);
     PMIX_CONSTRUCT(&prte_rml_base.lateral_links, pmix_bitmap_t);
     pmix_bitmap_init(&prte_rml_base.lateral_links, 64);
+    PMIX_CONSTRUCT(&prte_rml_base.revived_dmns, pmix_bitmap_t);
+    pmix_bitmap_init(&prte_rml_base.revived_dmns, 64);
 }
 
 /*
@@ -179,6 +181,7 @@ static void bitmaps_destruct(void)
     PMIX_DESTRUCT(&prte_rml_base.dead_dmns);
     PMIX_DESTRUCT(&prte_rml_base.absent_dmns);
     PMIX_DESTRUCT(&prte_rml_base.lateral_links);
+    PMIX_DESTRUCT(&prte_rml_base.revived_dmns);
 }
 
 /* forget every failure mark between cases */
@@ -460,6 +463,347 @@ static int test_departed_ranks_survive_recompute(void)
     bitmaps_reset();
     if (0 == failures) {
         fprintf(stdout, "PASSED test_departed_ranks_survive_recompute\n");
+    }
+    return failures;
+}
+
+/*
+ * Ancestry reconciliation -- prte_rml_reconcile_ancestry().
+ *
+ * Both notices that reshape the tree carry a peer's view of THIS daemon's
+ * lineage: the adoption notice a parent sends down, and (since the failure
+ * notice learned to carry one) the report a re-homed child sends up.  Both
+ * reconcile it here, and the whole point of the exercise is that the two
+ * daemons converge without waiting for a send to a dead rank to time out.
+ *
+ * This is the piece of fault recovery that IS unit-testable: it is pure
+ * computation over prte_rml_base, where prte_rml_repair_routing_tree() -- which
+ * is what acts on the verdict -- ends in the grpcomm/filem/relm fault handlers
+ * and RML sends that do not exist in this process.  The reports here are not
+ * hand-written constants: each is the ancestor list the peer's own
+ * prte_rml_compute_routing_tree() produces from the failures that peer knows
+ * about, so a change to the radix math moves both sides of the comparison.
+ */
+
+/* The ancestor list `rank` computes when the given ranks have departed, as a
+ * detached copy.  This is exactly the peer's view: same code, different
+ * knowledge. */
+static pmix_data_array_t ancestry_of(int radix, pmix_rank_t ndmns, pmix_rank_t rank,
+                                     const pmix_rank_t *dead, size_t ndead)
+{
+    pmix_data_array_t out = PMIX_DATA_ARRAY_STATIC_INIT;
+    size_t i;
+
+    bitmaps_reset();
+    for (i = 0; i < ndead; i++) {
+        pmix_bitmap_set_bit(&prte_rml_base.dead_dmns, dead[i]);
+    }
+    build_dvm(radix, ndmns, rank);
+
+    PMIx_Data_array_construct(&out, prte_rml_base.ancestors.size, PMIX_PROC_RANK);
+    for (i = 0; i < prte_rml_base.ancestors.size; i++) {
+        ((pmix_rank_t *) out.array)[i] = ((pmix_rank_t *) prte_rml_base.ancestors.array)[i];
+    }
+    return out;
+}
+
+/* Drop the trailing entry, as the receiver of a failure notice does once it has
+ * confirmed that entry names itself. */
+static void ranks_drop_last(pmix_data_array_t *arr)
+{
+    pmix_data_array_t cut = PMIX_DATA_ARRAY_STATIC_INIT;
+    size_t i;
+
+    if (0 == arr->size) {
+        return;
+    }
+    if (1 < arr->size) {
+        PMIx_Data_array_construct(&cut, arr->size - 1, PMIX_PROC_RANK);
+        for (i = 0; i + 1 < arr->size; i++) {
+            ((pmix_rank_t *) cut.array)[i] = ((pmix_rank_t *) arr->array)[i];
+        }
+    }
+    PMIx_Data_array_destruct(arr);
+    *arr = cut;
+}
+
+static pmix_data_array_t mk_ranks(const pmix_rank_t *r, size_t n)
+{
+    pmix_data_array_t out = PMIX_DATA_ARRAY_STATIC_INIT;
+    size_t i;
+
+    if (0 < n) {
+        PMIx_Data_array_construct(&out, n, PMIX_PROC_RANK);
+        for (i = 0; i < n; i++) {
+            ((pmix_rank_t *) out.array)[i] = r[i];
+        }
+    }
+    return out;
+}
+
+static bool holds_exactly(const pmix_data_array_t *arr, const pmix_rank_t *r, size_t n)
+{
+    size_t i;
+
+    if (arr->size != n) {
+        return false;
+    }
+    for (i = 0; i < n; i++) {
+        if (((pmix_rank_t *) arr->array)[i] != r[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/* Snapshot of the failed set, so every case can insist that a reconciliation
+ * left nothing marked behind: the walk sets bits as it hypothesises deaths and
+ * MUST undo them, because the caller is the thing that decides whether any of
+ * it is real. */
+static bool failed_set_is(pmix_rank_t ndmns, const pmix_rank_t *set, size_t n)
+{
+    pmix_rank_t r;
+    size_t i;
+
+    for (r = 0; r < ndmns; r++) {
+        bool want = false;
+        for (i = 0; i < n; i++) {
+            want |= (set[i] == r);
+        }
+        if (want != pmix_bitmap_is_set_bit(&prte_rml_base.failed_dmns, r)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static int test_reconcile_ancestry(void)
+{
+    int failures = 0;
+    pmix_data_array_t report, inferred, mine;
+    prte_rml_ancestry_t verdict;
+    const pmix_rank_t r1[] = {1}, r2[] = {2}, r5[] = {5}, none[] = {0};
+
+    /*
+     * (a) The two views agree.  Radix 2 over 7 daemons with nothing wrong:
+     * rank 4's parent is rank 2, and what rank 4 reports upward is [0,2].
+     * Rank 2 strips itself off the end and finds its own list.
+     */
+    report = ancestry_of(2, 7, 4, NULL, 0);
+    ranks_drop_last(&report);
+    bitmaps_reset();
+    build_dvm(2, 7, 2);
+    inferred = (pmix_data_array_t) PMIX_DATA_ARRAY_STATIC_INIT;
+    verdict = prte_rml_reconcile_ancestry(&report, &inferred);
+    CHECK("an agreeing report is agreement", PRTE_RML_ANCESTRY_AGREED == verdict);
+    CHECK("...and infers nothing", 0 == inferred.size);
+    PMIx_Data_array_destruct(&report);
+    PMIx_Data_array_destruct(&inferred);
+
+    /*
+     * (b) The case the upward report exists for.  Rank 2 dies; rank 6 inherits
+     * its slot and rank 4 re-homes onto rank 6.  Rank 4's failure notice can
+     * say nothing about rank 2 -- the array it carries is filtered to rank 4's
+     * own subtree and an ancestor is never in it -- so the ONLY thing that can
+     * tell rank 6 why it suddenly has a child is the lineage.
+     */
+    report = ancestry_of(2, 7, 4, r2, 1);
+    CHECK("the re-homed child reports its new parent last",
+          6 == ((pmix_rank_t *) report.array)[report.size - 1]);
+    ranks_drop_last(&report);
+    bitmaps_reset();
+    build_dvm(2, 7, 6); /* rank 6 has not detected anything yet */
+    inferred = (pmix_data_array_t) PMIX_DATA_ARRAY_STATIC_INIT;
+    verdict = prte_rml_reconcile_ancestry(&report, &inferred);
+    CHECK("a re-homed child's lineage yields an inference",
+          PRTE_RML_ANCESTRY_INFERRED == verdict);
+    CHECK("...naming the ancestor that must have died",
+          holds_exactly(&inferred, r2, 1));
+    CHECK("...and leaves nothing marked failed", failed_set_is(7, none, 0));
+    PMIx_Data_array_destruct(&report);
+    PMIx_Data_array_destruct(&inferred);
+
+    /*
+     * (c) The same shape two levels deep, which is where the timeout it saves
+     * is not merely a socket away: radix 2 over 15, ranks 1 and 5 both gone.
+     * Rank 3 re-homes all the way onto rank 13 -- and rank 13, whose only lost
+     * socket was to rank 5, has no way of its own to learn that rank 1 died.
+     */
+    {
+        const pmix_rank_t dead_15[] = {1, 5};
+        report = ancestry_of(2, 15, 3, dead_15, 2);
+        CHECK("the deep child re-homes onto rank 13",
+              13 == ((pmix_rank_t *) report.array)[report.size - 1]);
+        ranks_drop_last(&report);
+        bitmaps_reset();
+        build_dvm(2, 15, 13); /* rank 13 knows only about the parent it lost */
+        pmix_bitmap_set_bit(&prte_rml_base.dead_dmns, 5);
+        build_dvm(2, 15, 13);
+        inferred = (pmix_data_array_t) PMIX_DATA_ARRAY_STATIC_INIT;
+        verdict = prte_rml_reconcile_ancestry(&report, &inferred);
+        CHECK("a two-level re-home is reconcilable",
+              PRTE_RML_ANCESTRY_INFERRED == verdict);
+        CHECK("...inferring the death nothing else would have told us about",
+              holds_exactly(&inferred, r1, 1));
+        CHECK("...and leaves only the death we already knew about marked",
+              failed_set_is(15, r5, 1));
+        PMIx_Data_array_destruct(&report);
+        PMIx_Data_array_destruct(&inferred);
+    }
+
+    /*
+     * (d) The regression that used to take the DVM down.  The HNP loses rank 1
+     * and adopts rank 5 directly, so the adoption notice it sends carries the
+     * shortest list there is: [0].  Rank 5 has not noticed anything yet, so its
+     * own list is [0,1] -- one entry longer.
+     *
+     * That difference used to be "fixed" by padding the report out to our own
+     * length and letting update_ancestors fill the invented slot, which walks
+     * from the root to its next living node and yields rank 2 -- the root's
+     * OTHER child, no ancestor of rank 5 at any point in the DVM's life.  The
+     * padded report reconciled against nothing, and an unreconcilable adoption
+     * notice is a FORCED_EXIT.  A dead interior daemon plus a parent that
+     * noticed first is not an exotic race; it is the ordinary one.
+     */
+    report = mk_ranks((const pmix_rank_t[]){0}, 1);
+    bitmaps_reset();
+    build_dvm(2, 7, 5);
+    inferred = (pmix_data_array_t) PMIX_DATA_ARRAY_STATIC_INIT;
+    verdict = prte_rml_reconcile_ancestry(&report, &inferred);
+    CHECK("an adoption straight from the root is reconcilable",
+          PRTE_RML_ANCESTRY_INFERRED == verdict);
+    CHECK("...inferring the intervening daemon's death",
+          holds_exactly(&inferred, r1, 1));
+    CHECK("...and leaves nothing marked failed", failed_set_is(7, none, 0));
+    PMIx_Data_array_destruct(&report);
+    PMIx_Data_array_destruct(&inferred);
+
+    /*
+     * (e) A peer that is BEHIND us reports a deeper lineage.  Our own knowledge
+     * accounts for the difference, so there is nothing to infer and nothing to
+     * complain about -- this is the common ordering, since a report is a
+     * snapshot of the sender's view when it sent.
+     */
+    report = ancestry_of(2, 7, 5, NULL, 0); /* [0,1], from before the death */
+    bitmaps_reset();
+    pmix_bitmap_set_bit(&prte_rml_base.dead_dmns, 1);
+    build_dvm(2, 7, 5); /* we know rank 1 is gone: [0] */
+    inferred = (pmix_data_array_t) PMIX_DATA_ARRAY_STATIC_INIT;
+    verdict = prte_rml_reconcile_ancestry(&report, &inferred);
+    CHECK("a report our own knowledge explains is agreement",
+          PRTE_RML_ANCESTRY_AGREED == verdict);
+    CHECK("...and infers nothing", 0 == inferred.size);
+    PMIx_Data_array_destruct(&report);
+    PMIx_Data_array_destruct(&inferred);
+
+    /*
+     * (f) A lineage no set of deaths produces.  Rank 2 is alive and is not on
+     * rank 5's path to the root at any depth, so a report of [0,2] cannot be
+     * reconciled -- and, crucially, the walk must put back every bit it set
+     * while trying.
+     */
+    report = mk_ranks((const pmix_rank_t[]){0, 2}, 2);
+    bitmaps_reset();
+    build_dvm(2, 7, 5);
+    inferred = (pmix_data_array_t) PMIX_DATA_ARRAY_STATIC_INIT;
+    verdict = prte_rml_reconcile_ancestry(&report, &inferred);
+    CHECK("an impossible lineage is inconsistent",
+          PRTE_RML_ANCESTRY_INCONSISTENT == verdict);
+    CHECK("...and hands back no inferences to act on", 0 == inferred.size);
+    CHECK("...having undone every bit it set while trying",
+          failed_set_is(7, none, 0));
+    PMIx_Data_array_destruct(&report);
+    PMIx_Data_array_destruct(&inferred);
+
+    /*
+     * (g) The revival race, which is the one that costs a live daemon.  Rank 2
+     * departed and has come back (the bootstrap unheal path).  A failure notice
+     * that was already in flight when the revival xcast went out carries a
+     * lineage from before the return -- exactly the lineage of case (b), which
+     * reconciles perfectly if you let it, by declaring rank 2 dead a second
+     * time.  It must not: only a lost socket or the HNP's arbitrated broadcast
+     * may bury a daemon that is up and talking to us.
+     */
+    report = ancestry_of(2, 7, 4, r2, 1);
+    ranks_drop_last(&report);
+    bitmaps_reset();
+    build_dvm(2, 7, 6);
+    pmix_bitmap_set_bit(&prte_rml_base.revived_dmns, 2);
+    inferred = (pmix_data_array_t) PMIX_DATA_ARRAY_STATIC_INIT;
+    verdict = prte_rml_reconcile_ancestry(&report, &inferred);
+    CHECK("a lineage predating a return is stale, not actionable",
+          PRTE_RML_ANCESTRY_STALE == verdict);
+    CHECK("...and infers nothing", 0 == inferred.size);
+    CHECK("...leaving the returned daemon alive",
+          !pmix_bitmap_is_set_bit(&prte_rml_base.failed_dmns, 2));
+    PMIx_Data_array_destruct(&report);
+    PMIx_Data_array_destruct(&inferred);
+
+    /* ...and the mark is not permanent: a death somebody actually observed
+     * clears it, so a rank that returns and later really dies is not pinned
+     * alive forever. */
+    bitmaps_reset();
+    build_dvm(2, 7, 6);
+    pmix_bitmap_set_bit(&prte_rml_base.revived_dmns, 2);
+    pmix_bitmap_set_bit(&prte_rml_base.dead_dmns, 2);
+    pmix_bitmap_clear_bit(&prte_rml_base.revived_dmns, 2);
+    CHECK("a confirmed death clears the returned mark",
+          !pmix_bitmap_is_set_bit(&prte_rml_base.revived_dmns, 2));
+
+    /*
+     * (h) The root is never inferable.  Rank 0 is every daemon's first
+     * ancestor and has no inheritor to be routed around -- which is why
+     * update_ancestors starts its walk at index 1, and why losing the HNP is
+     * fatal by construction rather than recoverable.  A well-formed report can
+     * never ask for it, since every ancestor list begins with 0 and index 0
+     * therefore never differs; an empty one reaching a daemon that is NOT the
+     * root would fall into the tail loop and take the whole DVM with it.
+     */
+    report = mk_ranks(NULL, 0);
+    bitmaps_reset();
+    build_dvm(2, 7, 5);
+    inferred = (pmix_data_array_t) PMIX_DATA_ARRAY_STATIC_INIT;
+    verdict = prte_rml_reconcile_ancestry(&report, &inferred);
+    CHECK("an empty lineage cannot bury the root",
+          PRTE_RML_ANCESTRY_INCONSISTENT == verdict);
+    CHECK("...and infers nothing", 0 == inferred.size);
+    CHECK("...leaving the HNP alive",
+          !pmix_bitmap_is_set_bit(&prte_rml_base.failed_dmns, 0));
+    PMIx_Data_array_destruct(&report);
+    PMIx_Data_array_destruct(&inferred);
+
+    /*
+     * (i) The root has no ancestors, so every child's report reduces to nothing
+     * once its trailing entry (the HNP itself) is stripped.  The HNP can never
+     * infer anything from one, which is right -- it is the arbiter, not a
+     * daemon that can be wrong about its lineage.
+     */
+    report = ancestry_of(2, 7, 1, NULL, 0);
+    ranks_drop_last(&report);
+    bitmaps_reset();
+    build_dvm(2, 7, 0);
+    inferred = (pmix_data_array_t) PMIX_DATA_ARRAY_STATIC_INIT;
+    verdict = prte_rml_reconcile_ancestry(&report, &inferred);
+    CHECK("a report to the root is trivially agreement",
+          PRTE_RML_ANCESTRY_AGREED == verdict);
+    CHECK("...and infers nothing", 0 == inferred.size);
+    PMIx_Data_array_destruct(&report);
+    PMIx_Data_array_destruct(&inferred);
+
+    /*
+     * (j) At the default radix the tree is flat, so there is no lineage to
+     * disagree about at all: every daemon's list is [0] and every report
+     * reduces to empty.  The notice costs a handful of bytes and says nothing,
+     * which is why this whole class of bug is invisible until a small radix
+     * gives the tree some depth.
+     */
+    mine = ancestry_of(64, 10, 7, NULL, 0);
+    CHECK("a flat tree gives every daemon one ancestor", 1 == mine.size);
+    PMIx_Data_array_destruct(&mine);
+
+    bitmaps_reset();
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_reconcile_ancestry\n");
     }
     return failures;
 }
@@ -821,6 +1165,7 @@ int main(void)
     failures += test_radix_traversal();
     failures += test_routing_tree();
     failures += test_departed_ranks_survive_recompute();
+    failures += test_reconcile_ancestry();
     failures += test_dead_dmns_round_trip();
     failures += test_num_contributors();
     failures += test_lateral_links();


### PR DESCRIPTION
Two daemons that disagree about the shape of a repaired routing tree have
only one way to converge today, and it runs in one direction.

When a repair reshapes the tree, a parent sends its new children an
adoption notice carrying their ancestor list, and each child reconciles
that against its own to work out which ancestors must have died. The
notice travelling the other way — a child telling its parent which ranks
have failed — carries no lineage at all, and the array it does carry
cannot supply one: it is filtered to the sender's own subtree, and the
ancestor whose death re-homed the sender is by definition not in it. So
the notice a re-homing daemon sends its new parent is, in the ordinary
case, **empty**.

A parent that has not yet detected that death therefore learns nothing
from it. It does not know it has acquired a child, and it keeps routing
that child's traffic through a dead ancestor until one of its own sends
times out. The gap is widest exactly where it costs most: lose two
interior daemons at once and the new parent never held a socket to the
ancestor in question, so it has no way of its own to learn of it at all.

This PR makes the upward notice carry the sender's ancestor list, whose
last entry is the parent it was sent to — strip that entry and what
remains is the sender's view of the receiver's own lineage, directly
comparable with it. The reconciliation the adoption path already
performed becomes `prte_rml_reconcile_ancestry()`, shared by both
directions. The list rides only the upward leg; the HNP reuses the same
message to broadcast the confirmed set downward, where a lineage would
mean nothing to the recipients.

The two directions deliberately differ on a report that cannot be
reconciled. An adoption notice is how a daemon learns its own place in
the tree, so one it cannot place still ends the job. The upward report is
an accelerant — everything it conveys also arrives by a path that does
not depend on a peer's honesty — so one that cannot be placed is logged
and dropped rather than taken as grounds to end a DVM.

### An existing bug this uncovered (first commit)

Before comparing, the reconciliation padded a short report out to its own
length. `update_ancestors` fills an empty slot with "the previous
ancestor's next inheritor", which is right for a hole in a list somebody
really holds and nonsense for a slot invented past its end. A report of
`[0]` — exactly what the HNP sends when it loses a daemon and adopts the
grandchild below it directly — became `[0,2]` at radix 2, rank 2 being
the root's *other* child and no ancestor of the receiver at any point in
the DVM's life. That reconciles against nothing, and an unplaceable
adoption notice is `PRTE_ERROR_LOG` followed by `FORCED_EXIT`.

The race that produces it is an ordinary one: an interior daemon dies and
its parent notices before its grandchild does. It is a standalone commit
so it can be judged on its own.

### Bounding what may be inferred

Inferring a death from a peer's report is a race against every other way
that news travels, so three refusals bound it:

* **A rank that has RETURNED may not be inferred dead.** A report is a
  snapshot of the sender's view when it sent, and a revival travels as
  its own broadcast, so a notice that crossed with one carries a lineage
  from before the return — and reconciles perfectly, by burying a daemon
  that is alive and talking to us. A new `revived_dmns` set holds those
  ranks until a death somebody observed directly is recorded.
* **A rank already believed dead may not be inferred.** Nothing can be
  inferred about one, so meeting it means the walk is not converging.
  This is what bounds the walk at one inference per daemon.
* **The root may not be inferred at all.** It is every ancestor list's
  first entry and has no inheritor to be routed around, which is why
  `update_ancestors` starts at index 1 — and therefore why a hypothesised
  root death is never revisited and the walk spins. A well-formed report
  cannot ask for it; a truncated one could.

### Testing

`test/unit/rml/test_rml_routing.c::test_reconcile_ancestry` — ten cases,
including the padding bug above and each refusal. The reports are not
hand-written constants: each is the ancestor list the *peer's own*
`compute_routing_tree()` produces from the failures that peer knows
about, so a change to the radix math moves both sides of every
comparison. Every case asserts the failed set is left exactly as it was
found. Each guard was checked to be load-bearing by removing it: the
padding breaks seven assertions, the revival guard two, and the root
guard hangs the test rather than failing it.

`contrib/dockerswarm` gains a case that kills two interior daemons at
once on a radix-2 ten-node DVM — the shape that separates a daemon's new
parent from the death that gave it one. Four daemons re-homed, twelve
lineages checked end to end, no unreconcilable report, clean teardown;
the rml phase passes 30/30.

**What the container harness cannot force,** and this is stated in the
test and in `AGENTS.md` rather than papered over: the *inference* itself.
The new parent discovers the death by trying to send to it, and in a
container the dead daemon's host is still up, so that connect is refused
immediately rather than hanging the way a vanished node's would — the
parent wins its own race and finds nothing left to learn. The swarm log
shows exactly that. The window this closes is a real cluster's, where a
node that goes away sends no RST; the inference is pinned by the unit
tests instead.

Also: warning-free debug build, `make check` 21/21, docs build clean,
live DVM smoke test. The multi-node run was made before rebasing onto
current master, whose changes are confined to the data server.

`docs/todo.rst` loses the entry and the marker-table row this closes;
`src/rml/AGENTS.md` and the RML how-things-work page describe the shared
reconciliation and both traps.

### The opposite requirement, now covered too (third commit)

Losing a child and losing the HNP are opposite requirements, and only the
first was tested. Since this PR is about what a daemon may conclude from
a lost connection, the suite now also kills the HNP under a live job and
asserts all three parts of the daemon's answer: every daemon is gone, no
application process was left behind, and the tool did not hang. It runs
at radix 2 so that the ranks below the HNP's own children reach the
conclusion the long way — losing their parent, repairing the tree,
landing on rank 0, and only then finding the root gone.

Verified by breaking it: with `route_lost` returning SUCCESS for the HNP,
all six daemons outlive it and three application processes are orphaned.
That run also showed that `SWARM_CLEAN` did not kill a stray `sleep`,
which is exactly what this case looks for — so a failing case could make
the *next* run report a failure in innocent code. Fixed in the same
commit.
