### PR TITLE
Tell a daemon joining a recovered DVM which collective epoch it is at

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -1079,6 +1079,21 @@ already exists (re-growing a shrunk node relies on it).
 `run-tests.sh` covers re-growing the same node, growing a different one
 afterwards, and that a grow leaves every node it was not given alone.
 
+**A daemon grown in after a shrink starts behind the DVM in two ways, and
+only one of them is about routing.** The suite covers both, in adjacent
+cases, because neither can see the other's defect:
+
+- Its *departed-vpid set* is empty, so it can compute a first routing tree
+  whose parent is a retired rank. Only visible at a radix small enough for
+  the tree to have depth — hence the explicit `rml_base_radix 2` in that
+  case, without which every daemon's parent is rank 0 and rank 0 is always
+  alive.
+- Its *collective recovery epoch* is zero, because the shrink's
+  `DAEMON_DIED` broadcast went out while it was unreachable. Every fence or
+  group contribution it makes is dropped as stale, at any radix. Invisible
+  to every case that launches `hostname`, which never fences — so that case
+  runs a `fencer` job that spans the grown-in node.
+
 Still bound elastic commands with `timeout` in any new test: a grow that does
 not complete otherwise wedges the whole suite rather than failing one case.
 

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -6834,6 +6834,77 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     fi
     cleanup_swarm
 
+    banner "elastic DVM: a collective spans a node grown in after a shrink"
+    # The collective analogue of the case above, and the same shape of gap.
+    #
+    # An elastic shrink departs its daemon through the fault machinery, so it
+    # ends in a global DAEMON_DIED broadcast and every surviving daemon
+    # advances its collective recovery epoch. The daemon the next grow launches
+    # was not there to receive that broadcast -- the routing tree holds its
+    # vpid from the moment the grow records it, so a broadcast sent while its
+    # launch is in flight is addressed to a daemon with no contact info and is
+    # dropped by design -- and a fence or group contribution stamped below the
+    # receiver's epoch is discarded as a leftover from a round the failure has
+    # since restarted. Every collective over a job placed on that node then
+    # hangs, at ANY radix. The epoch therefore travels as an absolute value the
+    # master issues, carried both on the failure notice and on the WIREUP
+    # broadcast -- the first message that can reach a daemon which has just
+    # joined.
+    #
+    # This needs its own case because nothing above can see it: `hostname`
+    # never fences, and the epoch is not a routing property, so the deep-tree
+    # case passes with the DVM in exactly this state. A FRESH node rather than
+    # the released one is deliberate -- the reuse is incidental, what matters
+    # is that the daemon was launched after the epoch moved.
+    cleanup_swarm
+    RUN 'nohup prte --daemonize --prtemca prte_elastic_mode 1 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    if ! RUN 'pgrep -x prte >/dev/null'; then
+        bad "could not start an elastic DVM for the collective-epoch test"
+    elif ! RUN "test -x $FENCER"; then
+        skp "fencer client not installed -- re-run ./build.sh"
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        RUN 'timeout 90 elastic grow node2:2,node3:2' >/dev/null 2>&1
+        out=$(RUN 'timeout 90 elastic shrink node3' 2>&1); sleep 3
+        echo "$out" | grep -q PMIX_DVM_IS_READY \
+            && ok "shrink node3 completed, so the epoch has moved" \
+            || bad "shrink node3 did not complete"
+        out=$(RUN 'timeout 90 elastic grow node4:2' 2>&1); sleep 3
+        echo "$out" | grep -q PMIX_DVM_IS_READY \
+            && ok "grow of a fresh node after the shrink completed" \
+            || bad "grow after the shrink did not complete"
+        # Launch first, so a fence that never returns cannot be confused with a
+        # job that never started. node4 is the daemon launched after the epoch
+        # moved, and the fence below is only a test if a rank sits on it.
+        out=$(RUN 'timeout 60 prun -n 3 --map-by ppr:1:node hostname' 2>&1)
+        for n in node1 node2 node4; do
+            echo "$out" | grep -qw "$n" && ok "$n ran its proc after grow/shrink/grow" \
+                                        || bad "$n launched nothing after grow/shrink/grow"
+        done
+        # A modex: every rank contributes, and every rank must be able to read
+        # every other rank back afterwards. Without the epoch the grown-in
+        # daemon contributes at 0, its parent drops that as stale, and the
+        # controller waits one contribution short until the timeout.
+        out=$(RUN "timeout 90 prun -n 3 --map-by ppr:1:node $FENCER collect" 2>&1)
+        n=$(echo "$out" | grep -c 'FENCER collect rank .* rc PMIX_SUCCESS')
+        [ "$n" = 3 ] \
+            && ok "all 3 ranks completed a modex fence spanning the grown-in node" \
+            || bad "$n of 3 ranks completed the fence: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        n=$(echo "$out" | grep -c 'peers-bad 0')
+        [ "$n" = 3 ] \
+            && ok "...and every rank read every peer's contribution back" \
+            || bad "$n of 3 ranks got a complete modex: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        # ...and a bare barrier, which carries no data at all, so it fails only
+        # on the epoch rather than on anything about the payload.
+        out=$(RUN "timeout 90 prun -n 3 --map-by ppr:1:node $FENCER barrier" 2>&1)
+        n=$(echo "$out" | grep -c 'FENCER barrier rank .* rc PMIX_SUCCESS')
+        [ "$n" = 3 ] \
+            && ok "all 3 ranks completed a bare barrier across the same DVM" \
+            || bad "$n of 3 ranks completed the barrier: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    fi
+    cleanup_swarm
+
     banner "elastic DVM: a grow launches ONLY on the nodes it was given"
     # An allocation request naming node4 must start a daemon on node4 and
     # nowhere else. Shrink node2 first so the DVM holds a node that is in the

--- a/src/grpcomm/AGENTS.md
+++ b/src/grpcomm/AGENTS.md
@@ -150,7 +150,7 @@ always one thing.
 | `fence_ops` | List of `prte_grpcomm_fence_t`. A tracker is found here by its signature alone, so it must come **off** this list before its result is delivered — see *Retire before you deliver* below. |
 | `group_ops` | List of `prte_grpcomm_group_t`. |
 | `completed_group_ops` | Bounded memo of already-released group ops (see below). |
-| `recovery_epoch` | The collective recovery epoch, shared by fence and group: one failure, one restart, one epoch. |
+| `recovery_epoch` | The collective recovery epoch, shared by fence and group: one failure, one restart, one epoch. Issued by the master, absolute on the wire, adopted by highest value seen — see "The epoch" below. |
 
 Note the verbosity variable that backs the MCA parameter is at **file
 scope** in `grpcomm.c`, not a local: the MCA layer keeps the pointer it is
@@ -657,6 +657,20 @@ collectives, stamped on every `PRTE_RML_TAG_GROUP` and
 `PRTE_RML_TAG_FENCE` message as `[epoch][body]`. A contribution stamped
 older than the receiver's epoch belongs to a round that no longer exists
 and is dropped before it is merged.
+
+**The value is the master's, and absolute.** The DVM master issues it —
+`prte_grpcomm_issue_epoch()`, called once per global failure notice it
+emits — and packs it into that notice; every daemon adopts what it is
+given (`prte_grpcomm_advance_epoch(status->epoch)`), taking the highest
+value it has seen. Each daemon counting the notices *it* received would be
+simpler and is wrong: the number would then be a function of delivery, so
+a daemon that missed one broadcast is a step behind for the rest of the
+DVM's life, with every contribution it offers dropped as stale and every
+collective over a job placed on it hung. That is not a hypothetical — a
+daemon launched by an elastic grow has missed **all** of them: the routing
+tree holds its vpid from the moment the grow records it, so a broadcast
+sent while its launch is in flight is addressed to a daemon with no
+contact info and is dropped by design (`prte_oob_base_send_nb`).
 
 **Why a per-link round does not work here, and why one epoch does.** The
 obvious model is xcast's — `ack_id_down` chosen by the parent, echoed by

--- a/src/grpcomm/AGENTS.md
+++ b/src/grpcomm/AGENTS.md
@@ -672,6 +672,25 @@ tree holds its vpid from the moment the grow records it, so a broadcast
 sent while its launch is in flight is addressed to a daemon with no
 contact info and is dropped by design (`prte_oob_base_send_nb`).
 
+An absolute value is also what makes the epoch **tellable**, which is the
+other half of the same problem. The `PRTE_RML_TAG_WIREUP` broadcast — sent
+once every expected daemon has reported in, and the first message that can
+reach a daemon which has just joined — carries `prte_grpcomm_current_epoch()`,
+and `process_wireup()` adopts it. Because adoption is by highest value
+seen, the seed and any notice still in flight commute: a daemon already at
+or past that epoch is unaffected, and a late wireup cannot walk anyone
+back. The issued counter is deliberately separate from the applied one:
+the master's own epoch does not move until its broadcast is relayed back
+to it, and a second failure inside that window would otherwise reissue the
+number the first notice is already carrying, collapsing two restarts into
+one — a hang, not a wrong answer.
+
+A daemon that joins a **bootstrapped** DVM, with no HNP-built wireup
+behind it, still starts at zero. `rml_base_dead_dmns` and the vpid holes
+the nidmap encodes carry the same limitation, and for the same reason:
+everything that repairs a late joiner's view of the DVM is something the
+HNP sends it.
+
 **Why a per-link round does not work here, and why one epoch does.** The
 obvious model is xcast's — `ack_id_down` chosen by the parent, echoed by
 the child. It does not transfer. xcast's payload flows *down*, so the

--- a/src/grpcomm/grpcomm.c
+++ b/src/grpcomm/grpcomm.c
@@ -8,7 +8,7 @@
  * Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2026      Sandia National Laboratories  All rights reserved.
  * $COPYRIGHT$
  *
@@ -224,6 +224,21 @@ bool prte_grpcomm_procs_lost(const pmix_proc_t *procs, size_t nprocs)
     return false;
 }
 
+/* The master's issued-epoch counter: the number it has handed out, which is
+ * not the same as the number it has applied.  See prte_grpcomm_issue_epoch()
+ * in grpcomm.h for why the two are separate. */
+static uint32_t issued_epoch = 0;
+
+uint32_t prte_grpcomm_current_epoch(void)
+{
+    return prte_grpcomm_globals.recovery_epoch;
+}
+
+uint32_t prte_grpcomm_issue_epoch(void)
+{
+    return ++issued_epoch;
+}
+
 void prte_grpcomm_advance_epoch(uint32_t to)
 {
     if (to <= prte_grpcomm_globals.recovery_epoch) {
@@ -254,7 +269,15 @@ void prte_grpcomm_fault_handler(const prte_rml_recovery_status_t* status)
      * global scope is what provides that - one broadcast, same order
      * everywhere, after the routing tree has been repaired. */
     if (PRTE_RML_FAULT_SCOPE_GLOBAL == status->scope) {
-        prte_grpcomm_advance_epoch(
-            prte_grpcomm_globals.recovery_epoch + 1);
+        /* The epoch is the master's to decide and rides on the notice as an
+         * absolute value, rather than each daemon counting the notices it has
+         * seen.  Counting locally makes the number a function of what a daemon
+         * received: one missed broadcast leaves it a step behind for the rest
+         * of the DVM's life, with every contribution it offers dropped as
+         * stale, and a daemon launched into a DVM that has already recovered
+         * has necessarily missed all of them.  Taking the value from the
+         * notice makes the number reconstructable from any message that
+         * carries one, which is what lets a joining daemon be told it. */
+        prte_grpcomm_advance_epoch(status->epoch);
     }
 }

--- a/src/grpcomm/grpcomm.h
+++ b/src/grpcomm/grpcomm.h
@@ -16,7 +16,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2017-2020 Intel, Inc.  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2024 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * Copyright (c) 2026      Sandia National Laboratories  All rights reserved.
  * $COPYRIGHT$
  *
@@ -152,6 +152,27 @@ PRTE_EXPORT int prte_grpcomm_group(pmix_group_operation_t op, char *grpid,
  * refused with PRTE_ERR_NOT_SUPPORTED rather than quietly served; relay the
  * request to the master instead. */
 PRTE_EXPORT int prte_grpcomm_assign_context_id(size_t *ctxid);
+
+/* The collective recovery epoch this daemon is currently at.
+ *
+ * Exposed because the epoch has to travel to a daemon that joins an already
+ * recovered DVM, and the two places that send it - the WIREUP broadcast and
+ * the global DAEMON_DIED notice - are outside grpcomm.  The counter itself
+ * stays in grpcomm_internal.h with the rest of the collective state, so this
+ * is the only way in. */
+PRTE_EXPORT uint32_t prte_grpcomm_current_epoch(void);
+
+/* Reserve the epoch a global failure notice will move the DVM to.
+ *
+ * **Only the DVM master may call this**, and only when it originates such a
+ * notice: the value is what every daemon adopts on receipt, so a second
+ * issuer would hand out a number someone else has already spent.  It is a
+ * counter of its own rather than "current + 1" because the master's own
+ * epoch does not move until its broadcast is relayed back to it, and a
+ * second failure detected inside that window would otherwise reissue the
+ * number the first one is already carrying - collapsing two restarts into
+ * one, which is a hang rather than a wrong answer. */
+PRTE_EXPORT uint32_t prte_grpcomm_issue_epoch(void);
 
 END_C_DECLS
 

--- a/src/grpcomm/grpcomm_xcast.c
+++ b/src/grpcomm/grpcomm_xcast.c
@@ -1054,6 +1054,23 @@ static void process_wireup(pmix_data_buffer_t *msg){
        return;
     }
 
+    /* the collective recovery epoch the DVM has reached.  This is how a daemon
+     * that joined an already-recovered DVM learns it: the failure notices that
+     * moved the epoch were broadcast before this daemon was routable, so they
+     * never arrived, and its contributions would be dropped as stale forever
+     * after (see the epoch member of prte_rml_recovery_status_t).  Adopting is
+     * by highest value seen, so a daemon already at or past this one is
+     * unaffected and no in-flight notice can be undone by a late wireup. */
+    uint32_t epoch = 0;
+    int ecnt = 1;
+    ret = PMIx_Data_unpack(NULL, msg, &epoch, &ecnt, PMIX_UINT32);
+    if(PMIX_SUCCESS != ret){
+       PMIX_ERROR_LOG(ret);
+       PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
+       return;
+    }
+    prte_grpcomm_advance_epoch(epoch);
+
     pmix_value_t val = PMIX_VALUE_STATIC_INIT;
     pmix_value_t sval = PMIX_VALUE_STATIC_INIT;
     pmix_proc_t dmn;

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -883,7 +883,7 @@ static void shrink_campaign_complete(int sd, short args, void *cbdata)
         for (t = 0; t < camp->ntargets; t++) {
             fr[t] = camp->targets[t];
         }
-        prte_rml_repair_routing_tree(&failed, false);
+        prte_rml_repair_routing_tree(&failed, false, /* epoch = */ 0);
         free(failed.array);
         failed.array = NULL;
     }

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -270,6 +270,7 @@ static void vm_ready(int fd, short args, void *cbdata)
     prte_job_t *jptr;
     prte_proc_t *dmn;
     int32_t v;
+    uint32_t epoch;
     pmix_value_t *val, *sval;
     pmix_status_t ret;
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
@@ -308,6 +309,33 @@ static void vm_ready(int fd, short args, void *cbdata)
             rc = prte_util_pack_job_catchup(&buf, caddy->jdata);
             if (PRTE_SUCCESS != rc) {
                 PRTE_ERROR_LOG(rc);
+                PMIX_DATA_BUFFER_DESTRUCT(&buf);
+                PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
+                PMIX_RELEASE(caddy);
+                return;
+            }
+
+            /* ...and the collective recovery epoch this DVM has reached.  A
+             * daemon that just joined starts at zero, and every fence or group
+             * contribution it makes is then dropped as stale by daemons that
+             * have recovered from a failure - or from an elastic shrink, which
+             * departs its daemon through the same machinery.  It cannot learn
+             * the epoch from the failure notices that moved it: those were
+             * broadcast while this daemon either did not exist or had not yet
+             * reported in, and a broadcast to a daemon with no contact info is
+             * dropped by design (prte_oob_base_send_nb).  This message is
+             * built only once every expected daemon HAS reported, so it is the
+             * first thing that can carry the value to one of them.  Daemons
+             * already at this epoch take it as a no-op.
+             *
+             * The epoch we have applied, rather than the last one issued: a
+             * notice still in flight will also reach the new daemon, which is
+             * routable by now, and the epoch is adopted by highest value seen
+             * so the two orders agree. */
+            epoch = prte_grpcomm_current_epoch();
+            rc = PMIx_Data_pack(NULL, &buf, &epoch, 1, PMIX_UINT32);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_DESTRUCT(&buf);
                 PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
                 PMIX_RELEASE(caddy);

--- a/src/rml/AGENTS.md
+++ b/src/rml/AGENTS.md
@@ -167,6 +167,17 @@ set downward, which is why the first field on the wire is the `global` flag and
 why the ancestor list rides only the upward leg. A lineage means nothing to a
 daemon receiving a broadcast.
 
+The downward leg carries one more field the upward leg does not: the
+**collective recovery epoch** this failure moves the DVM to, packed straight
+after the `global` flag and delivered to the fault handlers on
+`prte_rml_recovery_status_t::epoch`. Only the HNP issues one
+(`prte_grpcomm_issue_epoch()`), because the point of the value is that every
+daemon adopts the *same* number rather than counting the notices it happened
+to receive — a daemon that missed one would otherwise be a step behind
+forever, which is precisely the state a daemon launched into an already
+recovered DVM is in. The RML carries it and does not read it; what it means is
+in [`src/grpcomm/AGENTS.md`](../grpcomm/AGENTS.md), under "The epoch".
+
 The upward notice's rank array cannot describe a re-home. It is filtered by
 `radix_subtree_contains(&cur_node, …)`, and the ancestor whose death moved the
 sender is by definition *not* in the sender's subtree — so the notice a

--- a/src/rml/rml.c
+++ b/src/rml/rml.c
@@ -624,6 +624,7 @@ PMIX_CLASS_INSTANCE(prte_rml_recv_request_t, pmix_object_t, prq_cons, prq_des);
 static void rscon(prte_rml_recovery_status_t* p){
     p->scope = PRTE_RML_FAULT_SCOPE_LOCAL;
     p->failed_ranks = (pmix_data_array_t) PMIX_DATA_ARRAY_STATIC_INIT;
+    p->epoch = 0;
     p->promoted = false;
     p->demoted = false;
 

--- a/src/rml/rml.h
+++ b/src/rml/rml.h
@@ -425,8 +425,13 @@ PRTE_EXPORT void prte_rml_update_ancestors(pmix_data_array_t* ancestors);
  * act on the inference by driving prte_rml_repair_routing_tree(). */
 PRTE_EXPORT prte_rml_ancestry_t prte_rml_reconcile_ancestry(pmix_data_array_t* report,
                                                             pmix_data_array_t* inferred);
+/* Repair the routing tree around a set of departed ranks and notify the fault
+ * handlers.  `epoch` is the collective recovery epoch the HNP issued with the
+ * global notice being applied; it is carried through to the handlers on the
+ * status and is meaningful only when `global` is true - pass 0 on every local
+ * repair, which does not move the epoch. */
 PRTE_EXPORT void prte_rml_repair_routing_tree(pmix_data_array_t* failed_ranks,
-                                              bool global);
+                                              bool global, uint32_t epoch);
 PRTE_EXPORT void prte_rml_revive_routing_tree(pmix_rank_t rank);
 PRTE_EXPORT void prte_rml_fault_handler(const prte_rml_recovery_status_t* s);
 PRTE_EXPORT int prte_rml_get_num_contributors(pmix_rank_t *dmns, size_t ndmns);

--- a/src/rml/rml_fault_handler.c
+++ b/src/rml/rml_fault_handler.c
@@ -17,6 +17,7 @@
 #include "src/util/pmix_output.h"
 #include "src/mca/state/state.h"
 
+#include "src/grpcomm/grpcomm.h"
 #include "src/rml/radix.h"
 #include "src/rml/rml.h"
 #include "src/runtime/prte_globals.h"
@@ -347,7 +348,7 @@ static void reconcile_child_ancestry(pmix_data_array_t* report,
             PRTE_NAME_PRINT(sender), (unsigned long) inferred.size
         ));
         report_new_departures(&inferred);
-        prte_rml_repair_routing_tree(&inferred, /* global = */ false);
+        prte_rml_repair_routing_tree(&inferred, /* global = */ false, /* epoch = */ 0);
         break;
 
     case PRTE_RML_ANCESTRY_STALE:
@@ -379,6 +380,22 @@ void prte_rml_recv_failures_notice(
         return;
     }
 
+    /* A global notice carries the collective recovery epoch it moves the DVM
+     * to - see the epoch member of prte_rml_recovery_status_t.  The upward leg
+     * does not: only the HNP issues an epoch, and only its broadcast applies
+     * one. */
+    uint32_t epoch = 0;
+    if(global){
+        cnt = 1;
+        ret = PMIx_Data_unpack(NULL, buf, &epoch, &cnt, PMIX_UINT32);
+        if(PMIX_SUCCESS != ret){
+            PMIX_ERROR_LOG(ret);
+            PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
+            return;
+        }
+    }
+
+    cnt = 1;
     pmix_data_array_t failed_ranks = PMIX_DATA_ARRAY_STATIC_INIT;
     ret = PMIx_Data_unpack(NULL, buf, &failed_ranks, &cnt, PMIX_DATA_ARRAY);
     if(PMIX_SUCCESS != ret){
@@ -395,7 +412,7 @@ void prte_rml_recv_failures_notice(
      * around, and a duplicate notice is a no-op. */
     report_new_departures(&failed_ranks);
 
-    prte_rml_repair_routing_tree(&failed_ranks, global);
+    prte_rml_repair_routing_tree(&failed_ranks, global, epoch);
 
     /* repair takes a copy of what it needs, so the unpacked array is ours */
     PMIx_Data_array_destruct(&failed_ranks);
@@ -451,7 +468,7 @@ void prte_rml_recv_adoption_notice(
     case PRTE_RML_ANCESTRY_INFERRED:
         // Finally, report the inferred deaths and do a full repair on them
         report_new_departures(&inferred);
-        prte_rml_repair_routing_tree(&inferred, /* global = */ false);
+        prte_rml_repair_routing_tree(&inferred, /* global = */ false, /* epoch = */ 0);
         break;
 
     case PRTE_RML_ANCESTRY_STALE:
@@ -540,6 +557,23 @@ static void send_failures_notice(const prte_rml_recovery_status_t* status){
         PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         PMIX_DATA_BUFFER_RELEASE(msg);
         return;
+    }
+
+    /* Only the broadcast carries an epoch, and issuing it here - once per
+     * notice actually emitted - is what makes the value the same everywhere
+     * and strictly increasing.  Every daemon adopts it rather than counting
+     * the notices it has received, so a daemon that missed one (a daemon
+     * launched into a DVM that has already recovered has missed all of them)
+     * is corrected by the next notice or by the WIREUP broadcast. */
+    if(global){
+        uint32_t epoch = prte_grpcomm_issue_epoch();
+        ret = PMIx_Data_pack(NULL, msg, &epoch, 1, PMIX_UINT32);
+        if(PMIX_SUCCESS != ret){
+            PMIX_ERROR_LOG(ret);
+            PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
+            PMIX_DATA_BUFFER_RELEASE(msg);
+            return;
+        }
     }
 
     // Build array of failures to pass up to my parent

--- a/src/rml/rml_types.h
+++ b/src/rml/rml_types.h
@@ -399,6 +399,18 @@ typedef struct {
 
     pmix_data_array_t failed_ranks;
 
+    // The collective recovery epoch this event moves the DVM to, and the
+    // reason it is carried here rather than counted by each handler: it is
+    // issued by the HNP when it originates the global notice, so every daemon
+    // adopts the same number no matter how many notices it has seen. A daemon
+    // that missed one - which a daemon launched into an already-recovered DVM
+    // necessarily has - is corrected by the next one that reaches it, and by
+    // the WIREUP broadcast it receives on joining.
+    //
+    // Only meaningful when scope is GLOBAL; zero on the local pass, which
+    // does not move the epoch.
+    uint32_t epoch;
+
     // Ancestor deaths could lead to this rank substituting for a hole further
     // up the tree. If we've been promoted, our subtree has grown. At most, one
     // of our old children can be the same. Their position in the children list

--- a/src/rml/routed_radix.c
+++ b/src/rml/routed_radix.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      Cisco Systems, Inc.  All rights reserved
- * Copyright (c) 2021-2023 Nanook Consulting.  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting.  All rights reserved.
  * Copyright (c) 2023      Triad National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2026      Sandia National Laboratories  All rights reserved.
@@ -228,7 +228,8 @@ static void update_descendants(void){
 // Defined below, shared with prte_rml_compute_routing_tree.
 static void build_tree_from_base(void);
 
-void prte_rml_repair_routing_tree(pmix_data_array_t* failed_ranks, bool global){
+void prte_rml_repair_routing_tree(pmix_data_array_t* failed_ranks, bool global,
+                                  uint32_t epoch){
     if(global){
         // Make sure these are given local notice first, but mark as globally
         // failed just before, to avoid redundant failure notices up the tree
@@ -236,12 +237,16 @@ void prte_rml_repair_routing_tree(pmix_data_array_t* failed_ranks, bool global){
         for(size_t i = 0; i < failed_ranks->size; i++){
             pmix_bitmap_set_bit(&prte_rml_base.global_failed_dmns, ranks[i]);
         }
-        prte_rml_repair_routing_tree(failed_ranks, false);
+        // the local pass never moves the epoch, so it needs no value
+        prte_rml_repair_routing_tree(failed_ranks, false, 0);
     }
 
     prte_rml_recovery_status_t status;
     PMIX_CONSTRUCT(&status, prte_rml_recovery_status_t);
-    if(global) status.scope = PRTE_RML_FAULT_SCOPE_GLOBAL;
+    if(global){
+        status.scope = PRTE_RML_FAULT_SCOPE_GLOBAL;
+        status.epoch = epoch;
+    }
 
     resize_ranks(&status.failed_ranks, failed_ranks->size);
     size_t j = 0;
@@ -665,7 +670,7 @@ int prte_rml_route_lost(pmix_rank_t route){
     resize_ranks(&failed_ranks, 1);
     ((pmix_rank_t*)failed_ranks.array)[0] = route;
 
-    prte_rml_repair_routing_tree(&failed_ranks, /* global = */ false);
+    prte_rml_repair_routing_tree(&failed_ranks, /* global = */ false, /* epoch = */ 0);
 
     PMIx_Data_array_destruct(&failed_ranks);
     return PRTE_SUCCESS;

--- a/test/unit/grpcomm/test_grpcomm.c
+++ b/test/unit/grpcomm/test_grpcomm.c
@@ -750,6 +750,106 @@ static int test_fence_fault_handler(void)
     return failures;
 }
 
+/*
+ * The recovery epoch tells one round of a restarted collective from the
+ * next, and it is issued by the DVM master and carried on the global failure
+ * notice as an absolute value.  The alternative - each daemon counting the
+ * notices it has seen - makes the number a function of what a daemon
+ * received, so a daemon that missed one is a step behind for the rest of the
+ * DVM's life and has every contribution it offers dropped as stale.  A
+ * daemon launched into a DVM that has already recovered (an elastic grow
+ * after a shrink) has missed all of them, which is why the value has to be
+ * something it can simply be told.
+ */
+static int test_recovery_epoch(void)
+{
+    int failures = 0;
+#if PRTE_TEST_GRPCOMM_INTERNALS
+    prte_rml_recovery_status_t status;
+    uint32_t first, second;
+
+    /* the master issues the numbers, and they increase strictly.  They do
+     * not wait on the master applying them: its own epoch does not move
+     * until its broadcast is relayed back to it, and a second failure
+     * detected inside that window must not reissue the number the first
+     * notice is already carrying - that would collapse two restarts into
+     * one, which is a hang rather than a wrong answer */
+    first = prte_grpcomm_issue_epoch();
+    second = prte_grpcomm_issue_epoch();
+    CHECK("epoch: issued values increase", second > first);
+    CHECK("epoch: issuing does not move the applied epoch",
+          0 == prte_grpcomm_current_epoch());
+
+    /* the state the fault handler walks.  Nothing is in flight, so every
+     * restart below is a walk over empty lists - what is under test is the
+     * counter, not what it restarts */
+    PMIX_CONSTRUCT(&prte_grpcomm_globals.xcast_ops, prte_grpcomm_xcast_t);
+    PMIX_CONSTRUCT(&prte_grpcomm_globals.group_ops, pmix_list_t);
+    PMIX_CONSTRUCT(&prte_grpcomm_globals.completed_group_ops, pmix_list_t);
+    PMIX_CONSTRUCT(&prte_rml_base.failed_dmns, pmix_bitmap_t);
+    pmix_bitmap_init(&prte_rml_base.failed_dmns, 8);
+
+    /* the local pass never moves the epoch: the restart has to be
+     * simultaneous across the DVM, and only the global notice is */
+    PMIX_CONSTRUCT(&status, prte_rml_recovery_status_t);
+    status.scope = PRTE_RML_FAULT_SCOPE_LOCAL;
+    status.epoch = 4;
+    prte_grpcomm_fault_handler(&status);
+    PMIX_DESTRUCT(&status);
+    CHECK("epoch: the local pass does not move the epoch",
+          0 == prte_grpcomm_current_epoch());
+
+    /* the global notice carries the epoch, and it is adopted as given -
+     * not incremented.  A daemon seeing its first notice at 7 must land on
+     * 7, exactly where a daemon that saw all six before it lands */
+    PMIX_CONSTRUCT(&status, prte_rml_recovery_status_t);
+    status.scope = PRTE_RML_FAULT_SCOPE_GLOBAL;
+    status.epoch = 7;
+    prte_grpcomm_fault_handler(&status);
+    PMIX_DESTRUCT(&status);
+    CHECK("epoch: a global notice is adopted as given",
+          7 == prte_grpcomm_current_epoch());
+
+    /* replaying it changes nothing.  This is what makes the value safe to
+     * send by more than one route - the WIREUP broadcast a joining daemon
+     * receives carries it too, and the two can arrive in either order */
+    PMIX_CONSTRUCT(&status, prte_rml_recovery_status_t);
+    status.scope = PRTE_RML_FAULT_SCOPE_GLOBAL;
+    status.epoch = 7;
+    prte_grpcomm_fault_handler(&status);
+    PMIX_DESTRUCT(&status);
+    CHECK("epoch: a replayed notice does not advance it",
+          7 == prte_grpcomm_current_epoch());
+
+    /* and an older one cannot walk it back */
+    PMIX_CONSTRUCT(&status, prte_rml_recovery_status_t);
+    status.scope = PRTE_RML_FAULT_SCOPE_GLOBAL;
+    status.epoch = 3;
+    prte_grpcomm_fault_handler(&status);
+    PMIX_DESTRUCT(&status);
+    CHECK("epoch: an older notice does not walk it back",
+          7 == prte_grpcomm_current_epoch());
+
+    /* seeding a daemon that joined late - what the WIREUP broadcast does -
+     * is the same operation, and lands it where the DVM already is */
+    prte_grpcomm_advance_epoch(9);
+    CHECK("epoch: a seed carries a late joiner forward",
+          9 == prte_grpcomm_current_epoch());
+
+    prte_grpcomm_globals.recovery_epoch = 0;
+    PMIX_DESTRUCT(&prte_grpcomm_globals.xcast_ops);
+    PMIX_LIST_DESTRUCT(&prte_grpcomm_globals.group_ops);
+    PMIX_CONSTRUCT(&prte_grpcomm_globals.group_ops, pmix_list_t);
+    PMIX_LIST_DESTRUCT(&prte_grpcomm_globals.completed_group_ops);
+    PMIX_DESTRUCT(&prte_rml_base.failed_dmns);
+#endif
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_recovery_epoch\n");
+    }
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0;
@@ -780,6 +880,7 @@ int main(void)
     failures += test_group_directives();
     failures += test_fence_tracker();
     failures += test_fence_fault_handler();
+    failures += test_recovery_epoch();
 
     PMIx_server_finalize();
     prte_finalize();


### PR DESCRIPTION
## The problem

An elastic shrink departs its daemon through the fault machinery, so it ends in a global `DAEMON_DIED` broadcast and every surviving daemon advances its collective recovery epoch. The daemon the next grow launches starts at zero, and nothing brings it up to date — so every fence or group contribution it makes is stamped below its parent's epoch, dropped as stale, and any collective over a job placed on that node hangs. The job *launches*, which is what makes this hard to spot.

Reported and diagnosed by @Petter-Programs (AccelCom, Barcelona Supercomputing Center) in #2693, with a reproducer and a DVM log. This is an alternative fix for the same bug, taking up the [question raised there](https://github.com/openpmix/prrte/pull/2693#issuecomment-5343280208) about the window between building the daemon command line and the daemon actually joining.

## Why the epoch could not simply be handed over

The epoch was a count each daemon kept for itself: every global notice advanced it by one. That makes the number a function of what a daemon *received* rather than of what happened. Two consequences:

- A daemon that misses one broadcast is a step behind for the rest of the DVM's life, and nothing can put it right — the only thing that moves the counter is the next notice, which moves everyone else's too. A daemon launched by a grow has missed **all** of them: the routing tree holds its vpid from the moment the grow records it, so a broadcast sent while its launch is in flight is addressed to a daemon with no contact info and is dropped by design (`prte_oob_base_send_nb`).
- A value arrived at by counting cannot be told to someone who did not do the counting — which is exactly what seeding a joining daemon requires.

## The fix, in two commits

**1. Issue the epoch from the DVM master.** `prte_grpcomm_issue_epoch()` hands out the number once per global notice the master emits, the notice carries it, and every daemon adopts what it is given rather than incrementing. Adoption is by highest value seen, which it already was, so a replayed or reordered notice is a no-op and the value can travel by more than one route without the routes having to agree on an order. The issued counter is deliberately not `current + 1`: the master's own epoch does not move until its broadcast is relayed back to it, so a second failure inside that window would reissue the number the first notice is already carrying — two failures sharing one epoch is one restart where two were needed, which hangs. For a DVM whose daemons all receive every notice, no value any of them arrive at changes.

**2. Carry it on the `WIREUP` broadcast.** That message is built only once every expected daemon has reported in, which makes it the first thing that can reach one that has just joined, and it already carries the two other things such a daemon has no other way to learn — the nidmap and the jobs already running. Because the epoch is now absolute, the seed and any notice still in flight commute.

This is the collective analogue of #2491: a daemon grown in after a shrink starts behind the DVM in two independent ways, and neither the routing repair nor this one can see the other's defect. A daemon joining a **bootstrapped** DVM still starts at zero — the same limitation `rml_base_dead_dmns` carries, and for the same reason.

## Testing

- **New dockerswarm case**, `elastic DVM: a collective spans a node grown in after a shrink`: grow, shrink, grow a fresh node, then fence across it — a modex (every rank must read every peer back) and a bare barrier. It is a case of its own rather than an assertion bolted onto the re-grow tests because none of those can fail on this: they launch `hostname`, and the epoch is not a routing property, so they pass with the DVM in exactly this state. This also gives `fencer` its first caller.
- **Negative control.** With the seed disabled, both fence forms hang to their 90s timeout — 0 of 3 ranks — while the same job launches on all three nodes. With it restored, 3 of 3 on both.
- **New unit test** `test_recovery_epoch`: issued values increase and do not move the applied epoch; the local pass does not advance; a global notice at 7 lands on 7; a replayed and an older notice change nothing. Verified against a reverted fault handler — three checks go red.
- Full dockerswarm suite: **619 passed, 0 failed, 3 skipped** (skips unrelated — no network device in the container topologies). `make check` 21/21, and each commit builds and passes it standalone.

Credits: AccelCom @ Barcelona Supercomputing Center.