### PR TITLE
Report a deduced daemon death, and retire the COMM_FAILED ownership marker

### DIFF
--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -39,14 +39,6 @@ since the transport it stages over (xcast) is already resilient.  Until then,
 a daemon lost while files are in flight fails the staging rather than
 re-driving it.
 
-**Nobody owns marking failed procs ``COMM_FAILED``.**  The recovery
-sequence in ``src/rml/rml_fault_handler.c`` calls each subsystem's
-``fault_handler`` in turn, and the marked question there is whether that
-one place should also be what sets the affected procs to
-``PRTE_PROC_STATE_COMM_FAILED``, instead of leaving each handler to do it.
-It is a question about where the responsibility belongs, not a known
-misbehavior.
-
 **A RELM message-id clash is logged and ignored.**  Two places in
 ``src/rml/relm/base/state_updates.c`` detect that a message uid already
 belongs to a different message — a second start for the same uid, or a
@@ -228,8 +220,6 @@ the marker is stale.
    * - ``rml/oob/oob_tcp_connection.c``,
        ``prte_oob_tcp_peer_recv_connect_ack``
      - a TCP peer closed rather than retried at its next address
-   * - ``rml/routed_radix.c``, ``prte_rml_repair_routing_tree``
-     - nobody owns marking failed procs ``COMM_FAILED``
    * - ``rml/routed_radix.c``, ``prte_rml_compute_routing_tree``
      - routing-tree state is not preserved across a DVM resize
    * - ``rml/relm/relm.c``, ``prte_relm_register``
@@ -520,6 +510,37 @@ so that the next person does not rediscover the idea and spend the effort
 again: each says what was measured and what the measurement decided.  Moving
 one back up the page takes new evidence, not a fresh reading of the same
 facts.
+
+**Making the routing-tree repair the one place that raises
+``COMM_FAILED``.**  ``prte_rml_repair_routing_tree`` ends by calling every
+subsystem's ``fault_handler`` in turn, and a marker there asked whether that
+one place should also set the departed ranks to
+``PRTE_PROC_STATE_COMM_FAILED`` rather than leaving each caller to do it.  It
+should not.  Repairing the tree and telling the errmgr a daemon is gone are
+different questions, and the code has both halves without the other:
+
+* A DVM shrink repairs in one batch for the whole campaign and must **not**
+  raise it — ``shrink_campaign_complete`` (``src/mca/ras/base/ras_base_allocate.c``)
+  tears the targets out of the DVM itself, and the already-departed guard in
+  ``errmgr/dvm`` exists precisely to swallow the comm-failure their real
+  departure produces afterwards.
+* During an ordered teardown ``prte_rml_route_lost`` returns without repairing
+  anything, yet the OOB still raises ``COMM_FAILED`` — and that raise is what
+  drives "all my routes and children are gone, terminate" in *both* errmgr
+  components.  Centralizing the raise would break orderly shutdown.
+* ``errmgr/prted`` heals the tree around a peer it has given up connecting to
+  from inside its own error handler, where raising the state again would
+  re-enter it.
+
+Four of the six call sites therefore repair without reporting, for three
+different reasons, and one report happens where no repair does.  What the
+paths that *do* report must not do is diverge, because the routing tree's
+``failed_dmns`` set is what they all use to tell a first report from a
+duplicate — a path that repairs without reporting makes every later report
+for that rank look like a duplicate and suppresses it for good.  They are
+collected behind ``report_new_departures`` in
+``src/rml/rml_fault_handler.c``; the two lineage-inference paths used to be
+outside it, and are not any more.
 
 **Aggregating the launch-message cpuset slices per next hop.**  The scatter
 itself has landed: the launch message is packed ``PRTE_JOB_PACK_NO_CPUSETS``

--- a/src/rml/AGENTS.md
+++ b/src/rml/AGENTS.md
@@ -142,6 +142,15 @@ whichever of them won the race against the real notice silently ate the
 *before* the repair, which is safe because the state activation is
 thread-shifted and cannot outrun it.
 
+Do **not** be tempted to move the raise into `prte_rml_repair_routing_tree`
+itself, next to the fault-handler fan-out. Repairing the tree and reporting a
+departure are different questions and the code needs each without the other: a
+DVM shrink repairs for every target and must not report (the campaign tears them
+out itself), an ordered teardown reports without repairing at all (and that
+report is what terminates the daemons), and `errmgr/prted` repairs from inside
+its own error handler, where a report would re-enter it. `docs/todo.rst`,
+"Decided against", carries the full reasoning.
+
 ### Both recovery notices carry a lineage, and both reconcile it the same way
 
 A repair emits two notices, and until recently only one of them said anything

--- a/src/rml/AGENTS.md
+++ b/src/rml/AGENTS.md
@@ -104,16 +104,19 @@ relm fault handlers.
 
 `PRTE_PROC_STATE_COMM_FAILED` is what makes the HNP act on a departure: mark the
 daemon not-alive, decrement `num_daemons`, print `node-died`, and fail the jobs
-that had procs on it. It is raised in **two** places, and both are needed:
+that had procs on it. It is raised from **two kinds of place**, and both are
+needed:
 
 - `prte_mca_oob_tcp_component_lost_connection` — the daemon that actually lost
   the socket. This is also what drives the HNP's countdown to
   `DAEMONS_TERMINATED` during a *normal* teardown (the errmgr's
   `prte_prteds_term_ordered` branch), so it cannot be removed.
-- `prte_rml_recv_failures_notice` — a daemon that only *heard* about the death,
-  for the ranks it had not already recorded.
+- `report_new_departures()` in `rml_fault_handler.c` — a daemon that only
+  *learned* of the death, for the ranks it had not already recorded. Three
+  paths call it: the failure notice (`prte_rml_recv_failures_notice`) and the
+  two lineage inferences, from a child's report and from an adoption notice.
 
-The second one is easy to think unnecessary, and its absence was a real hang.
+The second kind is easy to think unnecessary, and its absence was a real hang.
 At the default radix a ten-node DVM is **flat**, so the HNP is every daemon's
 parent and is always the one that loses the socket; the first path alone looks
 sufficient. Give the tree any depth and an interior daemon becomes the detector:
@@ -123,10 +126,21 @@ dead node's procs are never marked terminated, the job never completes, and its
 tool waits forever. `prun` against a radix-2 DVM hung indefinitely where the
 same DVM at radix 64 released instantly.
 
-Two properties keep the pair from double-reporting: the notice path reports only
-ranks not already in `failed_dmns` (so the detector's own rank, echoed back by
-the HNP's global broadcast, is skipped), and the errmgr independently ignores a
-comm failure for a daemon it has already torn out.
+Two properties keep these from double-reporting: a report names only ranks not
+already in `failed_dmns` (so the detector's own rank, echoed back by the HNP's
+global broadcast, is skipped), and the errmgr independently ignores a comm
+failure for a daemon it has already torn out.
+
+That dedup is also why the three learning paths have to stay behind one
+function. `failed_dmns` is the *only* record of what this daemon already knows,
+and `prte_rml_repair_routing_tree` sets it — so a path that repairs without
+reporting does not merely stay quiet, it makes every later report for that rank
+look like a duplicate and suppresses it permanently. The two inference paths
+were exactly that: they repaired the tree on a deduced death and told nobody, so
+whichever of them won the race against the real notice silently ate the
+`COMM_FAILED`. Hence the ordering rule in `report_new_departures` — report
+*before* the repair, which is safe because the state activation is
+thread-shifted and cannot outrun it.
 
 ### Both recovery notices carry a lineage, and both reconcile it the same way
 

--- a/src/rml/rml_fault_handler.c
+++ b/src/rml/rml_fault_handler.c
@@ -217,6 +217,65 @@ prte_rml_ancestry_t prte_rml_reconcile_ancestry(pmix_data_array_t* report,
     return verdict;
 }
 
+/* Hand a set of departed daemon ranks to the errmgr, skipping any this daemon
+ * had already recorded.
+ *
+ * PRTE_PROC_STATE_COMM_FAILED is what makes a daemon act on a departure rather
+ * than merely route around it - on the HNP it is what sweeps the dead node's
+ * procs to TERM_WO_SYNC so their job can complete.  It is otherwise raised only
+ * by prte_mca_oob_tcp_component_lost_connection, i.e. only on the daemon that
+ * was holding the socket.  At the default radix that is always the HNP - a
+ * ten-node DVM at radix 64 is flat, so the HNP is every daemon's parent - and
+ * the DVM therefore looked correct.  Give the routing tree any depth and it
+ * stops being true: an interior daemon detects the loss, the notice walks up
+ * and correctly marks the rank failed everywhere including the HNP, and the HNP
+ * - never having lost a socket - never runs the errmgr.  The procs that were on
+ * the dead node are never marked terminated, so the job never completes and its
+ * tool waits forever.  A `prun` against a radix-2 DVM whose job's node was
+ * killed hung indefinitely, where the same DVM at radix 64 released it at once.
+ *
+ * Every path in this file that learns of a departure reports it here, whether
+ * it was told (a failure notice) or deduced it (a peer's lineage that only an
+ * unrecorded death explains).  Those must not diverge: the routing tree's
+ * failed_dmns set is the sole record of what we already know, so a path that
+ * repairs the tree without reporting does not merely stay quiet - it makes
+ * every later notice for that rank look like a duplicate and suppresses the
+ * report for good.
+ *
+ * Which is also why this MUST be called before the repair that records the
+ * ranks, and why it can be: the state activation is thread-shifted, so the
+ * errmgr cannot run ahead of the repair no matter what order the two calls
+ * appear in, whereas the failed_dmns test is only meaningful while the repair
+ * has yet to set the bits.
+ *
+ * For an inferred death that also depends on prte_rml_reconcile_ancestry
+ * having undone the marks it sets while walking - it does, deliberately, "so
+ * the caller can do the full error handling process", and
+ * test_reconcile_ancestry pins it.  A bit left behind there would not merely
+ * skip one report; it would make the rank look known to every path forever.
+ */
+static void report_new_departures(const pmix_data_array_t* failed)
+{
+    /* mirrors the OOB's guard: while finalizing there is nobody left to tell */
+    if (prte_finalizing) {
+        return;
+    }
+    pmix_rank_t* ranks = (pmix_rank_t*) failed->array;
+    for (size_t i = 0; i < failed->size; i++) {
+        pmix_proc_t dmn;
+        /* PMIX_RANK_INVALID is the padding an ancestor walk leaves behind, not
+         * a departure */
+        if (PMIX_RANK_INVALID == ranks[i]) {
+            continue;
+        }
+        if (pmix_bitmap_is_set_bit(&prte_rml_base.failed_dmns, ranks[i])) {
+            continue;
+        }
+        PMIX_LOAD_PROCID(&dmn, PRTE_PROC_MY_NAME->nspace, ranks[i]);
+        PRTE_ACTIVATE_PROC_STATE(&dmn, PRTE_PROC_STATE_COMM_FAILED);
+    }
+}
+
 /* A child's report of its own lineage, riding its failure notice (see
  * send_failures_notice). Its last entry is the parent it sent to, which is what
  * makes it checkable: strip that entry and what remains is the child's view of
@@ -287,6 +346,7 @@ static void reconcile_child_ancestry(pmix_data_array_t* report,
             " death(s) we had not recorded", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
             PRTE_NAME_PRINT(sender), (unsigned long) inferred.size
         ));
+        report_new_departures(&inferred);
         prte_rml_repair_routing_tree(&inferred, /* global = */ false);
         break;
 
@@ -328,56 +388,14 @@ void prte_rml_recv_failures_notice(
         return;
     }
 
-    /* Note which of these we did not already know about, BEFORE the repair
-     * records them - see the errmgr hand-off below. */
-    pmix_rank_t* incoming = (pmix_rank_t*) failed_ranks.array;
-    size_t n_incoming = failed_ranks.size;
-    bool* newly = NULL;
-    if (0 < n_incoming) {
-        newly = (bool*) calloc(n_incoming, sizeof(bool));
-    }
-    if (NULL != newly) {
-        for (size_t i = 0; i < n_incoming; i++) {
-            newly[i] = (PMIX_RANK_INVALID != incoming[i]) &&
-                       !pmix_bitmap_is_set_bit(&prte_rml_base.failed_dmns, incoming[i]);
-        }
-    }
+    /* Hand the departure to the errmgr before the repair records it - only
+     * ranks we had not already recorded are reported, so the daemon that
+     * detected the loss itself (and already raised COMM_FAILED from the OOB)
+     * does not raise it twice when the HNP's global broadcast comes back
+     * around, and a duplicate notice is a no-op. */
+    report_new_departures(&failed_ranks);
 
     prte_rml_repair_routing_tree(&failed_ranks, global);
-
-    /* Hand the departure to the errmgr.
-     *
-     * PRTE_PROC_STATE_COMM_FAILED is otherwise raised only by
-     * prte_mca_oob_tcp_component_lost_connection, i.e. only on the daemon that
-     * was holding the socket.  At the default radix that is always the HNP -
-     * a ten-node DVM at radix 64 is flat, so the HNP is every daemon's parent -
-     * and the DVM therefore looked correct.  Give the routing tree any depth
-     * and it stops being true: an interior daemon detects the loss, the notice
-     * walks up and correctly marks the rank failed everywhere including the
-     * HNP, and the HNP - never having lost a socket - never runs the errmgr.
-     * The procs that were on the dead node are never marked terminated, so the
-     * job never completes and its tool waits forever.  A `prun` against a
-     * radix-2 DVM whose job's node was killed hung indefinitely, where the same
-     * DVM at radix 64 released it at once.
-     *
-     * Only ranks this daemon had not already recorded are reported, so the
-     * daemon that detected the loss itself (and already raised COMM_FAILED from
-     * the OOB) does not raise it twice when the HNP's global broadcast comes
-     * back around, and a duplicate notice is a no-op.  The guard mirrors the
-     * OOB's: while finalizing there is nobody left to tell. */
-    if (NULL != newly) {
-        if (!prte_finalizing) {
-            for (size_t i = 0; i < n_incoming; i++) {
-                pmix_proc_t dmn;
-                if (!newly[i]) {
-                    continue;
-                }
-                PMIX_LOAD_PROCID(&dmn, PRTE_PROC_MY_NAME->nspace, incoming[i]);
-                PRTE_ACTIVATE_PROC_STATE(&dmn, PRTE_PROC_STATE_COMM_FAILED);
-            }
-        }
-        free(newly);
-    }
 
     /* repair takes a copy of what it needs, so the unpacked array is ours */
     PMIx_Data_array_destruct(&failed_ranks);
@@ -431,7 +449,8 @@ void prte_rml_recv_adoption_notice(
         break;
 
     case PRTE_RML_ANCESTRY_INFERRED:
-        // Finally, do a full repair on the inferred faults
+        // Finally, report the inferred deaths and do a full repair on them
+        report_new_departures(&inferred);
         prte_rml_repair_routing_tree(&inferred, /* global = */ false);
         break;
 

--- a/src/rml/routed_radix.c
+++ b/src/rml/routed_radix.c
@@ -366,11 +366,32 @@ void prte_rml_repair_routing_tree(pmix_data_array_t* failed_ranks, bool global){
 
     }
 
-    // Notify components
+    // Notify components.
+    //
+    // Deliberately NOT the place that raises PRTE_PROC_STATE_COMM_FAILED for
+    // the departed ranks, tempting though the symmetry is. Repairing the tree
+    // and telling the errmgr a daemon is gone are not the same question, and
+    // each happens without the other:
+    //
+    //  - A DVM shrink repairs in one batch for every target and must not raise
+    //    it: the campaign tears the targets out of the DVM itself, and the
+    //    errmgr's already-departed guard exists precisely to swallow the
+    //    comm-failure their real departure produces later
+    //    (ras_base_allocate.c, errmgr_dvm.c).
+    //  - During an ordered teardown prte_rml_route_lost returns without
+    //    repairing at all, yet the OOB still raises COMM_FAILED - and that
+    //    raise is what drives "all my routes and children are gone, terminate"
+    //    in both errmgr components. Moving the raise in here would break
+    //    orderly shutdown.
+    //  - errmgr/prted heals the tree around a peer it has given up connecting
+    //    to from inside its own error handler; raising there would re-enter it.
+    //
+    // What must not diverge is the set of paths that DO report, because this
+    // function's failed_dmns set is what they all use to tell a first report
+    // from a duplicate. They are collected in rml_fault_handler.c behind
+    // report_new_departures(); see the comment there.
     const prte_rml_recovery_status_t* s = &status;
     prte_rml_fault_handler(s);
-    // TODO: Should this fn become the central point responsible for setting
-    // failed procs to PRTE_PROC_STATE_COMM_FAILED?
     prte_grpcomm_fault_handler(s);
     prte_filem  .fault_handler(s);
     prte_relm   .fault_handler(s);

--- a/test/unit/rml/test_rml_routing.c
+++ b/test/unit/rml/test_rml_routing.c
@@ -476,6 +476,16 @@ static int test_departed_ranks_survive_recompute(void)
  * reconcile it here, and the whole point of the exercise is that the two
  * daemons converge without waiting for a send to a dead rank to time out.
  *
+ * The "leaves nothing marked failed" checks below are load-bearing, not
+ * tidiness.  The walk marks each rank it hypothesises dead so the next pass of
+ * update_ancestors steps over it, and undoes those marks before returning.
+ * Its caller then reports the inferred deaths to the errmgr, and the test it
+ * reports on is exactly failed_dmns -- "did we already know about this rank"
+ * (report_new_departures(), src/rml/rml_fault_handler.c).  A bit left set here
+ * would therefore not just leak state: it would make every inferred death look
+ * like one already handled, and silently suppress the COMM_FAILED that ends
+ * the dead node's jobs.
+ *
  * This is the piece of fault recovery that IS unit-testable: it is pure
  * computation over prte_rml_base, where prte_rml_repair_routing_tree() -- which
  * is what acts on the verdict -- ends in the grpcomm/filem/relm fault handlers


### PR DESCRIPTION
A `TODO` in `prte_rml_repair_routing_tree` asked whether that function — the
one place every routing-tree repair funnels through, and which ends by calling
each subsystem's `fault_handler` in turn — should also be what sets the
departed ranks to `PRTE_PROC_STATE_COMM_FAILED`, instead of leaving each caller
to do it. Investigating that question turned up a real bug sitting next to it.

## The answer to the question: no

Repairing the tree and telling the errmgr a daemon is gone are different
questions, and the code needs each without the other:

* A **DVM shrink** repairs in one batch for the whole campaign and must *not*
  raise it — `shrink_campaign_complete` tears the targets out of the DVM
  itself, and `errmgr/dvm`'s already-departed guard exists precisely to swallow
  the comm failure their real departure produces afterwards.
* During an **ordered teardown** `prte_rml_route_lost` returns without
  repairing anything at all, yet the OOB still raises `COMM_FAILED` — and that
  raise is what drives "all my routes and children are gone, terminate" in
  *both* errmgr components. Centralizing the raise would break orderly
  shutdown.
* `errmgr/prted` heals the tree around a peer it has given up connecting to
  from inside its own error handler, where raising the state again would
  re-enter it.

Four of the six call sites therefore repair without reporting, for three
different reasons, and one report happens where no repair does. The marker is
retired and the reasoning moved to `docs/todo.rst`'s *Decided against* section,
with a short version left at the fan-out so the asymmetry stops reading as an
oversight.

## The bug it was sitting next to

A daemon learns of an ancestor's departure three ways: it is *told*, by a
failure notice; or it *deduces* it from a lineage that only an unrecorded death
explains — either a child's report riding its failure notice, or an adoption
notice from a would-be new parent. All three end in
`prte_rml_repair_routing_tree`, but only the first told the errmgr anything.

That is worse than a missing report. `failed_dmns` is the only record of what
this daemon already knows, and the repair writes it — so an inference did not
merely stay quiet, it marked the rank *known*, and the authoritative notice
arriving afterwards was then indistinguishable from a duplicate and dropped.
Whichever path won the race silently ate the `COMM_FAILED` for good: the state
that makes a daemon act on a departure rather than merely route around it, and
on the HNP the state that sweeps the dead node's procs to `TERM_WO_SYNC` so
their job can complete.

All three paths now go through `report_new_departures()`. It runs *before* the
repair, which is what makes the "did we already know" test meaningful, and is
safe because the state activation is thread-shifted and so cannot outrun the
repair either way. Reporting first also lets the notice path drop the parallel
array it allocated to carry the answer across the repair — whose
allocation-failure arm silently skipped every report.

## Scope of the impact

Currently benign, which is why it survived: the HNP can never take an inference
path (empty ancestor list ⇒ always `AGREED`, and it receives no adoption
notices), and on a `prted` a peer-daemon `COMM_FAILED` only feeds the
term-ordered accounting. It is a silent divergence between two paths meant to
converge on the same state, and it would bite the moment anything
role-independent hangs off `COMM_FAILED`.

## Testing

* `make check` — all 21 unit tests pass; warning-free `--enable-debug` build.
* Correctness rests on `prte_rml_reconcile_ancestry` handing back a clean slate
  (it sets a failed bit per hypothesised death so `update_ancestors` steps over
  it, and undoes them before returning). `test_reconcile_ancestry` cases (b),
  (c) and (f) already pin that; they now say which consumer depends on it,
  since they read as tidiness and are not.
* `contrib/dockerswarm` full Linux suite: **605 passed / 5 failed / 3 skipped**,
  byte-identical to the same suite on unmodified `master` in the same swarm and
  against the same PMIx build. The 5 pre-existing failures are in
  `tools: prun waits for the jobs its job spawned` and
  `runtime/data_server: access permissions`, neither of which involves a daemon
  departure. The fault-path cases all pass, including the two that exercise
  this change directly — "a loss detected by an interior daemon reached the HNP"
  and "a re-homed daemon reports the lineage that explains the re-home".
* The inference itself **cannot** be forced on the harness: a dead daemon's host
  stays up in a container, so the connect is refused immediately and the
  receiver wins its own race — which `run-tests.sh` already records at that
  case. The computation is unit-tested; the wire path and recovery are covered
  by the radix-2 cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)