### PR TITLE
Scope a hostfile slots= count to the job that named the hostfile

### DIFF
--- a/src/docs/prrte-rst-content/detail-hostfiles.rst
+++ b/src/docs/prrte-rst-content/detail-hostfiles.rst
@@ -46,3 +46,11 @@ RM.
 
 .. important:: If using a resource manager, the user-specified number
                of slots is capped by the RM-assigned value.
+
+A hostfile given to a job that is being submitted to an already-running
+DVM *selects within* the DVM's allocation: it names the subset of nodes
+that job may use, and a ``slots`` count smaller than the node's own is
+the number of slots that job may take there.  It says nothing about how
+big the node is, so it applies to that job alone |mdash| the node is
+back to its allocated size for the next job, which may be someone
+else's.  Changing the allocation is what ``--add-hostfile`` is for.

--- a/src/mca/rmaps/AGENTS.md
+++ b/src/mca/rmaps/AGENTS.md
@@ -352,6 +352,14 @@ and `--map-by core:oversubscribe`, `-n 8` is 3/3/2, `-n 12` is 4/4/4 and
 this, an object map put the whole overflow on the head of the list (8/0/0,
 8/2/2, 14/2/2).
 
+The same machinery covers the other direction, and the other spelling. A
+hostfile `slots=` *smaller* than the node caps the job the same way — that is
+what lets a user subdivide an allocation — and
+`prte_util_filter_hostfile_nodes()` writes it straight onto the pool's node
+object, so it records the resize first. Unrecorded (issue #2698), one job's
+hostfile shrank the node for every job the DVM ran afterwards. See
+[`src/util/hostfile/AGENTS.md`](../../util/hostfile/AGENTS.md).
+
 **A cap that is *larger* than the node is reconciled in `get_target_nodes`,
 and the answer depends on who sized the node.** A resource manager decided
 how much of that node is ours and we cannot hand a job more, so the request
@@ -605,7 +613,7 @@ without a node pool, a topology, or a DVM:
 | `test_resolve_options.c` | `resolve_app_options` and the rank/bind default derivations |
 | `test_ranking.c` | `compute_vpids`: by-slot/by-node traversal, the per-app cursor, by-user pass-through, and that a cycling scheme terminates |
 | `test_check_avail.c` | `check_avail`: the map-add-once rule, `max_slots`, and the node-removal contract above |
-| `test_resize.c` | `record_resize`/`restore_resized`: a node grown for one map goes back — the count and the SLOTS_GIVEN flag |
+| `test_resize.c` | `record_resize`/`restore_resized`: a node re-sized for one map goes back — the count and the SLOTS_GIVEN flag — and the hostfile `slots=` cap that rides the same list |
 | `test_dispatch.c`, `test_<component>.c` | each mapper's accept/defer gate |
 
 `test_ranking.c` builds a job map by hand — synthetic nodes carrying

--- a/src/mca/rmaps/AGENTS.md
+++ b/src/mca/rmaps/AGENTS.md
@@ -362,7 +362,9 @@ map, not to the allocation — `--host` says how many slots *this job* may have
 (`--add-host` is what changes an allocation) — so it is recorded with
 `prte_rmaps_base_record_resize()` and undone by
 `prte_rmaps_base_restore_resized()` at `map_job`'s `cleanup`, on both
-outcomes. `prte_ras_base.total_slots_alloc` describes the allocation and is
+outcomes — along with the node's `PRTE_NODE_FLAG_SLOTS_GIVEN`, which the
+growth sets and which a *later* job reads to decide whether it may
+oversubscribe. `prte_ras_base.total_slots_alloc` describes the allocation and is
 deliberately left alone. `prte_ras_base.scheduler_owned` is what tells the two
 cases apart — the same flag that decides whether `--add-host` may grow the
 pool, and for the same reason: both ask whether the node counts are ours to
@@ -603,6 +605,7 @@ without a node pool, a topology, or a DVM:
 | `test_resolve_options.c` | `resolve_app_options` and the rank/bind default derivations |
 | `test_ranking.c` | `compute_vpids`: by-slot/by-node traversal, the per-app cursor, by-user pass-through, and that a cycling scheme terminates |
 | `test_check_avail.c` | `check_avail`: the map-add-once rule, `max_slots`, and the node-removal contract above |
+| `test_resize.c` | `record_resize`/`restore_resized`: a node grown for one map goes back — the count and the SLOTS_GIVEN flag |
 | `test_dispatch.c`, `test_<component>.c` | each mapper's accept/defer gate |
 
 `test_ranking.c` builds a job map by hand — synthetic nodes carrying

--- a/src/mca/rmaps/base/base.h
+++ b/src/mca/rmaps/base/base.h
@@ -101,6 +101,11 @@ typedef struct {
     pmix_list_item_t super;
     prte_node_t *node;
     int32_t slots;
+    /* whether the node carried PRTE_NODE_FLAG_SLOTS_GIVEN before we re-sized
+     * it. Growing a node to satisfy a "-host node:N" sets that flag, and it
+     * decides whether a later job may oversubscribe the node - so it has to
+     * go back with the count. */
+    bool slots_given;
 } prte_rmaps_base_resize_t;
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_rmaps_base_resize_t);
 
@@ -129,9 +134,9 @@ PRTE_EXPORT void prte_rmaps_base_map_job(int sd, short args, void *cbdata);
 PRTE_EXPORT char *prte_rmaps_base_print_mapping(prte_mapping_policy_t mapping);
 PRTE_EXPORT char *prte_rmaps_base_print_ranking(prte_ranking_policy_t ranking);
 
-/* Record that this mapping grew a node, so the count it had before can be
+/* Record that this mapping re-sized a node, so the count it had before can be
  * put back when the map completes. Recording the same node twice keeps the
- * first (original) value. */
+ * first (original) value. Call this BEFORE changing the node. */
 PRTE_EXPORT void prte_rmaps_base_record_resize(prte_node_t *node, int32_t slots);
 
 /* Put every re-sized node back the way we found it. Called on both outcomes

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -79,6 +79,7 @@ static void rsz_con(prte_rmaps_base_resize_t *p)
 {
     p->node = NULL;
     p->slots = 0;
+    p->slots_given = false;
 }
 PMIX_CLASS_INSTANCE(prte_rmaps_base_resize_t, pmix_list_item_t, rsz_con, NULL);
 

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -143,6 +143,7 @@ void prte_rmaps_base_record_resize(prte_node_t *node, int32_t slots)
     rsz = PMIX_NEW(prte_rmaps_base_resize_t);
     rsz->node = node;   // borrowed - the pool owns it
     rsz->slots = slots;
+    rsz->slots_given = PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
     pmix_list_append(&prte_rmaps_base.resized_nodes, &rsz->super);
 }
 
@@ -157,6 +158,16 @@ void prte_rmaps_base_restore_resized(void)
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                              rsz->node->name, rsz->slots));
         rsz->node->slots = rsz->slots;
+        /* the flag says the slot count was stated rather than detected, and
+         * a later job reads it to decide whether it may oversubscribe this
+         * node. Growing the node for a "-host node:N" sets it, so a job that
+         * merely said how many slots it wanted would otherwise have left the
+         * node refusing oversubscription to every job that followed. */
+        if (rsz->slots_given) {
+            PRTE_FLAG_SET(rsz->node, PRTE_NODE_FLAG_SLOTS_GIVEN);
+        } else {
+            PRTE_FLAG_UNSET(rsz->node, PRTE_NODE_FLAG_SLOTS_GIVEN);
+        }
         PMIX_RELEASE(rsz);
     }
 }

--- a/src/util/hostfile/AGENTS.md
+++ b/src/util/hostfile/AGENTS.md
@@ -17,7 +17,7 @@ keyword modifiers.
 | Entry point | Used for | Behavior |
 |-------------|----------|----------|
 | `prte_util_add_hostfile_nodes()` | building an allocation (`prte --hostfile`, `--add-hostfile`) | Adds every named node to the caller's list, merging duplicates and dropping the excluded ones. |
-| `prte_util_filter_hostfile_nodes()` | selecting for a job (`prun --hostfile`) | Removes from the caller's list every node the hostfile does not name. Returns `PRTE_ERR_TAKE_NEXT_OPTION` if the hostfile was empty, and refuses a hostfile naming a node the allocation does not have. |
+| `prte_util_filter_hostfile_nodes()` | selecting for a job (`prun --hostfile`) | Removes from the caller's list every node the hostfile does not name, and caps the ones it keeps (see below). Returns `PRTE_ERR_TAKE_NEXT_OPTION` if the hostfile was empty, and refuses a hostfile naming a node the allocation does not have. |
 | `prte_util_get_ordered_host_list()` | `rmaps/seq`, `rmaps/rank_file` | Keeps duplicates and order: the list *is* the sequence of placements. |
 
 `hostfile_lex.c` is **generated** by flex from `hostfile_lex.l` and is not in
@@ -116,6 +116,35 @@ same index means a different node depending on which one the user typed it at.
 
 ---
 
+## A `slots=` that selects is a cap on the *job*, and it must be given back
+
+`prte_util_filter_hostfile_nodes()` does more than select: a `slots=` count
+smaller than the node's own replaces it, which is how a user subdivides an
+allocation somebody else built. The nodes on the caller's list are the node
+**pool's own objects**, so that write is to the DVM's idea of the node, and
+what the hostfile stated is only what *this job* may take there — exactly what
+a `-host node:N` states, and the opposite of `--add-hostfile`, which is how an
+allocation is changed.
+
+So the count has to come back. Record it with
+`prte_rmaps_base_record_resize()` before writing, and
+`prte_rmaps_base_restore_resized()` at `map_job`'s `cleanup` puts it back on
+both outcomes of the map. Left unrecorded (issue #2698), one job's hostfile
+shrank the node for every job the DVM ran afterwards — jobs that never named
+the hostfile — and since the write only ever lowers the count, the allocation
+could only shrink, with nothing short of restarting the DVM to undo it.
+
+**Only the `remove == true` caller may do this**, because that is the one
+running inside `prte_rmaps_base_map_job()`, which restores what it recorded
+before it returns. `prte_rmaps_base.resized_nodes` is a framework global, not
+a per-job list, and a DVM maps one job while another is still forming its
+daemons — so an entry made outside a map is one that some unrelated job's map
+would put back. The other caller, `prte_plm_base_setup_virtual_machine()`, is
+marking which nodes are to host a daemon: it never maps and reads no slot
+count, so it has nothing to resize for.
+
+---
+
 ## Ownership, and the `keep` list
 
 `prte_util_filter_hostfile_nodes()` moves the caller's nodes onto a local
@@ -134,6 +163,12 @@ appearing more than once.
 
 ## Testing
 
+- `test/unit/rmaps/test_resize.c` (`test_hostfile_cap`) covers the section
+  above: that the cap applies and is recorded when selecting for a map, that
+  it is restored, that VM-setup marking leaves the node alone, and that a
+  count *larger* than the node changes nothing. It lives under `rmaps`
+  because the record/restore list is a framework global that needs the
+  framework opened.
 - `test/unit/util/test_util.c` writes temporary hostfiles and parses them:
   slot counts, `max_slots`, comments, the `^` exclusion (including a duplicated
   excluded name), a malformed file, and a good file parsed straight after a

--- a/src/util/hostfile/hostfile.c
+++ b/src/util/hostfile/hostfile.c
@@ -44,6 +44,7 @@
 
 #include "src/mca/errmgr/errmgr.h"
 #include "src/mca/ras/base/base.h"
+#include "src/mca/rmaps/base/base.h"
 #include "src/runtime/prte_globals.h"
 #include "src/util/name_fns.h"
 #include "src/util/proc_info.h"
@@ -793,10 +794,33 @@ int prte_util_filter_hostfile_nodes(pmix_list_t *nodes, char *hostfile, bool rem
                     /* if the slot count here is less than the
                      * total slots avail on this node, set it
                      * to the specified count - this allows people
-                     * to subdivide an allocation
+                     * to subdivide an allocation.
+                     *
+                     * The nodes on this list are the pool's own objects, so
+                     * the smaller count has to be handed back when the map is
+                     * done: the "slots=" says how many slots THIS job may
+                     * have on the node, not how big the node is, exactly as a
+                     * "-host node:N" does. Left unrecorded, one job's hostfile
+                     * shrank the node for every job the DVM ran afterwards -
+                     * jobs that never named the hostfile - and the allocation
+                     * could only ever get smaller, with nothing short of
+                     * restarting the DVM to put it back.
+                     *
+                     * Only do this when we are selecting the nodes a job will
+                     * map onto ("remove"), because that is the one caller
+                     * running inside prte_rmaps_base_map_job(), which restores
+                     * what it recorded before it returns. The record list is a
+                     * framework global, not a per-job one, and a DVM maps one
+                     * job while another is still forming its daemons - so an
+                     * entry made anywhere else is one some unrelated job's map
+                     * would put back. The other caller, the VM setup, is only
+                     * marking which nodes are to host a daemon; it never maps
+                     * and reads no slot count, so it has nothing to resize for.
                      */
-                    if (PRTE_FLAG_TEST(node_from_file, PRTE_NODE_FLAG_SLOTS_GIVEN)
+                    if (remove
+                        && PRTE_FLAG_TEST(node_from_file, PRTE_NODE_FLAG_SLOTS_GIVEN)
                         && node_from_file->slots < node_from_list->slots) {
+                        prte_rmaps_base_record_resize(node_from_list, node_from_list->slots);
                         node_from_list->slots = node_from_file->slots;
                     }
                     if (remove) {

--- a/test/unit/rmaps/test_resize.c
+++ b/test/unit/rmaps/test_resize.c
@@ -80,6 +80,27 @@ int test_resize(void)
     prte_rmaps_base_restore_resized();
     CHECK("regrown: back to the original 4", 4 == n1->slots);
 
+    /* the "slots were stated, not detected" flag goes back with the count.
+     * Growing a node for a "-host node:N" sets it, and a later job reads it
+     * to decide whether it may oversubscribe - so a job that only said how
+     * many slots it wanted would otherwise leave the node refusing
+     * oversubscription to every job that came after it. */
+    PRTE_FLAG_UNSET(n1, PRTE_NODE_FLAG_SLOTS_GIVEN);
+    prte_rmaps_base_record_resize(n1, n1->slots);
+    n1->slots = 8;
+    PRTE_FLAG_SET(n1, PRTE_NODE_FLAG_SLOTS_GIVEN);
+    prte_rmaps_base_restore_resized();
+    CHECK("restored: slots-given cleared again",
+          !PRTE_FLAG_TEST(n1, PRTE_NODE_FLAG_SLOTS_GIVEN));
+
+    /* and a node the allocation itself sized keeps the flag it came with */
+    PRTE_FLAG_SET(n2, PRTE_NODE_FLAG_SLOTS_GIVEN);
+    prte_rmaps_base_record_resize(n2, n2->slots);
+    n2->slots = 6;
+    prte_rmaps_base_restore_resized();
+    CHECK("restored: slots-given kept",
+          PRTE_FLAG_TEST(n2, PRTE_NODE_FLAG_SLOTS_GIVEN));
+
     PMIX_RELEASE(n1);
     PMIX_RELEASE(n2);
 

--- a/test/unit/rmaps/test_resize.c
+++ b/test/unit/rmaps/test_resize.c
@@ -18,17 +18,27 @@
  * successful one - a job that could not map has no more claim on the extra
  * slots than one that did.  These two functions are the whole of that
  * contract, and neither needs a topology or a DVM to check.
+ *
+ * The same contract binds the other direction.  A hostfile "slots=N" smaller
+ * than the node makes the node smaller for the job that named the hostfile,
+ * and the nodes the mapper narrows are the node pool's own objects - so a
+ * shrink that was not recorded left every later job in the DVM looking at a
+ * node that had lost slots it never gave up, and the allocation could only
+ * ever get smaller.  test_hostfile_cap() below covers that path.
  */
 
 #include "prte_config.h"
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "constants.h"
 #include "src/runtime/prte_globals.h"
 #include "src/mca/rmaps/base/base.h"
+#include "src/util/hostfile/hostfile.h"
 
 int test_resize(void);
+int test_hostfile_cap(void);
 
 #define CHECK(label, cond)                                              \
     do {                                                                \
@@ -106,6 +116,94 @@ int test_resize(void)
 
     if (0 == failures) {
         fprintf(stdout, "  PASS test_resize\n");
+    }
+    return failures;
+}
+
+/* write a hostfile into the current directory; returns path or NULL */
+static char *write_hostfile(const char *body, char *path, size_t pathlen)
+{
+    FILE *fp;
+
+    snprintf(path, pathlen, "prte_test_resize_hostfile_%lu.txt",
+             (unsigned long) getpid());
+    fp = fopen(path, "w");
+    if (NULL == fp) {
+        return NULL;
+    }
+    fputs(body, fp);
+    fclose(fp);
+    return path;
+}
+
+static prte_node_t *one_node(pmix_list_t *nodes, const char *name, int32_t slots)
+{
+    prte_node_t *nd;
+
+    nd = PMIX_NEW(prte_node_t);
+    nd->name = strdup(name);
+    nd->slots = slots;
+    pmix_list_append(nodes, &nd->super);
+    return nd;
+}
+
+int test_hostfile_cap(void)
+{
+    int failures = 0;
+    int rc;
+    char path[512];
+    pmix_list_t nodes;
+    prte_node_t *nd;
+
+    if (NULL == write_hostfile("hostA slots=1\n", path, sizeof(path))) {
+        fprintf(stderr, "FAIL [hostfile-cap]: could not write a temp hostfile\n");
+        return 1;
+    }
+
+    /* selecting the nodes a job will map onto: the smaller count applies to
+     * the job, and is recorded so the node goes back to its own size */
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    nd = one_node(&nodes, "hostA", 4);
+    rc = prte_util_filter_hostfile_nodes(&nodes, path, true);
+    CHECK("cap: filter succeeded", PRTE_SUCCESS == rc);
+    CHECK("cap: node capped for this job", 1 == nd->slots);
+    CHECK("cap: the shrink was recorded",
+          1 == pmix_list_get_size(&prte_rmaps_base.resized_nodes));
+    prte_rmaps_base_restore_resized();
+    CHECK("cap: node back to its own size", 4 == nd->slots);
+    PMIX_LIST_DESTRUCT(&nodes);
+
+    /* marking which nodes are to host a daemon (remove == false) is not a
+     * map: it reads no slot count, and nothing puts back what it changes,
+     * because it runs before the map that would have restored it */
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    nd = one_node(&nodes, "hostA", 4);
+    rc = prte_util_filter_hostfile_nodes(&nodes, path, false);
+    CHECK("mark: filter succeeded", PRTE_SUCCESS == rc);
+    CHECK("mark: node left alone", 4 == nd->slots);
+    CHECK("mark: nothing recorded",
+          0 == pmix_list_get_size(&prte_rmaps_base.resized_nodes));
+    PMIX_LIST_DESTRUCT(&nodes);
+
+    /* a count larger than the node is not a cap - a hostfile can only
+     * subdivide an allocation, never enlarge it */
+    if (NULL == write_hostfile("hostA slots=8\n", path, sizeof(path))) {
+        fprintf(stderr, "FAIL [hostfile-cap]: could not write a temp hostfile\n");
+        return failures + 1;
+    }
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    nd = one_node(&nodes, "hostA", 4);
+    rc = prte_util_filter_hostfile_nodes(&nodes, path, true);
+    CHECK("grow: filter succeeded", PRTE_SUCCESS == rc);
+    CHECK("grow: node not enlarged", 4 == nd->slots);
+    CHECK("grow: nothing recorded",
+          0 == pmix_list_get_size(&prte_rmaps_base.resized_nodes));
+    PMIX_LIST_DESTRUCT(&nodes);
+
+    unlink(path);
+
+    if (0 == failures) {
+        fprintf(stdout, "  PASS test_hostfile_cap\n");
     }
     return failures;
 }

--- a/test/unit/rmaps/test_rmaps_main.c
+++ b/test/unit/rmaps/test_rmaps_main.c
@@ -27,6 +27,7 @@ extern int test_ranking(void);
 extern int test_binding(void);
 extern int test_check_avail(void);
 extern int test_resize(void);
+extern int test_hostfile_cap(void);
 extern int test_dispatch(void);
 extern int test_round_robin(void);
 extern int test_ppr(void);
@@ -106,6 +107,7 @@ int main(void)
     failures += test_binding();
     failures += test_check_avail();
     failures += test_resize();
+    failures += test_hostfile_cap();
     failures += test_dispatch();
     failures += test_round_robin();
     failures += test_ppr();


### PR DESCRIPTION
Fixes #2698.

## The problem

A hostfile given to `prun` selects *within* the DVM's allocation, and a `slots=` count smaller than the node's own narrows what that job may take there — the documented way to subdivide an allocation. But `prte_util_filter_hostfile_nodes()` writes the smaller count onto the node objects on the caller's list, and those are the node pool's own objects: the DVM's idea of the node, not a copy made for the job. Nothing put it back, and the write only ever lowers the count, so a node could only shrink.

A DVM is shared and persistent, so the consequences reach everyone. The next job to run — one that never mentioned the hostfile, possibly submitted by someone else — maps against a node that has silently lost slots it was never asked to give up, and a job that fitted before the hostfile job ran is refused afterwards with a plain "not enough slots". Nothing short of restarting the DVM restores the node.

The reporter's one-node reproducer: a four-slot node, one `slots=1` hostfile job, and the node is a one-slot node from then on.

## The fix

The mapper already has the machinery for exactly this, built for the `--host node:N` that *grows* a node: record the count before changing it and put it back at `map_job`'s cleanup, on both outcomes. This uses it.

The count still applies in full to the job that named the hostfile — that job is refused if it asks for more, and `--display map` shows it the smaller node — and no other job sees it at all.

Only the caller that is selecting the nodes for a map may do this. That caller runs inside `prte_rmaps_base_map_job()`, which restores what it recorded before it returns; the record list is a framework global rather than a per-job one, and a DVM maps one job while another is still forming its daemons, so an entry made anywhere else is one that some unrelated job's map would put back. The other caller is the VM setup, which is only marking which nodes are to host a daemon — it never maps and reads no slot count, so it has nothing to re-size for.

## Second commit: an adjacent leak in the same machinery

Growing a node for a `--host node:N` also sets `PRTE_NODE_FLAG_SLOTS_GIVEN`, and only the slot count was handed back. That flag is not cosmetic: `check_oversubscribed()` reads it to decide whether a job that outruns a node's slots may proceed, and a node whose count was *detected* rather than *stated* is one PRRTE is willing to oversubscribe silently. So a job that merely said how many slots it wanted left the node refusing oversubscription to every job that came after it. The resize record now carries the flag and restores it too.

## Testing

- `test_hostfile_cap()` in `test/unit/rmaps/test_resize.c` — the cap applies and is recorded when selecting for a map, it is restored, VM-setup marking leaves the node alone, and a count larger than the node changes nothing. Three of its checks fail on the unpatched tree.
- `test_resize.c` also gains the SLOTS_GIVEN round-trip.
- `make check` clean; offline mapper harness 2449 pass / 0 fail; docs rebuild warning-free.
- Live: on a four-slot DVM, the capped job is refused at `-n 2` and shows `Num slots: 1`, while every other job before and after it sees the node at four slots.