### PR TITLE
Resolve the RELM message-id clash question, and the generator behind it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ test/unit/plm/test_plm
 test/unit/rml/Makefile
 test/unit/rml/test_rml
 test/unit/rml/test_rml_routing
+test/unit/rml/test_relm
 test/unit/ras/Makefile
 test/unit/ras/test_ras
 test/unit/schizo/Makefile

--- a/docs/how-things-work/rml/relm.rst
+++ b/docs/how-things-work/rml/relm.rst
@@ -51,6 +51,16 @@ UID could be reused.  The top of the range is reserved for sentinels
 ``PRTE_RELM_UID_MAX`` and ``prte_relm_next_uid()`` steps over the sentinels as
 it wraps.
 
+Because the UIDs are generated, two live messages sharing one signature means
+the identity space has already broken, and there is no recovery: only one of
+the two can be delivered under that signature, and the other is silently lost
+by a layer whose whole purpose is not to lose it.  A daemon that detects the
+collision — a second ``NEW`` for a UID that already names a message, or a
+``SENDING`` carrying different bytes than the ones already held under that
+signature — therefore reports it and activates
+``PRTE_JOB_STATE_FORCED_EXIT``, the same response every other broken protocol
+invariant in RELM gets.
+
 State is kept per destination.  ``prte_relm_state_machine_t`` holds a hash table
 of ``prte_relm_rank_t`` objects keyed by destination rank; each of those holds a
 hash table of ``prte_relm_msg_t`` objects keyed by GUID.  A ``prte_relm_msg_t``

--- a/docs/how-things-work/rml/relm.rst
+++ b/docs/how-things-work/rml/relm.rst
@@ -48,7 +48,8 @@ The UID (``prte_relm_uid_t``) is a 32-bit counter that is allowed to wrap; the
 design assumes a message is globally complete and unreferenced long before its
 UID could be reused.  The top of the range is reserved for sentinels
 (``UNKNOWN`` / ``NONE`` / ``INVALID``), so valid UIDs run up to
-``PRTE_RELM_UID_MAX``.
+``PRTE_RELM_UID_MAX`` and ``prte_relm_next_uid()`` steps over the sentinels as
+it wraps.
 
 State is kept per destination.  ``prte_relm_state_machine_t`` holds a hash table
 of ``prte_relm_rank_t`` objects keyed by destination rank; each of those holds a

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -39,14 +39,6 @@ since the transport it stages over (xcast) is already resilient.  Until then,
 a daemon lost while files are in flight fails the staging rather than
 re-driving it.
 
-**A RELM message-id clash is logged and ignored.**  Two places in
-``src/rml/relm/base/state_updates.c`` detect that a message uid already
-belongs to a different message — a second start for the same uid, or a
-payload whose size disagrees with the one already held — log
-``PRTE_ERR_OP_IN_PROGRESS`` and carry on.  What the right answer is (fail
-the job, or something narrower) has never been decided.  The ids are
-generated, so a clash means something upstream is already wrong.
-
 **A TCP peer that cannot be reached at one address is closed, not
 retried.**  In ``src/rml/oob/oob_tcp_connection.c`` the final
 connect-failure arm closes the peer and returns ``PRTE_ERR_UNREACH``
@@ -224,9 +216,6 @@ the marker is stale.
      - routing-tree state is not preserved across a DVM resize
    * - ``rml/relm/relm.c``, ``prte_relm_register``
      - RELM has one module and no way to choose another
-   * - ``rml/relm/base/state_updates.c``, ``upstream_update`` and
-       ``local_update``
-     - a RELM message-id clash is logged and ignored
    * - ``mca/filem/raw/filem_raw_module.c``, ``raw_fault_handler``
      - ``filem/raw`` does not survive losing a daemon mid-staging
    * - ``mca/odls/base/odls_base_bind.c``, ``prte_odls_base_set``

--- a/src/rml/relm/AGENTS.md
+++ b/src/rml/relm/AGENTS.md
@@ -77,6 +77,20 @@ new neighbors so in-flight messages resume over the repaired tree.
   answers NULL, so three of every 2^32 reliable messages took the daemon down
   instead of being sent. Every lookup helper enforces `PRTE_RELM_UID_MAX`;
   anything that generates a UID must respect it.
+- **A signature collision is fatal, by decision.** Two live messages under one
+  `<src,uid,dst>` cannot both be delivered, and the one that is dropped is
+  silently lost by the layer that exists to not lose it — with no way to tell
+  which of the two is real. So both detectors in `base/state_updates.c` (a
+  second `NEW` for a UID that already names a message, and a `SENDING` whose
+  payload differs from the one already held) report and activate
+  `PRTE_JOB_STATE_FORCED_EXIT`, like every other broken invariant here. They
+  used to log `PRTE_ERR_OP_IN_PROGRESS` and carry on. Since the UIDs are
+  generated, reaching either detector means the identity space is already
+  broken; there is no narrower repair, because handing the message a different
+  UID leaves the stale entry that proved the counter untrustworthy and every
+  other daemon on the path keys on the same duplicated pair. Note the
+  `SENDING` detector compares the *bytes*, not just their length: a
+  same-length collision is exactly as damaging and was previously undetected.
 - **Data lifetime.** A message's `data` is unloaded/emptied when it is posted or
   evicted; cached data is dropped by timer (`relm_base_cache_ms`) or when the
   cache exceeds `relm_base_cache_max_count`. Don't assume `msg->data.bytes` is

--- a/src/rml/relm/AGENTS.md
+++ b/src/rml/relm/AGENTS.md
@@ -66,10 +66,17 @@ new neighbors so in-flight messages resume over the repaired tree.
   `PRTE_RELM_EPHEMERAL_STATES_START` (`NEW`, `ACKACKED`, `CACHED`, `EVICTED`)
   drive transitions but must **never** be stored as a message's `state`. The
   engine asserts this; don't defeat it.
-- **UIDs wrap.** `prte_relm_uid_t` is a `uint32_t` that is allowed to wrap; the
-  design assumes a message is globally complete (and dereferenced) long before
-  its UID is reused. Reserved sentinels (`UNKNOWN`/`NONE`/`INVALID`) sit at the
-  top of the range — respect `PRTE_RELM_UID_MAX`.
+- **UIDs wrap, and the wrap has to step over the sentinels.**
+  `prte_relm_uid_t` is a `uint32_t` that is allowed to wrap; the design assumes
+  a message is globally complete (and dereferenced) long before its UID is
+  reused. Reserved sentinels (`UNKNOWN`/`NONE`/`INVALID`) sit at the top of the
+  range, *above* `PRTE_RELM_UID_MAX` — which is why the counter is handed out
+  by `prte_relm_next_uid()` and not by a bare `next_uid++`. The bare increment
+  walked through all three on its way back to zero, and a UID above the max is
+  not a wrap but a poisoned signature: `prte_relm_get_msg()` refuses it and
+  answers NULL, so three of every 2^32 reliable messages took the daemon down
+  instead of being sent. Every lookup helper enforces `PRTE_RELM_UID_MAX`;
+  anything that generates a UID must respect it.
 - **Data lifetime.** A message's `data` is unloaded/emptied when it is posted or
   evicted; cached data is dropped by timer (`relm_base_cache_ms`) or when the
   cache exceeds `relm_base_cache_max_count`. Don't assume `msg->data.bytes` is

--- a/src/rml/relm/AGENTS.md
+++ b/src/rml/relm/AGENTS.md
@@ -111,12 +111,19 @@ new neighbors so in-flight messages resume over the repaired tree.
 
 ## Testing
 
-RELM has no unit test, and the reason is structural rather than an oversight:
-every entry point either thread-shifts onto `prte_event_base` or is reached
-from the RML's fault handler, and the state machine's whole purpose is what
-happens across *several* daemons when one of them dies. Coverage therefore
+Most of RELM cannot be unit tested, and the reason is structural rather than an
+oversight: every entry point either thread-shifts onto `prte_event_base` or is
+reached from the RML's fault handler, and the state machine's whole purpose is
+what happens across *several* daemons when one of them dies. That coverage
 lives in `contrib/dockerswarm` — the `test_rml` phase drives the relay and
 lost-daemon paths RELM sits on, and the elastic grow/shrink phases exercise the
-link-update exchange after a tree change. If you add a unit test here, the
-tractable pieces are the pure ones: the pack/unpack helpers in `util.c` and the
-UID/GUID identity and ordering logic in `types.h`/`state_machine.c`.
+link-update exchange after a tree change.
+
+What *is* pure computation is the identity layer, and
+`test/unit/rml/test_relm.c` (run by `make check`) covers it: the UID generator
+and its wrap, the `<src,uid,dst>` signature and GUID, the find/get lookup
+helpers and what they refuse, the prev/next ordering chain, and
+`prte_relm_release_msg`. It stands the state machine up by hand — `PMIX_NEW`
+plus the `new_rank`/`new_msg` callbacks — rather than calling the base module's
+`init()`, which would also post RML receives. The other tractable piece, not
+yet covered, is the pack/unpack helpers in `util.c`.

--- a/src/rml/relm/base/AGENTS.md
+++ b/src/rml/relm/base/AGENTS.md
@@ -50,6 +50,17 @@ For the protocol itself see
   reported depth matches the expected parent/child depth. If you change how
   promotions renumber depth, keep `pack_link_update`/`update_link` in sync or
   recovery messages will be silently dropped.
+- **A detected signature collision fails the job.** `local_update`'s `NEW` arm
+  and `upstream_update`'s `SENDING` arm both check whether a second message is
+  arriving under a signature that already names one, and both now report and
+  activate `PRTE_JOB_STATE_FORCED_EXIT`. They used to log
+  `PRTE_ERR_OP_IN_PROGRESS` and carry on, which meant the layer whose job is
+  not to lose messages silently dropped one and ACKed its sender for the other.
+  See [`../AGENTS.md`](../AGENTS.md) for the reasoning and why nothing narrower
+  works. The `SENDING` arm compares the payload bytes, not just their length —
+  a repeat of a message we already hold is ordinary (a replay, or a resend
+  after the tree moved) and carries identical bytes, so anything else is a
+  genuine collision regardless of size.
 - **Never persist ephemeral states.** `CACHED`/`EVICTED`/`NEW`/`ACKACKED` are
   transitions, not stored states (see `../AGENTS.md`).
 - **The purge frees objects, not just table entries.** `purge()` drops a failed

--- a/src/rml/relm/base/state_updates.c
+++ b/src/rml/relm/base/state_updates.c
@@ -8,6 +8,10 @@
  */
 
 #include "constants.h"
+
+#include <string.h>
+
+#include "src/mca/state/state.h"
 #include "src/pmix/pmix-internal.h"
 #include "src/runtime/prte_globals.h"
 
@@ -101,11 +105,29 @@ static void upstream_update(
         if(0 == bo.size){
             PRTE_RELM_MSG_ERROR_LOG(msg, PRTE_ERR_BAD_PARAM);
         } else if(NULL != msg->data.bytes){
-            if(bo.size != msg->data.size){
-                PRTE_RELM_MSG_ERROR_LOG(msg, PRTE_ERR_OP_IN_PROGRESS);
-                // TODO: GUID clash = job failure?
-            }
+            /* Seeing SENDING again for a message we already hold the data for
+             * is ordinary - a replay we asked for, or a resend after the tree
+             * moved - and it carries the same bytes, so keeping ours and
+             * dropping the copy is right.
+             *
+             * Different bytes under the same <src,uid,dst> is not ordinary.
+             * Two distinct messages are wearing one identity, and only one of
+             * them can be delivered under it: whichever we drop here is lost
+             * for good, and its sender will be ACKed for the other one and
+             * believe it arrived. Silently losing a message is the one thing
+             * this layer exists to prevent, and we cannot tell which of the
+             * two payloads is the real one, so stop rather than deliver the
+             * wrong bytes and call it success. The UIDs are generated, so
+             * arriving here at all means our identity space is already
+             * broken. */
+            bool same = bo.size == msg->data.size &&
+                        0 == memcmp(bo.bytes, msg->data.bytes, bo.size);
             PMIx_Byte_object_destruct(&bo);
+            if(!same){
+                PRTE_RELM_MSG_ERROR_LOG(msg, PRTE_ERR_FATAL);
+                PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
+                break;
+            }
         } else {
             msg->data = bo;
         }
@@ -236,10 +258,18 @@ static void local_update(
 
     case PRTE_RELM_STATE_NEW:
         if(PRTE_RELM_STATE_INVALID != msg->state){
-            // Either two attempts to start the same msg, or somehow a new
-            // msg was given the same uid as an existing msg
-            PRTE_RELM_MSG_ERROR_LOG(msg, PRTE_ERR_OP_IN_PROGRESS);
-            // TODO: GUID clash = job failure?
+            /* Either two attempts to start the same msg, or somehow a new msg
+             * was given the same uid as an existing msg. The UID came from our
+             * own counter and every message we start is a fresh signature, so
+             * neither can happen while this daemon's own bookkeeping is sound:
+             * getting here means our message table no longer identifies
+             * messages uniquely, and from now on an ACK may credit the wrong
+             * one. There is nothing narrower to do - handing the message a
+             * different UID would leave the stale entry that proves the
+             * counter is untrustworthy, and every other daemon on the path
+             * keys on the same <src,uid> we just duplicated. */
+            PRTE_RELM_MSG_ERROR_LOG(msg, PRTE_ERR_FATAL);
+            PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         } else if(NULL == buf){
             // We need the msg data for this state update
             PRTE_RELM_MSG_ERROR_LOG(msg, PRTE_ERR_BAD_PARAM);

--- a/src/rml/relm/state_machine.c
+++ b/src/rml/relm/state_machine.c
@@ -168,16 +168,43 @@ static void des_msg_cd(start_msg_caddy_t* ptr){
 }
 PMIX_CLASS_INSTANCE(start_msg_caddy_t, pmix_object_t, con_msg_cd, des_msg_cd);
 
+/* Hand out the next UID for a locally-started message.
+ *
+ * The counter is allowed to wrap - the design assumes a message is globally
+ * complete, and every reference to it gone, long before its UID comes round
+ * again. What it may not do is step *onto* the reserved values. The three
+ * sentinels UNKNOWN/NONE/INVALID sit at the top of the range, above
+ * PRTE_RELM_UID_MAX, and a plain "next_uid++" walked straight through them on
+ * its way back to zero. That is not a wrap, it is a poisoned signature:
+ * prte_relm_get_msg() refuses any UID above the max and answers NULL, so
+ * three of every 2^32 reliable messages took the daemon down rather than
+ * being sent. Step over the sentinels so the wrap the design documents is the
+ * wrap the code performs.
+ */
+prte_relm_uid_t prte_relm_next_uid(void){
+    prte_relm_uid_t uid = prte_relm_sm->next_uid;
+    prte_relm_sm->next_uid = (PRTE_RELM_UID_MAX == uid) ? 0 : uid + 1;
+    return uid;
+}
+
 static void prte_relm_start_msg_cb(int fd, short argn, void* cbdata){
     PRTE_HIDE_UNUSED_PARAMS(fd, argn);
     start_msg_caddy_t* cd = (start_msg_caddy_t*) cbdata;
 
     prte_relm_signature_t sig = {
         .src = PRTE_PROC_MY_NAME->rank,
-        .uid = prte_relm_sm->next_uid++,
+        .uid = prte_relm_next_uid(),
         .dst = cd->dst
     };
     prte_relm_msg_t* msg = prte_relm_get_msg(&sig);
+    if(NULL == msg){
+        /* get_msg answers NULL for a rank outside the DVM or a hash-table
+         * failure, and the NEW update has no message to update */
+        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
+        PMIX_RELEASE(cd);
+        return;
+    }
     PRTE_RELM_MSG_OUTPUT(2, msg, "updating state to NEW");
 
     prte_relm_sm->update_state(

--- a/src/rml/relm/state_machine.h
+++ b/src/rml/relm/state_machine.h
@@ -109,6 +109,11 @@ prte_relm_msg_t* prte_relm_get_msg(prte_relm_signature_t* sig);
 prte_relm_msg_t* prte_relm_get_prev_msg(prte_relm_msg_t* msg);
 prte_relm_rank_t* prte_relm_get_rank(pmix_rank_t dst);
 
+// Hand out the next UID for a locally-started message, stepping over the
+// reserved sentinels at the top of the range so the counter's documented
+// wrap never yields a UID above PRTE_RELM_UID_MAX
+prte_relm_uid_t prte_relm_next_uid(void);
+
 // Create a new message from a local reliable_send call and start it
 int prte_relm_start_msg(
     pmix_rank_t dst, pmix_data_buffer_t* buf, prte_rml_tag_t tag

--- a/test/unit/rml/Makefile.am
+++ b/test/unit/rml/Makefile.am
@@ -7,7 +7,7 @@ AM_CPPFLAGS = \
     -I$(top_srcdir)/include \
     -I$(top_srcdir)
 
-check_PROGRAMS = test_rml test_rml_routing
+check_PROGRAMS = test_rml test_rml_routing test_relm
 
 test_rml_SOURCES = \
     test_rml.c
@@ -19,7 +19,12 @@ test_rml_routing_SOURCES = \
 
 test_rml_routing_LDADD = $(top_builddir)/src/libprrte.la
 
-TESTS = test_rml test_rml_routing
+test_relm_SOURCES = \
+    test_relm.c
+
+test_relm_LDADD = $(top_builddir)/src/libprrte.la
+
+TESTS = test_rml test_rml_routing test_relm
 
 # Run against the components in this build tree, not just an installed
 # one: without this a --enable-mca-dso build has no components to find

--- a/test/unit/rml/test_relm.c
+++ b/test/unit/rml/test_relm.c
@@ -1,0 +1,297 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Unit tests for RELM's message identity: the UID generator, the
+ * <src,uid,dst> signature and its GUID hash, the find/get lookup helpers,
+ * and the prev/next ordering chain.
+ *
+ * This is the part of RELM that is pure computation over the state machine's
+ * hash tables -- no progress thread, no sockets, no peer daemons -- so it is
+ * the part a unit test can reach.  Everything else in RELM is about what
+ * several daemons do when one of them dies, and lives in the container
+ * harness (contrib/dockerswarm).
+ *
+ * The state machine is stood up by hand: PMIX_NEW plus the two constructor
+ * callbacks the lookup helpers actually call.  prte_relm_base_module's init()
+ * would also post two persistent RML receives, which needs an RML that is
+ * open.
+ */
+
+#include "prte_config.h"
+#include "constants.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "src/runtime/prte_globals.h"
+#include "src/runtime/runtime.h"
+#include "src/util/proc_info.h"
+
+#include "src/rml/rml.h"
+#include "src/rml/relm/state_machine.h"
+#include "src/rml/relm/types.h"
+#include "src/rml/relm/base/state_machine.h"
+
+#define CHECK(label, cond)                                    \
+    do {                                                      \
+        if (!(cond)) {                                        \
+            fprintf(stderr, "FAIL [%s]: %s\n", label, #cond); \
+            failures++;                                       \
+        }                                                     \
+    } while (0)
+
+#define NDMNS 8
+
+/* Rebuild the state machine so each test starts from an empty message
+ * table and a UID counter at zero */
+static void sm_reset(void)
+{
+    if (NULL != prte_relm_sm) {
+        PMIX_RELEASE(prte_relm_sm);
+    }
+    prte_relm_sm = PMIX_NEW(prte_relm_state_machine_t);
+    prte_relm_sm->new_rank = prte_relm_base_new_rank;
+    prte_relm_sm->new_msg = prte_relm_base_new_msg;
+}
+
+static prte_relm_msg_t *get_msg(pmix_rank_t src, prte_relm_uid_t uid, pmix_rank_t dst)
+{
+    prte_relm_signature_t sig = {.src = src, .uid = uid, .dst = dst};
+    return prte_relm_get_msg(&sig);
+}
+
+static prte_relm_msg_t *find_msg(pmix_rank_t src, prte_relm_uid_t uid, pmix_rank_t dst)
+{
+    prte_relm_signature_t sig = {.src = src, .uid = uid, .dst = dst};
+    return prte_relm_find_msg(&sig);
+}
+
+/*
+ * The UID counter is documented as wrapping, and the wrap has to land on a
+ * UID the rest of the layer will accept.  The top three values of a uint32_t
+ * are the UNKNOWN/NONE/INVALID sentinels -- above PRTE_RELM_UID_MAX -- and a
+ * bare "next_uid++" handed them out like any other, whereupon
+ * prte_relm_get_msg() refuses the signature and the message that was being
+ * started has nowhere to live.  Three messages out of every 2^32.
+ */
+static int test_uid_wrap(void)
+{
+    int failures = 0;
+
+    sm_reset();
+
+    CHECK("the counter starts at zero", 0 == prte_relm_next_uid());
+    CHECK("...and then counts up", 1 == prte_relm_next_uid());
+    CHECK("...one at a time", 2 == prte_relm_next_uid());
+
+    /* park the counter just short of the top of the usable range and walk it
+     * over the wrap */
+    prte_relm_sm->next_uid = PRTE_RELM_UID_MAX - 1;
+    CHECK("the last two usable UIDs are handed out",
+          PRTE_RELM_UID_MAX - 1 == prte_relm_next_uid());
+    CHECK("...both of them", PRTE_RELM_UID_MAX == prte_relm_next_uid());
+    CHECK("and then the counter wraps to zero rather than onto a sentinel",
+          0 == prte_relm_next_uid());
+    CHECK("...and keeps counting from there", 1 == prte_relm_next_uid());
+
+    /* the property that actually matters: whatever the counter is at, it
+     * never yields a UID prte_relm_get_msg() will refuse */
+    prte_relm_sm->next_uid = PRTE_RELM_UID_MAX - 3;
+    for (int i = 0; i < 8; i++) {
+        prte_relm_uid_t uid = prte_relm_next_uid();
+        CHECK("every UID handed out is usable", uid <= PRTE_RELM_UID_MAX);
+        CHECK("...and names a message", NULL != get_msg(0, uid, 1));
+    }
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_uid_wrap\n");
+    }
+    return failures;
+}
+
+/*
+ * <src,uid> is the message's global identity and dst completes the signature.
+ * The GUID packs src into the high half and uid into the low half, so the
+ * pairs must not alias each other.
+ */
+static int test_signature_identity(void)
+{
+    int failures = 0;
+
+    sm_reset();
+
+    prte_relm_msg_t *a = get_msg(1, 2, 3);
+    prte_relm_msg_t *b = get_msg(2, 1, 3);
+    CHECK("a message is created for a fresh signature", NULL != a);
+    CHECK("...and for its transposed twin", NULL != b);
+    CHECK("<1,2> and <2,1> are different messages", a != b);
+    CHECK("...because their GUIDs differ", PRTE_RELM_GUID(a) != PRTE_RELM_GUID(b));
+
+    CHECK("a fresh message starts INVALID", PRTE_RELM_STATE_INVALID == a->state);
+    CHECK("...with no data", NULL == a->data.bytes);
+    CHECK("...and knows its own signature",
+          1 == a->src && 2 == a->uid && 3 == a->dst);
+
+    CHECK("getting the same signature twice finds the same message",
+          a == get_msg(1, 2, 3));
+    CHECK("...and find agrees", a == find_msg(1, 2, 3));
+
+    /* the same <src,uid> to a different destination is a different message,
+     * and lives in a different rank's table */
+    prte_relm_msg_t *c = get_msg(1, 2, 4);
+    CHECK("the same <src,uid> to another dst is a separate message", a != c);
+    CHECK("...and does not shadow the first", a == find_msg(1, 2, 3));
+
+    CHECK("find answers NULL for a signature nobody created",
+          NULL == find_msg(1, 5, 3));
+
+    fprintf(stdout, "-- the next cases drive rejected signatures;"
+                    " the errors they print are expected --\n");
+    fflush(stdout);
+    CHECK("a src outside the DVM is refused", NULL == get_msg(NDMNS, 1, 2));
+    CHECK("a dst outside the DVM is refused", NULL == get_msg(1, 1, NDMNS));
+    CHECK("a UID above the max is refused",
+          NULL == get_msg(1, PRTE_RELM_UID_INVALID, 2));
+    CHECK("...for every sentinel", NULL == get_msg(1, PRTE_RELM_UID_NONE, 2));
+    CHECK("...including UNKNOWN", NULL == get_msg(1, PRTE_RELM_UID_UNKNOWN, 2));
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_signature_identity\n");
+    }
+    return failures;
+}
+
+/*
+ * Messages to one destination are chained by prev_uid/next_uid so ordering is
+ * preserved and an ACK implicitly acks everything before it.  The chain is
+ * per <src,dst>: walking it must not stray into another destination's
+ * messages, and it must terminate on the sentinels rather than walking off
+ * the end.
+ */
+static int test_ordering_chain(void)
+{
+    int failures = 0;
+
+    sm_reset();
+
+    prte_relm_msg_t *first = get_msg(1, 10, 3);
+    prte_relm_msg_t *second = get_msg(1, 11, 3);
+    prte_relm_msg_t *third = get_msg(1, 12, 3);
+    if (NULL == first || NULL == second || NULL == third) {
+        fprintf(stderr, "FAIL [ordering]: could not create the chain\n");
+        return failures + 1;
+    }
+    second->prev_uid = first->uid;
+    first->next_uid = second->uid;
+    third->prev_uid = second->uid;
+    second->next_uid = third->uid;
+
+    CHECK("the chain walks back", first == prte_relm_find_prev_msg(second));
+    CHECK("...and forward", third == prte_relm_find_next_msg(second));
+
+    CHECK("the head has no predecessor", NULL == prte_relm_find_prev_msg(first));
+    CHECK("the tail has no successor", NULL == prte_relm_find_next_msg(third));
+
+    /* a UID that was never created is not a predecessor, even though it is
+     * inside the usable range -- find must answer NULL rather than inventing
+     * one, which is what get is for */
+    third->prev_uid = 99;
+    CHECK("an absent predecessor is not found", NULL == prte_relm_find_prev_msg(third));
+    prte_relm_msg_t *made = prte_relm_get_prev_msg(third);
+    CHECK("...but get creates it", NULL != made);
+    CHECK("...under this message's own src and dst",
+          NULL != made && 1 == made->src && 3 == made->dst && 99 == made->uid);
+
+    /* the chain is per-destination: the same UIDs to another dst are a
+     * separate chain */
+    prte_relm_msg_t *other = get_msg(1, 11, 4);
+    CHECK("another dst gets its own message", NULL != other && other != second);
+    other->prev_uid = 10;
+    CHECK("...and its chain does not reach into dst 3's",
+          NULL == prte_relm_find_prev_msg(other));
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_ordering_chain\n");
+    }
+    return failures;
+}
+
+/*
+ * Releasing a message takes its predecessors with it -- they are implicitly
+ * acked -- and unhooks its successor so nothing is left pointing at freed
+ * memory.
+ */
+static int test_release_chain(void)
+{
+    int failures = 0;
+
+    sm_reset();
+
+    prte_relm_msg_t *first = get_msg(1, 20, 3);
+    prte_relm_msg_t *second = get_msg(1, 21, 3);
+    prte_relm_msg_t *third = get_msg(1, 22, 3);
+    if (NULL == first || NULL == second || NULL == third) {
+        fprintf(stderr, "FAIL [release]: could not create the chain\n");
+        return failures + 1;
+    }
+    second->prev_uid = first->uid;
+    first->next_uid = second->uid;
+    third->prev_uid = second->uid;
+    second->next_uid = third->uid;
+
+    prte_relm_release_msg(second);
+
+    CHECK("the released message is gone", NULL == find_msg(1, 21, 3));
+    CHECK("...and so is its predecessor", NULL == find_msg(1, 20, 3));
+    CHECK("its successor survives", third == find_msg(1, 22, 3));
+    CHECK("...no longer pointing at freed memory",
+          PRTE_RELM_UID_NONE == third->prev_uid);
+
+    /* releasing the last message for a destination drops the destination's
+     * table too */
+    prte_relm_release_msg(third);
+    CHECK("an emptied destination is dropped", NULL == prte_relm_find_rank(3));
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_release_chain\n");
+    }
+    return failures;
+}
+
+int main(void)
+{
+    int rc, failures = 0;
+
+    rc = prte_init_util(PRTE_PROC_MASTER);
+    if (PRTE_SUCCESS != rc) {
+        fprintf(stderr, "prte_init_util failed: %d\n", rc);
+        return 1;
+    }
+    PMIX_LOAD_NSPACE(PRTE_PROC_MY_NAME->nspace, "prte-relm-unit-test");
+    PRTE_PROC_MY_NAME->rank = 0;
+    prte_rml_base.radix = 64;
+    prte_rml_base.n_dmns = NDMNS;
+
+    failures += test_uid_wrap();
+    failures += test_signature_identity();
+    failures += test_ordering_chain();
+    failures += test_release_chain();
+
+    PMIX_RELEASE(prte_relm_sm);
+    prte_relm_sm = NULL;
+    prte_finalize();
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED all relm unit tests\n");
+    } else {
+        fprintf(stdout, "FAILED %d relm unit test(s)\n", failures);
+    }
+    return (0 == failures) ? 0 : 1;
+}


### PR DESCRIPTION
`docs/todo.rst` has been carrying an item since RELM landed: two arms of
`src/rml/relm/base/state_updates.c` detect that a message UID already belongs
to a different message, log `PRTE_ERR_OP_IN_PROGRESS`, and carry on, each with
a `// TODO: GUID clash = job failure?`. The note observed that "the ids are
generated, so a clash means something upstream is already wrong."

That turned out to be the answer. The wrongness was in the generator.

## The problem

`prte_relm_start_msg_cb` handed out UIDs with a bare
`prte_relm_sm->next_uid++`. The counter is documented as being allowed to wrap
— the design assumes a message is globally complete long before its UID comes
round again — but a `uint32_t`'s top three values are the
`UNKNOWN`/`NONE`/`INVALID` sentinels, *above* `PRTE_RELM_UID_MAX`, and the bare
increment walked straight through all three on its way back to zero.

A UID above the max is not a wrap, it is a poisoned signature:
`prte_relm_get_msg()` refuses it and answers NULL, nothing checked the result,
and the `NEW` state update then dereferenced it. **Three of every 2^32 reliable
messages took the daemon down rather than being sent.** RELM is not a cold path
— every IOF chunk, `show_help` relay, errmgr alert, direct-modex response and
xcast relay travels over it — so a long-lived DVM can reach that count, and the
wrap the guides promise is not the wrap the code performed.

The `SENDING` clash detector was also incomplete: it compared only the payload
*length*, so a collision between two same-length messages was accepted in
silence and the wrong bytes delivered.

## The change

Three commits, each self-contained:

1. **Step the UID counter over its reserved sentinels.**
   `prte_relm_next_uid()` returns to zero from `PRTE_RELM_UID_MAX` instead of
   stepping onto the sentinels above it, and `prte_relm_start_msg_cb` checks
   `prte_relm_get_msg()` for the NULL it can still answer.

2. **Give RELM a unit test for its message identity.** RELM had none, and most
   of it genuinely cannot have one — that coverage belongs to
   `contrib/dockerswarm` and stays there. The identity layer is different: the
   UID generator, the `<src,uid,dst>` signature and its GUID, the find/get
   helpers, the prev/next chain and `prte_relm_release_msg` are pure
   computation over two hash tables. The counter's inability to survive its own
   documented wrap went unnoticed precisely because nothing exercised it.

3. **Fail the job when two messages appear under one signature.** Ignoring it
   is the one answer that cannot be right: only one of the two can be delivered
   under that signature, so whichever is dropped is lost for good and its
   sender is ACKed for the other one and believes it arrived — silent message
   loss from the layer that exists to prevent it, with no way for a daemon to
   tell which payload is real. Nothing narrower works either: re-issuing the
   local message under a different UID leaves the stale entry that proved the
   counter untrustworthy, and every other daemon on the path keys on the same
   duplicated pair. So both arms now report and activate
   `PRTE_JOB_STATE_FORCED_EXIT`, which is already what every other broken
   invariant in RELM does. The `SENDING` arm now compares the bytes: a repeat
   of a message we already hold is ordinary (a replay, or a resend after the
   tree moved) and carries identical bytes, so the comparison costs nothing
   outside that cold path.

With the generator fixed, reaching either detector means the identity space is
already broken.

`docs/todo.rst` loses the item and its table row; `docs/how-things-work/rml/relm.rst`
and both RELM `AGENTS.md` files record the decision and the wrap trap.

## Testing

- Warning-free `--enable-debug` build and `make check` on **each commit
  separately**, not just the tip.
- The new unit test was verified against the old generator: it fails 8 checks
  there and passes on the fix.
- `contrib/dockerswarm/run-tests.sh linux`: **611 passed, 0 failed, 3 skipped**
  — the suite's green baseline.
- Single-host DVM smoke test (launch, MPMD, teardown).

One note on the swarm: a first suite run scored 610/1/3 on *"elastic DVM: a job
spanning a surviving daemon runs after grow/shrink/grow"*. That case is
intermittent — it passed 8/8 driven in isolation on the identical build, and
passed in the full re-run above. It is unrelated to this change (a
`FORCED_EXIT` would have taken the DVM down, and the other three nodes reported
normally), but it is worth knowing about.