### PR TITLE
ras: an allocation has exactly one owner

### DIFF
--- a/contrib/slurmswarm/AGENTS.md
+++ b/contrib/slurmswarm/AGENTS.md
@@ -165,7 +165,19 @@ it finds, and a broken cluster would make all of them lie.
 **`test_ras_alloc`** — what an allocation *means* to the DVM. The DVM forms
 across the whole allocation with no `--host`; the slot count is SLURM's, not
 the core count; `--host` selects within the allocation and refuses outside
-it. Two cases here cannot exist anywhere else:
+it. Several cases here cannot exist anywhere else:
+
+- **Who owns the allocation.** `ras` selects a single module, and this is the
+  only harness where the choice is a real one: `ras/slurm` (priority 50) and
+  `ras/hosts` (1) both answer the query, so a regression to keeping both is
+  visible here and nowhere else. In an unmanaged environment only one
+  component answers and single- and multi-select look identical. The case
+  reads the selector's own verbose output for both candidates, exactly one
+  winner, and the `scheduler-owned` mark.
+- **`--add-host` against an allocation PRRTE does not own.** Refused, with the
+  reason named, and — the half that matters — the DVM survives the refusal.
+  Before, the node was inserted and the daemon launch on it failed, which
+  takes the whole DVM down rather than just the job that asked.
 
 - **SLURM's compressed node list.** SLURM hands out `node[2,4,6]`, and
   `ras/slurm` has its own parser for that notation — a fake scheduler handing

--- a/contrib/slurmswarm/run-tests.sh
+++ b/contrib/slurmswarm/run-tests.sh
@@ -431,6 +431,50 @@ test_ras_alloc() {
     dvm_stop
     cleanup_cluster
 
+    banner "ras: the allocation has exactly one owner, and it is ras/slurm"
+    # The only place this is observable.  In an unmanaged environment just one
+    # component answers the query, so single- and multi-select look identical;
+    # here ras/slurm (50) and ras/hosts (1) both answer and only one may be
+    # selected.  It used to keep both, which is what let a request ras/slurm
+    # declined fall through to ras/hosts, and ras/hosts claims NEW/EXTEND/
+    # RELEASE on the directive alone - so a PMIX_ALLOC_NEW naming hostnames
+    # was answered PMIX_SUCCESS with an allocation id minted while SLURM was
+    # never asked, and the daemon launch on the un-allocated node then took
+    # the whole DVM down.
+    cleanup_cluster
+    ALLOC new --tag dvm --nodes 3 --tasks-per-node 2 >/dev/null 2>&1
+    out=$(SA 'timeout 60 prterun --prtemca ras_base_verbose 5 -n 1 hostname 2>&1')
+    echo "$out" | grep -q 'Component: slurm Priority: 50' \
+        && ok "ras/slurm is a candidate" \
+        || bad "ras/slurm did not answer the query"
+    echo "$out" | grep -q 'Component: hosts Priority: 1' \
+        && ok "ras/hosts is a candidate too, so the choice is a real one" \
+        || bad "ras/hosts did not answer the query"
+    echo "$out" | grep -q 'active allocator is .slurm.*scheduler-owned' \
+        && ok "slurm wins, and the allocation is marked scheduler-owned" \
+        || bad "wrong allocator: $(echo "$out" | grep -i 'active allocator' | tr '\n' ' ')"
+    [ "$(echo "$out" | grep -c 'active allocator is')" = 1 ] \
+        && ok "exactly one allocator was selected" \
+        || bad "more than one allocator selected"
+
+    banner "ras: add-host cannot grow an allocation the scheduler owns"
+    # The same authority, reached from the command line instead of a PMIx
+    # directive.  This used to insert the node and then kill the DVM trying to
+    # launch a daemon on it.
+    out=$(SA 'timeout 60 prterun --add-host node9:2 -n 2 hostname 2>&1 | tr -d "\0"')
+    echo "$out" | grep -q "is owned by a resource manager" \
+        && ok "add-host is refused, and says why" \
+        || bad "add-host was not refused: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+    echo "$out" | grep -qE '^node[0-9]+$' \
+        && bad "the job ran anyway after add-host was refused" \
+        || ok "the job did not launch on a node SLURM never granted"
+    # ...and the refusal is a refusal, not a casualty: launching still works
+    out=$(SA 'timeout 60 prterun -n 3 --map-by node hostname' 2>&1)
+    n=$(echo "$out" | grep -E '^node[0-9]+$' | sort -u | wc -l | tr -d ' ')
+    [ "$n" = 3 ] && ok "the allocation still launches after the refusal" \
+                 || bad "launching broke after the add-host refusal ($n/3)"
+    cleanup_cluster
+
     banner "ras/slurm: SLURM's compressed node list expands to exactly those nodes"
     # SLURM hands out "node[2,4,6]" and ras/slurm has its own parser for that
     # notation -- a scheduler handing out comma-separated names never reaches

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -52,6 +52,39 @@ grow and restores only the permanent sets (``dead_dmns``, ``absent_dmns``);
 whether anything else should survive the recompute is an open question marked
 in ``src/rml/routed_radix.c``.
 
+**A node in the allocation that has no daemon cannot be brought into the
+DVM.**  The node pool holds every node the allocation contains, and
+``--host``/``--hostfile`` given when the DVM starts only narrow which of them
+get daemons (``prte_plm_base_setup_virtual_machine`` builds its candidate list
+from the whole pool and filters a working copy).  So an allocated node that
+was filtered out sits in the pool, up, with ``node->daemon`` NULL, and there
+is no way to ask for a daemon on it afterwards.  ``--add-host`` used to do it
+by accident - ``prte_ras_base_node_insert`` carries
+``PRTE_NODE_STATE_ADDED`` onto an existing pool entry, so naming a known node
+marked it for the next grow - but that same option would just as readily
+insert a node the scheduler never granted, so it is now refused outright
+against an allocation PRRTE does not own.  The operation itself is worth
+having and is nearly free: mark the chosen pool entries
+``PRTE_NODE_STATE_ADDED`` and call ``prte_ras_base_activate_dvm_grow()``.  It
+needs no ``ras`` module, touches no scheduler, and is safe by construction
+since it can only name nodes the allocation already contains.  What has not
+been decided is the request surface - a new PMIx directive, a
+``PMIX_ALLOC_EXTEND`` whose ``PMIX_ALLOC_NODE_LIST`` is restricted to known
+nodes, or a command-line option.
+
+**Mixed allocators are not supported, and would need more than the ``ras``
+framework.**  The motivating case is a cloud/local combination: an allocation
+from a scheduler plus a set of unmanaged nodes outside it.  The ``ras``
+framework was made multi-select for this, and it never delivered it -
+``prte_ras_base_allocate`` breaks at the first module that succeeds, so there
+is no union step and the second allocator never contributed a node.  That
+selection is now single, which loses nothing that worked.  Supporting the case
+properly is a larger piece of work than re-admitting multiple ``ras`` modules:
+``plm`` is not multi-select either, so nothing tracks which launcher owns
+which nodes, and the daemon-launch path would have to fan out through more
+than one.  At minimum it needs a launcher affinity recorded per node and
+honored by ``prte_plm_base_setup_virtual_machine``.
+
 **RELM has one module and no way to choose another.**
 ``prte_relm_register`` registers the base implementation unconditionally
 (``src/rml/relm/relm.c``); the MCA variable that would select between modules

--- a/src/mca/ras/AGENTS.md
+++ b/src/mca/ras/AGENTS.md
@@ -141,33 +141,81 @@ distinct requester among its targets: one campaign can cover several grows.
 
 ---
 
-## Component selection is not "pick one"
+## An allocation has exactly one owner
 
-`prte_ras_base_select()` (in `ras_base_select.c`) works like the `rmaps`
-selector, not the usual single-winner MCA pattern: it queries every
-component, runs each returned module's `init`, and stores **all** of
-them **priority-sorted** in `prte_ras_base.selected_modules`
-(a `pmix_list_t` of `prte_ras_base_selected_module_t`, each holding
-`pri`, `module`, `component`). The driver then walks that list at
-allocate time. With `ras_base_verbose > 4` the selector prints the final
-prioritized list.
+`prte_ras_base_select()` (in `ras_base_select.c`) queries every component and
+builds a **priority-ordered candidate list**, then takes the first candidate
+whose `init()` succeeds. That one module is stored in
+`prte_ras_base.selected_modules` — still a `pmix_list_t` of
+`prte_ras_base_selected_module_t`, holding exactly one entry, so that every
+consumer (allocate, modify, release, shrink-complete, finalize) iterates
+unchanged. Only the winner is initialized, which is why `ras/slurm` no longer
+stands up its elastic bookkeeping in a DVM it is not allocating for. With
+`ras_base_verbose > 4` the selector prints the candidates and names the winner.
 
-Query priorities (higher wins first):
+Query priorities (higher wins):
 
 ```
 simulator 1000  =  testrm 1000  >  pbs 100  =  gridengine 100  =  flux 100
    >  lsf 75  >  slurm 50  >  bootstrap 20  =  pmix 20  >  hosts 1
 ```
 
-`hosts` is the catch-all default at priority **1** — it is always
-available and is tried last, handling `--host`/`--hostfile`/default
-hostfile and (via the base) the ultimate fall-back to a 1-slot local
-node. The RM components make themselves available only when their
-environment is detected (e.g. `slurm` requires a Slurm job id in the
-environment — see [`common/slurm`](../common/slurm/AGENTS.md)), so on any
-given machine at most one RM answers, then `hosts` closes out the list.
+`hosts` is the catch-all at priority **1**: always available, it handles
+`--host`/`--hostfile`/the default hostfile and (via the base) the ultimate
+fall-back to a 1-slot local node. The RM components make themselves available
+only when their environment is detected (e.g. `slurm` requires a Slurm job id
+— see [`common/slurm`](../common/slurm/AGENTS.md)), so at most one RM answers
+on a given machine. `pmix` answers only when it has actually been pointed at a
+scheduler (a URI, nspace, pid, host, connection order, or the
+system-scheduler switch); it used to answer unconditionally, which was
+harmless only while every module was kept, and would now shadow `hosts` in
+every unmanaged environment — its `allocate()` always returns
+`TAKE_NEXT_OPTION`, so nothing would read a hostfile.
 `simulator`/`testrm` sit at 1000 so that when explicitly configured they
 pre-empt everything.
+
+**This was multi-select until recently, and it never delivered what it was
+for.** The idea was a mixed allocator — a scheduler allocation plus extra
+hosts from a hostfile — but `prte_ras_base_allocate()` breaks at the first
+module that succeeds, so there is no union step and the second allocator never
+contributed a node. (Under a scheduler a hostfile is a *filter*; one naming a
+node outside the allocation is refused outright.) What the extra modules did
+do was serve `prte_ras_base_modify()`: a request the real allocator declined
+fell through to a module with no authority over the allocation. `ras/slurm`
+answers `PMIX_ERR_NOT_SUPPORTED` to anything that is not EXTEND/RELEASE/CANCEL
+and the driver reads that as "ask the next module", so a `PMIX_ALLOC_NEW`
+naming hostnames inside a Slurm allocation was served by `ras/hosts` — answered
+`PMIX_SUCCESS` with an allocation id minted, while Slurm was never asked and
+had granted nothing. The daemon launch on the un-allocated node then failed
+and took the DVM down. `docs/todo.rst` records what supporting mixed
+allocators would actually take.
+
+## Who may add a node
+
+Each module states, in `prte_ras_base_module_t::scheduler_owned`, whether an
+external resource manager owns what it allocated. Slurm, PBS, LSF, Flux,
+gridengine and the PMIx scheduler say yes; hosts, bootstrap, simulator and
+testrm say no. The base copies the selected module's answer into
+`prte_ras_base.scheduler_owned`.
+
+Where it is yes, **PRRTE may select from the allocation but must never add to
+it.** `prte_ras_base_add_hosts()` refuses `--add-host`/`--add-hostfile`
+outright (`ras-base:add-host-managed`), and refuses when no active component
+can serve the directive at all (`ras-base:add-host-unsupported`, which a
+bootstrapped DVM reaches). The refusal is issued **before** the request is
+posted, and that placement is load-bearing: serving it is asynchronous, the
+DVM is marked not-ready and the job parked in the cache, and only the grow's
+`VM_READY` re-entry releases it — so a request nothing answers leaves the job
+waiting on a DVM that never becomes ready again.
+
+Note what already handles the other direction: a node a scheduler has taken
+back is marked `PRTE_NODE_STATE_NOT_INCLUDED` by
+`prte_ras_slurm_exclude_shrunk_nodes()`, and both `setup_virtual_machine`
+branches and the mapper skip that state. Its pool entry deliberately survives
+— the pool index is `PMIX_NODEID` and must never be reused. The only thing
+that ever brought such a node back was `--add-host`, because
+`prte_ras_base_node_insert()` carries `PRTE_NODE_STATE_ADDED` onto an existing
+pool entry; refusing add-host under a scheduler closes that.
 
 ---
 
@@ -189,7 +237,7 @@ framework. Its phases:
    it twice. (The sanctioned way to grow an allocation is
    add-host/add-hostfile or an allocation request →
    `prte_ras_base_modify`.)
-2. **Cycle modules.** Walk `selected_modules` in priority order calling
+2. **Ask the allocator.** Walk `selected_modules` — one entry — calling
    `mod->module->allocate(jdata, &nodes)`, honoring the return protocol
    above.
 3. **Empty-list handling.** If no module contributed and
@@ -358,7 +406,8 @@ deviation*.)
 
 | Field | Meaning |
 |-------|---------|
-| `selected_modules` | Priority-sorted list of selected components. |
+| `selected_modules` | The selected component. A one-entry list so every consumer can iterate it. |
+| `scheduler_owned` | Does an external RM own our allocation? Copied from the selected module. |
 | `total_slots_alloc` | Sum of `slots` across the pool. |
 | `multiplier` | `ras_base_multiplier` — fabricate N daemons/node to simulate scale (default 1). |
 | `launch_orted_on_hn` | `ras_base_launch_orted_on_hn` — run a daemon on the head node. |

--- a/src/mca/ras/base/base.h
+++ b/src/mca/ras/base/base.h
@@ -54,6 +54,10 @@ PRTE_EXPORT int prte_ras_base_select(void);
 typedef struct prte_ras_base_t {
     /* list of selected modules */
     pmix_list_t selected_modules;
+    /* Does an external resource manager own our allocation?  Copied from the
+     * selected module (prte_ras_base_module_t::scheduler_owned) once, because
+     * everything that wants to know is nowhere near the ras. */
+    bool scheduler_owned;
     /* PMIX_ALLOC_RELEASE requests parked because the DVM was still growing
      * when they arrived, in arrival order. See prte_ras_base_dvm_is_growing()
      * and prte_ras_base_replay_deferred_releases() below. */

--- a/src/mca/ras/base/help-ras-base.txt
+++ b/src/mca/ras/base/help-ras-base.txt
@@ -53,3 +53,24 @@ to the DVM but was given a negative number of slots:
 We cannot subtract slots from an unknown host. Please
 correct the file or ensure that we are allocated the
 host in advance.
+
+[ras-base:add-host-managed]
+An add-host or add-hostfile directive was given, but this DVM's allocation
+is owned by a resource manager.
+
+Only the scheduler can decide which nodes this DVM holds. PRRTE cannot add
+one on its own authority - a daemon launched on a node the scheduler has not
+granted fails to start, and that failure takes the whole DVM down rather than
+just the job that asked for it.
+
+To obtain additional nodes, ask the scheduler for them: outside PRRTE before
+starting the DVM, or through a PMIx allocation request that the resource
+manager's component can serve.
+
+[ras-base:add-host-unsupported]
+An add-host or add-hostfile directive was given, but no active component can
+serve it.
+
+The nodes this DVM holds were established by an allocator that does not
+support adding to them after the fact - a bootstrapped DVM, for instance,
+takes its membership from the configuration file every daemon reads.

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -1901,9 +1901,42 @@ void prte_ras_base_complete_request(prte_pmix_server_req_t *req)
     }
 }
 
+/*
+ * May an add-host/add-hostfile directive be honored here?
+ *
+ * Two different noes.  Under an allocation owned by an external resource
+ * manager it is not PRRTE's to grant: only the scheduler can say which nodes
+ * this DVM holds, and launching a daemon on one it did not grant does not
+ * fail locally - the launch fails and takes the whole DVM with it.  That was
+ * the behavior before this check existed.
+ *
+ * Otherwise the request is routed by name to the component that serves it, so
+ * refuse if that component is not the active allocator.  A bootstrapped DVM
+ * is the case that reaches this: its membership comes from a configuration
+ * file every daemon reads, and ras/bootstrap outranks ras/hosts.
+ */
+static int ras_base_add_hosts_allowed(void)
+{
+    prte_ras_base_selected_module_t *mod;
+
+    if (prte_ras_base.scheduler_owned) {
+        prte_show_help("help-ras-base.txt", "ras-base:add-host-managed", true);
+        return PRTE_ERR_NOT_SUPPORTED;
+    }
+
+    PMIX_LIST_FOREACH(mod, &prte_ras_base.selected_modules, prte_ras_base_selected_module_t) {
+        if (0 == strcasecmp("hosts", mod->component->pmix_mca_component_name)) {
+            return PRTE_SUCCESS;
+        }
+    }
+
+    prte_show_help("help-ras-base.txt", "ras-base:add-host-unsupported", true);
+    return PRTE_ERR_NOT_SUPPORTED;
+}
+
 int prte_ras_base_add_hosts(prte_job_t *jdata)
 {
-    int i;
+    int i, rc;
     prte_app_context_t *app;
     char *hosts, **hostfiles, **addhosts, *tmp;
     prte_pmix_server_req_t *req;
@@ -1936,6 +1969,18 @@ int prte_ras_base_add_hosts(prte_job_t *jdata)
     if (NULL == hostfiles && NULL == addhosts) {
         // there were no directives
         return PRTE_SUCCESS;
+    }
+
+    /* Can this be served at all?  Refuse here, synchronously, rather than
+     * posting a request nothing will answer: a few lines below this marks the
+     * DVM not-ready and the caller parks the job in the cache, and only the
+     * grow's VM_READY re-entry releases it.  A request no module serves would
+     * leave the job waiting on a DVM that never becomes ready again. */
+    rc = ras_base_add_hosts_allowed();
+    if (PRTE_SUCCESS != rc) {
+        PMIx_Argv_free(hostfiles);
+        PMIx_Argv_free(addhosts);
+        return rc;
     }
 
     // create an allocation request tracker

--- a/src/mca/ras/base/ras_base_frame.c
+++ b/src/mca/ras/base/ras_base_frame.c
@@ -51,6 +51,7 @@
  */
 prte_ras_base_t prte_ras_base = {
     .selected_modules = PMIX_LIST_STATIC_INIT,
+    .scheduler_owned = false,
     .deferred_releases = PMIX_LIST_STATIC_INIT,
     .total_slots_alloc = 0,
     .multiplier = 0,

--- a/src/mca/ras/base/ras_base_select.c
+++ b/src/mca/ras/base/ras_base_select.c
@@ -44,6 +44,7 @@ int prte_ras_base_select(void)
     pmix_mca_base_module_t *module = NULL;
     prte_ras_base_module_t *nmodule;
     prte_ras_base_selected_module_t *newmodule, *mod;
+    pmix_list_t candidates;
     int rc, priority;
     bool inserted;
 
@@ -52,6 +53,8 @@ int prte_ras_base_select(void)
         return PRTE_SUCCESS;
     }
     selected = true;
+
+    PMIX_CONSTRUCT(&candidates, pmix_list_t);
 
     /* Query all available components and ask if they have a module */
     PMIX_LIST_FOREACH(cli, &prte_ras_base_framework.framework_components,
@@ -87,21 +90,13 @@ int prte_ras_base_select(void)
             continue;
         }
 
-        /* If we got a module, keep it */
+        /* If we got a module, keep it as a CANDIDATE.  Its init() is not run
+         * here: only the winner is initialized, and which component wins is
+         * not known until every one has been queried.  ras/slurm's init(),
+         * for instance, stands up the whole elastic bookkeeping surface. */
         nmodule = (prte_ras_base_module_t *) module;
 
-        /* Initialize the module */
-        if (NULL != nmodule->init) {
-            rc = nmodule->init();
-            if (PRTE_SUCCESS != rc) {
-                pmix_output_verbose(5, prte_ras_base_framework.framework_output,
-                                    "mca:ras:select: Skipping component [%s]. Module init failed",
-                                    component->pmix_mca_component_name);
-                continue;
-            }
-        }
-
-        /* add to the list of selected modules */
+        /* add to the candidate list */
         newmodule = PMIX_NEW(prte_ras_base_selected_module_t);
         newmodule->pri = priority;
         newmodule->module = nmodule;
@@ -109,10 +104,10 @@ int prte_ras_base_select(void)
 
         /* maintain priority order */
         inserted = false;
-        PMIX_LIST_FOREACH(mod, &prte_ras_base.selected_modules, prte_ras_base_selected_module_t)
+        PMIX_LIST_FOREACH(mod, &candidates, prte_ras_base_selected_module_t)
         {
             if (priority > mod->pri) {
-                pmix_list_insert_pos(&prte_ras_base.selected_modules, (pmix_list_item_t *) mod,
+                pmix_list_insert_pos(&candidates, (pmix_list_item_t *) mod,
                                      &newmodule->super);
                 inserted = true;
                 break;
@@ -120,19 +115,69 @@ int prte_ras_base_select(void)
         }
         if (!inserted) {
             /* must be lowest priority - add to end */
-            pmix_list_append(&prte_ras_base.selected_modules, &newmodule->super);
+            pmix_list_append(&candidates, &newmodule->super);
         }
     }
     if (4 < pmix_output_get_verbosity(prte_ras_base_framework.framework_output)) {
-        pmix_output(0, "%s: Final ras priorities", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
-        /* show the prioritized list */
-        PMIX_LIST_FOREACH(mod, &prte_ras_base.selected_modules, prte_ras_base_selected_module_t)
+        pmix_output(0, "%s: ras candidates, in priority order", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
+        PMIX_LIST_FOREACH(mod, &candidates, prte_ras_base_selected_module_t)
         {
             pmix_output(0, "\tComponent: %s Priority: %d", mod->component->pmix_mca_component_name,
                         mod->pri);
         }
     }
 
+    /* Exactly one module is selected: an allocation has exactly one owner.
+     *
+     * The framework used to keep every module that answered, in priority
+     * order, and walk them.  Nothing was ever gained by that and two things
+     * were lost.  prte_ras_base_allocate() breaks at the first module that
+     * succeeds, so the extra modules never contributed nodes - the mixed
+     * allocator this was built for (a scheduler allocation plus a hostfile)
+     * was never assembled, because there is no union step and never was.
+     * What the extra modules did do was serve prte_ras_base_modify(): a
+     * request the real allocator declined fell through to a lower-priority
+     * module with no authority over the allocation, and ras/hosts would
+     * cheerfully add nodes the scheduler had never granted, after which the
+     * daemon launch failed and took the DVM with it.
+     *
+     * Walk the candidates in priority order and take the first whose init()
+     * succeeds.  A failed init is a component that cannot run here, so the
+     * next one down is the right answer - that is the only fallback this
+     * selection has, and it is a fallback between whole allocators rather
+     * than a chain that lets several of them each serve part of a request.
+     */
+    while (NULL != (mod = (prte_ras_base_selected_module_t *)
+                              pmix_list_remove_first(&candidates))) {
+        if (NULL != mod->module->init) {
+            rc = mod->module->init();
+            if (PRTE_SUCCESS != rc) {
+                pmix_output_verbose(5, prte_ras_base_framework.framework_output,
+                                    "mca:ras:select: Skipping component [%s]. Module init failed",
+                                    mod->component->pmix_mca_component_name);
+                PMIX_RELEASE(mod);
+                continue;
+            }
+        }
+        pmix_list_append(&prte_ras_base.selected_modules, &mod->super);
+        break;
+    }
+    PMIX_LIST_DESTRUCT(&candidates);
+
+    if (pmix_list_is_empty(&prte_ras_base.selected_modules)) {
+        /* Not fatal by itself: prte_ras_base_allocate() falls back to the
+         * local host when nothing supplies an allocation, which is what a
+         * single-node run with no hostfile has always done. */
+        pmix_output_verbose(5, prte_ras_base_framework.framework_output,
+                            "mca:ras:select: no ras module could be initialized");
+        return PRTE_SUCCESS;
+    }
+
+    mod = (prte_ras_base_selected_module_t *)
+              pmix_list_get_first(&prte_ras_base.selected_modules);
+    pmix_output_verbose(5, prte_ras_base_framework.framework_output,
+                        "mca:ras:select: active allocator is [%s] (priority %d)",
+                        mod->component->pmix_mca_component_name, mod->pri);
+
     return PRTE_SUCCESS;
-    ;
 }

--- a/src/mca/ras/base/ras_base_select.c
+++ b/src/mca/ras/base/ras_base_select.c
@@ -175,9 +175,12 @@ int prte_ras_base_select(void)
 
     mod = (prte_ras_base_selected_module_t *)
               pmix_list_get_first(&prte_ras_base.selected_modules);
+    prte_ras_base.scheduler_owned = mod->module->scheduler_owned;
     pmix_output_verbose(5, prte_ras_base_framework.framework_output,
-                        "mca:ras:select: active allocator is [%s] (priority %d)",
-                        mod->component->pmix_mca_component_name, mod->pri);
+                        "mca:ras:select: active allocator is [%s] (priority %d, %s)",
+                        mod->component->pmix_mca_component_name, mod->pri,
+                        prte_ras_base.scheduler_owned ? "scheduler-owned"
+                                                      : "locally owned");
 
     return PRTE_SUCCESS;
 }

--- a/src/mca/ras/bootstrap/ras_boot.c
+++ b/src/mca/ras/bootstrap/ras_boot.c
@@ -31,6 +31,7 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes);
  * Global variable
  */
 prte_ras_base_module_t prte_ras_bootstrap_module = {
+    .scheduler_owned = false,
     .init = NULL,
     .allocate = allocate,
     .modify = NULL,

--- a/src/mca/ras/flux/ras_flux_module.c
+++ b/src/mca/ras/flux/ras_flux_module.c
@@ -74,6 +74,7 @@ static int parse_json_payload(json_t *root,  pmix_list_t *prte_nodelist);
  * Global variable
  */
 prte_ras_base_module_t prte_ras_flux_module = {
+    .scheduler_owned = true,
     .init = init,
     .allocate = allocate,
     .modify = modify,

--- a/src/mca/ras/gridengine/ras_gridengine_module.c
+++ b/src/mca/ras/gridengine/ras_gridengine_module.c
@@ -55,6 +55,7 @@ static int get_slot_count(char* node_name, int* slot_cnt);
  * Global variable
  */
 prte_ras_base_module_t prte_ras_gridengine_module = {
+    .scheduler_owned = true,
     .allocate = prte_ras_gridengine_allocate,
     .finalize = prte_ras_gridengine_finalize
 };

--- a/src/mca/ras/lsf/ras_lsf_module.c
+++ b/src/mca/ras/lsf/ras_lsf_module.c
@@ -59,6 +59,7 @@ static int finalize(void);
  * Global variable
  */
 prte_ras_base_module_t prte_ras_lsf_module = {
+    .scheduler_owned = true,
     .init = NULL,
     .allocate = allocate,
     .finalize = finalize

--- a/src/mca/ras/pbs/ras_pbs_module.c
+++ b/src/mca/ras/pbs/ras_pbs_module.c
@@ -58,6 +58,7 @@ static char *filename;
  * Global variable
  */
 prte_ras_base_module_t prte_ras_pbs_module = {
+    .scheduler_owned = true,
     .allocate = allocate,
     .finalize = finalize
 };

--- a/src/mca/ras/pmix/ras_pmix.c
+++ b/src/mca/ras/pmix/ras_pmix.c
@@ -33,6 +33,7 @@ static pmix_status_t modify(prte_pmix_server_req_t *req);
  * Global variable
  */
 prte_ras_base_module_t prte_ras_pmix_module = {
+    .scheduler_owned = true,
     .init = NULL,
     .allocate = allocate,
     .modify = modify,

--- a/src/mca/ras/pmix/ras_pmix_component.c
+++ b/src/mca/ras/pmix/ras_pmix_component.c
@@ -27,6 +27,8 @@
 #include "prte_config.h"
 #include "constants.h"
 
+#include <string.h>
+
 #include "src/mca/base/pmix_base.h"
 
 #include "src/prted/pmix/pmix_server_internal.h"
@@ -148,9 +150,33 @@ static int ras_pmix_component_open(void)
 
 static int ras_pmix_component_query(pmix_mca_base_module_t **module, int *priority)
 {
-    /* always make ourselves available in case the system includes a
-     * scheduler that supports PMIx operations
-     */
+    /* Be available only when someone has actually pointed us at a scheduler.
+     *
+     * This used to answer unconditionally, "in case the system includes a
+     * scheduler that supports PMIx operations".  That was harmless only while
+     * the framework kept every module that answered: our allocate() always
+     * returns TAKE_NEXT_OPTION - this component forwards requests to a
+     * scheduler, it never discovers nodes itself - so the next module down
+     * did the allocating.  With one module selected there is no next module,
+     * and answering here on spec would shadow ras/hosts (priority 1) in every
+     * unmanaged environment, leaving nothing to read a hostfile.
+     *
+     * The connection parameters are the statement of intent: a URI, a
+     * scheduler nspace, a pid or host to find it at, an explicit connection
+     * order, or the system-scheduler switch.  With none of them set there is
+     * no scheduler to forward anything to, and saying so is the honest
+     * answer. */
+    if (NULL == prte_mca_ras_pmix_component.uri &&
+        NULL == prte_mca_ras_pmix_component.connection_order &&
+        NULL == prte_mca_ras_pmix_component.server_host &&
+        0 == prte_mca_ras_pmix_component.server_pid &&
+        !prte_mca_ras_pmix_component.connect_to_system_scheduler &&
+        0 == strlen(prte_mca_ras_pmix_component.server.nspace)) {
+        *module = NULL;
+        *priority = 0;
+        return PRTE_ERROR;
+    }
+
     *module = (pmix_mca_base_module_t *) &prte_ras_pmix_module;
     *priority = 20;
     return PRTE_SUCCESS;

--- a/src/mca/ras/pmix/ras_pmix_component.c
+++ b/src/mca/ras/pmix/ras_pmix_component.c
@@ -133,15 +133,16 @@ static int ras_pmix_register(void)
 
 static int ras_pmix_component_open(void)
 {
-    // initialize the globals
-    prte_mca_ras_pmix_component.connect_to_system_scheduler = false;
-    PMIx_Load_procid(&prte_mca_ras_pmix_component.server, NULL, PMIX_RANK_INVALID);
-    prte_mca_ras_pmix_component.uri = NULL;
-    prte_mca_ras_pmix_component.connection_order = NULL;
-    prte_mca_ras_pmix_component.server_pid = 0;
-    prte_mca_ras_pmix_component.server_host = NULL;
-    prte_mca_ras_pmix_component.max_retries = 5;
-    prte_mca_ras_pmix_component.retry_delay = 1;
+    /* Deliberately empty.  This used to re-initialize every field below,
+     * which are precisely the storage locations ras_pmix_register() binds to
+     * MCA variables - and a framework registers before it opens
+     * (pmix_mca_base_framework_open calls _register first), so those
+     * assignments ran AFTER the user's values had been read into them.  Every
+     * ras_pmix_* parameter was therefore discarded: a scheduler URI, an
+     * nspace, a pid, a host, the retry counts, all of them reset to the
+     * defaults the registration had already applied.  Nothing here needs
+     * initializing that registration does not already do; the component is a
+     * static global, so anything it does not bind starts zeroed. */
     return PRTE_SUCCESS;
 }
 

--- a/src/mca/ras/ras.h
+++ b/src/mca/ras/ras.h
@@ -117,6 +117,18 @@ typedef int (*prte_ras_base_module_finalize_fn_t)(void);
  * ras module
  */
 struct prte_ras_base_module_2_0_0_t {
+    /** Does an external resource manager own this allocation?
+     *
+     * True when the nodes came from a scheduler that alone decides what this
+     * DVM holds - Slurm, PBS, LSF, Flux, gridengine, or a PMIx scheduler.
+     * PRRTE may then SELECT from the allocation but must never add to it: a
+     * node the scheduler did not grant cannot be launched on, and pretending
+     * otherwise produces a daemon launch that fails and takes the DVM with
+     * it.  False for the allocators that are themselves the authority - a
+     * hostfile, a bootstrap configuration, the synthetic test components -
+     * where growing the pool on the user's say-so is exactly the point.
+     */
+    bool                                scheduler_owned;
     /** init */
     prte_ras_base_module_init_fn_t      init;
     /** Allocation function pointer */
@@ -149,7 +161,7 @@ typedef pmix_mca_base_component_t prte_ras_base_component_t;
  * Bump it on any change to the module interface that a component built
  * against the previous one would not survive. */
 #define PRTE_MCA_ras_MAJOR_VERSION   2
-#define PRTE_MCA_ras_MINOR_VERSION   0
+#define PRTE_MCA_ras_MINOR_VERSION   1
 #define PRTE_MCA_ras_RELEASE_VERSION 0
 
 END_C_DECLS

--- a/src/mca/ras/simulator/ras_sim_module.c
+++ b/src/mca/ras/simulator/ras_sim_module.c
@@ -40,6 +40,7 @@ static int finalize(void);
  * Global variable
  */
 prte_ras_base_module_t prte_ras_sim_module = {
+    .scheduler_owned = false,
     .allocate = allocate,
     .finalize = finalize
 };

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -77,6 +77,7 @@ static int prte_ras_slurm_finalize(void);
  * RAS slurm module
  */
 prte_ras_base_module_t prte_ras_slurm_module = {
+    .scheduler_owned = true,
     .init = init,
     .allocate = prte_ras_slurm_allocate,
     .modify = modify,

--- a/src/mca/ras/testrm/ras_testrm.c
+++ b/src/mca/ras/testrm/ras_testrm.c
@@ -31,6 +31,7 @@ static int finalize(void);
  * Global variable
  */
 prte_ras_base_module_t prte_ras_testrm_module = {
+    .scheduler_owned = false,
     .allocate = allocate,
     .finalize = finalize
 };

--- a/test/unit/ras/test_ras.c
+++ b/test/unit/ras/test_ras.c
@@ -30,10 +30,9 @@
  *      forgets to fill in allocate contributes nothing and is invisible.
  *      Check every statically-built component's vtable.
  *
- *   3. prte_ras_base_select. Unlike the usual single-winner MCA pattern,
- *      ras keeps ALL modules that answer and stores them priority-sorted;
- *      the driver depends on that ordering, and on `hosts` (priority 1)
- *      always being present and last so the local-host fallback works.
+ *   3. prte_ras_base_select. Exactly one module is selected - an allocation
+ *      has one owner - and with no RM in the environment that is `hosts`
+ *      (priority 1), so the local-host fallback still works.
  *
  *   4. prte_ras_base_flag_string, which renders the node flag bitmask for
  *      --display-allocation.
@@ -63,6 +62,7 @@
 #include "src/util/proc_info.h"
 
 #include "src/mca/ras/base/base.h"
+#include "src/mca/ras/pmix/ras_pmix.h"
 #include "src/mca/ras/ras.h"
 
 #define CHECK(label, cond)                                              \
@@ -606,18 +606,25 @@ static int test_module_contract(void)
 }
 
 /*
- * ras keeps every module that answers, priority-sorted -- it is not a
- * single-winner selection. The driver walks that list in order, and the
- * always-available `hosts` component must sort last so the RM components
- * get first refusal and the local-host fallback still runs.
+ * An allocation has exactly one owner: ras selects a single module, the
+ * highest-priority candidate whose init() succeeds.
+ *
+ * It used to keep every module that answered and walk the list, and that is
+ * what made a PMIX_ALLOC_NEW the real allocator had declined fall through to
+ * ras/hosts, which added nodes the scheduler had never granted.  So "exactly
+ * one" is the property under test, not an implementation detail.
+ *
+ * This runs with every RM environment variable unset, so the only component
+ * that can answer is `hosts` -- which is also the assertion that ras/pmix
+ * stays out of the way: it is priority 20 against hosts' 1 and would win if
+ * it still answered unconditionally, and since its allocate() only ever
+ * returns TAKE_NEXT_OPTION there would then be nothing left to read a
+ * hostfile.
  */
 static int test_select(void)
 {
     int failures = 0;
     prte_ras_base_selected_module_t *mod;
-    int last_pri = INT_MAX;
-    bool ordered = true, found_hosts = false;
-    const char *tail = NULL;
     int rc;
 
     /* keep a developer's own allocation out of the result */
@@ -638,35 +645,38 @@ static int test_select(void)
 
     rc = prte_ras_base_select();
     CHECK("select: rc", PRTE_SUCCESS == rc);
-    CHECK("select: something selected",
-          0 < pmix_list_get_size(&prte_ras_base.selected_modules));
+    CHECK("select: exactly one module selected",
+          1 == pmix_list_get_size(&prte_ras_base.selected_modules));
 
-    PMIX_LIST_FOREACH(mod, &prte_ras_base.selected_modules,
-                      prte_ras_base_selected_module_t) {
-        if (mod->pri > last_pri) {
-            ordered = false;
-        }
-        last_pri = mod->pri;
-        CHECK("select: module present", NULL != mod->module);
-        CHECK("select: component present", NULL != mod->component);
-        if (NULL != mod->component) {
-            tail = mod->component->pmix_mca_component_name;
-            if (0 == strcmp(tail, "hosts")) {
-                found_hosts = true;
-                CHECK("select: hosts is priority 1", 1 == mod->pri);
-            }
-        }
+    mod = (prte_ras_base_selected_module_t *)
+              pmix_list_get_first(&prte_ras_base.selected_modules);
+    if (NULL == mod) {
+        fprintf(stderr, "FAIL [select]: nothing selected\n");
+        return failures + 1;
     }
-    CHECK("select: descending priority order", ordered);
-    /* hosts is the unconditional catch-all: without it there is no
-     * --host/--hostfile handling and no local-host fallback */
-    CHECK("select: hosts selected", found_hosts);
-    CHECK("select: hosts sorts last", NULL != tail && 0 == strcmp(tail, "hosts"));
+    CHECK("select: module present", NULL != mod->module);
+    CHECK("select: component present", NULL != mod->component);
+    /* hosts is the catch-all: without it there is no --host/--hostfile
+     * handling and no local-host fallback */
+    CHECK("select: hosts is the owner with no RM in the environment",
+          NULL != mod->component &&
+          0 == strcmp("hosts", mod->component->pmix_mca_component_name));
+    CHECK("select: hosts is priority 1", 1 == mod->pri);
+
+    /* ...and PRRTE is its own authority over a hostfile allocation, so
+     * add-host may grow the pool */
+    CHECK("select: a hostfile allocation is not scheduler-owned",
+          !prte_ras_base.scheduler_owned);
+    CHECK("select: the flag came from the module",
+          NULL != mod->module &&
+          mod->module->scheduler_owned == prte_ras_base.scheduler_owned);
 
     /* select() latches -- a second call must be a harmless no-op rather
-     * than appending every module a second time */
+     * than selecting a second time */
     rc = prte_ras_base_select();
     CHECK("select: idempotent rc", PRTE_SUCCESS == rc);
+    CHECK("select: still exactly one module",
+          1 == pmix_list_get_size(&prte_ras_base.selected_modules));
 
     return failures;
 }
@@ -715,6 +725,67 @@ static pmix_mca_base_component_t *find_ras_component(const char *name)
         }
     }
     return NULL;
+}
+
+/*
+ * ras/pmix must not answer a query unless someone has pointed it at a
+ * scheduler.
+ *
+ * It used to answer unconditionally, "in case the system includes a scheduler
+ * that supports PMIx operations".  That was survivable only while the
+ * framework kept every module that answered, because this component's
+ * allocate() always returns TAKE_NEXT_OPTION - it forwards requests to a
+ * scheduler, it never discovers nodes - so the next module down did the
+ * allocating.  With one module selected, an unconditional answer at priority
+ * 20 beats ras/hosts at 1 and there is nothing left to read a hostfile.
+ *
+ * Driven through the framework rather than by naming the component's symbols:
+ * ras-pmix may be a plugin, in which case it has none in libprrte.
+ */
+static int test_pmix_gate(void)
+{
+    int failures = 0;
+    pmix_mca_base_component_t *comp;
+    pmix_mca_base_module_t *module = NULL;
+    int pri = -1, rc;
+
+    comp = find_ras_component("pmix");
+    if (NULL == comp) {
+        fprintf(stdout, "SKIP test_pmix_gate: ras/pmix component not found\n");
+        return 0;
+    }
+    CHECK("pmix: has a query function", NULL != comp->pmix_mca_query_component);
+    if (NULL == comp->pmix_mca_query_component) {
+        return failures;
+    }
+
+    /* nothing configured: no scheduler to forward to, so no module */
+    rc = comp->pmix_mca_query_component(&module, &pri);
+    CHECK("pmix: refuses when not pointed at a scheduler",
+          PRTE_SUCCESS != rc || NULL == module);
+
+    /* point it at one - any one of the connection parameters is the
+     * statement of intent, and the system-scheduler switch is the one with
+     * no string to free afterwards */
+    prte_mca_ras_pmix_component.connect_to_system_scheduler = true;
+    module = NULL;
+    pri = -1;
+    rc = comp->pmix_mca_query_component(&module, &pri);
+    prte_mca_ras_pmix_component.connect_to_system_scheduler = false;
+
+    CHECK("pmix: answers once pointed at a scheduler", PRTE_SUCCESS == rc);
+    CHECK("pmix: returns a module", NULL != module);
+    CHECK("pmix: at priority 20", 20 == pri);
+    /* and what it allocates belongs to that scheduler, so add-host may not
+     * grow it */
+    CHECK("pmix: is scheduler-owned",
+          NULL == module ||
+          ((prte_ras_base_module_t *) module)->scheduler_owned);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_pmix_gate\n");
+    }
+    return failures;
 }
 
 /*
@@ -1010,6 +1081,7 @@ int main(void)
     /* after test_select(), which opens the framework and latches a
      * selection made with no SLURM allocation in the environment -- so
      * nothing has called slurm's init() before this does */
+    failures += test_pmix_gate();
     failures += test_slurm_allocation();
 
     prte_finalize();

--- a/test/unit/ras/test_ras.c
+++ b/test/unit/ras/test_ras.c
@@ -61,8 +61,8 @@
 #include "src/util/prte_bootstrap.h"
 #include "src/util/proc_info.h"
 
+#include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/ras/base/base.h"
-#include "src/mca/ras/pmix/ras_pmix.h"
 #include "src/mca/ras/ras.h"
 
 #define CHECK(label, cond)                                              \
@@ -740,18 +740,30 @@ static pmix_mca_base_component_t *find_ras_component(const char *name)
  * 20 beats ras/hosts at 1 and there is nothing left to read a hostfile.
  *
  * Driven through the framework rather than by naming the component's symbols:
- * ras-pmix may be a plugin, in which case it has none in libprrte.
+ * ras-pmix may be a plugin, in which case it has none in libprrte, and naming
+ * prte_mca_ras_pmix_component here fails the --enable-mca-dso link outright.
+ * The switch is reached the same way anything else reaches another
+ * component's parameter - look the MCA variable up by name, and write through
+ * the pointer to the registering code's own storage that get_value returns.
  */
 static int test_pmix_gate(void)
 {
     int failures = 0;
     pmix_mca_base_component_t *comp;
     pmix_mca_base_module_t *module = NULL;
-    int pri = -1, rc;
+    bool *sched_switch = NULL;
+    int pri = -1, rc, vari;
 
     comp = find_ras_component("pmix");
     if (NULL == comp) {
         fprintf(stdout, "SKIP test_pmix_gate: ras/pmix component not found\n");
+        return 0;
+    }
+    vari = pmix_mca_base_var_find("prte", "ras", "pmix", "system_scheduler");
+    if (0 > vari ||
+        PMIX_SUCCESS != pmix_mca_base_var_get_value(vari, &sched_switch, NULL, NULL) ||
+        NULL == sched_switch) {
+        fprintf(stdout, "SKIP test_pmix_gate: ras_pmix_system_scheduler not registered\n");
         return 0;
     }
     CHECK("pmix: has a query function", NULL != comp->pmix_mca_query_component);
@@ -767,11 +779,11 @@ static int test_pmix_gate(void)
     /* point it at one - any one of the connection parameters is the
      * statement of intent, and the system-scheduler switch is the one with
      * no string to free afterwards */
-    prte_mca_ras_pmix_component.connect_to_system_scheduler = true;
+    *sched_switch = true;
     module = NULL;
     pri = -1;
     rc = comp->pmix_mca_query_component(&module, &pri);
-    prte_mca_ras_pmix_component.connect_to_system_scheduler = false;
+    *sched_switch = false;
 
     CHECK("pmix: answers once pointed at a scheduler", PRTE_SUCCESS == rc);
     CHECK("pmix: returns a module", NULL != module);


### PR DESCRIPTION
Under a Slurm allocation, this worked:

```
$ elastic grow node4:2                      # PMIX_ALLOC_NEW naming a hostname
>>> PHASE 1: allocation request returned PMIX_SUCCESS
>>> ALLOC_ID prte-node1-282@1.1             <-- we minted an allocation id
squeue:  3 node[1-3]                        <-- Slurm allocated nothing
```

PRRTE then tried to start a `prted` on node4, failed, and took the **whole
DVM** down — not just the job that asked. `prun --add-host node5` did the same
thing from the command line.

## Why

`ras` kept every component that answered its query and walked the list.
`ras/slurm`'s `modify()` handles EXTEND/RELEASE/CANCEL and answers
`PMIX_ERR_NOT_SUPPORTED` to anything else — which `prte_ras_base_modify()`
reads as *"ask the next module"* — and `ras/hosts` claims NEW/EXTEND/RELEASE
on the directive alone, regardless of whether it found any hosts. So a request
the real allocator declined was served by a module with no authority over the
allocation.

Multi-select was added for a mixed allocator — a scheduler allocation plus
extra hosts from a hostfile. **It never delivered that.**
`prte_ras_base_allocate()` breaks at the first module that succeeds, so there
is no union step and the second allocator never contributed a node. (Under a
scheduler a hostfile is a *filter*; one naming a node outside the allocation is
refused outright.) The only thing the extra modules actually did was the
fall-through above.

## What changes

Seven commits, each self-contained:

1. **`ras/pmix`: stop discarding its own MCA parameters.** `ras_pmix_component_open()`
   re-initialized the eight fields `register` binds to MCA variables, and a
   framework registers *before* it opens — so every `ras_pmix_*` parameter was
   accepted and then overwritten with its default. The component could not be
   pointed at a scheduler at all. Found while implementing the gate below.
2. **`ras/pmix`: be available only when pointed at a scheduler.** It answered
   unconditionally, which was survivable only while every module was kept —
   its `allocate()` always returns `TAKE_NEXT_OPTION`. At priority 20 it would
   now shadow `ras/hosts` at 1 and leave nothing to read a hostfile.
3. **`ras`: select exactly one module.** Query everything into a priority-ordered
   *candidate* list, take the first whose `init()` succeeds. Only the winner is
   initialized, which also stops `ras/slurm` standing up its elastic
   bookkeeping in a DVM it is not allocating for. `selected_modules` stays a
   list of one so every consumer is unchanged.
4. **`ras`: refuse add-host against an allocation PRRTE does not own.** Each
   module now states whether an external RM owns what it allocated
   (`scheduler_owned`); the base records the selected module's answer and
   refuses `--add-host`/`--add-hostfile` when it is yes — *before* the request
   is posted, because serving it is asynchronous and the job is parked behind a
   DVM that would otherwise never become ready again. Bumps the `ras`
   interface to 2.1.0.
5. **docs** — rewrite the selection section, and record two deferred items in
   `docs/todo.rst` (below).
6. **`test/ras`** — pin the single owner and the `ras/pmix` gate. Verified
   against the defect: with the gate removed, four assertions fire.
7. **`contrib/slurmswarm`** — the only place the choice is a *real* one, since
   `slurm` and `hosts` both answer there.

## What this deliberately gives up

Naming a node that **is** in the allocation but was excluded by a
`-host`/`-hostfile` filter would bring it into the DVM, because
`prte_ras_base_node_insert()` carries `PRTE_NODE_STATE_ADDED` onto an existing
pool entry. That is a useful operation, and `--add-host` is the wrong spelling
for it — the same option cannot mean that *and* invent nodes the scheduler
never granted. `docs/todo.rst` carries the replacement, which is nearly free
(mark the pool entries `ADDED`, call `prte_ras_base_activate_dvm_grow()`); what
needs deciding is the request surface. The second todo entry records what
supporting mixed allocators would actually take — `plm` is not multi-select
either, so nothing tracks which launcher owns which nodes.

## Testing

- Warning-free `--enable-debug` build and `make check` on **each commit
  separately**, not just the tip.
- `contrib/dockerswarm/run-tests.sh linux` — **619 passed, 0 failed, 3 skipped**.
- `contrib/slurmswarm/run-tests.sh` — **115 passed, 0 failed, 0 skipped**
  (108 before the new cases).
- Against a live Slurm 24.11.6, confirmed directly: the `PMIX_ALLOC_NEW` above
  is now `PMIX_ERR_NOT_SUPPORTED` with the DVM surviving; `--add-host node5` is
  refused with its reason and the DVM survives; and the Slurm-shaped
  `PMIX_ALLOC_EXTEND` + `PMIX_ALLOC_RELEASE` still work end to end (Slurm
  grants node4, then reclaims it).

One thing checked and found **not** to need fixing: a node the scheduler has
taken back is already marked `PRTE_NODE_STATE_NOT_INCLUDED` by
`prte_ras_slurm_exclude_shrunk_nodes()`, and both `setup_virtual_machine`
branches and the mapper honor it. Its pool entry deliberately survives — the
index is `PMIX_NODEID` and must never be reused. The only thing that ever
brought such a node back was `--add-host` resetting the state, which #4 closes.

Related: #2699 (`ras/slurm` implements `PMIX_ALLOC_EXTEND` as
`PMIX_ALLOC_NEW`) came out of the same investigation.