### PR TITLE
Tell a launched daemon which collective epoch the DVM is at

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -495,6 +495,12 @@ section for where each half lives.
 daemon"** notice naming the shrunk node — **that notice is expected** (shrink
 completion is driven by the targeted daemon's death). The HNP must survive it.
 
+**Grow after a shrink, then fence over the new node.** A shrink advances every
+survivor's collective recovery epoch; a daemon the grow launches starts at zero,
+its contributions are dropped as stale, and the collective hangs. The order
+matters (grow-then-shrink cannot show it) and so does the job: `fencer`
+**spanning** the new node, since `hostname` passes either way.
+
 **Relay** (radix-2 deep grow, `run-tests.sh` does this): grown across node2–node9
 with `--prtemca prte_rml_radix 2`, the daemon tree is 3–4 deep, so the
 `PMIX_DVM_IS_READY` completion fence must relay through intermediate daemons. If

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 # Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# Copyright (c) 2026      Barcelona Supercomputing Center (BSC-CNS).
+#                         All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -6521,6 +6523,72 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     out=$(RUN 'prun --np 1 hostname')
     [ "$out" = node1 ] && ok "prun works post-shrink" || bad "prun broken post-shrink"
     RUN 'pterm' >/dev/null 2>&1; cleanup_swarm
+
+    banner "elastic DVM: a collective spans a node grown in after a shrink"
+    # A shrink advances every surviving daemon's collective recovery epoch; a
+    # daemon the next grow launches starts at zero, so its contributions are
+    # dropped as stale (prte_grpcomm_fence_recv) and the collective hangs.
+    #
+    # Two things the shape must keep.  The shrink comes FIRST -- the case above
+    # grows then shrinks, by which time the grown daemons are at the new epoch.
+    # And the job must FENCE, spanning the new node: `hostname`, or a fence
+    # placed entirely on node4, passes either way.  A fresh node rather than the
+    # released one is deliberate; the SLURM harness covers the reuse variant.
+    cleanup_swarm
+    RUN 'nohup prte --daemonize --prtemca prte_elastic_mode 1 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    if ! RUN "test -x $FENCER"; then
+        skp "fencer client not installed -- re-run ./build.sh"
+    elif ! pmix_cap PMIX_CAP_TOOL_FINALIZED; then
+        # Without it a departed elastic tool strands the nodes it grew, and
+        # the job below could not reach them.
+        skp "post-shrink collective (PMIx predates PMIX_CAP_TOOL_FINALIZED)"
+    elif ! RUN 'pgrep -x prte >/dev/null'; then
+        bad "could not start an elastic DVM for the post-shrink collective test"
+    else
+        out=$(RUN 'timeout 90 elastic grow node2:2,node3:2' 2>&1)
+        if ! echo "$out" | grep -q PMIX_DVM_IS_READY; then
+            bad "grow node2,node3 did not complete: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+            skp "the case needs a grown node to release"
+        else
+            out=$(RUN 'timeout 90 elastic shrink node3' 2>&1); sleep 3
+            echo "$out" | grep -q PMIX_DVM_IS_READY \
+                && ok "node3 released -- the shrink that advances the epoch" \
+                || bad "shrink node3 did not complete: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+            out=$(RUN 'timeout 90 elastic grow node4:2' 2>&1)
+            if ! echo "$out" | grep -q PMIX_DVM_IS_READY; then
+                bad "the post-shrink grow did not complete: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+            else
+                [ "$(prted_count 4)" = 1 ] \
+                    && ok "...and node4 joined the shrunken DVM" \
+                    || bad "no daemon on node4 after the post-shrink grow"
+                # Placement first: a fence failure below is then unambiguous.
+                out=$(RUN 'timeout 60 prun --host node1:1,node2:1,node4:1 -n 3 --map-by node hostname' 2>&1)
+                n=$(echo "$out" | grep -cE '^node[124]$')
+                [ "$n" = 3 ] \
+                    && ok "a job maps onto all three of them" \
+                    || bad "the job reached $n/3 nodes: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+                # The case itself, bounded under prun's own patience so a hang
+                # cannot be mistaken for a return.
+                out=$(RUN "timeout 60 prun --host node1:1,node2:1,node4:1 -n 3 --map-by node $FENCER barrier" 2>&1)
+                n=$(echo "$out" | grep -c 'FENCER barrier rank .* rc PMIX_SUCCESS')
+                [ "$n" = 3 ] \
+                    && ok "all 3 ranks completed a barrier fence spanning node4" \
+                    || bad "$n of 3 ranks completed the barrier -- the grown daemon is an epoch behind: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+                # ...and again carrying data: the fence MPI_Init raises.
+                out=$(RUN "timeout 60 prun --host node1:1,node2:1,node4:1 -n 3 --map-by node $FENCER collect" 2>&1)
+                n=$(echo "$out" | grep -c 'FENCER collect rank .* rc PMIX_SUCCESS')
+                [ "$n" = 3 ] \
+                    && ok "...and all 3 completed a modex fence" \
+                    || bad "$n of 3 ranks completed the modex fence: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+                n=$(echo "$out" | grep -c 'peers-bad 0')
+                [ "$n" = 3 ] \
+                    && ok "...with every rank reading every peer contribution back" \
+                    || bad "$n of 3 ranks got a complete modex: $(echo "$out" | grep peers- | tr '\n' ' ' | tail -c 300)"
+            fi
+        fi
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    fi
+    cleanup_swarm
 
     banner "elastic DVM: a shrink accounts for the procs on the node it releases"
     # Every shrink above releases an IDLE node.  This one releases a node

--- a/contrib/slurmswarm/AGENTS.md
+++ b/contrib/slurmswarm/AGENTS.md
@@ -36,7 +36,7 @@ differences are in §3, §9 and §10 and nowhere else.
 | `slurm-alloc.py` | Creates and holds a real allocation across many `docker exec` calls, and replays the environment SLURM put in it. See §11. |
 | `slurm-shim.py` | A recording, optionally misbehaving, **wrapper** around the real `salloc`/`scontrol`/`scancel`. Answers the two questions slurmctld cannot: what PRRTE *asked* for, and what PRRTE does when the scheduler misbehaves. See §14. |
 | `docker-compose.yml` | The ten nodes `prteslurm-node1..prteslurm-node10`. Every name derives from `$PRTE_SLURM_SWARM`, so two clones can each run a cluster. |
-| *(no file here)* | The `elastic` test client is compiled from [`../dockerswarm/elastic.c`](../dockerswarm/elastic.c) rather than copied — it is the same program, and two copies would drift. |
+| *(no file here)* | The `elastic` and `fencer` test clients are compiled from [`../dockerswarm/`](../dockerswarm/) rather than copied — they are the same programs, and two copies would drift. |
 
 ## 2. How it works
 
@@ -227,7 +227,10 @@ Four cases are worth calling out:
   that does not complete is a bug wherever it landed); only the claim that a
   *reuse* happened is downgraded to a skip when the scheduler had a spare.
   (The sibling harness covers the same shape chosen by *hostname*; [#2491]
-  closed the routing half of it.)
+  closed the routing half of it.) The case ends with a **fence** spanning the
+  head node and the granted-back one: a daemon launched after a release starts
+  at collective recovery epoch zero and its contributions are dropped as stale,
+  which every placement assertion above it passes straight through.
 - **Which brings in the one piece of SLURM bookkeeping this suite has to
   work around.** A node released by an in-place resize can sit in state
   `IDLE` with its cores still accounted to the job that was shrunk off it —

--- a/contrib/slurmswarm/build.sh
+++ b/contrib/slurmswarm/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 # Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# Copyright (c) 2026      Barcelona Supercomputing Center (BSC-CNS).
+#                         All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -329,6 +331,14 @@ build_linux() {
             echo ">>>> elastic test client (from ../dockerswarm)"
             gcc -O0 -g -o /opt/prte/prte/bin/elastic \
                 /prrte-src/contrib/dockerswarm/elastic.c \
+                -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
+
+            # fencer: one fence and nothing else -- every other job this suite
+            # runs is hostname, which never fences.  Same rpath and apostrophe
+            # rules as above.
+            echo ">>>> fencer test client (from ../dockerswarm)"
+            gcc -O0 -g -o /opt/prte/prte/bin/fencer \
+                /prrte-src/contrib/dockerswarm/fencer.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
             # The recording wrapper around salloc/scontrol/scancel.  It goes

--- a/contrib/slurmswarm/run-tests.sh
+++ b/contrib/slurmswarm/run-tests.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 #
 # Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# Copyright (c) 2026      Barcelona Supercomputing Center (BSC-CNS).
+#                         All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -982,6 +984,25 @@ elastic_reextend_reuse_group() {
     [ "$(echo "$out" | tail -1 | tr -d '\r')" = "$reused" ] \
         && ok "a job maps onto that node" \
         || bad "$reused ran nothing: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+    # ...and mapping onto a node is not running a COLLECTIVE over it.  The
+    # release advanced every surviving daemon's collective recovery epoch; the
+    # daemon this extend launched starts at zero, so its contributions are
+    # dropped as stale and the fence hangs, while everything above still passes.
+    # The job must SPAN node1 and the reused node -- a fence whose procs sit on
+    # one daemon is answered by that daemon alone.
+    if ! SA 'command -v fencer >/dev/null'; then
+        skp "fencer client not installed -- re-run ./build.sh"
+    else
+        out=$(SA "timeout 90 prun --host node1:1,$reused:1 -n 2 --map-by node fencer collect" 2>&1)
+        n=$(echo "$out" | grep -c 'FENCER collect rank .* rc PMIX_SUCCESS')
+        [ "$n" = 2 ] \
+            && ok "a fence completes across the reused node" \
+            || bad "$n of 2 ranks completed the fence -- the reused node is an epoch behind: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        n=$(echo "$out" | grep -c 'peers-bad 0')
+        [ "$n" = 2 ] \
+            && ok "...and both ranks read the other's contribution back" \
+            || bad "$n of 2 ranks got a complete modex: $(echo "$out" | grep peers- | tr '\n' ' ' | tail -c 300)"
+    fi
     out=$(SA 'timeout 30 prun -n 1 hostname' 2>&1 | tail -1)
     [ "$(echo "$out" | tr -d '\r')" = node1 ] \
         && ok "DVM still responsive afterwards" \

--- a/src/grpcomm/grpcomm.c
+++ b/src/grpcomm/grpcomm.c
@@ -10,6 +10,8 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
  * Copyright (c) 2026      Sandia National Laboratories  All rights reserved.
+ * Copyright (c) 2026      Barcelona Supercomputing Center (BSC-CNS).
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -54,6 +56,10 @@ prte_grpcomm_release_bcast_fn_t prte_grpcomm_release_bcast = prte_grpcomm_xcast;
  * a dangling write the moment this function returns. */
 static int verbosity = 0;
 
+/* File scope for the same reason as verbosity; int because the MCA layer has no
+ * unsigned type. */
+static int launched_epoch = 0;
+
 void prte_grpcomm_register(void)
 {
     verbosity = 0;
@@ -82,6 +88,24 @@ void prte_grpcomm_register(void)
                                "grpcomm_base_verbose 1.",
                                PMIX_MCA_BASE_VAR_TYPE_BOOL,
                                &prte_grpcomm_globals.enable_timing);
+
+    /* Set by the launcher on the prted command line, never by a user - see
+     * prte_plm_base_prted_append_basic_args. */
+    launched_epoch = 0;
+    pmix_mca_base_var_register("prte", "grpcomm", NULL, "recovery_epoch",
+                               "Collective recovery epoch this DVM had reached when this "
+                               "daemon was launched. Set by the launcher; not intended "
+                               "for users",
+                               PMIX_MCA_BASE_VAR_TYPE_INT,
+                               &launched_epoch);
+    if (0 < launched_epoch) {
+        prte_grpcomm_globals.recovery_epoch = (uint32_t) launched_epoch;
+    }
+}
+
+uint32_t prte_grpcomm_current_epoch(void)
+{
+    return prte_grpcomm_globals.recovery_epoch;
 }
 
 /**

--- a/src/grpcomm/grpcomm.h
+++ b/src/grpcomm/grpcomm.h
@@ -18,6 +18,8 @@
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
  * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
  * Copyright (c) 2026      Sandia National Laboratories  All rights reserved.
+ * Copyright (c) 2026      Barcelona Supercomputing Center (BSC-CNS).
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -152,6 +154,10 @@ PRTE_EXPORT int prte_grpcomm_group(pmix_group_operation_t op, char *grpid,
  * refused with PRTE_ERR_NOT_SUPPORTED rather than quietly served; relay the
  * request to the master instead. */
 PRTE_EXPORT int prte_grpcomm_assign_context_id(size_t *ctxid);
+
+/* The collective recovery epoch this daemon is at. The launcher passes it to
+ * every daemon it starts. */
+PRTE_EXPORT uint32_t prte_grpcomm_current_epoch(void);
 
 END_C_DECLS
 

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -2157,6 +2157,19 @@ int prte_plm_base_prted_append_basic_args(int *argc, char ***argv, char *ess, in
         param = NULL;
     }
 
+    /* A collective message stamped below the receiver's epoch is dropped as
+     * stale, so a daemon launched at zero into a recovered DVM hangs every
+     * collective over a job placed on it. Like the departed vpids above, this
+     * has to be in hand before the daemon's first collective. */
+    if (0 < prte_grpcomm_current_epoch()) {
+        pmix_argv_append(argc, argv, "--prtemca");
+        pmix_argv_append(argc, argv, "grpcomm_recovery_epoch");
+        pmix_asprintf(&param, "%u", prte_grpcomm_current_epoch());
+        pmix_argv_append(argc, argv, param);
+        free(param);
+        param = NULL;
+    }
+
     /* Tell the daemon whether this DVM is persistent. Only the HNP knows -
      * it is decided in prte(), which no daemon runs - and a daemon that is
      * not told simply assumes the default. Pass it only when true, since


### PR DESCRIPTION
## Tell a launched daemon which collective epoch the DVM is at

A daemon launched into a DVM that has already shrunk starts at collective
recovery epoch 0, and nothing brings it up to date. Every fence or group
contribution it makes is dropped as stale, so any collective over a job placed
on that node hangs.

This is the collective analogue of #2491, which closed the routing half of the
same gap (`870408d6b5`, `rml_base_dead_dmns`).

### Cause

- Fence and group messages open with the sender's epoch, and one below the
  receiver's is discarded as a leftover from a round a failure has since
  restarted — `prte_grpcomm_fence_recv()`, `prte_grpcomm_grp_recv()`.
- An elastic shrink departs its daemon through the fault machinery, so it ends
  in a `DAEMON_DIED` broadcast and every surviving daemon advances the epoch in
  `prte_grpcomm_fault_handler()`.
- The daemon the next grow launches starts at 0. The epoch travels only on
  collective messages, which that daemon only ever sends, so it never learns.

From a DVM log at the hang (`grpcomm_base_verbose 5`); daemon 3 is the one the
grow launched:

```
grpcomm restarting collectives at epoch 1
...
grpcomm fence recv nexpected 3 nrep 1
grpcomm fence recvd from [prte-mc-slurmd-1-5994@0,3]
grpcomm fence stale epoch 0 (at 1) - dropping
grpcomm fence recvd from [prte-mc-slurmd-1-5994@0,1]
grpcomm fence recv nexpected 3 nrep 2
```

`nreported` stops one short of `nexpected` and stays there.

### Fix

- `prte_grpcomm_current_epoch()` exposes the counter.
- `prte_plm_base_prted_append_basic_args()` appends
  `--prtemca grpcomm_recovery_epoch N` when N is non-zero.
- `prte_grpcomm_register()` registers that parameter and seeds
  `prte_grpcomm_globals.recovery_epoch` from it, before `prte_grpcomm_init()`
  and so before any collective.

The command line rather than the wireup broadcast, for the same reason the
departed vpids use it: the value has to be in hand before the daemon's first
collective. One counter serves both fence and group.

A daemon that joins without an HNP-built command line (bootstrap) still starts
at 0. `rml_base_dead_dmns` has the same limitation.

### Testing

- New dockerswarm case, `elastic DVM: a collective spans a node grown in after a
  shrink`: 
grow, shrink, grow onto a fresh node, then fence across it. 6/6 pass
  with the fix; the fence hangs to its timeout without it. A fresh node rather
  than the released one is deliberate — the reuse is incidental, what matters is
  that the daemon was launched after the epoch moved.
- `contrib/slurmswarm`: the same fence added to `elastic_reextend_reuse_group`,
  which covers the variant where the scheduler picks the reused node.
  `build.sh` there now compiles `fencer`.

Credits: AccelCom @ Barcelona Supercomputing Center