### PR TITLE
Give the access-permission publishers a slot each

### DIFF
--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -1717,7 +1717,7 @@ test_runtime() {
     # process: publish, confirm, unpublish, confirm gone.
     if ! RUN "test -x $DS"; then
         skp "dataserver client not installed -- re-run ./build.sh"
-    elif ! prted_dvm_start 'node1:2,node2:2,node3:2'; then
+    elif ! prted_dvm_start 'node1:2,node2:4,node3:2'; then
         bad "could not start a DVM for the unpublish test"
     else
         out=$(PRUN "--host node2:1 -n 1 $DS unpublish prte.test.gone 15" 2>&1)
@@ -1762,6 +1762,23 @@ test_runtime() {
                 "--host node2:1 -n 1 $DS publish prte.test.acc.$spec val session 60 $spec"
         done
         sleep 8
+        # Confirm all four are actually published before reading anything.
+        # They must be resident TOGETHER -- the data server purges a
+        # publisher's items when it terminates -- so node2 has to have a slot
+        # for each, and it did not: two of the four died with
+        # JOB_FAILED_TO_MAP, their keys were never published, and the lookups
+        # below then read the resulting NOT_FOUND as a permission verdict.
+        # That reported the gid half of this test as a data-server bug for as
+        # long as it has existed, so check the premise rather than assume it.
+        nacc=0
+        for spec in self-uid other-uid self-gid other-gid; do
+            RUN "grep -q '^PUBLISHED prte.test.acc.$spec' /tmp/ds-acc-$spec.out" \
+                && nacc=$((nacc+1)) \
+                || bad "the $spec publish never happened: $(RUN "cat /tmp/ds-acc-$spec.out" 2>&1 | tr '\n' ' ' | tail -c 200)"
+        done
+        [ "$nacc" = 4 ] \
+            && ok "all four access-permission keys were published" \
+            || bad "only $nacc of 4 access-permission keys were published"
         for spec in self-uid self-gid; do
             out=$(PRUN "--host node3:1 -n 1 $DS lookup prte.test.acc.$spec 15" 2>&1)
             echo "$out" | grep -q "^FOUND prte.test.acc.$spec" \


### PR DESCRIPTION
The `runtime/data_server: access permissions decide who may read` case in
`contrib/dockerswarm/run-tests.sh` publishes four keys — an accessor list
naming our own uid, one naming somebody else's, and the same pair for gids —
then reads each back to see who is admitted. All four publishers must be
resident *simultaneously*, because the data server purges a publisher's items
when it terminates, so each needs a slot for the duration of the case.

The DVM it runs under gives node2 **two** slots, and all four publishers are
pinned to `node2:1`. The last two died with `PMIX_ERR_JOB_FAILED_TO_MAP` and
their keys were never published.

Nothing noticed, because the case goes straight from launching the publishers
to looking the keys up. The two lookups that were supposed to exercise
`PMIX_ACCESS_GRPIDS` got an entirely truthful `NOT_FOUND` and reported it as
two data-server bugs:

```
FAIL a permitted reader was refused (self-gid): STATUS PMIX_ERR_NOT_FOUND
FAIL a refusal was not reported as NO_PERMISSIONS (other-gid): STATUS PMIX_ERR_NOT_FOUND
```

So the gid half of this case has never executed, and what it reported instead
was a defect that does not exist. `prte_data_server_check_access()` reads both
lists correctly; with the publishers given room, all four assertions pass:

```
PASS all four access-permission keys were published
PASS a list naming our own identity (self-gid) admits the reader
PASS a list naming somebody else (other-gid) refused the reader
PASS ...and said so with NO_PERMISSIONS, not NOT_FOUND
```

Two changes:

* Widen node2 to four slots in that block's DVM.
* Check the premise before resting anything on it. A case that assumes its own
  setup worked cannot tell "the data server got this wrong" from "there was
  nothing there to get right" — and that is the more expensive failure, because
  it accuses working code, in whichever direction the missing data happens to
  point. The case now confirms all four keys are published and names the one
  that was not.

## Testing

Full `contrib/dockerswarm` Linux suite: **611 passed, 0 failed, 3 skipped**
(the 3 skips are `map-by device=network`, absent from these topologies).

Worth noting for anyone bisecting this area: the suite also had three failures
in `tools: prun waits for the jobs its job spawned` that were purely a stale
baked PMIx in the swarm image. Rebuilding the image against current openpmix
master resolves them, and the gid support this case exercises needs openpmix
`e81d5cdd` ("Tell the host the group id of a publish or lookup") to work at
all — before it, the host was never told the requestor's group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)