### PR TITLE
Consolidate the OOB and odls thread pools into one worker pool

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -886,39 +886,34 @@ foreground under `docker exec -d` (see §5).
 
 ---
 
-### The suite runs the OOB with worker threads
+### The suite runs with the worker thread pool on
 
-`prte_oob_base.num_progress_threads` defaults to **0** in the library: every
-peer's socket send/recv events are serviced on the main progress thread, so
-the OOB is effectively single-threaded. With workers configured, each peer is
-assigned to a worker base and its handlers run on that thread, posting
-completions back to `prte_event_base` — and that is the arrangement in which a
-missing lock, a peer touched from two threads, or a completion that assumes it
-runs on the main thread has any consequence at all.
+`prte_num_worker_threads` (default **8**) sizes one process-wide pool of
+worker progress threads, shared by two subsystems: a peer's socket send/recv
+handlers run on a base drawn from it, and so does each local `fork`/`exec`.
+With the pool off, all of that runs on the main progress thread and the
+ordering is fixed. With it on, a missing lock, a peer touched from two
+threads, or a completion that assumes it runs on the main thread has
+consequences — which is the whole reason to test in that mode.
 
-At the library default this suite could never reach that path: not one case
-would exercise it, and a race introduced there would ship. So `run-tests.sh`
-opts in, exporting `PRTE_MCA_oob_progress_threads` into every tool it runs —
-and thereby into every daemon, since `prte_plm_base_setup_virtual_machine`
+`run-tests.sh` states the setting explicitly rather than inheriting it,
+exporting `PRTE_MCA_prte_num_worker_threads` into every tool it runs — and
+thereby into every daemon, since `prte_plm_base_setup_virtual_machine`
 harvests `PRTE_MCA_*` from the launcher's environment onto the daemon command
-line.
+line. The preflight prints the number it used, so a suite log always says
+which mode produced it.
 
-**The default here is 2**, the smallest genuinely multi-threaded setting: one
-worker plus the main thread is already two threads touching the OOB, and two
-workers means two peers can be serviced at once. The preflight prints the
-number it used, so a suite log always says which mode produced it.
-
-Override with `PRTE_SWARM_OOB_THREADS`:
+Override with `PRTE_SWARM_WORKER_THREADS`:
 
 ```sh
-PRTE_SWARM_OOB_THREADS=0 ./run-tests.sh linux   # library default, single-threaded
-PRTE_SWARM_OOB_THREADS=8 ./run-tests.sh linux   # push the threading harder
+PRTE_SWARM_WORKER_THREADS=0 ./run-tests.sh linux   # everything on the main thread
+PRTE_SWARM_WORKER_THREADS=16 ./run-tests.sh linux  # push the threading harder
 ```
 
 **If a case fails, re-run it at 0 before reading the failure as a bug in what
 you just changed.** A failure that reproduces only with workers is a genuine
 threading defect worth chasing; one that reproduces at 0 as well has nothing
-to do with the OOB threading. Keeping that distinction cheap is the reason the
+to do with the threading. Keeping that distinction cheap is the reason the
 knob exists rather than the number being hard-coded.
 
 ### Components as DSOs (`PRTE_SWARM_MCA_DSO`)

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -81,29 +81,27 @@ bounded() {
 # Linux: the full 10-node swarm
 ########################################################################
 
-# THE SUITE RUNS WITH OOB PROGRESS THREADS ON, AND THAT IS DELIBERATE.
+# THE SUITE RUNS WITH THE WORKER THREAD POOL ON, AND THAT IS DELIBERATE.
 #
-# prte_oob_base.num_progress_threads defaults to 0 in the library: every
-# peer's socket send/recv events are serviced on the main progress thread, so
-# the OOB is effectively single-threaded and the ordering between a send
+# With the pool off, every peer's socket send/recv events and every local
+# fork/exec run on the main progress thread, so the ordering between a send
 # completing and anything else the daemon does is fixed. With workers, each
-# peer is assigned to a worker base and its handlers run on that thread,
-# posting completions back to prte_event_base -- which is the arrangement
-# where a missing lock, a peer touched from two threads, or a completion that
-# assumes it runs on the main thread actually has consequences.
+# peer is assigned a worker base and its handlers run on that thread, posting
+# completions back to prte_event_base, and forks are dispatched to the same
+# threads -- which is the arrangement where a missing lock, a peer touched
+# from two threads, or a completion that assumes it runs on the main thread
+# actually has consequences.
 #
-# At the default of 0 this suite could never reach any of that: not one case
-# would exercise the threaded path, and a race introduced there would ship.
-# So the suite opts in, for every tool and (via the PRTE_MCA_ forwarding in
-# prte_plm_base_setup_virtual_machine) every daemon it launches.
-#
-# Two is the smallest number that is genuinely multi-threaded -- one worker
-# plus the main thread is already two threads touching the OOB, and two
-# workers means two peers can be serviced concurrently. Override with
-# PRTE_SWARM_OOB_THREADS to sweep it, or set it to 0 to reproduce the old
-# single-threaded behavior when bisecting a failure.
-OOB_THREADS="${PRTE_SWARM_OOB_THREADS:-2}"
-OOBENV=(-e "PRTE_MCA_oob_progress_threads=$OOB_THREADS")
+# The pool is now process-wide (prte_num_worker_threads, default 8) and shared
+# with the odls fork path, so the threaded path runs by default and this suite
+# no longer has to opt in to reach it. The forcing stays anyway, for two
+# reasons: it states in one place what the suite actually ran at, and setting
+# PRTE_SWARM_WORKER_THREADS=0 reproduces the single-threaded behavior for every
+# tool and (via the PRTE_MCA_ forwarding in
+# prte_plm_base_setup_virtual_machine) every daemon it launches, which is the
+# first thing to try when bisecting a failure that smells like a race.
+WORKER_THREADS="${PRTE_SWARM_WORKER_THREADS:-8}"
+OOBENV=(-e "PRTE_MCA_prte_num_worker_threads=$WORKER_THREADS")
 
 # run a command on the head node (login env so PATH/LD_LIBRARY_PATH are set)
 RUN() { docker exec -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
@@ -5094,7 +5092,7 @@ test_odls() {
 }
 
 test_rml() {
-    local out rc n c
+    local out rc n c w t wthr0 wthr4
 
     banner "rml: a small radix builds an interior tree and messages get relayed"
     # radix 2 over 7 nodes gives the HNP two children and four grandchildren,
@@ -5382,33 +5380,60 @@ test_rml() {
     fi
     cleanup_swarm
 
-    banner "rml/oob: peer sockets serviced by dedicated OOB progress threads"
-    # prte_oob_progress_threads (default 0) moves each peer's send/recv socket
-    # events off the main progress thread onto one of N worker bases, chosen
-    # round-robin at peer construction.  The connection state machine, routing,
-    # message delivery and every send completion stay on the main thread.  This
-    # is the only place that threaded path runs at all, so all four things it
-    # could break are checked here rather than assumed.
+    banner "rml/oob: peer sockets serviced by the worker thread pool"
+    # prte_num_worker_threads (default 8) moves each peer's send/recv socket
+    # events off the main progress thread onto one of N worker bases, handed
+    # out in rotation at peer construction.  The connection state machine,
+    # routing, message delivery and every send completion stay on the main
+    # thread.  This is the only place that threaded path runs at all, so all
+    # four things it could break are checked here rather than assumed.
     cleanup_swarm
 
     # (a) the parameter has to reach the *daemons*, not just the HNP -- the
-    # whole point is remote sockets.  oob_base_verbose 5 makes each daemon
-    # announce the pool it built; --leave-session-attached is what gets a
-    # prted's stderr back to us.
-    out=$(RUN 'timeout -k 5 90 prterun --prtemca prte_oob_progress_threads 4 \
-                  --prtemca oob_base_verbose 5 --leave-session-attached \
-                  --host node1:1,node2:1,node3:1 -np 3 --map-by node hostname' 2>&1)
-    n=$(echo "$out" | grep -c 'starting 4 OOB progress threads')
-    [ "$n" -ge 2 ] \
-        && ok "the daemons started their OOB progress-thread pools ($n reported)" \
-        || bad "the thread pool was not built on the daemons: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+    # whole point is remote sockets.  The observable is a remote daemon's own
+    # thread count, taken with the pool off and again with four workers: the
+    # difference has to be exactly four.
+    #
+    # Pick the daemon by the value on ITS OWN command line rather than by
+    # whatever pgrep finds first.  The cases just above this one kill daemons
+    # deliberately, and a stray prted left behind by one of them is running at
+    # the suite-wide default -- which is a perfectly plausible thread count, so
+    # sampling the wrong process does not look like an error, it looks like a
+    # wrong answer.  (It was one: this case first reported "10 threads with 0",
+    # i.e. a daemon carrying the suite default of 8 on top of a 2-thread
+    # baseline.)  Selecting on the command line also makes the case say what it
+    # means -- the parameter arrived, and the daemon acted on it.
+    wthr0="" ; wthr4=""
+    for w in 0 4; do
+        cleanup_swarm
+        if prted_dvm_start_mca 'node1:1,node2:1,node3:1' \
+               "--prtemca prte_num_worker_threads $w"; then
+            t=$(ON 2 'for p in $(pgrep -x prted); do
+                          printf "%s %s %s\n" "$p" "$(ls /proc/$p/task | wc -l)" \
+                                 "$(tr "\0" " " < /proc/$p/cmdline)"
+                      done' 2>/dev/null |
+                awk -v w="$w" '$0 ~ ("prte_num_worker_threads " w " ") { print $2; exit }')
+            RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+        else
+            t=""
+            bad "could not start a DVM with $w worker threads"
+        fi
+        [ "$w" = 0 ] && wthr0="$t" || wthr4="$t"
+    done
     cleanup_swarm
+    if [ -z "$wthr0" ] || [ -z "$wthr4" ]; then
+        bad "no prted on node2 carried the requested prte_num_worker_threads (got '$wthr0' / '$wthr4')"
+    elif [ "$wthr4" = "$((wthr0 + 4))" ]; then
+        ok "a remote daemon built the worker pool it was told to ($wthr0 -> $wthr4 threads)"
+    else
+        bad "the worker pool did not reach the daemons ($wthr0 threads with 0, $wthr4 with 4)"
+    fi
 
     # (b) a relayed tree still delivers.  radix 2 over 7 nodes means every leaf
     # is reached through an interior daemon, so a message crosses a worker base
     # on the way in (recv handler) and again on the way out (relay -> send).
     out=$(RUN 'timeout -k 5 120 prterun --prtemca rml_base_radix 2 \
-                  --prtemca prte_oob_progress_threads 4 \
+                  --prtemca prte_num_worker_threads 4 \
                   --host node1:1,node2:1,node3:1,node4:1,node5:1,node6:1,node7:1 \
                   -np 7 --map-by node hostname' 2>&1); rc=$?
     n=$(echo "$out" | grep -cE '^node[1-7]$')
@@ -5421,7 +5446,7 @@ test_rml() {
     # second thread is exactly what could corrupt, and a byte count is the only
     # check that catches a corrupted one -- a truncated relay still "runs".
     out=$(RUN 'timeout -k 5 120 prterun --prtemca rml_base_radix 2 \
-                  --prtemca prte_oob_progress_threads 4 \
+                  --prtemca prte_num_worker_threads 4 \
                   --host node1:1,node2:1,node3:1,node4:1,node5:1,node6:1,node7:1 \
                   -np 7 --map-by node \
                   sh -c "head -c 500000 /dev/zero | tr \"\\0\" \"x\""' 2>&1)
@@ -5440,7 +5465,7 @@ test_rml() {
     # nothing else; the deep-tree half of the same scenario is the case above,
     # which runs it at radix 2 with the threads off.
     if prted_dvm_start_mca 'node1:1,node2:1,node3:1,node4:1,node5:1,node6:1,node7:1' \
-           '--prtemca prte_oob_progress_threads 4'; then
+           '--prtemca prte_num_worker_threads 4'; then
         PRUN_BG /tmp/rml-thr-longrun.out '--host node7:1 -n 1 sleep 120'
         sleep 6
         if ! RUN 'pgrep -x prun' >/dev/null 2>&1; then
@@ -5463,7 +5488,7 @@ test_rml() {
         fi
         RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     else
-        bad "could not start a DVM with OOB progress threads"
+        bad "could not start a DVM with worker threads"
     fi
     cleanup_swarm
 }
@@ -5717,15 +5742,14 @@ test_linux() {
     stamp=$(RUN 'cat /opt/prte/.build-stamp 2>/dev/null' | tr -d '\r')
     if [ -n "$stamp" ]; then
         ok "install built $stamp"
-        # Say which OOB threading the whole run used. The library defaults to
-        # 0 (everything on the main progress thread); this suite opts in to
-        # workers so the threaded send/recv path is covered at all. A failure
-        # that only appears here is the first thing to re-check with
-        # PRTE_SWARM_OOB_THREADS=0, which is why the number is in the log.
-        if [ "$OOB_THREADS" = 0 ]; then
-            ok "...running with OOB progress threads OFF (single-threaded OOB)"
+        # Say which worker threading the whole run used. The pool services
+        # both peer sockets and local fork/exec; a failure that only appears
+        # here is the first thing to re-check with
+        # PRTE_SWARM_WORKER_THREADS=0, which is why the number is in the log.
+        if [ "$WORKER_THREADS" = 0 ]; then
+            ok "...running with the worker pool OFF (everything on the main progress thread)"
         else
-            ok "...running with $OOB_THREADS OOB progress threads (library default is 0)"
+            ok "...running with $WORKER_THREADS worker threads (library default is 8)"
         fi
         # ...and whether the components are inside libprrte or loaded from
         # disk.  Asked of the install rather than of a variable, because the

--- a/contrib/scaling/cluster-sweep.sh
+++ b/contrib/scaling/cluster-sweep.sh
@@ -27,7 +27,7 @@
 #
 #   The sweep also prices three things we found dominate on a single host and
 #   need confirming (or refuting) on a cluster: the PMIx GDS component, the
-#   OOB worker threads, and how much of a fence's cost is payload at all.
+#   worker threads, and how much of a fence's cost is payload at all.
 #
 # HOW TO RUN IT
 #
@@ -518,11 +518,11 @@ sweep() {
             done
         fi
 
-        # --- threads: OOB worker bases off against on ---------------------
+        # --- threads: the worker thread pool off against on ---------------
         if has_phase threads; then
             for t in 0 $((64 / 4)); do
-                say "threads phase: nodes=$n oob_threads=$t"
-                if dvm_start "$n" "$slots" 64 "--prtemca prte_oob_progress_threads $t"; then
+                say "threads phase: nodes=$n worker_threads=$t"
+                if dvm_start "$n" "$slots" 64 "--prtemca prte_num_worker_threads $t"; then
                     run_job warm "$n" 64 1 "$nkeys" 1024 default "$t" 0 >/dev/null 2>&1 || true
                     run_reps threads "$n" 64 1 "$nkeys" 1024 default "$t"
                     dvm_stop
@@ -599,7 +599,7 @@ fi
 
 mkdir -p "$outdir" || die "cannot create $outdir"
 : > "$LOG"
-echo "phase,nodes,radix,ppn,nprocs,nkeys,size,bytes_per_rank,total_bytes,gds,oob_threads,rep,put_us,collect_us,barrier_us,data_cost_us" > "$RAW"
+echo "phase,nodes,radix,ppn,nprocs,nkeys,size,bytes_per_rank,total_bytes,gds,worker_threads,rep,put_us,collect_us,barrier_us,data_cost_us" > "$RAW"
 
 say "results  -> $outdir"
 say "plan     -> $plan_dvms DVM cycles, $plan_jobs jobs (~$(( (plan_dvms * 45 + plan_jobs * 10) / 60 )) min estimated)"

--- a/docs/how-things-work/rml/oob.rst
+++ b/docs/how-things-work/rml/oob.rst
@@ -134,17 +134,17 @@ tree can be repaired (see :ref:`rml-label`).
 Which thread moves the bytes
 ----------------------------
 
-By default every part of the transport runs on the one PRRTE progress thread,
-and this section describes something you can turn on rather than something that
-is already happening.
+A daemon runs a pool of **worker progress threads**, sized by
+``prte_num_worker_threads`` (default ``8``).  It is one pool for the whole
+process, shared with the local fork/exec path; the OOB does not have a pool of
+its own.  Each peer is assigned a base from that pool, in rotation, when the
+peer is created.
 
-``prte_oob_progress_threads`` (default ``0``) starts that many additional
-progress threads and assigns each peer one of them, round-robin, when the peer
-is created.  Only the peer's **send and recv socket handlers** move there, and
-only once the connection is established.  Everything those handlers hand
-onwards — delivering a message to the RML, relaying one on, running a send's
-completion callback, reacting to a lost connection — comes back to the main
-progress thread, as does the whole connection state machine.
+Only the peer's **send and recv socket handlers** run there, and only once the
+connection is established.  Everything those handlers hand onwards —
+delivering a message to the RML, relaying one on, running a send's completion
+callback, reacting to a lost connection — comes back to the main progress
+thread, as does the whole connection state machine.
 
 The reason to want this is not raw bandwidth.  A single thread copies into the
 kernel several times faster than a 10-25 GbE link drains, so the transport is
@@ -155,8 +155,10 @@ for that fraction of the launch.  Giving the sockets their own threads keeps
 them busy across those stalls.  It also lifts a real ceiling on 100 GbE and on
 nodes with several NICs, where one thread's copy rate *is* the limit.
 
-Start with ``0`` (the default, and identical to the behavior that predates the
-option) and raise it only where a launch is demonstrably stalling the wire.
+Setting ``prte_num_worker_threads`` to ``0`` puts every peer back on the main
+progress thread — the behavior that predates the pool — and is the thing to
+try when you suspect the extra threads are costing more than they earn, which
+they can on a node with no spare cores.
 
 Bootstrap specifics
 -------------------

--- a/docs/plans/scalable_collectives/scalable-collectives.rst
+++ b/docs/plans/scalable_collectives/scalable-collectives.rst
@@ -1683,7 +1683,9 @@ inside that spread, so the apparent ordering is not evidence.
    depth-1 series does show.
 
 **The OOB worker bases were measured, and made the barrier worse here.**
-``prte_oob_progress_threads`` defaults to 0, so every other number in this
+``prte_oob_progress_threads`` (since replaced by the process-wide
+``prte_num_worker_threads``, which defaults to 8) defaulted to 0 at the time,
+so every other number in this
 document was taken with each daemon servicing all its peer sockets on one
 event base.  Forced to 4 — verified by thread count, +4 on both the HNP and
 remote daemons — the barrier was 1.2-1.9x *worse* at five of six points.  That

--- a/src/mca/odls/AGENTS.md
+++ b/src/mca/odls/AGENTS.md
@@ -143,56 +143,10 @@ Because there is only one component and it delegates almost everything,
 message construction, parsing, wireup, environment assembly, threading,
 `waitpid` interpretation, and cleanup. Walk these in order.
 
-### 1. Framework globals and the spawn-thread pool (`odls_base_frame.c`)
+### 1. Framework globals (`odls_base_frame.c`)
 
 `prte_odls_globals` (`prte_odls_globals_t` in `base.h`) holds:
 
-- **`ev_bases` / `ev_threads` / `num_threads` / `max_threads` / `cutoff` /
-  `next_base`** — a pool of libevent progress threads used to *parallelize
-  forking* when a node hosts many local procs. `prte_odls_base_start_threads()`
-  decides how many to spin up: a persistent DVM uses `max_threads` (default
-  16); otherwise, below `cutoff` (default 32) local procs it uses **zero**
-  dedicated threads (fork straight on `prte_event_base`), and above it
-  scales to `num_local_procs / 8` capped at `max_threads`.
-  `prte_odls_base_harvest_threads()` tears them down and resets the pool
-  state to "nothing built yet".
-
-  Two things about this that are easy to get wrong, because both failures
-  are invisible:
-  - **"Have we built a pool?" is `ev_bases != NULL`, not
-    `ev_threads != NULL`.** `ev_threads` holds the *names* of dedicated
-    threads and stays NULL whenever the answer was "no dedicated threads
-    at all", so keying the guard off it re-entered the sizing code on
-    every job.
-  - **`num_threads` is both the request and the answer**, which makes it
-    dangerous to reset. It is registered at `-1` ("you decide") and
-    `start_threads` *overwrites* it with the size it picked. So `-1` in
-    that variable is a standing invitation to size a pool from whatever
-    job comes next — and `harvest_threads` runs from framework **close**.
-    Putting the sentinel back there let a `start_threads` call arriving
-    during teardown build a whole new pool of real threads on the way out
-    (a 40-proc node printed `START 5 LAUNCH THREADS` twice, the second
-    time after `kill_local_procs`). Harvest records `0` — "no threads" —
-    and `start_threads` returns immediately once `prte_finalizing` is set.
-    Do not "restore" the sentinel there.
-
-  **`prte_persistent` is what makes the difference here, and a daemon has
-  to be *told* it.** `start_threads` short-circuits to `max_threads` (16)
-  when `prte_persistent` is set, on the reasoning that a persistent DVM
-  will service many jobs and should size for the worst of them. That flag
-  is decided in `prte()` (`src/prted/prte.c`) — which only the HNP runs.
-  It used to default to **true** and be assigned nowhere else, so every
-  daemon believed it was persistent no matter how the DVM had started: a
-  plain `prterun -n 1 hostname` spun 16 progress threads on each compute
-  node, and the cutoff/`num_local_procs / 8` scaling below was dead
-  everywhere but the head node. It is now an MCA parameter that the HNP
-  appends to each daemon's command line
-  (`prte_plm_base_prted_append_basic_args`), defaulting to false; a
-  bootstrapped daemon, which has no launcher to tell it anything, sets it
-  for itself because that DVM is persistent by construction. If you add
-  daemon-side code that reads `prte_persistent`, it now means what it
-  says — but check `--prtemca odls_base_verbose 5` for `START n LAUNCH
-  THREADS` if you are ever unsure which way a given daemon decided.
 - **`xterm_ranks` / `xtermcmd`** — support for `--xterm`: a list of ranks
   whose output should be shown in separate `xterm` windows, parsed at
   framework open from the `prte_xterm` global.
@@ -200,11 +154,26 @@ message construction, parsing, wireup, environment assembly, threading,
   go to the child only or its whole process group.
 - **`exec_agent`** — an optional wrapper command to exec instead of the app.
 
-MCA params, all under `prte odls base`: `max_threads`, `num_threads`,
-`cutoff`, `signal_direct_children_only`, `exec_agent`. Framework open also
-**unblocks `SIGCHLD`** (odls must see child deaths) and builds the xterm
-command vector. Framework close reaps the thread pool and releases the
-global `prte_local_children` array.
+**Forking is parallelized on the process-wide worker pool, which odls does
+not own.** The launch walk asks `prte_worker_pool_assign()`
+([`src/runtime/prte_worker_pool.h`](../../runtime/prte_worker_pool.h)) for a
+base per child and posts the fork there; the pool is sized by
+`prte_num_worker_threads` (default 8) and is shared with the OOB, which puts
+peer sockets on the same threads. odls used to carry a pool of its own —
+`ev_bases`/`ev_threads`/`num_threads`/`max_threads`/`cutoff`/`next_base`, sized
+from the first job it was handed — and every one of those fields and
+parameters is gone. Two of its failure modes are worth remembering, because
+anything that reintroduces per-subsystem sizing invites them back: the "have
+we built a pool yet?" guard has to key off the pool itself and not off the
+*names* of the threads (which stay NULL whenever the answer was "no dedicated
+threads"), and a variable that is both the request and the answer must not
+have its "you decide" sentinel restored by a teardown path, or a call arriving
+during finalize builds a whole new set of real threads on the way out.
+
+MCA params, all under `prte odls base`: `signal_direct_children_only`,
+`exec_agent`, `scatter_cpusets`. Framework open also **unblocks `SIGCHLD`**
+(odls must see child deaths) and builds the xterm command vector. Framework
+close releases the global `prte_local_children` array.
 
 This file also defines the two caddy classes (below) via
 `PMIX_CLASS_INSTANCE`.
@@ -550,11 +519,12 @@ computed proc state.
 - **Message build/parse, wireup, waitpid interpretation, kill/signal, and
   state activation** all run on the **progress thread** (`prte_event_base`)
   — the normal PRRTE event-driven model.
-- **Only the fork/exec spawn step** may be off-loaded to the **odls
-  worker-thread pool** (`prte_odls_globals.ev_bases`) to parallelize
-  launching many procs. Each spawn is a self-contained caddy handed to one
-  worker base; it touches only its own child, so no shared-state locking is
-  needed on the hot path.
+- **Only the fork/exec spawn step** may be off-loaded to the **process-wide
+  worker pool** (`prte_worker_pool_assign()`) to parallelize launching many
+  procs. Each spawn is a self-contained caddy handed to one worker base; it
+  touches only its own child, so no shared-state locking is needed on the hot
+  path. The pool is shared with the OOB — a worker base servicing your fork
+  may also be servicing a peer socket.
 - `SIGCHLD` must stay unblocked (done at framework open); child death is
   delivered through `src/runtime/prte_wait.c`, which fires the registered
   `wait_local_proc` callback on `prte_event_base`.
@@ -715,9 +685,9 @@ prun --xterm 0,1 ...                        # route ranks 0,1 to xterm windows (
 prun --report-bindings ...                  # print each child's applied binding (odls_base_bind.c)
 ```
 
-Useful tuning params: `--prtemca odls_base_num_threads N` /
-`odls_base_cutoff N` (spawn-thread pool sizing),
-`--prtemca odls_base_exec_agent CMD` (wrap every exec),
+Useful tuning params: `--prtemca prte_num_worker_threads N` (the process-wide
+worker pool the forks are dispatched to; `0` forks on the main progress
+thread), `--prtemca odls_base_exec_agent CMD` (wrap every exec),
 `--prtemca odls_base_signal_direct_children_only 1` (don't signal the
 child's whole process group).
 
@@ -769,7 +739,7 @@ code sorts after every fatal code); and the two caddy classes
 the documented NULL/zero defaults and destruct cleanly (both the
 all-NULL and the fully-populated paths).
 
-Three cases go further than structure, because the code under them is a
+Two cases go further than structure, because the code under them is a
 pure function of its inputs:
 
 - **`prte_odls_base_process_envars`** — exported (rather than file-static)
@@ -780,11 +750,10 @@ pure function of its inputs:
 - **The child→parent pipe record** — `child_warn` across a real pipe, and
   `child_fail` across a real `fork`, checking both the decoded record and
   that the child died with the exit status it was handed.
-- **The spawn-thread pool sizing** — that the "already built?" guard and
-  the `-1` sentinel survive a `harvest_threads`. The persistent-DVM branch
-  is *not* exercised: it spins `max_threads` real progress threads, which a
-  bare test process cannot start and stop, so the test clears
-  `prte_persistent` first.
+
+The worker pool the spawns are dispatched to is no longer odls's, so its
+sizing and rotation are covered in `test/unit/runtime/test_runtime.c`
+(`test_worker_pool`) rather than here.
 
 Add structural regression guards here; anything that needs a running
 launch belongs in the swarm harness or the integration harness.

--- a/src/mca/odls/base/base.h
+++ b/src/mca/odls/base/base.h
@@ -56,13 +56,6 @@ typedef struct {
     pmix_list_t xterm_ranks;
     /* the xterm cmd to be used */
     char **xtermcmd;
-    /* thread pool */
-    int max_threads;
-    int num_threads;
-    int cutoff;
-    prte_event_base_t **ev_bases; // event base array for progress threads
-    char **ev_threads;            // event progress thread names
-    int next_base;                // counter to load-level thread use
     bool signal_direct_children_only;
     char *exec_agent;
     /* send each daemon its own procs' bindings instead of broadcasting
@@ -202,10 +195,6 @@ PRTE_EXPORT int prte_odls_base_default_restart_proc(prte_proc_t *child,
  * Preload binary/files functions
  */
 PRTE_EXPORT int prte_odls_base_preload_files_app_context(prte_app_context_t *context);
-
-PRTE_EXPORT void prte_odls_base_start_threads(prte_job_t *jdata);
-
-PRTE_EXPORT void prte_odls_base_harvest_threads(void);
 
 /* Binding support.
  *

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -80,6 +80,7 @@
 #include "src/prted/prted.h"
 #include "src/runtime/prte_globals.h"
 #include "src/runtime/prte_wait.h"
+#include "src/runtime/prte_worker_pool.h"
 #include "src/threads/pmix_threads.h"
 #include "src/util/pmix_context_fns.h"
 #include "src/util/name_fns.h"
@@ -478,13 +479,8 @@ static void job_reg_join(prte_odls_jcaddy_t *cd)
             PMIX_RELEASE(cd);
             return;
         }
-        /* spin up the spawn threads */
-        prte_odls_base_start_threads(cd->jdata);
         return;
     }
-
-    /* spin up the spawn threads */
-    prte_odls_base_start_threads(cd->jdata);
 
     /* no local support setup is required, so we can proceed
      * directly to launching the local procs */
@@ -2040,11 +2036,7 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
             if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_STOP_ON_EXEC, NULL, PMIX_BOOL)) {
                 evb = prte_event_base;
             } else {
-                ++prte_odls_globals.next_base;
-                if (prte_odls_globals.num_threads <= prte_odls_globals.next_base) {
-                    prte_odls_globals.next_base = 0;
-                }
-                evb = prte_odls_globals.ev_bases[prte_odls_globals.next_base];
+                evb = prte_worker_pool_assign();
             }
 
             /* set the waitpid callback here for thread protection and
@@ -2105,9 +2097,10 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
                 }
             }
             pmix_output_verbose(1, prte_odls_base_framework.framework_output,
-                                "%s odls:dispatch %s to thread %d",
+                                "%s odls:dispatch %s to %s",
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&child->name),
-                                prte_odls_globals.next_base);
+                                (prte_event_base == evb) ? "the main progress thread"
+                                                         : "a worker thread");
             prte_event_set(evb, &cd->ev, -1, PRTE_EV_WRITE, prte_odls_base_spawn_proc, cd);
             prte_event_active(&cd->ev, PRTE_EV_WRITE, 1);
         }
@@ -2819,11 +2812,7 @@ int prte_odls_base_default_restart_proc(prte_proc_t *child,
     if (prte_get_attribute(&jobdat->attributes, PRTE_JOB_STOP_ON_EXEC, NULL, PMIX_BOOL)) {
         evb = prte_event_base;
     } else {
-        ++prte_odls_globals.next_base;
-        if (prte_odls_globals.num_threads <= prte_odls_globals.next_base) {
-            prte_odls_globals.next_base = 0;
-        }
-        evb = prte_odls_globals.ev_bases[prte_odls_globals.next_base];
+        evb = prte_worker_pool_assign();
     }
     /* flag the proc alive BEFORE registering the waitpid, exactly as
      * launch_local does. prte_wait_cb short-circuits a registration for a

--- a/src/mca/odls/base/odls_base_frame.c
+++ b/src/mca/odls/base/odls_base_frame.c
@@ -30,11 +30,9 @@
 #include <signal.h>
 #include <string.h>
 
-#include "src/class/pmix_ring_buffer.h"
 #include "src/hwloc/hwloc-internal.h"
 #include "src/mca/base/pmix_base.h"
 #include "src/mca/mca.h"
-#include "src/runtime/prte_progress_threads.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_output.h"
 #include "src/util/pmix_path.h"
@@ -73,43 +71,15 @@ prte_odls_globals_t prte_odls_globals = {
     .output = 0,
     .xterm_ranks = PMIX_LIST_STATIC_INIT,
     .xtermcmd = NULL,
-    .max_threads = 0,
-    .num_threads = 0,
-    .cutoff = 0,
-    .ev_bases = NULL,
-    .ev_threads = NULL,
-    .next_base = 0,
     .signal_direct_children_only = false,
     .exec_agent = NULL,
     .scatter_cpusets = true,
     .pending_slices = PMIX_LIST_STATIC_INIT
 };
 
-static prte_event_base_t **prte_event_base_ptr = NULL;
-
 static int prte_odls_base_register(pmix_mca_base_register_flag_t flags)
 {
     PRTE_HIDE_UNUSED_PARAMS(flags);
-
-    prte_odls_globals.max_threads = 16;
-    (void) pmix_mca_base_var_register("prte", "odls", "base", "max_threads",
-                                      "Maximum number of threads to use for spawning local procs",
-                                      PMIX_MCA_BASE_VAR_TYPE_INT,
-                                      &prte_odls_globals.max_threads);
-
-    /* -1 means "you decide" - start_threads then sizes the pool from the
-     * first job it is handed, and writes its choice back here */
-    prte_odls_globals.num_threads = -1;
-    (void) pmix_mca_base_var_register("prte", "odls", "base", "num_threads",
-                                      "Specific number of threads to use for spawning local procs",
-                                      PMIX_MCA_BASE_VAR_TYPE_INT,
-                                      &prte_odls_globals.num_threads);
-
-    prte_odls_globals.cutoff = 32;
-    (void) pmix_mca_base_var_register("prte", "odls", "base", "cutoff",
-                                      "Minimum number of local procs before using thread pool for spawn",
-                                      PMIX_MCA_BASE_VAR_TYPE_INT,
-                                      &prte_odls_globals.cutoff);
 
     prte_odls_globals.signal_direct_children_only = false;
     (void) pmix_mca_base_var_register("prte", "odls", "base", "signal_direct_children_only",
@@ -132,111 +102,6 @@ static int prte_odls_base_register(pmix_mca_base_register_flag_t flags)
                                       &prte_odls_globals.scatter_cpusets);
 
     return PRTE_SUCCESS;
-}
-
-void prte_odls_base_harvest_threads(void)
-{
-    int i;
-
-    if (0 < prte_odls_globals.num_threads) {
-        /* stop the progress threads */
-        if (NULL != prte_odls_globals.ev_threads) {
-            for (i = 0; NULL != prte_odls_globals.ev_threads[i]; i++) {
-                prte_progress_thread_finalize(prte_odls_globals.ev_threads[i]);
-            }
-            PMIx_Argv_free(prte_odls_globals.ev_threads);
-            prte_odls_globals.ev_threads = NULL;
-        }
-        /* this pool owned its array (the no-thread case borrows the shared
-         * prte_event_base_ptr instead, freed below) */
-        free(prte_odls_globals.ev_bases);
-    }
-    /* release the shared one-element array used when no dedicated threads
-     * were spun up. Nothing freed it before, so a daemon that launched any
-     * job below the cutoff leaked it at teardown */
-    if (NULL != prte_event_base_ptr) {
-        free(prte_event_base_ptr);
-        prte_event_base_ptr = NULL;
-    }
-    /* the pool is gone. Record that as "no threads" rather than restoring
-     * the -1 "you decide" sentinel: harvest runs from framework close, and
-     * leaving the sizing question open there invites start_threads to
-     * build a WHOLE NEW POOL on the way out if anything calls it again
-     * during teardown - which is exactly what happened (a 40-proc job on
-     * one node spun its five threads a second time while finalizing). */
-    prte_odls_globals.ev_bases = NULL;
-    prte_odls_globals.next_base = 0;
-    prte_odls_globals.num_threads = 0;
-}
-
-void prte_odls_base_start_threads(prte_job_t *jdata)
-{
-    int i;
-    char *tmp;
-
-    /* nothing to build on the way out - and harvest_threads has already
-     * torn down whatever there was */
-    if (prte_finalizing) {
-        return;
-    }
-
-    /* only do this once. NB: test ev_bases, not ev_threads - the
-     * no-dedicated-thread case leaves ev_threads NULL, so keying off it
-     * re-entered here on every subsequent job. */
-    if (NULL != prte_odls_globals.ev_bases) {
-        return;
-    }
-
-    /* if we are a persistent DVM, expect to service lots
-     * of clients */
-    if (prte_persistent) {
-        prte_odls_globals.num_threads = prte_odls_globals.max_threads;
-        goto startup;
-    }
-
-    /* setup the pool of worker threads */
-    prte_odls_globals.ev_threads = NULL;
-    prte_odls_globals.next_base = 0;
-    if (-1 == prte_odls_globals.num_threads) {
-        if ((int) jdata->num_local_procs < prte_odls_globals.cutoff) {
-            /* do not use any dedicated odls thread */
-            prte_odls_globals.num_threads = 0;
-        } else {
-            /* user didn't specify anything, so default to some fraction of
-             * the number of local procs, capping it at the max num threads
-             * parameter value. */
-            prte_odls_globals.num_threads = jdata->num_local_procs / 8;
-            if (0 == prte_odls_globals.num_threads) {
-                prte_odls_globals.num_threads = 1;
-            } else if (prte_odls_globals.max_threads < prte_odls_globals.num_threads) {
-                prte_odls_globals.num_threads = prte_odls_globals.max_threads;
-            }
-        }
-    }
-startup:
-    if (0 >= prte_odls_globals.num_threads) {
-        /* a negative num_threads only reaches here if the user asked for
-         * one; treat it as "no dedicated threads" rather than indexing
-         * ev_bases with it */
-        prte_odls_globals.num_threads = 0;
-        if (NULL == prte_event_base_ptr) {
-            prte_event_base_ptr = (prte_event_base_t **) malloc(sizeof(prte_event_base_t *));
-            /* use the default event base */
-            prte_event_base_ptr[0] = prte_event_base;
-        }
-        prte_odls_globals.ev_bases = prte_event_base_ptr;
-    } else {
-        pmix_output_verbose(5, prte_odls_base_framework.framework_output,
-                            "START %d LAUNCH THREADS", prte_odls_globals.num_threads);
-        prte_odls_globals.ev_bases = (prte_event_base_t **) malloc(prte_odls_globals.num_threads
-                                                                   * sizeof(prte_event_base_t *));
-        for (i = 0; i < prte_odls_globals.num_threads; i++) {
-            pmix_asprintf(&tmp, "PRTE-ODLS-%d", i);
-            prte_odls_globals.ev_bases[i] = prte_progress_thread_init(tmp);
-            PMIx_Argv_append_nosize(&prte_odls_globals.ev_threads, tmp);
-            free(tmp);
-        }
-    }
 }
 
 static int prte_odls_base_close(void)
@@ -262,8 +127,6 @@ static int prte_odls_base_close(void)
         }
     }
     PMIX_RELEASE(prte_local_children);
-
-    prte_odls_base_harvest_threads();
 
     return pmix_mca_base_framework_components_close(&prte_odls_base_framework, NULL);
 }

--- a/src/rml/AGENTS.md
+++ b/src/rml/AGENTS.md
@@ -500,9 +500,12 @@ worth stating rather than re-deriving:
   *caddy* + `PRTE_PMIX_THREADSHIFT` (see `PRTE_OOB_SEND`,
   `prte_rml_recv_buffer_nb`). Never read or write shared RML state off that
   thread, and never block on it. The one exception is deliberate and bounded:
-  a peer's *socket* send/recv handlers can be put on a worker progress thread
-  (`prte_oob_progress_threads`, default 0 — off), so that the wire keeps moving
-  while the main thread computes. Everything those handlers hand upward —
+  a peer's *socket* send/recv handlers run on a worker progress thread drawn
+  from the process-wide pool (`prte_worker_pool_assign()`, sized by
+  `prte_num_worker_threads`, default 8 — set it to 0 to put them back on the
+  main thread), so that the wire keeps moving while the main thread computes.
+  That pool is shared with the odls fork path, so a thread carrying your
+  sockets may also be forking a child. Everything those handlers hand upward —
   message delivery, relaying, send completions, the connection state machine —
   still comes back to `prte_event_base`. See [`oob/AGENTS.md`](oob/AGENTS.md),
   *Which thread services a peer's socket*, before adding anything to those

--- a/src/rml/oob/AGENTS.md
+++ b/src/rml/oob/AGENTS.md
@@ -158,13 +158,19 @@ In a launcher-less (bootstrapped) DVM daemons boot independently, so:
 
 ## Which thread services a peer's socket
 
-By default, all of it runs on `prte_event_base` — one progress thread, exactly
-as it always did. `prte_oob_progress_threads` (`prte_oob_base.num_progress_threads`,
-default **0**) starts N worker progress threads and hands each peer one of them,
-round-robin, at construction (`peer->evbase`). The point is not extra bandwidth —
-one thread's `writev` copy rate is several times a 10-25 GbE link — it is
-**occupancy**: while the main thread is deflating an xcast, registering a
-namespace, or running the odls fork path, nothing services a socket at all.
+`peer_cons` asks the **process-wide worker pool**
+([`src/runtime/prte_worker_pool.h`](../../runtime/prte_worker_pool.h)) for a
+base at construction (`peer->evbase`); the pool holds
+`prte_num_worker_threads` bases (default **8**) on a ring and hands them out in
+rotation. The OOB does not own that pool — it is shared with the odls fork
+path, and it is built by `prte_init` and torn down by `prte_finalize`. Setting
+`prte_num_worker_threads` to 0 makes every assignment `prte_event_base`, which
+is exactly how the transport ran before any of this existed.
+
+The point is not extra bandwidth — one thread's `writev` copy rate is several
+times a 10-25 GbE link — it is **occupancy**: while the main thread is
+deflating an xcast, registering a namespace, or running the odls fork path,
+nothing services a socket at all.
 
 The split is deliberate and narrow:
 
@@ -211,11 +217,12 @@ Four rules keep that safe, and all four are load-bearing:
   false`. If you add a third place that queues onto a peer, it needs the same
   tail.
 
-With `num_progress_threads == 0`, `peer->evbase` **is** `prte_event_base`:
+With an empty pool, `peer->evbase` **is** `prte_event_base`:
 `PRTE_OOB_COMPLETE_SEND` completes inline instead of posting, the rebind is a
 delete/re-set onto the base the events were already on, and the mutex is
-uncontended. `prte_oob_base.ev_bases` still exists and still holds one entry, so
-every call site indexes it unconditionally — do not "optimize" that array away.
+uncontended. `prte_worker_pool_assign()` never returns NULL, precisely so
+`peer_cons` needs no special case — and a peer built before the pool is up, or
+after it is gone, still gets a usable base.
 
 The one piece of state outside this directory that a worker touches directly is
 the RML's incarnation table (`prte_rml_epoch_ok`, bootstrap only), which

--- a/src/rml/oob/oob.h
+++ b/src/rml/oob/oob.h
@@ -104,18 +104,6 @@ typedef struct {
                                delay backs off exponentially up to this value (0 => fixed delay) */
     int connect_max_time;   /**< max seconds to keep retrying a non-lifeline peer before giving up
                                and letting the routing tree heal to an ancestor (0 => forever) */
-
-    /* Worker progress threads servicing peer socket events.  Each peer's
-     * send/recv events are bound to one of these bases (round-robin), so the
-     * wire keeps moving while the main progress thread is busy computing.
-     * num_progress_threads == 0 (the default) means "no worker threads": the
-     * array still exists, holding exactly one entry - prte_event_base - so
-     * every call site can index it unconditionally and the code path is
-     * bit-for-bit the one that ran before any of this existed. */
-    int num_progress_threads;      /**< number of dedicated worker progress threads */
-    prte_event_base_t **ev_bases;  /**< the bases peers are assigned to */
-    char **ev_threads;             /**< names of the threads we started (NULL when none) */
-    int next_base;                 /**< round-robin cursor into ev_bases */
 } prte_oob_base_t;
 PRTE_EXPORT extern prte_oob_base_t prte_oob_base;
 
@@ -123,13 +111,6 @@ PRTE_EXPORT extern prte_oob_base_t prte_oob_base;
 PRTE_EXPORT int prte_oob_open(void);
 PRTE_EXPORT void prte_oob_close(void);
 PRTE_EXPORT int prte_oob_register(void);
-
-/* Build and tear down the pool of bases that peer sockets are serviced on.
- * Called by prte_oob_open/prte_oob_close; exported (rather than left static)
- * so the unit test can drive the sizing and the round-robin assignment
- * without standing up listeners. */
-PRTE_EXPORT int prte_oob_start_progress_threads(void);
-PRTE_EXPORT void prte_oob_harvest_progress_threads(void);
 
 /* Simulate this node's failure better than simply killing the process */
 PRTE_EXPORT void prte_oob_simulate_node_failure(void);

--- a/src/rml/oob/oob_tcp.c
+++ b/src/rml/oob/oob_tcp.c
@@ -51,7 +51,6 @@
 #include <ctype.h>
 
 #include "src/include/prte_socket_errno.h"
-#include "src/runtime/prte_progress_threads.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/error.h"
 #include "src/util/pmix_if.h"
@@ -108,80 +107,8 @@ prte_oob_base_t prte_oob_base = {
     .keepalive_time = 0,
     .keepalive_intvl = 0,
     .retry_delay = 0,
-    .max_recon_attempts = 0,
-    .num_progress_threads = 0,
-    .ev_bases = NULL,
-    .ev_threads = NULL,
-    .next_base = 0
+    .max_recon_attempts = 0
 };
-
-/* Stand up the pool of event bases that peer sockets are serviced on.
- *
- * The zero case deliberately still allocates a one-element array holding
- * prte_event_base, so every call site can index ev_bases unconditionally and
- * a peer assigned "worker 0" with no workers configured is simply a peer on
- * the main progress thread - the behavior that predates this pool.
- */
-int prte_oob_start_progress_threads(void)
-{
-    int i;
-    char *tmp;
-
-    prte_oob_base.next_base = 0;
-    if (0 >= prte_oob_base.num_progress_threads) {
-        /* a negative value only reaches here if the user asked for one;
-         * treat it as "no worker threads" rather than sizing an array with it */
-        prte_oob_base.num_progress_threads = 0;
-        prte_oob_base.ev_bases = (prte_event_base_t **) malloc(sizeof(prte_event_base_t *));
-        if (NULL == prte_oob_base.ev_bases) {
-            return PRTE_ERR_OUT_OF_RESOURCE;
-        }
-        prte_oob_base.ev_bases[0] = prte_event_base;
-        return PRTE_SUCCESS;
-    }
-
-    pmix_output_verbose(5, prte_oob_base.output,
-                        "%s oob:tcp: starting %d OOB progress threads",
-                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), prte_oob_base.num_progress_threads);
-    prte_oob_base.ev_bases = (prte_event_base_t **)
-        malloc(prte_oob_base.num_progress_threads * sizeof(prte_event_base_t *));
-    if (NULL == prte_oob_base.ev_bases) {
-        return PRTE_ERR_OUT_OF_RESOURCE;
-    }
-    for (i = 0; i < prte_oob_base.num_progress_threads; i++) {
-        pmix_asprintf(&tmp, "PRTE-OOB-%d", i);
-        prte_oob_base.ev_bases[i] = prte_progress_thread_init(tmp);
-        if (NULL == prte_oob_base.ev_bases[i]) {
-            /* fall back to the main base for this slot rather than leaving a
-             * NULL that every peer assigned to it would dereference */
-            prte_oob_base.ev_bases[i] = prte_event_base;
-            free(tmp);
-            continue;
-        }
-        PMIx_Argv_append_nosize(&prte_oob_base.ev_threads, tmp);
-        free(tmp);
-    }
-    return PRTE_SUCCESS;
-}
-
-void prte_oob_harvest_progress_threads(void)
-{
-    int i;
-
-    if (NULL != prte_oob_base.ev_threads) {
-        for (i = 0; NULL != prte_oob_base.ev_threads[i]; i++) {
-            prte_progress_thread_finalize(prte_oob_base.ev_threads[i]);
-        }
-        PMIx_Argv_free(prte_oob_base.ev_threads);
-        prte_oob_base.ev_threads = NULL;
-    }
-    if (NULL != prte_oob_base.ev_bases) {
-        free(prte_oob_base.ev_bases);
-        prte_oob_base.ev_bases = NULL;
-    }
-    prte_oob_base.num_progress_threads = 0;
-    prte_oob_base.next_base = 0;
-}
 
 int prte_oob_open(void)
 {
@@ -376,14 +303,6 @@ int prte_oob_open(void)
         return PRTE_ERR_NOT_AVAILABLE;
     }
 
-    /* stand up the pool of bases peer sockets will be serviced on.  This has
-     * to precede the listeners: the first thing an accepted connection does is
-     * build a peer, and peer construction assigns it a base from this pool. */
-    if (PRTE_SUCCESS != (rc = prte_oob_start_progress_threads())) {
-        PRTE_ERROR_LOG(rc);
-        return rc;
-    }
-
     // start the listeners
     if (PRTE_SUCCESS != (rc = prte_oob_tcp_start_listening())) {
         prte_show_help("help-oob-tcp.txt", "no-listeners", true);
@@ -409,11 +328,12 @@ void prte_oob_close(void)
 
     }
 
-    /* stop servicing peer sockets before the peers themselves go away - a
-     * worker still in a send handler would be reading a peer we are about to
-     * destruct */
-    prte_oob_harvest_progress_threads();
-
+    /* Peer sockets are serviced on the process-wide worker pool, which we do
+     * not own and therefore do not harvest here.  Nothing is running on it by
+     * now either: prte_finalize stops every progress thread before it calls
+     * prte_ess.finalize(), which is the only path that reaches this
+     * function - so no worker is inside a send handler reading a peer we are
+     * about to destruct. */
     PMIX_LIST_DESTRUCT(&prte_oob_base.local_ifs);
     PMIX_LIST_DESTRUCT(&prte_oob_base.peers);
     /* the listener objects and the parsed port ranges are ours too - this tree
@@ -665,12 +585,6 @@ int prte_oob_register(void)
                                         "Maximum time (in sec) to keep retrying a connection to a non-lifeline peer before giving up so the routing tree can heal to an ancestor; 0 means retry forever",
                                         PMIX_MCA_BASE_VAR_TYPE_INT,
                                         &prte_oob_base.connect_max_time);
-
-    prte_oob_base.num_progress_threads = 0;
-    (void) pmix_mca_base_var_register("prte", "prte", NULL, "oob_progress_threads",
-                                        "Number of dedicated progress threads to service peer socket send/recv events (0 = service them on the main progress thread, as before)",
-                                        PMIX_MCA_BASE_VAR_TYPE_INT,
-                                        &prte_oob_base.num_progress_threads);
 
     prte_oob_base.max_msg_size = 100;
     (void) pmix_mca_base_var_register("prte", "prte", NULL, "max_msg_size",

--- a/src/rml/oob/oob_tcp_component.c
+++ b/src/rml/oob/oob_tcp_component.c
@@ -66,7 +66,7 @@
 #include "src/class/pmix_list.h"
 #include "src/event/event-internal.h"
 #include "src/include/prte_socket_errno.h"
-#include "src/runtime/prte_progress_threads.h"
+#include "src/runtime/prte_worker_pool.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_if.h"
 #include "src/util/error.h"
@@ -163,20 +163,11 @@ static void peer_cons(prte_oob_tcp_peer_t *peer)
 {
     peer->auth_method = NULL;
     peer->sd = -1;
-    /* claim the next base in the pool.  Peers are only ever built on the main
-     * progress thread (the send path, the URI parser, the accept handler), so
-     * the cursor needs no protection.  prte_oob_open always leaves ev_bases
-     * holding at least one entry, but a peer built before it ran - or after
-     * prte_oob_close harvested the pool - has to land somewhere. */
-    if (NULL == prte_oob_base.ev_bases) {
-        peer->evbase = prte_event_base;
-    } else {
-        peer->evbase = prte_oob_base.ev_bases[prte_oob_base.next_base];
-        if (0 < prte_oob_base.num_progress_threads) {
-            prte_oob_base.next_base = (prte_oob_base.next_base + 1)
-                                      % prte_oob_base.num_progress_threads;
-        }
-    }
+    /* claim the next base in the process-wide worker pool.  With no workers
+     * configured - or before the pool is up, or after it is gone - this is
+     * prte_event_base, which is where peer sockets were serviced before any
+     * of this existed. */
+    peer->evbase = prte_worker_pool_assign();
     PMIX_CONSTRUCT(&peer->lock, pmix_mutex_t);
     PMIX_CONSTRUCT(&peer->addrs, pmix_list_t);
     peer->active_addr = NULL;

--- a/src/rml/rml.c
+++ b/src/rml/rml.c
@@ -72,11 +72,11 @@ static char *dead_dmns_spec = NULL;
 
 /* The incarnation table is the one piece of RML state a peer's socket handler
  * reaches directly, and that handler runs on whichever base is servicing the
- * peer - one of the OOB progress threads when any were configured (see
- * prte_oob_base.num_progress_threads).  Two of them arriving at once would
- * both realloc the array.  The lock is taken only on the bootstrap incarnation
- * check, which is a handful of instructions per message and uncontended
- * whenever the OOB is running on the main thread alone. */
+ * peer - one of the process-wide worker threads when any are configured (see
+ * prte_num_worker_threads).  Two of them arriving at once would both realloc
+ * the array.  The lock is taken only on the bootstrap incarnation check, which
+ * is a handful of instructions per message and uncontended whenever the OOB is
+ * running on the main thread alone. */
 static pmix_mutex_t epoch_lock = PMIX_MUTEX_STATIC_INIT;
 
 /* Grow the per-rank epoch table so index rank is valid, zero-filling new slots

--- a/src/runtime/AGENTS.md
+++ b/src/runtime/AGENTS.md
@@ -22,7 +22,7 @@ Five separable things share the directory:
 | **Object model & globals** | `prte_globals.[ch]` | The three central data structures (`prte_job_t`, `prte_node_t`, `prte_proc_t`), plus `prte_session_t`, `prte_app_context_t`, `prte_topology_t`, the launch-fence campaign objects — their class instances, and the global registries (`prte_job_data`, `prte_node_pool`, `prte_sessions`, ...) with the lookup functions over them. |
 | **Lifecycle** | `prte_init.c`, `prte_finalize.c`, `prte_quit.[ch]`, `prte_locks.[ch]` | The three-stage startup (`prte_init_minimum` → `prte_init_util` → `prte_init`), teardown, the "stop looping the event base" path, and the one-shot mutexes that keep re-entrant shutdown from bouncing. |
 | **MCA parameters** | `prte_mca_params.c` | `prte_register_paramfile_params()` — the parameters naming the MCA parameter files, registered ahead of those files being read — and `prte_register_params()`, every other `prte_*` MCA variable, registered once afterwards. |
-| **Threads & timers** | `prte_progress_threads.[ch]`, `prte_wait.[ch]` | Named progress threads (event base + engine thread + refcount), the SIGCHLD/waitpid plumbing, and the `PRTE_DETECT_TIMEOUT`/`PRTE_TIMER_EVENT` macros. |
+| **Threads & timers** | `prte_progress_threads.[ch]`, `prte_worker_pool.[ch]`, `prte_wait.[ch]` | Named progress threads (event base + engine thread + refcount), the process-wide pool of worker threads built on top of them, the SIGCHLD/waitpid plumbing, and the `PRTE_DETECT_TIMEOUT`/`PRTE_TIMER_EVENT` macros. |
 | **Sub-directories** | [`data_server/`](data_server/AGENTS.md), [`data_type_support/`](data_type_support/AGENTS.md) | The PMIx publish/lookup service, and the pack/unpack/copy/print functions for the objects above. Each has its own AGENTS.md. |
 
 ---
@@ -198,6 +198,40 @@ specification. It is deliberately outside the `HAVE_PTHREAD_SETAFFINITY_NP`
 guard its only caller sits behind, so it can be tested on a platform without
 `pthread_setaffinity_np`; ranges are **inclusive** of their upper bound.
 
+### The worker pool
+
+`prte_worker_pool.[ch]` is the **one** pool of worker threads in the process.
+Two subsystems want work off the main progress thread — the OOB, for a peer's
+socket send/recv handlers, and odls, for the fork/exec of a local child — and
+both used to carry a private pool, private sizing rules and a private
+round-robin cursor. They now both call `prte_worker_pool_assign()`.
+
+- Sized by `prte_num_worker_threads` (default **8**). Zero means no workers,
+  and then every assignment is `prte_event_base` — the shape the tree ran in
+  before any of this existed.
+- Built in `prte_init()` and only for `PRTE_PROC_IS_MASTER ||
+  PRTE_PROC_IS_DAEMON`; a tool has neither peers to service nor children to
+  fork, so it spins nothing. Released in `prte_finalize()` right after the
+  `ess` framework closes, which is what tears the OOB and odls down.
+- **The threads are already stopped by then.** `prte_finalize` calls
+  `prte_progress_thread_pause(NULL)` at its very top, long before
+  `prte_ess.finalize()` runs, so no worker is inside an event handler while
+  the OOB destructs its peers. `prte_worker_pool_finalize()` is giving the
+  trackers back, not racing anything.
+- **The rotation is the ring, not a cursor.** The bases sit on a
+  `pmix_ring_buffer_t`; an assignment pops the oldest and pushes it straight
+  back, which advances the ring by one. That is the whole point of using a
+  ring here — there is no separate index that can fall out of step with the
+  pool's size, which is the bug both of the old private pools were shaped
+  around avoiding.
+- `prte_worker_pool_assign()` **never returns NULL.** Callers use the result
+  unconditionally, so "no pool" has to be an answer rather than a special
+  case: before init, after finalize, and with zero threads configured, it
+  hands back `prte_event_base`.
+- A thread that fails to start shrinks the pool rather than failing the init.
+  `prte_worker_pool_size()` is the answer; `prte_num_worker_threads` is only
+  the request.
+
 ---
 
 ## Gotchas before you edit
@@ -296,7 +330,9 @@ map with more nodes than one array block, and the refcount arithmetic when
 both maps are released), the pack/unpack round trips for job/app/proc/node/map
 and the GLOBAL-vs-LOCAL attribute split, object lifetimes and the borrowed
 backpointer contract, the exit-status macros, the data server's range checks
-and object construction, the progress-thread cpu parser and lifecycle, and
+and object construction, the progress-thread cpu parser and lifecycle, the
+worker pool (the empty and negative cases, and two laps of the rotation over
+three real threads), and
 the two-phase parameter registration (it writes a parameter file and points
 `prte_param_files` at it *before* calling `prte_init_util`, then checks that
 a core `prte_*` parameter and an RML one came back carrying the file's

--- a/src/runtime/Makefile.am
+++ b/src/runtime/Makefile.am
@@ -35,7 +35,8 @@ headers += \
         runtime/prte_quit.h \
         runtime/runtime_internals.h \
         runtime/prte_wait.h \
-        runtime/prte_progress_threads.h
+        runtime/prte_progress_threads.h \
+        runtime/prte_worker_pool.h
 
 libprrte_la_SOURCES += \
         runtime/prte_finalize.c \
@@ -49,6 +50,7 @@ libprrte_la_SOURCES += \
         runtime/data_type_support/prte_dt_unpacking_fns.c \
         runtime/prte_mca_params.c \
         runtime/prte_wait.c \
-        runtime/prte_progress_threads.c
+        runtime/prte_progress_threads.c \
+        runtime/prte_worker_pool.c
 
 include runtime/data_server/Makefile.am

--- a/src/runtime/prte_finalize.c
+++ b/src/runtime/prte_finalize.c
@@ -46,6 +46,7 @@
 #include "src/runtime/prte_globals.h"
 #include "src/runtime/prte_locks.h"
 #include "src/runtime/prte_progress_threads.h"
+#include "src/runtime/prte_worker_pool.h"
 #include "src/runtime/runtime.h"
 #include "src/util/name_fns.h"
 #include "src/util/proc_info.h"
@@ -114,6 +115,12 @@ int prte_finalize(void)
         PRTE_ERROR_LOG(rc);
     }
     (void) pmix_mca_base_framework_close(&prte_ess_base_framework);
+
+    /* The ess finalize above tore down the OOB and the odls, so nothing is
+     * left that wants a worker base.  The threads themselves were already
+     * stopped by the prte_progress_thread_pause(NULL) at the top of this
+     * function, so this just gives the trackers back. */
+    prte_worker_pool_finalize();
 
     /* Tear the sessions down, and with them the node pool.
      *

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -84,6 +84,7 @@
 #include "src/runtime/pmix_init_util.h"
 #include "src/runtime/prte_globals.h"
 #include "src/runtime/prte_locks.h"
+#include "src/runtime/prte_worker_pool.h"
 #include "src/runtime/runtime.h"
 #include "src/runtime/runtime_internals.h"
 
@@ -557,6 +558,21 @@ int prte_init(int *pargc, char ***pargv, prte_proc_type_t flags)
     if (PRTE_SUCCESS != (ret = prte_ess_base_select())) {
         error = "prte_ess_base_select";
         goto error;
+    }
+
+    /* Stand up the pool of worker threads.  Only the DVM master and the
+     * daemons have anything to put on it - peer sockets and local children -
+     * so a tool spins no threads it will never use.
+     *
+     * This must precede prte_ess.init(), which is where the OOB is opened:
+     * a peer built before the pool exists is pinned to the main progress
+     * thread for its whole life, and a daemon's peer to the HNP - the one
+     * socket everything it does crosses - is built right there. */
+    if (PRTE_PROC_IS_MASTER || PRTE_PROC_IS_DAEMON) {
+        if (PRTE_SUCCESS != (ret = prte_worker_pool_init())) {
+            error = "prte_worker_pool_init";
+            goto error;
+        }
     }
 
     /* initialize the RTE for this environment */

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -50,6 +50,7 @@
 #include "src/mca/errmgr/errmgr.h"
 
 #include "src/runtime/prte_globals.h"
+#include "src/runtime/prte_worker_pool.h"
 #include "src/runtime/runtime.h"
 #include "src/runtime/runtime_internals.h"
 
@@ -606,6 +607,17 @@ int prte_register_params(void)
                                       "Whether binding of internal PRRTE progress thread is required",
                                       PMIX_MCA_BASE_VAR_TYPE_BOOL,
                                       &prte_bind_progress_thread_reqd);
+
+    /* One pool of worker threads serves everything PRRTE wants off the main
+     * progress thread - peer socket handlers and local fork/exec both draw
+     * from it.  See src/runtime/prte_worker_pool.h. */
+    prte_num_worker_threads = 8;
+    (void) pmix_mca_base_var_register("prte", "prte", NULL, "num_worker_threads",
+                                      "Number of worker progress threads used to service peer "
+                                      "sockets and to fork/exec local processes (0 = do both on "
+                                      "the main progress thread)",
+                                      PMIX_MCA_BASE_VAR_TYPE_INT,
+                                      &prte_num_worker_threads);
 
     (void) pmix_mca_base_var_register("prte", "prte", NULL, "uniform_nodes",
                                       "Allocation contains homogeneous nodes",

--- a/src/runtime/prte_worker_pool.c
+++ b/src/runtime/prte_worker_pool.c
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "prte_config.h"
+#include "constants.h"
+
+#include "src/class/pmix_ring_buffer.h"
+#include "src/threads/pmix_threads.h"
+#include "src/util/pmix_argv.h"
+#include "src/util/pmix_output.h"
+#include "src/util/pmix_printf.h"
+
+#include "src/pmix/pmix-internal.h"
+#include "src/runtime/prte_progress_threads.h"
+#include "src/runtime/prte_worker_pool.h"
+
+/* The requested pool size, from the prte_num_worker_threads MCA parameter
+ * (registered in prte_register_params, which is where its default is set). */
+int prte_num_worker_threads = 8;
+
+/* The bases, on a ring.  A request pops the oldest and pushes it straight
+ * back, which advances the ring by one - so the rotation is the ring's own
+ * head/tail bookkeeping and there is no separate cursor that could fall out
+ * of step with the pool's size. */
+static pmix_ring_buffer_t bases = PMIX_RING_BUFFER_STATIC_INIT;
+
+/* Whether `bases` is currently constructed.  PMIX_DESTRUCT zeroes an object's
+ * magic id and a debug PMIx asserts on the next one, so "finalize is safe to
+ * call twice" - and it is, from a failed startup and again from
+ * prte_finalize - has to mean something more careful than destructing
+ * unconditionally. */
+static bool ring_built = false;
+
+/* Names of the progress threads we started, in the order we started them.
+ * prte_progress_thread_finalize() is keyed by name, so this is what lets us
+ * give back exactly the threads we took. */
+static char **thread_names = NULL;
+
+/* How many workers are actually running.  Not the same as
+ * prte_num_worker_threads: that is the request, this is the answer. */
+static int nworkers = 0;
+
+/* Assignment is expected to happen on the main progress thread - peers are
+ * built there, and so is the launch walk - but this pool is now shared by
+ * subsystems that used to have a cursor each, so serialize the rotation
+ * rather than rest on that expectation.  It is two pointer updates on a
+ * path that is already doing a connect() or a fork(). */
+static pmix_mutex_t pool_lock = PMIX_MUTEX_STATIC_INIT;
+
+int prte_worker_pool_init(void)
+{
+    prte_event_base_t *evb;
+    char *tmp;
+    int i, rc;
+
+    if (0 < nworkers) {
+        /* already up */
+        return PRTE_SUCCESS;
+    }
+
+    if (0 >= prte_num_worker_threads) {
+        /* a negative value only gets here because someone asked for one;
+         * treat it as "no workers" rather than sizing a ring with it */
+        nworkers = 0;
+        return PRTE_SUCCESS;
+    }
+
+    PMIX_CONSTRUCT(&bases, pmix_ring_buffer_t);
+    ring_built = true;
+    rc = pmix_ring_buffer_init(&bases, prte_num_worker_threads);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_DESTRUCT(&bases);
+        ring_built = false;
+        return prte_pmix_convert_status(rc);
+    }
+
+    for (i = 0; i < prte_num_worker_threads; i++) {
+        pmix_asprintf(&tmp, "PRTE-WORKER-%d", i);
+        evb = prte_progress_thread_init(tmp);
+        if (NULL == evb) {
+            /* we could not get another thread - keep the ones we did get.
+             * The ring is only partially filled, which the rotation copes
+             * with, and nworkers records what we actually have. */
+            free(tmp);
+            break;
+        }
+        pmix_ring_buffer_push(&bases, evb);
+        PMIx_Argv_append_nosize(&thread_names, tmp);
+        free(tmp);
+        ++nworkers;
+    }
+
+    if (nworkers < prte_num_worker_threads) {
+        /* Say so unconditionally rather than behind a verbosity: this is not
+         * a tuning detail, it is the process failing to build what it was
+         * asked for, and it runs before any debug stream exists to hide it
+         * behind.  Everything still works - the shortfall costs occupancy,
+         * not correctness - so it is a notice, not an error. */
+        pmix_output(0, "PRRTE: started %d of the %d requested worker threads",
+                    nworkers, prte_num_worker_threads);
+    }
+
+    if (0 == nworkers) {
+        /* not one thread started - nothing is going to index this ring */
+        PMIX_DESTRUCT(&bases);
+        ring_built = false;
+    }
+    return PRTE_SUCCESS;
+}
+
+void prte_worker_pool_finalize(void)
+{
+    int i;
+
+    if (NULL != thread_names) {
+        for (i = 0; NULL != thread_names[i]; i++) {
+            prte_progress_thread_finalize(thread_names[i]);
+        }
+        PMIx_Argv_free(thread_names);
+        thread_names = NULL;
+    }
+    /* the ring holds borrowed pointers - the event bases belong to the
+     * progress-thread trackers just released - so this frees the ring's own
+     * storage and nothing else */
+    if (ring_built) {
+        PMIX_DESTRUCT(&bases);
+        ring_built = false;
+    }
+    nworkers = 0;
+}
+
+prte_event_base_t *prte_worker_pool_assign(void)
+{
+    prte_event_base_t *evb;
+
+    if (0 >= nworkers) {
+        /* no pool: everything runs where it always ran */
+        return prte_event_base;
+    }
+
+    pmix_mutex_lock(&pool_lock);
+    evb = (prte_event_base_t *) pmix_ring_buffer_pop(&bases);
+    if (NULL != evb) {
+        /* put it straight back at the head, which is what makes the next
+         * pop hand out the *next* base rather than this one again */
+        pmix_ring_buffer_push(&bases, evb);
+    }
+    pmix_mutex_unlock(&pool_lock);
+
+    if (NULL == evb) {
+        return prte_event_base;
+    }
+    return evb;
+}
+
+int prte_worker_pool_size(void)
+{
+    return nworkers;
+}

--- a/src/runtime/prte_worker_pool.h
+++ b/src/runtime/prte_worker_pool.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/** @file
+ *
+ * The process-wide pool of worker progress threads.
+ *
+ * PRRTE has two kinds of work it wants off the main progress thread: a
+ * peer's socket send/recv handlers (so the wire keeps moving while the main
+ * thread computes) and the fork/exec of a local child (so a big local proc
+ * count is not a serial walk).  Both used to carry their own private pool,
+ * their own sizing rules and their own round-robin cursor, which meant two
+ * sets of threads competing for the same cores and two sets of parameters
+ * to reason about.  There is now one pool, and both ask it for a base.
+ *
+ * The pool is built once, in prte_init(), for the roles that have peers and
+ * children - the DVM master and the daemons.  A tool builds nothing.
+ *
+ * Assignment is a rotation, not a placement decision: the bases live on a
+ * ring, and each request pops the oldest and pushes it back, so successive
+ * requests cycle around the ring with no cursor to keep in step with the
+ * pool's size.
+ */
+
+#ifndef PRTE_WORKER_POOL_H
+#define PRTE_WORKER_POOL_H
+
+#include "prte_config.h"
+
+#include "src/event/event-internal.h"
+
+/** Number of worker threads the pool should run, from the MCA parameter
+ * prte_num_worker_threads.  Zero (or less) means "no workers": every
+ * assignment hands back prte_event_base and the process runs exactly as it
+ * did before any of this existed. */
+PRTE_EXPORT extern int prte_num_worker_threads;
+
+/**
+ * Start the pool.  Idempotent - a second call while the pool is up is a
+ * no-op, which is what lets a caller ask for the pool without having to
+ * know whether some other subsystem got there first.
+ *
+ * Returns PRTE_SUCCESS even when prte_num_worker_threads is zero; the pool
+ * is then simply empty.  A thread that fails to start shrinks the pool
+ * rather than failing the call: fewer workers is a degradation, not a
+ * reason to refuse to run.
+ */
+PRTE_EXPORT int prte_worker_pool_init(void);
+
+/**
+ * Stop the pool and release it.  Safe to call when the pool was never
+ * started, and safe to call twice.
+ *
+ * Note that prte_finalize() has already stopped every progress thread
+ * (prte_progress_thread_pause(NULL)) before any framework teardown runs, so
+ * by the time this is reached no worker is executing an event handler.
+ */
+PRTE_EXPORT void prte_worker_pool_finalize(void);
+
+/**
+ * Claim the next base in the rotation.
+ *
+ * Never returns NULL: with no workers - not configured, not yet started, or
+ * already harvested - the answer is prte_event_base, so every caller can
+ * use the result unconditionally.
+ */
+PRTE_EXPORT prte_event_base_t *prte_worker_pool_assign(void);
+
+/**
+ * How many worker threads are actually running.  Zero means every
+ * assignment lands on the main progress thread.
+ */
+PRTE_EXPORT int prte_worker_pool_size(void);
+
+#endif /* PRTE_WORKER_POOL_H */

--- a/test/unit/odls/test_odls.c
+++ b/test/unit/odls/test_odls.c
@@ -542,92 +542,6 @@ static int test_child_pipe_protocol(void)
     return failures;
 }
 
-/*
- * The spawn-thread pool.  start_threads sizes the pool from the job it is
- * first handed, and writes its choice back into
- * prte_odls_globals.num_threads.  That makes the "have we already built a
- * pool?" test load-bearing: keying it off ev_threads (which stays NULL
- * whenever the pool is "no dedicated threads at all") let the choice made
- * for the first small job stand for the life of the daemon, so a later job
- * with thousands of local procs still forked them one at a time on the
- * progress thread.  Guard the guard, and the reset harvest_threads owes.
- */
-static int test_thread_pool_sizing(void)
-{
-    int failures = 0;
-    prte_job_t *jdata;
-    bool save_persistent = prte_persistent;
-
-    /* Drive the from-the-job sizing branch.  prte_persistent defaults to
-     * true, and a persistent DVM short-circuits to max_threads and spins
-     * that many real progress threads - which this bare test process is in
-     * no position to start and stop. */
-    prte_persistent = false;
-
-    /* start from a known-clean pool */
-    prte_odls_base_harvest_threads();
-    CHECK("harvest clears the base array", NULL == prte_odls_globals.ev_bases);
-    CHECK("harvest leaves no threads behind", 0 == prte_odls_globals.num_threads);
-    /* the sizing sentinel is what register() established; harvest must NOT
-     * put it back (see below) */
-    prte_odls_globals.num_threads = -1;
-
-    /* a job below the cutoff gets no dedicated threads, and forks on the
-     * shared default base */
-    jdata = PMIX_NEW(prte_job_t);
-    jdata->num_local_procs = 1;
-    prte_odls_base_start_threads(jdata);
-    CHECK("small job uses no dedicated threads", 0 == prte_odls_globals.num_threads);
-    /* ...which means the one entry is the shared default base itself.  (In
-     * this bare test process prte_event_base has never been created, so
-     * compare against it rather than asserting non-NULL.) */
-    CHECK("small job dispatches on the default base",
-          NULL != prte_odls_globals.ev_bases
-          && prte_event_base == prte_odls_globals.ev_bases[0]);
-    /* launch_local indexes ev_bases with next_base after incrementing and
-     * wrapping at num_threads; with no dedicated threads that must land on
-     * the single element, not past it */
-    ++prte_odls_globals.next_base;
-    if (prte_odls_globals.num_threads <= prte_odls_globals.next_base) {
-        prte_odls_globals.next_base = 0;
-    }
-    CHECK("the dispatch index stays inside the one-element array",
-          0 == prte_odls_globals.next_base);
-
-    /* asking again for the same pool must be a no-op, not a rebuild */
-    prte_odls_base_start_threads(jdata);
-    CHECK("start_threads is idempotent", 0 == prte_odls_globals.num_threads);
-    PMIX_RELEASE(jdata);
-
-    /* Harvest tears the pool down and must leave it torn down.  It runs
-     * from framework CLOSE, so anything that reopens the sizing question
-     * here is an invitation to build a whole new pool on the way out: with
-     * the "-1 = you decide" sentinel restored, a later start_threads during
-     * teardown re-sized from the job and spun a second set of real threads
-     * (seen on a 40-proc node, which printed "START 5 LAUNCH THREADS"
-     * twice).  Record "no threads", not "undecided". */
-    prte_odls_base_harvest_threads();
-    CHECK("harvest released the base array", NULL == prte_odls_globals.ev_bases);
-    CHECK("harvest leaves the pool at zero, not undecided",
-          0 == prte_odls_globals.num_threads);
-
-    /* ...and a call that arrives while finalizing builds nothing at all */
-    prte_finalizing = true;
-    jdata = PMIX_NEW(prte_job_t);
-    jdata->num_local_procs = (int32_t) prte_odls_globals.cutoff + 8;
-    prte_odls_base_start_threads(jdata);
-    CHECK("start_threads builds nothing once finalizing",
-          NULL == prte_odls_globals.ev_bases && 0 == prte_odls_globals.num_threads);
-    PMIX_RELEASE(jdata);
-    prte_finalizing = false;
-
-    prte_persistent = save_persistent;
-
-    if (0 == failures) {
-        fprintf(stdout, "PASSED test_thread_pool_sizing\n");
-    }
-    return failures;
-}
 
 /*
  * Signalling a proc that has no pid must not reach the daemon.
@@ -754,7 +668,6 @@ int main(void)
     failures += test_attribute_order();
     failures += test_process_envars();
     failures += test_child_pipe_protocol();
-    failures += test_thread_pool_sizing();
     failures += test_signal_skips_dead_procs();
 
     (void) pmix_mca_base_framework_close(&prte_odls_base_framework);

--- a/test/unit/rml/test_rml.c
+++ b/test/unit/rml/test_rml.c
@@ -63,6 +63,7 @@
 #endif
 
 #include "src/runtime/prte_globals.h"
+#include "src/runtime/prte_worker_pool.h"
 #include "src/runtime/runtime.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_if.h"
@@ -425,87 +426,62 @@ static int test_payload_outlives_sends(void)
     return failures;
 }
 
-/*
- * The pool of event bases that peer sockets are serviced on.
+/* Which base a peer's socket handlers run on.
  *
- * Two properties matter and neither needs a socket to check.  First, the
- * "no worker threads" case - which is the default, and therefore the shape
- * every existing deployment runs - must still leave ev_bases holding exactly
- * one entry, prte_event_base, because every call site indexes the array
- * unconditionally; a NULL array or a zero-length one is a segfault on the
- * first peer.  Second, peers must be handed out round-robin and the cursor
- * must wrap, since a cursor that ran off the end would index past the array.
+ * peer_cons does not decide - it asks the process-wide worker pool (see
+ * src/runtime/prte_worker_pool.h), and what matters here is that it asks at
+ * all, and that it copes with the answer in both shapes.  With no pool up -
+ * the state a peer built before prte_init stood one up, or after finalize
+ * took it down, is in - every peer must land on prte_event_base, because
+ * every socket path uses peer->evbase unconditionally.  With a pool up,
+ * successive peers must land on different bases, or the pool buys nothing.
  *
- * The multi-thread case is driven with a hand-built array rather than by
- * asking for real threads: prte_progress_thread_init spins an actual engine
- * thread per base, which a bare test process has no business starting.  What
- * is under test here is the assignment arithmetic, not libevent.
+ * The rotation itself is tested where it lives, in test_runtime.
  */
-static int test_progress_thread_pool(void)
+static int test_peer_base_assignment(void)
 {
-    int failures = 0, i;
-    prte_event_base_t *fake[3];
-    prte_oob_tcp_peer_t *peers[7];
+    int failures = 0, i, save = prte_num_worker_threads;
+    prte_oob_tcp_peer_t *peers[6];
 
-    /* the default: no dedicated threads */
-    prte_oob_base.num_progress_threads = 0;
-    prte_oob_base.ev_bases = NULL;
-    prte_oob_base.ev_threads = NULL;
-    prte_oob_base.next_base = 0;
-    CHECK("pool starts", PRTE_SUCCESS == prte_oob_start_progress_threads());
-    CHECK("array exists with no threads", NULL != prte_oob_base.ev_bases);
-    CHECK("no threads means the main base",
-          NULL != prte_oob_base.ev_bases && prte_event_base == prte_oob_base.ev_bases[0]);
-    CHECK("no threads recorded", 0 == prte_oob_base.num_progress_threads);
-    CHECK("no thread names recorded", NULL == prte_oob_base.ev_threads);
-
-    /* every peer lands on that one entry, and the cursor does not move */
+    /* no pool: every peer takes the main base.  (prte_event_base has never
+     * been created in this bare test process, so compare against it rather
+     * than asserting non-NULL.) */
+    prte_num_worker_threads = 0;
+    CHECK("empty pool starts", PRTE_SUCCESS == prte_worker_pool_init());
     for (i = 0; i < 3; i++) {
         peers[i] = PMIX_NEW(prte_oob_tcp_peer_t);
         CHECK("peer takes the main base", prte_event_base == peers[i]->evbase);
     }
-    CHECK("cursor pinned with no threads", 0 == prte_oob_base.next_base);
     for (i = 0; i < 3; i++) {
         PMIX_RELEASE(peers[i]);
     }
+    prte_worker_pool_finalize();
 
-    prte_oob_harvest_progress_threads();
-    CHECK("harvest clears the array", NULL == prte_oob_base.ev_bases);
-    CHECK("harvest clears the count", 0 == prte_oob_base.num_progress_threads);
-
-    /* a negative request is a request for none, not an array sized -1 */
-    prte_oob_base.num_progress_threads = -4;
-    CHECK("negative pool starts", PRTE_SUCCESS == prte_oob_start_progress_threads());
-    CHECK("negative clamps to none", 0 == prte_oob_base.num_progress_threads);
-    CHECK("negative still yields the main base",
-          NULL != prte_oob_base.ev_bases && prte_event_base == prte_oob_base.ev_bases[0]);
-    prte_oob_harvest_progress_threads();
-
-    /* three bases, seven peers: 0,1,2,0,1,2,0 */
-    for (i = 0; i < 3; i++) {
-        /* distinct non-NULL values are all the assignment arithmetic sees */
-        fake[i] = (prte_event_base_t *) &fake[i];
-    }
-    prte_oob_base.num_progress_threads = 3;
-    prte_oob_base.ev_bases = fake;
-    prte_oob_base.next_base = 0;
-    for (i = 0; i < 7; i++) {
+    /* three workers, six peers: each peer takes a worker base, and the
+     * assignment cycles with the pool's period rather than pinning them all
+     * to one thread */
+    prte_num_worker_threads = 3;
+    CHECK("worker pool starts", PRTE_SUCCESS == prte_worker_pool_init());
+    for (i = 0; i < 6; i++) {
         peers[i] = PMIX_NEW(prte_oob_tcp_peer_t);
     }
-    for (i = 0; i < 7; i++) {
-        CHECK("peer assigned round-robin", fake[i % 3] == peers[i]->evbase);
+    for (i = 0; i < 6; i++) {
+        CHECK("peer left the main base", prte_event_base != peers[i]->evbase);
+        CHECK("peer assignment cycles with the pool",
+              peers[i]->evbase == peers[i % 3]->evbase);
     }
-    CHECK("cursor wrapped", 1 == prte_oob_base.next_base);
-    for (i = 0; i < 7; i++) {
+    CHECK("consecutive peers get different bases",
+          peers[0]->evbase != peers[1]->evbase
+          && peers[1]->evbase != peers[2]->evbase
+          && peers[0]->evbase != peers[2]->evbase);
+    for (i = 0; i < 6; i++) {
         PMIX_RELEASE(peers[i]);
     }
-    /* the array is on our stack - do not let harvest free it */
-    prte_oob_base.ev_bases = NULL;
-    prte_oob_base.num_progress_threads = 0;
-    prte_oob_base.next_base = 0;
+    prte_worker_pool_finalize();
+    prte_num_worker_threads = save;
 
     if (0 == failures) {
-        fprintf(stdout, "PASSED test_progress_thread_pool\n");
+        fprintf(stdout, "PASSED test_peer_base_assignment\n");
     }
     return failures;
 }
@@ -648,7 +624,7 @@ int main(void)
     failures += test_bad_subnets_dropped();
     failures += test_subnet_resolves_and_dedupes();
     failures += test_payload_outlives_sends();
-    failures += test_progress_thread_pool();
+    failures += test_peer_base_assignment();
     failures += test_wire_header();
 
     prte_finalize();

--- a/test/unit/runtime/test_runtime.c
+++ b/test/unit/runtime/test_runtime.c
@@ -73,6 +73,7 @@
 #include "src/rml/rml.h"
 #include "src/runtime/prte_globals.h"
 #include "src/runtime/prte_progress_threads.h"
+#include "src/runtime/prte_worker_pool.h"
 #include "src/runtime/runtime.h"
 #include "src/util/attr.h"
 #include "src/util/proc_info.h"
@@ -1627,6 +1628,80 @@ static int test_progress_thread_lifecycle(void)
     return failures;
 }
 
+/* The process-wide worker pool.
+ *
+ * Two things are worth pinning.  The rotation must actually rotate: the
+ * bases sit on a ring and each assignment pops the oldest and pushes it
+ * straight back, so N successive requests must visit all N bases and the
+ * (N+1)th must come back around to the first.  A cursor kept alongside the
+ * ring is exactly what this replaced, and the failure it invites - a cursor
+ * that no longer matches the pool's size - is what "walk it twice around"
+ * catches.
+ *
+ * And the empty pool must still answer.  Every caller uses the result
+ * unconditionally, so "no workers configured" has to hand back
+ * prte_event_base rather than NULL.  (In this bare test process
+ * prte_event_base has never been created, so compare against it rather than
+ * asserting non-NULL.)
+ */
+static int test_worker_pool(void)
+{
+    int failures = 0, i, save = prte_num_worker_threads;
+    prte_event_base_t *first[3], *evb;
+
+    /* no workers: every assignment is the main progress thread */
+    prte_num_worker_threads = 0;
+    CHECK("pool: an empty pool starts", PRTE_SUCCESS == prte_worker_pool_init());
+    CHECK("pool: an empty pool has no threads", 0 == prte_worker_pool_size());
+    for (i = 0; i < 3; i++) {
+        CHECK("pool: no workers means the main base",
+              prte_event_base == prte_worker_pool_assign());
+    }
+    prte_worker_pool_finalize();
+
+    /* a negative request is a request for none, not a ring sized -1 */
+    prte_num_worker_threads = -4;
+    CHECK("pool: a negative request starts", PRTE_SUCCESS == prte_worker_pool_init());
+    CHECK("pool: a negative request clamps to none", 0 == prte_worker_pool_size());
+    CHECK("pool: a negative request still answers",
+          prte_event_base == prte_worker_pool_assign());
+    prte_worker_pool_finalize();
+
+    /* three workers */
+    prte_num_worker_threads = 3;
+    CHECK("pool: three workers start", PRTE_SUCCESS == prte_worker_pool_init());
+    CHECK("pool: three workers recorded", 3 == prte_worker_pool_size());
+
+    for (i = 0; i < 3; i++) {
+        first[i] = prte_worker_pool_assign();
+        CHECK("pool: an assignment is a real base", NULL != first[i]);
+        CHECK("pool: an assignment is not the main base", prte_event_base != first[i]);
+    }
+    CHECK("pool: the first lap visits three distinct bases",
+          first[0] != first[1] && first[1] != first[2] && first[0] != first[2]);
+
+    /* second lap: same order, which is what makes it a rotation rather than
+     * an arbitrary shuffle */
+    for (i = 0; i < 3; i++) {
+        evb = prte_worker_pool_assign();
+        CHECK("pool: the rotation wraps in order", first[i] == evb);
+    }
+
+    /* asking again while the pool is up must not build a second one */
+    CHECK("pool: init is idempotent", PRTE_SUCCESS == prte_worker_pool_init());
+    CHECK("pool: init did not add threads", 3 == prte_worker_pool_size());
+
+    prte_worker_pool_finalize();
+    CHECK("pool: finalize leaves no threads", 0 == prte_worker_pool_size());
+    CHECK("pool: a harvested pool falls back to the main base",
+          prte_event_base == prte_worker_pool_assign());
+    /* and finalizing twice is not a fault */
+    prte_worker_pool_finalize();
+
+    prte_num_worker_threads = save;
+    return failures;
+}
+
 /* ------------------------------------------------------------------ */
 
 int main(void)
@@ -1690,6 +1765,7 @@ int main(void)
     failures += test_data_server_requestor();
     failures += test_progress_thread_cpus();
     failures += test_progress_thread_lifecycle();
+    failures += test_worker_pool();
     failures += test_paramfile_ordering();
 
     if (paramfile_written) {


### PR DESCRIPTION
## The problem

PRRTE runs two pools of worker progress threads that never knew about each other:

- the **OOB's**, for a peer's socket send/recv handlers — `prte_oob_progress_threads`, default 0 (off);
- the **odls's**, for the `fork`/`exec` of a local child — sized from the first job the daemon happened to be handed, governed by `odls_base_num_threads`, `odls_base_max_threads` and `odls_base_cutoff`.

Each carried its own array of event bases, its own round-robin cursor, and its own spelling of "no threads at all". Each of those rules had already produced a bug: a cursor that has to stay in step with a count that is *both* the request and the answer, and a "have we built a pool yet?" test that keyed off the wrong field (the thread *names*, which stay NULL precisely when the answer was "no dedicated threads").

There is no reason for two. Both want the same thing — an event base that is not the main progress thread — and both compete for the same cores when they run at once.

## The change

One process-wide pool in `src/runtime/prte_worker_pool.[ch]`, sized by **`prte_num_worker_threads`**. Both call sites reduce to asking it for a base.

```c
int                 prte_worker_pool_init(void);      /* idempotent */
void                prte_worker_pool_finalize(void);  /* safe twice */
prte_event_base_t  *prte_worker_pool_assign(void);    /* never NULL */
int                 prte_worker_pool_size(void);      /* the answer, vs. the request */
```

**The rotation is the ring, not a cursor.** The bases sit on a `pmix_ring_buffer_t`; an assignment pops the oldest and pushes it straight back, which advances the ring by one. That is the point of using a ring rather than an index — there is no separate cursor that can fall out of step with the pool's size, which is the failure both of the old pools were shaped around avoiding. A partially filled ring (a thread that failed to start) rotates correctly too.

`prte_worker_pool_assign()` **never returns NULL** — with no workers, before the pool is built, or after it is torn down, it hands back `prte_event_base` — so no caller needs a special case for the empty pool.

### Lifecycle

Built in `prte_init()`, and only for `PRTE_PROC_IS_MASTER || PRTE_PROC_IS_DAEMON`, so a tool spins no threads it will never use.

It must be built **before `prte_ess.init()`**, which is where the OOB opens: a peer created before the pool exists is pinned to the main progress thread for its whole life, and a daemon's peer to the HNP — the socket everything it does crosses — is created right there.

Released in `prte_finalize()` after the `ess` framework closes, by which point `prte_progress_thread_pause(NULL)` has long since stopped every thread. That ordering also retires a latent use-after-free: the old `prte_oob_close()` harvested its pool at the top, calling `prte_event_base_free()` on bases whose peer events were `event_del`'d a few lines further down.

### Removed

MCA parameters `prte_oob_progress_threads`, `odls_base_num_threads`, `odls_base_max_threads`, `odls_base_cutoff`; the `num_progress_threads`/`ev_bases`/`ev_threads`/`next_base` fields of `prte_oob_base_t` and the six equivalents in `prte_odls_globals_t`; and `prte_oob_start/harvest_progress_threads()` plus `prte_odls_base_start/harvest_threads()`.

## Behavior change worth calling out

**The default is now 8 threads**, where it was previously "none for the OOB, and none for odls below 32 local procs". The threaded paths are the ones that run unless a user asks otherwise; `--prtemca prte_num_worker_threads 0` restores the single-threaded behavior exactly.

For scale, the measured thread inventory of a daemon at rest on Linux is **2 event loops plus, on the HNP only, the OOB listener** — so the HNP goes 3 → 11 threads and a `prted` 2 → 10. If 8 is the wrong default, that is the number to weigh it against.

The `fork` of a job marked `STOP_ON_EXEC` still goes to `prte_event_base`: `ptrace` only permits the detach from the thread that became the tracer, and that detach runs in `wait_local_proc()` on the main thread.

## Testing

- Warning-free `--enable-debug` build (warnings are errors).
- `make check`: 20/20 pass. The odls pool-sizing test is removed (the logic is gone), the rml one is rewritten to cover `peer_cons` consulting the pool, and `test_worker_pool` in `test/unit/runtime/test_runtime.c` is new — empty and negative pools, two laps of the rotation over three real threads, idempotent init, double finalize.
- `prte-convert-help.py --check-only` clean; Sphinx docs build clean.
- Live: `prterun` at 4/16/32 procs and a persistent DVM, with the pool on and off; thread counts verified against the parameter on both macOS and Linux.
- **`contrib/dockerswarm`, full 10-node suite: 636 passed, 0 failed, 3 skipped.** The 3 skips are the pre-existing `device=network` cases (no such device in the synthetic topologies). Run against a swarm image rebuilt with PMIx at current master head (`4507bfe`), with PRRTE built from this branch.

  The suite's references to the old parameter are updated (`PRTE_SWARM_OOB_THREADS` → `PRTE_SWARM_WORKER_THREADS`, default 8), and the case that used to grep for `starting N OOB progress threads` — a log line that no longer exists — now measures a remote `prted`'s thread count at 0 vs 4 workers and requires the difference to be exactly 4 (2 → 6 in practice: a daemon's baseline is its own event base plus PMIx's).

  That case failed on the first run and the failure was in the case, not the product: it sampled whatever `prted` `pgrep` found on node2, which in the wake of the daemon-killing cases just above it can be a stray running at the suite-wide default. It now selects the daemon by the value on its own command line, which also makes it assert what it means — that the parameter reached the daemon *and* that the daemon acted on it.

Docs and `AGENTS.md` updated in `src/runtime`, `src/rml`, `src/rml/oob`, `src/mca/odls`, `contrib/dockerswarm`, plus `docs/how-things-work/rml/oob.rst`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
