### PR TITLE
Honor --host slot caps when placing processes

### DIFF
--- a/contrib/slurmswarm/AGENTS.md
+++ b/contrib/slurmswarm/AGENTS.md
@@ -178,6 +178,13 @@ it. Several cases here cannot exist anywhere else:
   reason named, and — the half that matters — the DVM survives the refusal.
   Before, the node was inserted and the daemon launch on it failed, which
   takes the whole DVM down rather than just the job that asked.
+- **A `--host` claiming more of a node than SLURM allocated.** Refused, and
+  the message names the node and both counts. Same authority as the entry
+  above, applied to how much of a node a job may take rather than to which
+  nodes exist — and, like it, only reachable here: where PRRTE owns the node
+  counts a larger `:N` re-describes the node instead, so the refusing arm has
+  no other home. The case also runs a `--host` within the allocation, since a
+  check that refuses everything would pass the first half.
 - **`--activate` against the same allocation.** *Allowed* — the case that
   gives the refusal above its shape. A DVM started with `--host` forms across
   only part of its allocation, and `--activate` starts a daemon on one of the

--- a/contrib/slurmswarm/run-tests.sh
+++ b/contrib/slurmswarm/run-tests.sh
@@ -473,6 +473,24 @@ test_ras_alloc() {
     n=$(echo "$out" | grep -E '^node[0-9]+$' | sort -u | wc -l | tr -d ' ')
     [ "$n" = 3 ] && ok "the allocation still launches after the refusal" \
                  || bad "launching broke after the add-host refusal ($n/3)"
+
+    banner "rmaps: --host cannot claim more of a node than SLURM allocated"
+    # The same authority again, this time over how much of a node a job may
+    # take rather than which nodes exist.  Outside a scheduler's allocation a
+    # ":N" larger than the node re-describes it - the node counts are the
+    # user's own - so this arm is only reachable here.  Without the check the
+    # job was sized against the larger number and then mapped against the
+    # smaller one, and the user got a bare "failed to map" that said nothing
+    # about slots.
+    out=$(SA 'timeout 60 prterun --host node1:99 -n 99 hostname 2>&1 | tr -d "\0"')
+    echo "$out" | grep -q "asked for more slots on a node" \
+        && ok "the request is refused, and says which node and how many" \
+        || bad "--host over-claim was not refused: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+    # the same spec within what SLURM gave is still served
+    out=$(SA 'timeout 60 prterun --host node1:2,node2:2 -n 4 hostname' 2>&1)
+    n=$(echo "$out" | grep -cE '^node[0-9]+$')
+    [ "$n" = 4 ] && ok "a --host within the allocation still runs" \
+                 || bad "a legal --host stopped working ($n/4)"
     cleanup_cluster
 
     banner "ras: --activate CAN start a daemon on a node SLURM already granted"

--- a/src/docs/prrte-rst-content/cli-map-by.rst
+++ b/src/docs/prrte-rst-content/cli-map-by.rst
@@ -178,7 +178,12 @@ the ``--mapby`` option (except where noted):
 * ``SPAN`` load balance the processes across the allocation by treating
   the allocation as a single "super-node" (can not be used in
   combination with ``slot``, ``node``, ``seq``, ``ppr``, ``rankfile``, or
-  ``pe-list`` directives)
+  ``pe-list`` directives). One process is placed on each object in turn,
+  cycling across the nodes, so a job that does not fill the allocation
+  spreads over all of it instead of filling the first nodes. On three
+  4-slot nodes, ``-n 8 --map-by core:SPAN`` places 3, 3 and 2 processes,
+  where ``--map-by core`` alone places 4 and 4 and leaves the third node
+  empty.
 
 * ``OVERSUBSCRIBE`` allow more processes on a node than processing elements
 

--- a/src/docs/prrte-rst-content/detail-hosts-cli.rst
+++ b/src/docs/prrte-rst-content/detail-hosts-cli.rst
@@ -91,3 +91,15 @@ big the host is:
   taken to have that many slots **for that job**. The allocation itself
   is unchanged, and the next job sees the host at its original size.
   Use ``--add-host`` to change the allocation.
+
+Permission to oversubscribe does not change how processes are spread
+over the hosts you named, only how many a host may end up with. Each
+host is given the number of slots you asked for first, and the processes
+left over after that are then divided evenly among the hosts. So
+
+.. code::
+
+   prterun --host a:2,b:2,c:2 -n 12 --map-by core:oversubscribe ./app
+
+puts four processes on each host, and not eight on ``a``. Every mapping
+directive divides the overflow the same way.

--- a/src/docs/prrte-rst-content/detail-hosts-cli.rst
+++ b/src/docs/prrte-rst-content/detail-hosts-cli.rst
@@ -65,3 +65,14 @@ the DVM was started across only some of the allocation, or because a
 reservation holding it was released |mdash| use ``--activate``, which
 only starts a daemon and so is permitted even under a resource
 manager's allocation.
+
+The ``:slots`` count applies to *placement*, and not merely to the size
+of the job: it is the number of processes that may be placed on that
+host, whatever mapping policy is in effect. So
+
+.. code::
+
+   prterun --host node1:1,node2:1,node3:1 -n 3 ./app
+
+puts one process on each of the three hosts under every ``--map-by``
+directive, and not three on ``node1``.

--- a/src/docs/prrte-rst-content/detail-hosts-cli.rst
+++ b/src/docs/prrte-rst-content/detail-hosts-cli.rst
@@ -76,3 +76,18 @@ host, whatever mapping policy is in effect. So
 
 puts one process on each of the three hosts under every ``--map-by``
 directive, and not three on ``node1``.
+
+Asking for more slots on a host than it has depends on who decided how
+big the host is:
+
+* Under a resource manager, the number of slots on a host was set by
+  the scheduler, and PRRTE cannot hand a job more of a host than was
+  allocated to it. Naming a larger count is an error. Add the
+  ``:OVERSUBSCRIBE`` qualifier to your mapping directive if you really
+  do want more processes than slots.
+
+* Without a resource manager, the slot count is only a description you
+  gave PRRTE, so a larger ``:slots`` count re-states it: the host is
+  taken to have that many slots **for that job**. The allocation itself
+  is unchanged, and the next job sees the host at its original size.
+  Use ``--add-host`` to change the allocation.

--- a/src/mca/rmaps/AGENTS.md
+++ b/src/mca/rmaps/AGENTS.md
@@ -344,7 +344,9 @@ the field before placing, and `map_targets` checks it per placement.
 distribution.** Each node gets what it was given first, and the procs left
 over once every node has had its share are then split **evenly** over the
 nodes — the same arithmetic by-slot and by-node use for their second pass, so
-every mapper answers an oversubscribed job alike. With `-host a:2,b:2,c:2`
+every mapper answers an oversubscribed job alike. (`:SPAN` reaches the same
+balance without that arithmetic: it hands out one target per node per pass,
+so the rotation itself spreads the overflow.) With `-host a:2,b:2,c:2`
 and `--map-by core:oversubscribe`, `-n 8` is 3/3/2, `-n 12` is 4/4/4 and
 `-n 18` is 6/6/6, each identical to `--map-by slot:oversubscribe`. Before
 this, an object map put the whole overflow on the head of the list (8/0/0,

--- a/src/mca/rmaps/AGENTS.md
+++ b/src/mca/rmaps/AGENTS.md
@@ -294,7 +294,7 @@ A mapper is mostly glue around them:
 | `prte_rmaps_base_get_ncpus()` | How many usable cpus/cores an object (or whole node) offers under the current cpu-type. |
 | `prte_rmaps_base_check_avail()` | Can this node/object take more procs? Also adds the node to `jdata->map->nodes` exactly once and sets `options->target`. **It can also remove and release the node** — see below. |
 | `prte_rmaps_base_check_oversubscribed()` | After placing a proc, flag/deny oversubscription per the node's SLOTS_GIVEN and the job's OVERSUBSCRIBE directive. |
-| `prte_rmaps_base_setup_proc()` | Create the `prte_proc_t`, attach it to the node, assign node rank, bump `slots_inuse`, and **bind it** (`prte_rmaps_base_bind_proc`). |
+| `prte_rmaps_base_setup_proc()` | Create the `prte_proc_t`, attach it to the node, assign node rank, bump `slots_inuse`, draw down `slots_available`, and **bind it** (`prte_rmaps_base_bind_proc`). |
 | `prte_rmaps_base_compute_vpids()` | Assign global ranks by slot/node/fill/span, then derive local & app ranks. |
 | `prte_rmaps_base_bind_proc()` | Bind a proc: dispatch to `bind_generic` / `bind_multiple` (pe>1) / `bind_to_cpuset` (pe-list), or no-op for by-user/bind-none. |
 
@@ -323,6 +323,22 @@ obligations follow:
   The sequential mapper walks hostfile entries, not `prte_node_t`s, so it
   passes `NULL` and simply takes the "no" — handing over a list of the wrong
   type meant removing a `prte_node_t` from a list of `seq_node_t`.
+
+### `slots_available` is the per-job budget, and it is not `slots`
+
+`node->slots` is what the node has; `node->slots_available` is what *this
+job* may take from it. `get_target_nodes()` sets the second one, and a `:N`
+suffix on a `-host` entry makes it smaller than the first — that is the whole
+point of the suffix when the `-host` selects within an allocation somebody
+else built. `setup_proc()` consumes one per placed proc, so a mapper caps
+itself on a node by watching `slots_available` run out.
+
+Nothing below the mappers does that for them: `check_avail()` and
+`check_oversubscribed()` both measure against `node->slots`, so a mapper that
+consults neither the field nor its own count of what it has placed will fill
+the node to its slot count and leave the rest of the user's `-host` list
+empty. Every mapper here caps itself: by-slot/by-node/by-cpu and ppr read
+the field before placing, and `map_targets` checks it per placement.
 
 ### Who owns what in `options`
 

--- a/src/mca/rmaps/AGENTS.md
+++ b/src/mca/rmaps/AGENTS.md
@@ -340,6 +340,16 @@ the node to its slot count and leave the rest of the user's `-host` list
 empty. Every mapper here caps itself: by-slot/by-node/by-cpu and ppr read
 the field before placing, and `map_targets` checks it per placement.
 
+**Permission to oversubscribe lifts the ceiling, it does not change the
+distribution.** Each node gets what it was given first, and the procs left
+over once every node has had its share are then split **evenly** over the
+nodes — the same arithmetic by-slot and by-node use for their second pass, so
+every mapper answers an oversubscribed job alike. With `-host a:2,b:2,c:2`
+and `--map-by core:oversubscribe`, `-n 8` is 3/3/2, `-n 12` is 4/4/4 and
+`-n 18` is 6/6/6, each identical to `--map-by slot:oversubscribe`. Before
+this, an object map put the whole overflow on the head of the list (8/0/0,
+8/2/2, 14/2/2).
+
 **A cap that is *larger* than the node is reconciled in `get_target_nodes`,
 and the answer depends on who sized the node.** A resource manager decided
 how much of that node is ours and we cannot hand a job more, so the request

--- a/src/mca/rmaps/AGENTS.md
+++ b/src/mca/rmaps/AGENTS.md
@@ -340,6 +340,22 @@ the node to its slot count and leave the rest of the user's `-host` list
 empty. Every mapper here caps itself: by-slot/by-node/by-cpu and ppr read
 the field before placing, and `map_targets` checks it per placement.
 
+**A cap that is *larger* than the node is reconciled in `get_target_nodes`,
+and the answer depends on who sized the node.** A resource manager decided
+how much of that node is ours and we cannot hand a job more, so the request
+is refused (`dash-host:slots-exceed-allocation`); an unmanaged allocation is
+only the user's own description of a machine nobody is scheduling, so the
+`:N` re-states it and the node is grown to fit. That growth belongs to the
+map, not to the allocation — `--host` says how many slots *this job* may have
+(`--add-host` is what changes an allocation) — so it is recorded with
+`prte_rmaps_base_record_resize()` and undone by
+`prte_rmaps_base_restore_resized()` at `map_job`'s `cleanup`, on both
+outcomes. `prte_ras_base.total_slots_alloc` describes the allocation and is
+deliberately left alone. `prte_ras_base.scheduler_owned` is what tells the two
+cases apart — the same flag that decides whether `--add-host` may grow the
+pool, and for the same reason: both ask whether the node counts are ours to
+change. See [`src/mca/ras/AGENTS.md`](../ras/AGENTS.md).
+
 ### Who owns what in `options`
 
 `node->available` and `options->job_cpuset` are **never NULL**. The mappers

--- a/src/mca/rmaps/base/base.h
+++ b/src/mca/rmaps/base/base.h
@@ -86,7 +86,23 @@ typedef struct {
     /* whether the topology reports any core objects at all; when false, a
      * user request to map or bind to "core" must fall back to hwthreads */
     bool have_cores;
+    /* nodes this mapping operation re-sized, and what they said before.
+     * Only an unmanaged allocation can be re-sized, and only for the job
+     * being mapped - a "-host node:N" states how many slots that job may
+     * take on the node, not a change to the allocation - so the original
+     * counts go back when the map is done. Emptied by
+     * prte_rmaps_base_restore_resized() at the end of every map. */
+    pmix_list_t resized_nodes;
 } prte_rmaps_base_t;
+
+/* one entry of prte_rmaps_base.resized_nodes: the node is borrowed, since
+ * the pool owns it and outlives any mapping */
+typedef struct {
+    pmix_list_item_t super;
+    prte_node_t *node;
+    int32_t slots;
+} prte_rmaps_base_resize_t;
+PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_rmaps_base_resize_t);
 
 /**
  * Global instance of rmaps-wide framework data
@@ -112,6 +128,16 @@ PRTE_EXPORT void prte_rmaps_base_map_job(int sd, short args, void *cbdata);
 /* pretty-print functions */
 PRTE_EXPORT char *prte_rmaps_base_print_mapping(prte_mapping_policy_t mapping);
 PRTE_EXPORT char *prte_rmaps_base_print_ranking(prte_ranking_policy_t ranking);
+
+/* Record that this mapping grew a node, so the count it had before can be
+ * put back when the map completes. Recording the same node twice keeps the
+ * first (original) value. */
+PRTE_EXPORT void prte_rmaps_base_record_resize(prte_node_t *node, int32_t slots);
+
+/* Put every re-sized node back the way we found it. Called on both outcomes
+ * of a map: a job that failed to map has no more claim on the extra slots
+ * than one that succeeded. */
+PRTE_EXPORT void prte_rmaps_base_restore_resized(void);
 
 PRTE_EXPORT int prte_rmaps_base_filter_nodes(prte_app_context_t *app, pmix_list_t *nodes,
                                              bool remove);

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -71,8 +71,16 @@ prte_rmaps_base_t prte_rmaps_base = {
     .default_mapping_policy = NULL,
     .default_ranking_policy = NULL,
     .require_hwtcpus = false,
-    .have_cores = true
+    .have_cores = true,
+    .resized_nodes = PMIX_LIST_STATIC_INIT
 };
+
+static void rsz_con(prte_rmaps_base_resize_t *p)
+{
+    p->node = NULL;
+    p->slots = 0;
+}
+PMIX_CLASS_INSTANCE(prte_rmaps_base_resize_t, pmix_list_item_t, rsz_con, NULL);
 
 static int prte_rmaps_base_register(pmix_mca_base_register_flag_t flags)
 {
@@ -135,6 +143,9 @@ static int prte_rmaps_base_close(void)
         PMIX_RELEASE(item);
     }
     PMIX_DESTRUCT(&prte_rmaps_base.selected_modules);
+    /* a map always drains this, but a teardown in the middle of one must
+     * not leak what it left */
+    PMIX_LIST_DESTRUCT(&prte_rmaps_base.resized_nodes);
     hwloc_bitmap_free(prte_rmaps_base.available);
     hwloc_bitmap_free(prte_rmaps_base.baseset);
 
@@ -151,6 +162,7 @@ static int prte_rmaps_base_open(pmix_mca_base_open_flag_t flags)
 
     /* init the globals */
     PMIX_CONSTRUCT(&prte_rmaps_base.selected_modules, pmix_list_t);
+    PMIX_CONSTRUCT(&prte_rmaps_base.resized_nodes, pmix_list_t);
     prte_rmaps_base.available = hwloc_bitmap_alloc();
     prte_rmaps_base.baseset = hwloc_bitmap_alloc();
 

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -1756,6 +1756,10 @@ cleanup:
     }
     /* release the colocation target array if one was provided/created */
     PMIX_DATA_ARRAY_FREE(darray);
+    /* a node this map grew to satisfy a "-host node:N" goes back to the size
+     * the allocation says it is: the spec sized this job's claim on the node,
+     * not the node */
+    prte_rmaps_base_restore_resized();
     /* reset any node map flags we used so the next job will start clean */
     for (int i = 0; i < jdata->map->nodes->size; i++) {
         if (NULL != (node = (prte_node_t *) pmix_pointer_array_get_item(jdata->map->nodes, i))) {

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -551,6 +551,13 @@ prte_proc_t *prte_rmaps_base_setup_proc(prte_job_t *jdata,
         proc->node_rank = node->num_procs;
         node->num_procs++;
         ++node->slots_inuse;
+        /* slots_available is what this mapping operation may still take
+         * from the node - it is not always slots minus slots_inuse (a
+         * -host suffix can cap it below that), so it has to be consumed
+         * here rather than recomputed by the mappers */
+        if (0 < node->slots_available) {
+            --node->slots_available;
+        }
     }
 
     /* retain the proc struct so that we correctly track its release */

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -128,6 +128,39 @@ static bool node_in_targets(prte_node_t *nd,
 /*
  * Query the registry for all nodes allocated to a specified app_context
  */
+void prte_rmaps_base_record_resize(prte_node_t *node, int32_t slots)
+{
+    prte_rmaps_base_resize_t *rsz;
+
+    /* if this map already grew the node, the value it had the first time is
+     * the one to put back - a later app must not record the grown count as
+     * the original */
+    PMIX_LIST_FOREACH(rsz, &prte_rmaps_base.resized_nodes, prte_rmaps_base_resize_t) {
+        if (rsz->node == node) {
+            return;
+        }
+    }
+    rsz = PMIX_NEW(prte_rmaps_base_resize_t);
+    rsz->node = node;   // borrowed - the pool owns it
+    rsz->slots = slots;
+    pmix_list_append(&prte_rmaps_base.resized_nodes, &rsz->super);
+}
+
+void prte_rmaps_base_restore_resized(void)
+{
+    prte_rmaps_base_resize_t *rsz;
+
+    while (NULL != (rsz = (prte_rmaps_base_resize_t *)
+                    pmix_list_remove_first(&prte_rmaps_base.resized_nodes))) {
+        PMIX_OUTPUT_VERBOSE((5, prte_rmaps_base_framework.framework_output,
+                             "%s restoring node %s to %d slots",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                             rsz->node->name, rsz->slots));
+        rsz->node->slots = rsz->slots;
+        PMIX_RELEASE(rsz);
+    }
+}
+
 int prte_rmaps_base_get_target_nodes(pmix_list_t *allocated_nodes,
                                      int32_t *total_num_slots,
                                      prte_job_t *jdata, prte_app_context_t *app,
@@ -381,6 +414,48 @@ int prte_rmaps_base_get_target_nodes(pmix_list_t *allocated_nodes,
                     NULL != hosts) {
                     s = prte_util_dash_host_compute_slots(node, hosts);
                     free(hosts);
+                    /* the spec can name more slots on this node than the node
+                     * has left. Who may answer that depends on where the
+                     * allocation came from: a resource manager decided how
+                     * much of the node is ours and we cannot hand out more,
+                     * while an unmanaged allocation is only the description
+                     * the user gave us of a machine nobody is scheduling - so
+                     * the ":N" simply re-describes it - which is the same
+                     * authority prte_ras_base.scheduler_owned records for the
+                     * add-host directive. Left unreconciled, the
+                     * job was sized against the larger number and then mapped
+                     * against the smaller one, which is a "failed to map" with
+                     * nothing said about the slots. */
+                    if (s > node->slots - node->slots_inuse &&
+                        (PRTE_MAPPING_NO_OVERSUBSCRIBE &
+                         PRTE_GET_MAPPING_DIRECTIVE(policy))) {
+                        if (prte_ras_base.scheduler_owned) {
+                            prte_show_help("help-dash-host.txt",
+                                           "dash-host:slots-exceed-allocation", true,
+                                           node->name, s,
+                                           node->slots - node->slots_inuse);
+                            return PRTE_ERR_SILENT;
+                        }
+                        if (0 != node->slots_max &&
+                            node->slots_inuse + s > node->slots_max) {
+                            prte_show_help("help-dash-host.txt",
+                                           "dash-host:slots-exceed-max", true,
+                                           node->name, s,
+                                           node->slots_max - node->slots_inuse,
+                                           node->slots_max);
+                            return PRTE_ERR_SILENT;
+                        }
+                        /* grow the node to what the user just told us it is,
+                         * for the duration of this map. The ":N" says how many
+                         * slots THIS job may have on the node - the allocation
+                         * itself is unchanged, which is the difference between
+                         * -host and -add-host - so the count goes back at
+                         * cleanup and prte_ras_base.total_slots_alloc, which
+                         * describes the allocation, is left alone. */
+                        prte_rmaps_base_record_resize(node, node->slots);
+                        node->slots = node->slots_inuse + s;
+                        PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
+                    }
                 } else {
                     s = node->slots - node->slots_inuse;
                 }

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -477,6 +477,12 @@ int prte_rmaps_base_get_target_nodes(pmix_list_t *allocated_nodes,
                 PMIX_OUTPUT_VERBOSE((5, prte_rmaps_base_framework.framework_output,
                                      "%s node %s is fully used, but available for oversubscription",
                                      PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), node->name));
+                /* this node offers the job nothing - say so. The mappers read
+                 * slots_available as what they may take here, and this branch
+                 * used to leave whatever the last job to map left behind: a
+                 * count from a node that had room, against a node that has
+                 * none. */
+                node->slots_available = 0;
                 /* cache the available CPUs for later */
                 hwloc_bitmap_copy(node->jobcache, node->available);
             } else if (!keepall) {

--- a/src/mca/rmaps/round_robin/AGENTS.md
+++ b/src/mca/rmaps/round_robin/AGENTS.md
@@ -130,7 +130,8 @@ and quietly dropping the node shrinks the allocation the user gave us
 without telling them. `outofcpus` vs. `allfull` distinguish the two failure
 help messages (`allocation-overload` vs `failed-map`). Note this mapper has
 **no** second-pass block — the outer `do { … } while (!allfull)` loop handles
-iteration.
+iteration, and the per-pass budget below is what gives those later passes the
+job byslot's second pass does.
 
 **A node's budget is `slots_available`, not its slot count.** The loop asks
 for one proc at a time, so nothing in `check_avail`/`check_oversubscribed` —
@@ -141,6 +142,23 @@ that, `--host a:1,b:1,c:1 -n 3` selecting within an existing allocation put
 all three procs on `a` and left `b` and `c` out of the map — the total was
 still checked against the caps, so the job ran, just nowhere near where it
 was told to. See the framework guide.
+
+**Each pass gives a node a budget, and the budget is what makes an
+oversubscribed job come out balanced.** On the first pass it is
+`node->slots_available` — what the node offers this job. On every pass after
+that (which can only happen when oversubscription is allowed) it is an even
+share of the procs still unplaced, recomputed per pass over the nodes still
+on the list: the same `extra_procs_to_assign`/`nxtra_nodes` split byslot uses
+for its second pass, which is why the two now agree — `-host a:2,b:2,c:2`
+with `--map-by core:oversubscribe` gives 3/3/2 at `-n 8`, 4/4/4 at `-n 12`
+and 6/6/6 at `-n 18`, exactly as `--map-by slot:oversubscribe` does.
+Recomputing per pass (rather than once, as byslot does) also lets the split
+correct itself when a node cannot take its share because its cpus ran out or
+it hit `max_slots` and left the list.
+
+Being allowed to oversubscribe says how many procs a node may end up with,
+not that the head of the list may have them all: without the budget an
+object map filled the first node with the entire job.
 
 **The `redo:` loop and `check_avail` do not mix casually.** When
 `check_avail` declines a node it may also have removed it from `node_list`

--- a/src/mca/rmaps/round_robin/AGENTS.md
+++ b/src/mca/rmaps/round_robin/AGENTS.md
@@ -121,6 +121,26 @@ Two sub-modes:
 - **span** (`options->mapspan`): one proc per object cycling across *all*
   nodes as if they were one big node — load-balanced.
 
+**Span is an interleave, and that takes two things: a budget of one target
+per node per pass, and a cursor.** The outer `do { … } while` is the trip
+round the node list, so a budget of 1 makes each pass lay down one proc per
+node — which is the cycling, and is also why span needs none of the
+even-split arithmetic below: balance falls out of the rotation, oversubscribed
+or not. The cursor is what makes the *targets* advance: the k'th proc a node
+receives goes on that node's k'th target, so it is kept per node (keyed by
+`node->index`, the pool slot, which survives a node being dropped from the
+list) and the object loop starts there and wraps.
+
+Without both, span was not spanning at all: `mapspan` only suppressed the
+`goto redo`, so the loop still filled each node's targets before moving on
+and span differed from non-span only when a node was asked to hold more procs
+than it has targets. On 3 nodes of 4 slots, `-n 8 --map-by core:span` came out
+4/4/0 where the "one big node" reading it documents gives 3/3/2.
+
+A target set that cannot be revisited (`tgts->nowrap`, the device maps) is
+deliberately excluded: it gets a single pass by design, so there is no
+rotation to join, and a budget of 1 would place one proc per node and stop.
+
 Per object it checks free cpus against `cpus_per_rank` (only when
 actually binding; if binding was reset to NONE for an oversubscribed
 node, a cpu shortage must not block placement). A node with **zero** objects
@@ -158,7 +178,9 @@ it hit `max_slots` and left the list.
 
 Being allowed to oversubscribe says how many procs a node may end up with,
 not that the head of the list may have them all: without the budget an
-object map filled the first node with the entire job.
+object map filled the first node with the entire job (8/0/0 above), and with
+the budget applied only on the first pass it still gave that node the whole
+overflow (8/2/2 at `-n 12`).
 
 **The `redo:` loop and `check_avail` do not mix casually.** When
 `check_avail` declines a node it may also have removed it from `node_list`

--- a/src/mca/rmaps/round_robin/AGENTS.md
+++ b/src/mca/rmaps/round_robin/AGENTS.md
@@ -132,6 +132,16 @@ help messages (`allocation-overload` vs `failed-map`). Note this mapper has
 **no** second-pass block — the outer `do { … } while (!allfull)` loop handles
 iteration.
 
+**A node's budget is `slots_available`, not its slot count.** The loop asks
+for one proc at a time, so nothing in `check_avail`/`check_oversubscribed` —
+both of which measure against `node->slots` — stops it at the smaller number
+a `-host` entry's `:N` suffix asked for. It therefore checks the field itself
+before each placement (`setup_proc` draws it down by one per proc). Without
+that, `--host a:1,b:1,c:1 -n 3` selecting within an existing allocation put
+all three procs on `a` and left `b` and `c` out of the map — the total was
+still checked against the caps, so the job ran, just nowhere near where it
+was told to. See the framework guide.
+
 **The `redo:` loop and `check_avail` do not mix casually.** When
 `check_avail` declines a node it may also have removed it from `node_list`
 and released it (the `max_slots` case — see the framework guide). So the

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -773,6 +773,22 @@ int prte_rmaps_rr_map_targets(prte_job_t *jdata, prte_app_context_t *app,
             for (j=0; j < nobjs && nprocs_mapped < app->num_procs && !nodefull; j++) {
                 pmix_output_verbose(10, prte_rmaps_base_framework.framework_output,
                                     "mca:rmaps:rr: assigning proc to object %d", j);
+                /* has this node given the job all it is allowed to? The
+                 * number of slots a node contributes to a job is not always
+                 * its slot count: a ":N" suffix on a -host entry caps what
+                 * this job may take from it, and get_target_nodes records
+                 * that cap in slots_available (setup_proc consumes one per
+                 * placed proc). Nothing below sees it - check_avail and
+                 * check_oversubscribed both measure against node->slots -
+                 * so this loop would happily fill the node to its slot
+                 * count and leave the rest of the -host list empty. The
+                 * other mappers cap themselves the same way. */
+                if (!options->oversubscribe &&
+                    !PRTE_FLAG_TEST(app, PRTE_APP_FLAG_TOOL) &&
+                    0 >= node->slots_available) {
+                    nodefull = true;
+                    break;
+                }
                 /* get the target object */
                 obj = tgts->item(node, options, ctx, j);
                 if (NULL == obj) {

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -673,15 +673,17 @@ int prte_rmaps_rr_map_targets(prte_job_t *jdata, prte_app_context_t *app,
 {
     int rc=PRTE_SUCCESS, nprocs_mapped;
     prte_node_t *node, *nnext;
-    int ncpus, budget, nplaced;
+    int ncpus, budget, nplaced, ndx;
     int extra_procs_to_assign = 0, nxtra_nodes = 0;
     float balance;
     prte_proc_t *proc;
-    bool nodefull, allfull, outofcpus=false, firstpass, wasfirst;
+    bool nodefull, allfull, outofcpus=false, firstpass, wasfirst, interleave;
     hwloc_obj_t obj = NULL;
-    unsigned j, nobjs;
+    unsigned i, j, nobjs, start;
     void *ctx = NULL;
     bool began = false;
+    int *cursor = NULL;
+    int ncursor = 0;
 
     pmix_output_verbose(2, prte_rmaps_base_framework.framework_output,
                         "mca:rmaps:rr:byobj mapping by %s for job %s slots %d num_procs %lu",
@@ -718,6 +720,32 @@ int prte_rmaps_rr_map_targets(prte_job_t *jdata, prte_app_context_t *app,
      * to the next node. Thus, procs tend to be "front loaded" onto the
      * list of nodes, as opposed to being "load balanced" in the span mode
      */
+    /* Span cycles across the nodes, so it has to remember which target it
+     * used last on each of them: the k'th proc a node receives goes on its
+     * k'th target. Keyed by the node's slot in the global pool, which is the
+     * one identifier that survives a node being dropped from the list.
+     * A target set that cannot be revisited (nowrap) is left alone - it gets
+     * one pass, so there is nothing to cycle. */
+    interleave = (options->mapspan && !tgts->nowrap);
+    if (interleave) {
+        PMIX_LIST_FOREACH(node, node_list, prte_node_t) {
+            if (node->index >= ncursor) {
+                ncursor = node->index + 1;
+            }
+        }
+        if (0 < ncursor) {
+            cursor = (int *) calloc(ncursor, sizeof(int));
+            if (NULL == cursor) {
+                rc = PRTE_ERR_OUT_OF_RESOURCE;
+                goto errout;
+            }
+        } else {
+            /* no node carries a pool index - nothing to key on, so place
+             * these the way a non-span map would rather than guess */
+            interleave = false;
+        }
+    }
+
     allfull = true;
     nprocs_mapped = 0;
     firstpass = true;
@@ -731,7 +759,7 @@ int prte_rmaps_rr_map_targets(prte_job_t *jdata, prte_app_context_t *app,
          * each time round because a node may take less than its share (its
          * cpus ran out, or it hit max_slots and left the list), and the next
          * pass should then divide what is left among the nodes still here. */
-        if (!firstpass && options->oversubscribe) {
+        if (!firstpass && options->oversubscribe && !interleave) {
             int nnodes = (int) pmix_list_get_size(node_list);
             int remaining = (int) app->num_procs - nprocs_mapped;
             if (0 >= nnodes) {
@@ -809,8 +837,22 @@ int prte_rmaps_rr_map_targets(prte_job_t *jdata, prte_app_context_t *app,
              * pass still hands each node exactly what it offers, and the
              * passes after it hand out the even share computed above. A tool
              * does not consume slots at all, so nothing bounds it here. */
+            ndx = (NULL != cursor && 0 <= node->index && node->index < ncursor)
+                  ? node->index : -1;
+            start = 0;
             if (PRTE_FLAG_TEST(app, PRTE_APP_FLAG_TOOL)) {
                 budget = (int) app->num_procs;
+            } else if (interleave) {
+                /* one target per node per trip round the list - the cycling
+                 * IS the load balance, so there is no share to compute here
+                 * and no need to treat the first pass differently: a node
+                 * simply stops taking procs when it has given what it has,
+                 * unless we may oversubscribe, in which case it keeps its
+                 * place in the rotation and the overflow spreads itself. */
+                budget = (options->oversubscribe || 0 < node->slots_available) ? 1 : 0;
+                if (0 <= ndx) {
+                    start = (unsigned) (cursor[ndx] % (int) nobjs);
+                }
             } else if (firstpass || !options->oversubscribe) {
                 budget = node->slots_available;
             } else {
@@ -825,7 +867,11 @@ int prte_rmaps_rr_map_targets(prte_job_t *jdata, prte_app_context_t *app,
             nodefull = false;
             nplaced = 0;
         redo:
-            for (j=0; j < nobjs && nprocs_mapped < app->num_procs && !nodefull; j++) {
+            for (i=0; i < nobjs && nprocs_mapped < app->num_procs && !nodefull; i++) {
+                /* the node-major walk takes the targets in order; the
+                 * interleaved one resumes where this node left off, wrapping
+                 * so an oversubscribed second lap starts over at the front */
+                j = (0 == start) ? i : (unsigned) ((start + i) % nobjs);
                 pmix_output_verbose(10, prte_rmaps_base_framework.framework_output,
                                     "mca:rmaps:rr: assigning proc to object %d", j);
                 if (nplaced >= budget) {
@@ -887,6 +933,9 @@ int prte_rmaps_rr_map_targets(prte_job_t *jdata, prte_app_context_t *app,
                 }
                 nprocs_mapped++;
                 nplaced++;
+                if (0 <= ndx) {
+                    cursor[ndx]++;
+                }
                 rc = prte_rmaps_base_check_oversubscribed(jdata, app, node, options);
                 if (PRTE_ERR_TAKE_NEXT_OPTION == rc) {
                     /* move to next node */
@@ -939,10 +988,17 @@ int prte_rmaps_rr_map_targets(prte_job_t *jdata, prte_app_context_t *app,
              (!allfull || (options->oversubscribe && wasfirst)));
 
     if (nprocs_mapped == app->num_procs) {
+        if (NULL != cursor) {
+            free(cursor);
+        }
         return PRTE_SUCCESS;
     }
 
 errout:
+    if (NULL != cursor) {
+        free(cursor);
+        cursor = NULL;
+    }
     /* an early exit can leave the enumerator holding this node's state */
     if (began && NULL != tgts->end) {
         tgts->end(ctx);

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -673,9 +673,11 @@ int prte_rmaps_rr_map_targets(prte_job_t *jdata, prte_app_context_t *app,
 {
     int rc=PRTE_SUCCESS, nprocs_mapped;
     prte_node_t *node, *nnext;
-    int ncpus;
+    int ncpus, budget, nplaced;
+    int extra_procs_to_assign = 0, nxtra_nodes = 0;
+    float balance;
     prte_proc_t *proc;
-    bool nodefull, allfull, outofcpus=false;
+    bool nodefull, allfull, outofcpus=false, firstpass, wasfirst;
     hwloc_obj_t obj = NULL;
     unsigned j, nobjs;
     void *ctx = NULL;
@@ -718,8 +720,32 @@ int prte_rmaps_rr_map_targets(prte_job_t *jdata, prte_app_context_t *app,
      */
     allfull = true;
     nprocs_mapped = 0;
+    firstpass = true;
     do {
         allfull = true;
+        /* Every pass after the first is placing procs the nodes have no room
+         * for, which only happens when we were told we may oversubscribe.
+         * Spread those evenly rather than letting the head of the list absorb
+         * them: the same even split by-slot and by-node use for their second
+         * pass, so the mappers answer an oversubscribed job alike. Recomputed
+         * each time round because a node may take less than its share (its
+         * cpus ran out, or it hit max_slots and left the list), and the next
+         * pass should then divide what is left among the nodes still here. */
+        if (!firstpass && options->oversubscribe) {
+            int nnodes = (int) pmix_list_get_size(node_list);
+            int remaining = (int) app->num_procs - nprocs_mapped;
+            if (0 >= nnodes) {
+                break;
+            }
+            balance = (float) remaining / (float) nnodes;
+            extra_procs_to_assign = (int) balance;
+            nxtra_nodes = 0;
+            if (0 < (balance - (float) extra_procs_to_assign)) {
+                /* the first few nodes take one more than the rest */
+                nxtra_nodes = remaining - (extra_procs_to_assign * nnodes);
+                extra_procs_to_assign++;
+            }
+        }
         PMIX_LIST_FOREACH_SAFE(node, nnext, node_list, prte_node_t)
         {
             outofcpus = false;
@@ -768,24 +794,42 @@ int prte_rmaps_rr_map_targets(prte_job_t *jdata, prte_app_context_t *app,
                                 "mca:rmaps:rr: found %u %s objects on node %s",
                                 nobjs, tgts->name, node->name);
 
+            /* How many procs may this node take on this pass?
+             *
+             * What a node offers a job is node->slots_available, not its slot
+             * count: a ":N" suffix on a -host entry caps what this job may
+             * take from it, and get_target_nodes records the cap there
+             * (setup_proc consumes one per placed proc). Nothing below sees
+             * it - check_avail and check_oversubscribed both measure against
+             * node->slots - so without this the loop filled each node to its
+             * slot count and left the rest of the -host list empty.
+             *
+             * Permission to oversubscribe does not change how the procs are
+             * distributed, only how many a node may end up with. So the first
+             * pass still hands each node exactly what it offers, and the
+             * passes after it hand out the even share computed above. A tool
+             * does not consume slots at all, so nothing bounds it here. */
+            if (PRTE_FLAG_TEST(app, PRTE_APP_FLAG_TOOL)) {
+                budget = (int) app->num_procs;
+            } else if (firstpass || !options->oversubscribe) {
+                budget = node->slots_available;
+            } else {
+                budget = extra_procs_to_assign;
+                if (0 < nxtra_nodes) {
+                    --nxtra_nodes;
+                    if (0 == nxtra_nodes) {
+                        --extra_procs_to_assign;
+                    }
+                }
+            }
             nodefull = false;
+            nplaced = 0;
         redo:
             for (j=0; j < nobjs && nprocs_mapped < app->num_procs && !nodefull; j++) {
                 pmix_output_verbose(10, prte_rmaps_base_framework.framework_output,
                                     "mca:rmaps:rr: assigning proc to object %d", j);
-                /* has this node given the job all it is allowed to? The
-                 * number of slots a node contributes to a job is not always
-                 * its slot count: a ":N" suffix on a -host entry caps what
-                 * this job may take from it, and get_target_nodes records
-                 * that cap in slots_available (setup_proc consumes one per
-                 * placed proc). Nothing below sees it - check_avail and
-                 * check_oversubscribed both measure against node->slots -
-                 * so this loop would happily fill the node to its slot
-                 * count and leave the rest of the -host list empty. The
-                 * other mappers cap themselves the same way. */
-                if (!options->oversubscribe &&
-                    !PRTE_FLAG_TEST(app, PRTE_APP_FLAG_TOOL) &&
-                    0 >= node->slots_available) {
+                if (nplaced >= budget) {
+                    /* this node has had its share for this pass */
                     nodefull = true;
                     break;
                 }
@@ -842,6 +886,7 @@ int prte_rmaps_rr_map_targets(prte_job_t *jdata, prte_app_context_t *app,
                     tgts->placed(proc, options, ctx, j);
                 }
                 nprocs_mapped++;
+                nplaced++;
                 rc = prte_rmaps_base_check_oversubscribed(jdata, app, node, options);
                 if (PRTE_ERR_TAKE_NEXT_OPTION == rc) {
                     /* move to next node */
@@ -882,7 +927,16 @@ int prte_rmaps_rr_map_targets(prte_job_t *jdata, prte_app_context_t *app,
         if (tgts->nowrap) {
             break;
         }
-    } while (nprocs_mapped < app->num_procs && !allfull);
+        wasfirst = firstpass;
+        firstpass = false;
+        /* A first pass that placed nothing at all normally means the job
+         * cannot be placed - but not when we may oversubscribe: there every
+         * node offering nothing is exactly the case oversubscription exists
+         * for, and it is the pass after this one that places those procs.
+         * Ending the loop here failed the map instead, which is what a
+         * PMIx_Spawn onto a node its parent job has filled looks like. */
+    } while (nprocs_mapped < app->num_procs &&
+             (!allfull || (options->oversubscribe && wasfirst)));
 
     if (nprocs_mapped == app->num_procs) {
         return PRTE_SUCCESS;

--- a/src/util/dash_host/AGENTS.md
+++ b/src/util/dash_host/AGENTS.md
@@ -96,6 +96,12 @@ and every node came out with zero available slots: `--host +n1` was refused
 for lack of resources even though the node list had been resolved correctly,
 and only ever "worked" under `--map-by :OVERSUBSCRIBE`, which skips the check.
 
+The answer is a *cap*, not a slot count: when the `-host` selects within an
+allocation that already exists, the node keeps its own `slots` and the cap
+lands in `node->slots_available` — which is what the mappers have to place
+against, and what they did not all do.  See
+[`src/mca/rmaps/AGENTS.md`](../../mca/rmaps/AGENTS.md).
+
 ---
 
 ## No allocation check in the "add" path

--- a/src/util/dash_host/AGENTS.md
+++ b/src/util/dash_host/AGENTS.md
@@ -99,7 +99,9 @@ and only ever "worked" under `--map-by :OVERSUBSCRIBE`, which skips the check.
 The answer is a *cap*, not a slot count: when the `-host` selects within an
 allocation that already exists, the node keeps its own `slots` and the cap
 lands in `node->slots_available` — which is what the mappers have to place
-against, and what they did not all do.  See
+against, and what they did not all do.  A cap *larger* than the node is
+reconciled there too: refused under a resource manager, and otherwise taken
+as a re-description of the node for the duration of that map.  See
 [`src/mca/rmaps/AGENTS.md`](../../mca/rmaps/AGENTS.md).
 
 ---

--- a/src/util/dash_host/help-dash-host.txt
+++ b/src/util/dash_host/help-dash-host.txt
@@ -199,3 +199,37 @@ The requested number of empty hosts was not available — the system was
 short by %d hosts.  Please recheck your allocation.
 
 Re-run this command with "--help hosts" for further information.
+#
+[dash-host:slots-exceed-allocation]
+
+The "--host" specification asked for more slots on a node than the
+allocation provides:
+
+   Node:              %s
+   Slots requested:   %d
+   Slots available:   %d
+
+The allocation came from a resource manager, so the number of slots on
+this node is not PRRTE's to change — a "--host" entry can only select
+from what was allocated to you.
+
+Either reduce the number requested for this host, obtain a larger
+allocation, or add the ":OVERSUBSCRIBE" qualifier to your mapping
+directive if you truly want more processes than slots on this node.
+#
+[dash-host:slots-exceed-max]
+
+The "--host" specification asked for more slots on a node than its
+maximum permits:
+
+   Node:              %s
+   Slots requested:   %d
+   Slots available:   %d
+   Max slots:         %d
+
+The maximum slot count is a hard limit — unlike the slot count itself,
+it cannot be raised by a "--host" entry. It is usually set by a
+"max_slots=" entry in a hostfile.
+
+Either reduce the number requested for this host or raise the maximum
+for this node.

--- a/test/offline/README.rst
+++ b/test/offline/README.rst
@@ -74,3 +74,11 @@ exactly one object of the requested level, computed from the topology.
 golden snapshots rather than invariants.  Cases that PRRTE must reject
 (``rank-by fill/span`` without an object map; binding above the mapped
 object; bad tokens) are verified to be rejected.
+
+The ``hostcap`` group asks a different question from the rest: every other
+case hands ``-H`` to a ``prterun`` that has no allocation, so the spec
+*builds* one and each node's slot count is its own ``-H`` count.  Those cases
+use ``ras/simulator`` to supply an allocation first, so that a ``:N`` cap and
+the node's real slot count can disagree -- the shape in which the mapper has
+to place by the cap.  Such a case names the per-node counts it expects
+outright (``expect_counts``) rather than deriving them.

--- a/test/offline/golden/test-topo/group.test-topo.oversub.map
+++ b/test/offline/golden/test-topo/group.test-topo.oversub.map
@@ -5,7 +5,7 @@ Data for JOB prterun-JOBID@N offset 0 Total slots allocated N
     Cpu set: N/A  PPR: N/A  Cpus-per-rank: N/A  Cpu Type: CORE
 
 
-Data for node: node0	Num slots: 8	Max slots: 0	Num procs: 16
+Data for node: node0	Num slots: 8	Max slots: 0	Num procs: 10
         Process jobid: prterun-JOBID@N App: 0 Process rank: 0 Bound: package[0][core:L0]
         Process jobid: prterun-JOBID@N App: 0 Process rank: 1 Bound: package[0][core:L1]
         Process jobid: prterun-JOBID@N App: 0 Process rank: 2 Bound: package[0][core:L2]
@@ -16,9 +16,11 @@ Data for node: node0	Num slots: 8	Max slots: 0	Num procs: 16
         Process jobid: prterun-JOBID@N App: 0 Process rank: 7 Bound: package[0][core:L7]
         Process jobid: prterun-JOBID@N App: 0 Process rank: 8 Bound: package[0][core:L8]
         Process jobid: prterun-JOBID@N App: 0 Process rank: 9 Bound: package[0][core:L9]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 10 Bound: package[0][core:L10]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 11 Bound: package[0][core:L11]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 12 Bound: package[0][core:L12]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 13 Bound: package[0][core:L13]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 14 Bound: package[0][core:L14]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 15 Bound: package[0][core:L15]
+
+Data for node: node1	Num slots: 4	Max slots: 0	Num procs: 6
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 10 Bound: package[0][core:L0]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 11 Bound: package[0][core:L1]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 12 Bound: package[0][core:L2]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 13 Bound: package[0][core:L3]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 14 Bound: package[0][core:L4]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 15 Bound: package[0][core:L5]

--- a/test/offline/golden/test-topo2/group.test-topo2.oversub.map
+++ b/test/offline/golden/test-topo2/group.test-topo2.oversub.map
@@ -5,7 +5,7 @@ Data for JOB prterun-JOBID@N offset 0 Total slots allocated N
     Cpu set: N/A  PPR: N/A  Cpus-per-rank: N/A  Cpu Type: CORE
 
 
-Data for node: node0	Num slots: 8	Max slots: 0	Num procs: 16
+Data for node: node0	Num slots: 8	Max slots: 0	Num procs: 10
         Process jobid: prterun-JOBID@N App: 0 Process rank: 0 Bound: package[0][core:L0]
         Process jobid: prterun-JOBID@N App: 0 Process rank: 1 Bound: package[0][core:L1]
         Process jobid: prterun-JOBID@N App: 0 Process rank: 2 Bound: package[0][core:L2]
@@ -16,9 +16,11 @@ Data for node: node0	Num slots: 8	Max slots: 0	Num procs: 16
         Process jobid: prterun-JOBID@N App: 0 Process rank: 7 Bound: package[0][core:L7]
         Process jobid: prterun-JOBID@N App: 0 Process rank: 8 Bound: package[0][core:L8]
         Process jobid: prterun-JOBID@N App: 0 Process rank: 9 Bound: package[0][core:L9]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 10 Bound: package[0][core:L10]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 11 Bound: package[0][core:L11]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 12 Bound: package[0][core:L12]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 13 Bound: package[0][core:L13]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 14 Bound: package[0][core:L14]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 15 Bound: package[0][core:L15]
+
+Data for node: node1	Num slots: 4	Max slots: 0	Num procs: 6
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 10 Bound: package[0][core:L0]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 11 Bound: package[0][core:L1]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 12 Bound: package[0][core:L2]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 13 Bound: package[0][core:L3]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 14 Bound: package[0][core:L4]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 15 Bound: package[0][core:L5]

--- a/test/offline/golden/turin-4gpu-nvml/group.turin-4gpu-nvml.oversub.map
+++ b/test/offline/golden/turin-4gpu-nvml/group.turin-4gpu-nvml.oversub.map
@@ -5,7 +5,7 @@ Data for JOB prterun-JOBID@N offset 0 Total slots allocated N
     Cpu set: N/A  PPR: N/A  Cpus-per-rank: N/A  Cpu Type: CORE
 
 
-Data for node: node0	Num slots: 8	Max slots: 0	Num procs: 16
+Data for node: node0	Num slots: 8	Max slots: 0	Num procs: 10
         Process jobid: prterun-JOBID@N App: 0 Process rank: 0 Bound: package[0][core:L0]
         Process jobid: prterun-JOBID@N App: 0 Process rank: 1 Bound: package[0][core:L1]
         Process jobid: prterun-JOBID@N App: 0 Process rank: 2 Bound: package[0][core:L2]
@@ -16,9 +16,11 @@ Data for node: node0	Num slots: 8	Max slots: 0	Num procs: 16
         Process jobid: prterun-JOBID@N App: 0 Process rank: 7 Bound: package[0][core:L7]
         Process jobid: prterun-JOBID@N App: 0 Process rank: 8 Bound: package[0][core:L8]
         Process jobid: prterun-JOBID@N App: 0 Process rank: 9 Bound: package[0][core:L9]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 10 Bound: package[0][core:L10]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 11 Bound: package[0][core:L11]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 12 Bound: package[0][core:L12]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 13 Bound: package[0][core:L13]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 14 Bound: package[0][core:L14]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 15 Bound: package[0][core:L15]
+
+Data for node: node1	Num slots: 4	Max slots: 0	Num procs: 6
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 10 Bound: package[0][core:L0]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 11 Bound: package[0][core:L1]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 12 Bound: package[0][core:L2]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 13 Bound: package[0][core:L3]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 14 Bound: package[0][core:L4]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 15 Bound: package[0][core:L5]

--- a/test/offline/golden/turin-4gpu/group.turin-4gpu.oversub.map
+++ b/test/offline/golden/turin-4gpu/group.turin-4gpu.oversub.map
@@ -5,7 +5,7 @@ Data for JOB prterun-JOBID@N offset 0 Total slots allocated N
     Cpu set: N/A  PPR: N/A  Cpus-per-rank: N/A  Cpu Type: CORE
 
 
-Data for node: node0	Num slots: 8	Max slots: 0	Num procs: 16
+Data for node: node0	Num slots: 8	Max slots: 0	Num procs: 10
         Process jobid: prterun-JOBID@N App: 0 Process rank: 0 Bound: package[0][core:L0]
         Process jobid: prterun-JOBID@N App: 0 Process rank: 1 Bound: package[0][core:L1]
         Process jobid: prterun-JOBID@N App: 0 Process rank: 2 Bound: package[0][core:L2]
@@ -16,9 +16,11 @@ Data for node: node0	Num slots: 8	Max slots: 0	Num procs: 16
         Process jobid: prterun-JOBID@N App: 0 Process rank: 7 Bound: package[0][core:L7]
         Process jobid: prterun-JOBID@N App: 0 Process rank: 8 Bound: package[0][core:L8]
         Process jobid: prterun-JOBID@N App: 0 Process rank: 9 Bound: package[0][core:L9]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 10 Bound: package[0][core:L10]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 11 Bound: package[0][core:L11]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 12 Bound: package[0][core:L12]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 13 Bound: package[0][core:L13]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 14 Bound: package[0][core:L14]
-        Process jobid: prterun-JOBID@N App: 0 Process rank: 15 Bound: package[0][core:L15]
+
+Data for node: node1	Num slots: 4	Max slots: 0	Num procs: 6
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 10 Bound: package[0][core:L0]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 11 Bound: package[0][core:L1]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 12 Bound: package[0][core:L2]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 13 Bound: package[0][core:L3]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 14 Bound: package[0][core:L4]
+        Process jobid: prterun-JOBID@N App: 0 Process rank: 15 Bound: package[0][core:L5]

--- a/test/offline/run_offline_maps.py
+++ b/test/offline/run_offline_maps.py
@@ -474,7 +474,9 @@ def locate_prterun(top_builddir):
 
 
 def build_argv(prterun_argv0, topo_path, case):
-    argv = [prterun_argv0, "--rtos", "donotlaunch", "--display", "map",
+    argv = [prterun_argv0, "--rtos", "donotlaunch", "--display", "map"]
+    argv += list(case.alloc_args)
+    argv += [
             # pin the mapping-policy baseline so the harness is hermetic: do not
             # inherit a default mapping policy a developer may have set (e.g. in
             # ~/.prte/mca-params.conf). Defaults to the no-directive "" baseline;
@@ -587,6 +589,14 @@ class Case:
     n: int = 1
     apps: list = field(default_factory=list)   # list[AppSpec]
     extra_args: tuple = ()
+    # Args that build the ALLOCATION the case selects within, emitted ahead
+    # of everything else.  Every other case lets the -H spec build its own
+    # allocation, which makes each node's slot count equal to its -H count -
+    # the one shape in which a ":N" cap cannot disagree with the node.
+    alloc_args: tuple = ()
+    # {node: nprocs} this case must produce, for placements the generic
+    # invariants below do not describe.
+    expect_counts: dict = None
     expect: str = "map"          # "map" | "reject"
     expect_banner: str = None    # substring expected on reject
     # value pinned for the "mapby" MCA variable; "" = the no-directive
@@ -668,6 +678,55 @@ def group_cases(topo):
     yield Case("group.%s.multiapp" % topo.name, "multiapp", topo, "even",
                hostspec, pool, map_by="core", rank_by="slot", bind_to="core",
                apps=[AppSpec(2), AppSpec(3)], expect="map")
+
+
+def hostcap_cases(topo):
+    """A ":N" cap on a -H entry, applied to an allocation that already exists.
+
+    Every other case in this harness hands -H to a prterun that has no
+    allocation, so the spec builds one and each node's slot count *is* its
+    -H count.  The interesting case is the other one: an allocation already
+    in hand (here from ras/simulator, the only resource manager available
+    offline) and a -H that selects within it.  Then the cap and the node's
+    own slot count disagree, and the mapper has to place by the cap.
+
+    That is exactly what it did not do: the by-object mappers - which is
+    where the default mapping policy lands - filled the head of the list to
+    its slot count and left the tail of the -H list empty.
+    """
+    nslots = 8
+    alloc = ("--prtemca", "ras", "simulator",
+             "--prtemca", "ras_simulator_num_nodes", "3",
+             "--prtemca", "ras_simulator_slots", str(nslots),
+             "--prtemca", "ras_simulator_max_slots", "0")
+    nodes = ["nodeA0", "nodeA1", "nodeA2"]
+    pool = [(nd, 1) for nd in nodes]
+    hostspec = ",".join("%s:1" % nd for nd in nodes)
+    one_each = dict((nd, 1) for nd in nodes)
+
+    # one slot taken from each of three nodes: every policy has to put one
+    # proc on each, whether or not the policy names an object
+    for mb in (None, "core", "package", "node", "slot", "hwthread"):
+        if mb in ("package",) and topo.count("Package") < 1:
+            continue
+        yield Case("hostcap.%s.cap1.m-%s" % (topo.name, mb or "default"),
+                   "hostcap", topo, "capped", hostspec, pool,
+                   map_by=mb, n=len(nodes), alloc_args=alloc,
+                   expect_counts=dict(one_each), expect="map")
+
+    # uneven caps: the map has to follow the caps the user wrote, not spread
+    # the procs evenly and not fill the first node
+    yield Case("hostcap.%s.cap-uneven" % topo.name, "hostcap", topo,
+               "capped", "nodeA0:1,nodeA1:2", [("nodeA0", 1), ("nodeA1", 2)],
+               map_by="core", n=3, alloc_args=alloc,
+               expect_counts={"nodeA0": 1, "nodeA1": 2}, expect="map")
+
+    # asking for more than the caps total is refused, even though the
+    # allocation itself is big enough to hold the job
+    yield Case("hostcap.%s.cap-exceeded" % topo.name, "hostcap", topo,
+               "capped", hostspec, pool, map_by="core", n=len(nodes) + 1,
+               alloc_args=alloc, expect="reject",
+               expect_banner="not enough slots available")
 
 
 def device_cases(topo):
@@ -803,6 +862,7 @@ def generate_cases(topos, layouts, ns, full):
         cases.extend(matrix_cases(topo, layouts, ns))
         cases.extend(negative_cases(topo))
         cases.extend(group_cases(topo))
+        cases.extend(hostcap_cases(topo))
         cases.extend(device_cases(topo))
         cases.extend(perapp_cases(topo))
     return cases
@@ -935,6 +995,12 @@ def check_universal(case, pmap):
 
 def check_mapping(case, pmap):
     v = []
+    if case.expect_counts is not None:
+        actual = dict(_node_counts(pmap))
+        if actual != case.expect_counts:
+            v.append(("M-counts", "node counts %s != expected %s"
+                      % (actual, case.expect_counts)))
+        return v
     if case.apps:
         return v  # multi-app placement shape is pinned by golden snapshots
     if not case.map_by or ":" in case.map_by or case.map_by not in MAP_BY:

--- a/test/offline/run_offline_maps.py
+++ b/test/offline/run_offline_maps.py
@@ -728,6 +728,19 @@ def hostcap_cases(topo):
                alloc_args=alloc, expect="reject",
                expect_banner="not enough slots available")
 
+    # a cap ABOVE what the node holds is a different question, and the answer
+    # turns on who sized the node.  ras/simulator declares itself not
+    # scheduler-owned, so here the ":N" re-describes the node and the job maps
+    # against the larger count - the arm a scheduler would refuse instead is
+    # only reachable where a real one is running (contrib/slurmswarm).
+    small = ("--prtemca", "ras", "simulator",
+             "--prtemca", "ras_simulator_num_nodes", "3",
+             "--prtemca", "ras_simulator_slots", "2",
+             "--prtemca", "ras_simulator_max_slots", "0")
+    yield Case("hostcap.%s.cap-over-node" % topo.name, "hostcap", topo,
+               "capped", "nodeA0:4", [("nodeA0", 4)], map_by="core", n=4,
+               alloc_args=small, expect_counts={"nodeA0": 4}, expect="map")
+
 
 def device_cases(topo):
     """--map-by device=, whose placement is pinned by golden snapshots.

--- a/test/offline/run_offline_maps.py
+++ b/test/offline/run_offline_maps.py
@@ -728,15 +728,53 @@ def hostcap_cases(topo):
                alloc_args=alloc, expect="reject",
                expect_banner="not enough slots available")
 
+    # permission to oversubscribe changes how many procs a node may end up
+    # with, not how they are handed out: each node still gets what it was
+    # given first, and the leftovers are then split evenly - the same answer
+    # by-slot and by-node give for the same job
+    yield Case("hostcap.%s.cap-oversub" % topo.name, "hostcap", topo,
+               "capped", "nodeA0:2,nodeA1:2,nodeA2:2",
+               [("nodeA0", 2), ("nodeA1", 2), ("nodeA2", 2)],
+               map_by="core:oversubscribe", n=8, alloc_args=alloc,
+               expect_counts={"nodeA0": 3, "nodeA1": 3, "nodeA2": 2},
+               expect="map")
+
+    # the same rule with no cap in play: the ":N" here is exactly what the
+    # nodes hold, so what bounds the first pass is the node itself.  These
+    # nodes have more cores than slots (the simulator sizes the slots, the
+    # topology supplies the cores), which is the shape that tells a mapper
+    # that respects slots from one that fills a node to its core count.
+    small = ("--prtemca", "ras", "simulator",
+             "--prtemca", "ras_simulator_num_nodes", "3",
+             "--prtemca", "ras_simulator_slots", "2",
+             "--prtemca", "ras_simulator_max_slots", "0")
+    yield Case("hostcap.%s.slots-oversub" % topo.name, "hostcap", topo,
+               "capped", "nodeA0:2,nodeA1:2,nodeA2:2",
+               [("nodeA0", 2), ("nodeA1", 2), ("nodeA2", 2)],
+               map_by="core:oversubscribe", n=8, alloc_args=small,
+               expect_counts={"nodeA0": 3, "nodeA1": 3, "nodeA2": 2},
+               expect="map")
+
+    # A node with nothing left to give is what oversubscription is FOR, and it
+    # is reached without a spawn: the second app of an MPMD job maps against
+    # the slots the first one just consumed.  The first pass hands out what
+    # the nodes offer, which here is nothing, and the pass after it places
+    # them - so a mapper that reads "no node could take anything" as "this job
+    # cannot be placed" fails the map.  That is what a PMIx_Spawn onto a node
+    # its parent job has filled looked like.
+    yield Case("hostcap.%s.oversub-full" % topo.name, "hostcap", topo,
+               "capped", "nodeA0:2,nodeA1:2,nodeA2:2",
+               [("nodeA0", 2), ("nodeA1", 2), ("nodeA2", 2)],
+               map_by="core:oversubscribe",
+               apps=[AppSpec(6), AppSpec(2)], alloc_args=small,
+               expect_counts={"nodeA0": 3, "nodeA1": 3, "nodeA2": 2},
+               expect="map")
+
     # a cap ABOVE what the node holds is a different question, and the answer
     # turns on who sized the node.  ras/simulator declares itself not
     # scheduler-owned, so here the ":N" re-describes the node and the job maps
     # against the larger count - the arm a scheduler would refuse instead is
     # only reachable where a real one is running (contrib/slurmswarm).
-    small = ("--prtemca", "ras", "simulator",
-             "--prtemca", "ras_simulator_num_nodes", "3",
-             "--prtemca", "ras_simulator_slots", "2",
-             "--prtemca", "ras_simulator_max_slots", "0")
     yield Case("hostcap.%s.cap-over-node" % topo.name, "hostcap", topo,
                "capped", "nodeA0:4", [("nodeA0", 4)], map_by="core", n=4,
                alloc_args=small, expect_counts={"nodeA0": 4}, expect="map")
@@ -1036,15 +1074,20 @@ def check_mapping(case, pmap):
                 v.append(("M-slot",
                           "node counts %s != block-fill %s" % (actual, exp)))
     else:
-        # object-level maps (non-span) are node-local: all procs land on the
-        # first node, round-robin across that node's objects, oversubscribing
-        # rather than spilling to the next node.  (--map-by node / :SPAN are
-        # the directives that spread across nodes.)
-        first = case.pool[0][0]
-        if actual != {first: n}:
-            v.append(("M-%s" % case.map_by,
-                      "node counts %s != node-local {%s: %d}"
-                      % (actual, first, n)))
+        # object-level maps (non-span) are front-loaded like by-slot: each
+        # node is filled with what it offers - round-robin across that node's
+        # objects - before the mapper moves to the next one.  So while the job
+        # fits in the allocation the shape is a block fill, which for the
+        # common case of a job smaller than the first node is "everything on
+        # the first node".  (--map-by node / :SPAN are the directives that
+        # spread across nodes.)  Past the total slot count the procs left over
+        # come back around to oversubscribe, and that spread is left to
+        # golden, exactly as for by-slot.
+        if n <= total_slots:
+            exp = _expected_block_fill(case.pool, n)
+            if actual != exp:
+                v.append(("M-%s" % case.map_by,
+                          "node counts %s != block-fill %s" % (actual, exp)))
     return v
 
 

--- a/test/offline/run_offline_maps.py
+++ b/test/offline/run_offline_maps.py
@@ -755,6 +755,54 @@ def hostcap_cases(topo):
                expect_counts={"nodeA0": 3, "nodeA1": 3, "nodeA2": 2},
                expect="map")
 
+    yield Case("hostcap.%s.slots-oversub-span" % topo.name, "hostcap", topo,
+               "capped", "nodeA0:2,nodeA1:2,nodeA2:2",
+               [("nodeA0", 2), ("nodeA1", 2), ("nodeA2", 2)],
+               map_by="core:oversubscribe:span", n=8, alloc_args=small,
+               expect_counts={"nodeA0": 3, "nodeA1": 3, "nodeA2": 2},
+               expect="map")
+
+    # :SPAN answers the same job the same way - it reaches the balance by
+    # cycling the nodes rather than by splitting a remainder, so this is
+    # worth pinning on both paths
+    yield Case("hostcap.%s.cap-span" % topo.name, "hostcap", topo,
+               "capped", "nodeA0:2,nodeA1:2,nodeA2:2",
+               [("nodeA0", 2), ("nodeA1", 2), ("nodeA2", 2)],
+               map_by="core:span", n=6, alloc_args=alloc,
+               expect_counts={"nodeA0": 2, "nodeA1": 2, "nodeA2": 2},
+               expect="map")
+
+    yield Case("hostcap.%s.cap-span-oversub" % topo.name, "hostcap", topo,
+               "capped", "nodeA0:2,nodeA1:2,nodeA2:2",
+               [("nodeA0", 2), ("nodeA1", 2), ("nodeA2", 2)],
+               map_by="core:oversubscribe:span", n=8, alloc_args=alloc,
+               expect_counts={"nodeA0": 3, "nodeA1": 3, "nodeA2": 2},
+               expect="map")
+
+    # :SPAN treats the allocation as one big node, so it hands out one target
+    # per node per trip round the list.  What that buys is a balanced job:
+    # the same request without :SPAN fills each node in turn instead.  Pinned
+    # against an allocation whose nodes have more cores than slots, since a
+    # node-major walk and an interleaved one only differ once a node can hold
+    # more than its share.
+    four = ("--prtemca", "ras", "simulator",
+            "--prtemca", "ras_simulator_num_nodes", "3",
+            "--prtemca", "ras_simulator_slots", "4",
+            "--prtemca", "ras_simulator_max_slots", "0")
+    allfour = "nodeA0:4,nodeA1:4,nodeA2:4"
+    fourpool = [("nodeA0", 4), ("nodeA1", 4), ("nodeA2", 4)]
+    for cid, mb, n, cnt in (
+            ("span-balance", "core:span", 8, {"nodeA0": 3, "nodeA1": 3, "nodeA2": 2}),
+            ("span-fewer-than-nodes", "core:span", 2, {"nodeA0": 1, "nodeA1": 1}),
+            ("span-exact", "core:span", 12, {"nodeA0": 4, "nodeA1": 4, "nodeA2": 4}),
+            ("span-oversub", "core:oversubscribe:span", 14,
+             {"nodeA0": 5, "nodeA1": 5, "nodeA2": 4}),
+            # the contrast: no :SPAN, so the nodes are filled in turn
+            ("nospan-fills", "core", 8, {"nodeA0": 4, "nodeA1": 4})):
+        yield Case("hostcap.%s.%s" % (topo.name, cid), "hostcap", topo,
+                   "capped", allfour, fourpool, map_by=mb, n=n,
+                   alloc_args=four, expect_counts=cnt, expect="map")
+
     # A node with nothing left to give is what oversubscription is FOR, and it
     # is reached without a spawn: the second app of an MPMD job maps against
     # the slots the first one just consumed.  The first pass hands out what
@@ -769,7 +817,6 @@ def hostcap_cases(topo):
                apps=[AppSpec(6), AppSpec(2)], alloc_args=small,
                expect_counts={"nodeA0": 3, "nodeA1": 3, "nodeA2": 2},
                expect="map")
-
     # a cap ABOVE what the node holds is a different question, and the answer
     # turns on who sized the node.  ras/simulator declares itself not
     # scheduler-owned, so here the ":N" re-describes the node and the job maps

--- a/test/unit/rmaps/Makefile.am
+++ b/test/unit/rmaps/Makefile.am
@@ -19,6 +19,7 @@ test_rmaps_SOURCES = \
     test_ranking.c         \
     test_binding.c         \
     test_check_avail.c     \
+    test_resize.c          \
     test_dispatch.c        \
     test_round_robin.c     \
     test_ppr.c             \

--- a/test/unit/rmaps/test_resize.c
+++ b/test/unit/rmaps/test_resize.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Tests the node re-size bookkeeping the mapper uses when a "-host node:N"
+ * asks for more of a node than the node says it has.
+ *
+ * PRRTE may answer that only in an unmanaged allocation, and only for the
+ * job being mapped: "--host node:8" states how many slots THAT job may take
+ * on the node, while changing the allocation is what "--add-host" is for.
+ * So the grown count has to come back, on a failed map as surely as on a
+ * successful one - a job that could not map has no more claim on the extra
+ * slots than one that did.  These two functions are the whole of that
+ * contract, and neither needs a topology or a DVM to check.
+ */
+
+#include "prte_config.h"
+#include <stdio.h>
+#include <string.h>
+
+#include "constants.h"
+#include "src/runtime/prte_globals.h"
+#include "src/mca/rmaps/base/base.h"
+
+int test_resize(void);
+
+#define CHECK(label, cond)                                              \
+    do {                                                                \
+        if (!(cond)) {                                                  \
+            fprintf(stderr, "FAIL [%s]: %s\n", label, #cond);           \
+            failures++;                                                 \
+        }                                                               \
+    } while (0)
+
+int test_resize(void)
+{
+    int failures = 0;
+    prte_node_t *n1, *n2;
+
+    n1 = PMIX_NEW(prte_node_t);
+    n1->name = strdup("node0");
+    n1->slots = 4;
+    n2 = PMIX_NEW(prte_node_t);
+    n2->name = strdup("node1");
+    n2->slots = 2;
+
+    /* nothing recorded: restoring is a no-op, not a crash */
+    prte_rmaps_base_restore_resized();
+    CHECK("empty: node untouched", 4 == n1->slots);
+
+    /* the ordinary case - two nodes grown for one map, both put back */
+    prte_rmaps_base_record_resize(n1, n1->slots);
+    n1->slots = 8;
+    prte_rmaps_base_record_resize(n2, n2->slots);
+    n2->slots = 6;
+    CHECK("recorded: both listed",
+          2 == pmix_list_get_size(&prte_rmaps_base.resized_nodes));
+    prte_rmaps_base_restore_resized();
+    CHECK("restored: node0 back to 4", 4 == n1->slots);
+    CHECK("restored: node1 back to 2", 2 == n2->slots);
+    CHECK("restored: list emptied",
+          0 == pmix_list_get_size(&prte_rmaps_base.resized_nodes));
+
+    /* a second app of the same job can grow the same node again. The value
+     * to put back is the one it had before the FIRST growth - recording the
+     * already-grown count would leave the node permanently enlarged, which
+     * is the whole thing this is here to prevent. */
+    prte_rmaps_base_record_resize(n1, n1->slots);
+    n1->slots = 8;
+    prte_rmaps_base_record_resize(n1, n1->slots);
+    n1->slots = 12;
+    CHECK("regrown: recorded once",
+          1 == pmix_list_get_size(&prte_rmaps_base.resized_nodes));
+    prte_rmaps_base_restore_resized();
+    CHECK("regrown: back to the original 4", 4 == n1->slots);
+
+    PMIX_RELEASE(n1);
+    PMIX_RELEASE(n2);
+
+    if (0 == failures) {
+        fprintf(stdout, "  PASS test_resize\n");
+    }
+    return failures;
+}

--- a/test/unit/rmaps/test_rmaps_main.c
+++ b/test/unit/rmaps/test_rmaps_main.c
@@ -26,6 +26,7 @@ extern int test_resolve_options(void);
 extern int test_ranking(void);
 extern int test_binding(void);
 extern int test_check_avail(void);
+extern int test_resize(void);
 extern int test_dispatch(void);
 extern int test_round_robin(void);
 extern int test_ppr(void);
@@ -104,6 +105,7 @@ int main(void)
     failures += test_ranking();
     failures += test_binding();
     failures += test_check_avail();
+    failures += test_resize();
     failures += test_dispatch();
     failures += test_round_robin();
     failures += test_ppr();


### PR DESCRIPTION
Fixes #2696.

A `:N` suffix on a `--host` entry was honored when PRRTE decided *how many*
processes a job has, and ignored when it decided *where they go*. Selecting
within an existing allocation, `--host a:1,b:1,c:1 -n 3` put all three procs
on `a` and left `b` and `c` out of the map. The total is still checked, so
nothing fails: the job runs, on the wrong nodes, silently. The default
mapping policy resolves to a by-object one, so an ordinary launch is
affected; `--map-by slot`, `--map-by node` and `ppr` were not.

Four commits, each self-contained and each verified to build and pass on its
own.

**1. Honor a -host slot cap when placing processes** — the reported bug.
`get_target_nodes()` records what each node contributes to the job in
`node->slots_available`; the by-object mappers placed against `node->slots`
instead. Nothing below them can catch it — `check_avail()` and
`check_oversubscribed()` both measure the node's own size — so the shared
object loop now caps itself the way every other mapper does, and
`setup_proc()` draws the field down per placed proc.

**2. Reconcile a -host slot cap that exceeds the node.** `--host node:8`
against a 4-slot node was sized against 8, mapped against 4, and reported as
a bare "failed to map". Which answer is right turns on who sized the node,
and the ras framework already answers that: `prte_ras_base.scheduler_owned`,
the same flag that decides whether `--add-host` may grow the pool. Under a
scheduler-owned allocation the request is refused, naming the node and both
counts; otherwise the `:N` re-describes the node and it is grown to fit — for
the duration of that map only, since `--host` says how many slots *this job*
may take and `--add-host` is what changes an allocation.

**3. Spread an oversubscribed object map evenly over the nodes.** Permission
to oversubscribe said nothing about distribution, but the object mappers let
the head of the list absorb the whole overflow: with `--host a:2,b:2,c:2`,
`-n 12` gave 8/2/2 where by-slot gave 4/4/4. Each node now gets a per-pass
budget — what it offers on the first pass, an even share of what is left
after that — so all three mappers answer an oversubscribed job identically.

**4. Make :SPAN actually span the nodes.** `options->mapspan` only ever
suppressed the "refill this node" retry, so span still walked node-major:
`-n 8 --map-by core:span` on three 4-slot nodes gave 4/4/0 rather than the
3/3/2 the "single super-node" reading it documents. It now hands out one
target per node per trip round the list, with a per-node cursor so the k'th
proc on a node lands on that node's k'th target. Device maps (`nowrap`),
which get a single pass by design, are deliberately left alone.

## Testing

`make check` (22/22, including a new `test_resize` unit test) and the offline
mapper harness at 2445 pass / 0 fail with `--golden`, plus live DVM smoke
tests including the re-size case: a job re-sizes the node, and the next job
sees it at its original size.

The offline harness could not have caught any of this: every case hands `-H`
to a `prterun` with no allocation, so the spec *builds* one and each node's
slot count is its own `-H` count — the one shape in which a cap and the node
cannot disagree. The new `hostcap` group supplies an allocation from
`ras/simulator` first and then selects within it, and it had no
`--map-by <obj>:span` coverage at all before this.

**Not run here:** the refusing arm of commit 2 needs an allocation a scheduler
owns, and every ras component available offline correctly declares itself not
scheduler-owned. That case is asserted in `contrib/slurmswarm/run-tests.sh`
beside the `--add-host` refusal it shares its authority with, but this machine
has no SLURM, so it wants a run in that harness.

One golden moves: the harness's own oversubscribe case, 16/0 → 10/6, which is
what `--map-by slot:oversubscribe` produces for the same job.