### PR TITLE
Carry the globally-confirmed departures across a tree recompute

### DIFF
--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -39,12 +39,6 @@ since the transport it stages over (xcast) is already resilient.  Until then,
 a daemon lost while files are in flight fails the staging rather than
 re-driving it.
 
-**Routing-tree state is not preserved across a DVM resize.**
-``prte_rml_compute_routing_tree`` re-initializes the failure bitmaps on every
-grow and restores only the permanent sets (``dead_dmns``, ``absent_dmns``);
-whether anything else should survive the recompute is an open question marked
-in ``src/rml/routed_radix.c``.
-
 **Only a command line can ask for a daemon on an allocated node.**  The
 command-line half of this is done: ``--activate`` (``prun`` and
 ``prterun``) takes node names, ``+all``, ``+n<K>`` and ``file=<hostfile>``,
@@ -262,8 +256,6 @@ the marker is stale.
    * - ``rml/oob/oob_tcp_connection.c``,
        ``prte_oob_tcp_peer_try_connect``
      - a peer whose socket cannot be created
-   * - ``rml/routed_radix.c``, ``prte_rml_compute_routing_tree``
-     - routing-tree state is not preserved across a DVM resize
    * - ``rml/relm/relm.c``, ``prte_relm_register``
      - RELM has one module and no way to choose another
    * - ``mca/filem/raw/filem_raw_module.c``, ``raw_fault_handler``

--- a/src/rml/AGENTS.md
+++ b/src/rml/AGENTS.md
@@ -401,6 +401,31 @@ connection path.
   (#2491). The DVM never reuses a daemon vpid, so a hole in `[0, num_daemons)`
   is permanent.
 
+- **What a recompute may and may not throw away.** `compute_routing_tree` is
+  the whole of a resize's effect on the tree, and the rule it follows is that
+  it re-derives everything it can and preserves only what it cannot. Ancestors,
+  lifeline, children and `cur_node` are rebuilt from the fault-free radix
+  positions (`build_tree_from_base`) rather than mutated, and `failed_dmns` is
+  rebuilt too — every path that sets a bit in it also records the rank in
+  `dead_dmns` or `absent_dmns` (`repair_routing_tree`; `reconcile_ancestry`'s
+  provisional marks are undone before it returns), so restoring those two
+  reproduces it exactly, at the new width.
+  `global_failed_dmns` is the one thing that is **not** derivable: nothing else
+  in the daemon records that a departure has already been broadcast, so it is
+  re-initialized to the new span and its marks are copied back across the wipe.
+  Both halves of that are load-bearing. The set exists so a re-homed daemon can
+  subtract it from `failed_dmns` and report to a new parent only what that
+  parent may not know (`send_failures_notice`); dropping the marks made every
+  parent change after a grow re-report every departure in the subtree. And the
+  subtraction is `pmix_bitmap_bitwise_xor_inplace`, which returns
+  `PMIX_ERR_BAD_PARAM` and modifies **nothing** when the two bitmaps hold
+  different numbers of words — so simply carrying the set forward unwidened,
+  the obvious alternative, would silently defeat the very subtraction it was
+  preserved for. `test_global_failures_survive_recompute` pins both.
+  The remaining `prte_rml_base` sets — `absent_dmns`, `revived_dmns`,
+  `lateral_links`, `peer_epochs` — are never touched by the recompute at all,
+  each for its own reason given where it is declared.
+
 - **A daemon we LAUNCH is told the departure set on its command line**, by
   `prte_plm_base_prted_append_basic_args` (`rml_base_dead_dmns`, a
   range-collapsed list such as `2,7:9` — colon-separated, because every

--- a/src/rml/rml.h
+++ b/src/rml/rml.h
@@ -310,7 +310,14 @@ typedef struct {
     pmix_rank_t n_dmns;
     // All faults known, globally confirmed or not
     pmix_bitmap_t failed_dmns;
-    // All daemons globally confirmed to have failed
+    // All daemons globally confirmed to have failed - i.e. the subset of
+    // failed_dmns whose departure the HNP has already broadcast. Its one
+    // consumer is send_failures_notice, which subtracts it from failed_dmns
+    // to work out which of this daemon's subtree failures a NEW parent has
+    // yet to hear about. prte_rml_compute_routing_tree re-initializes it (the
+    // subtraction is a bitmap XOR, which needs both operands the same width,
+    // and a grow widens failed_dmns) but carries the marks across, because
+    // nothing else in the daemon records that a departure has been broadcast.
     pmix_bitmap_t global_failed_dmns;
     // Ranks that have permanently departed the DVM (shrunk out, or lost to a
     // fault in a launched/elastic DVM). Unlike failed_dmns, this set is NOT

--- a/src/rml/routed_radix.c
+++ b/src/rml/routed_radix.c
@@ -731,7 +731,17 @@ void prte_rml_compute_routing_tree(void){
     // Save our state prior to any daemon failures
     prte_rml_base.n_dmns = prte_process_info.num_daemons;
 
-    // TODO: Should we save this info when DVM is resized?
+    // Everything this routine wipes is re-derived below, with one exception:
+    // which of the departures have been GLOBALLY confirmed. That is derivable
+    // from nothing else, so hold it aside across the wipe and put it back.
+    // Both sets must still be re-initialized rather than merely carried
+    // forward: a grow widens the vpid span, and the difference these two are
+    // used for (send_failures_notice) is a pmix_bitmap XOR, which silently
+    // does nothing when the two operands are not the same number of words.
+    pmix_bitmap_t prev_global;
+    PMIX_CONSTRUCT(&prev_global, pmix_bitmap_t);
+    pmix_bitmap_copy(&prev_global, &prte_rml_base.global_failed_dmns);
+
     pmix_bitmap_init(&prte_rml_base.failed_dmns, prte_rml_base.n_dmns);
     pmix_bitmap_init(&prte_rml_base.global_failed_dmns, prte_rml_base.n_dmns);
 
@@ -750,8 +760,22 @@ void prte_rml_compute_routing_tree(void){
         if(pmix_bitmap_is_set_bit(&prte_rml_base.dead_dmns, r) ||
            pmix_bitmap_is_set_bit(&prte_rml_base.absent_dmns, r)){
             pmix_bitmap_set_bit(&prte_rml_base.failed_dmns, r);
+            // A departure the DVM has already broadcast stays broadcast: a
+            // grow reshapes the tree, it does not un-tell anybody. This set
+            // is what a re-homed daemon subtracts to work out which of its
+            // subtree's failures a NEW parent has yet to hear about
+            // (send_failures_notice); losing it made every recompute turn the
+            // next parent change into a report of every departure the daemon
+            // knows, which its parent then has to recognize and drop one by
+            // one. Restored inside this arm, so the documented invariant
+            // global_failed_dmns is a subset of failed_dmns holds by
+            // construction rather than by the caller's good behavior.
+            if(pmix_bitmap_is_set_bit(&prev_global, r)){
+                pmix_bitmap_set_bit(&prte_rml_base.global_failed_dmns, r);
+            }
         }
     }
+    PMIX_DESTRUCT(&prev_global);
 
     // Derive ancestors, lifeline, and children from the base radix positions
     // and route around whatever is currently failed (the restored holes above).

--- a/test/unit/rml/test_rml_routing.c
+++ b/test/unit/rml/test_rml_routing.c
@@ -468,6 +468,83 @@ static int test_departed_ranks_survive_recompute(void)
 }
 
 /*
+ * The confirmation state of a departure has to survive the recompute too.
+ *
+ * global_failed_dmns is the subset of failed_dmns whose departure the HNP has
+ * already broadcast to the whole DVM.  Its only consumer is
+ * send_failures_notice(), which subtracts it from failed_dmns when this
+ * daemon's parent changes: what is left is the failures in our subtree that a
+ * NEW parent may not have heard about, and only those are reported upward.
+ * Nothing else in the daemon records that a departure has been broadcast, so
+ * unlike ancestors, children and failed_dmns itself, this set is derivable
+ * from nothing -- wiping it on a grow told the daemon that every departure it
+ * knows is still unconfirmed, and the next parent change re-reported all of
+ * them for the parent to recognize and drop one at a time.
+ *
+ * The widths matter as much as the contents: the subtraction is
+ * pmix_bitmap_bitwise_xor_inplace(), which returns PMIX_ERR_BAD_PARAM and
+ * changes NOTHING when the two bitmaps hold different numbers of words.  A
+ * grow widens failed_dmns, so global_failed_dmns must be re-initialized to the
+ * new span and refilled, not merely carried forward -- carrying it forward
+ * would leave the two a word apart and silently defeat the subtraction it was
+ * being preserved for.
+ */
+static int test_global_failures_survive_recompute(void)
+{
+    int failures = 0;
+
+    /* radix 2, 7 daemons, we are the root.  Rank 1 departed and the DVM was
+     * told; rank 2 departed and has not been broadcast yet. */
+    bitmaps_reset();
+    build_dvm(2, 7, 0);
+    pmix_bitmap_set_bit(&prte_rml_base.dead_dmns, 1);
+    pmix_bitmap_set_bit(&prte_rml_base.dead_dmns, 2);
+    build_dvm(2, 7, 0);
+    pmix_bitmap_set_bit(&prte_rml_base.global_failed_dmns, 1);
+
+    /* the grow: a wider span, tree recomputed from scratch */
+    build_dvm(2, 200, 0);
+
+    CHECK("both departures are still failed",
+          pmix_bitmap_is_set_bit(&prte_rml_base.failed_dmns, 1) &&
+          pmix_bitmap_is_set_bit(&prte_rml_base.failed_dmns, 2));
+    CHECK("a broadcast departure is still globally confirmed",
+          pmix_bitmap_is_set_bit(&prte_rml_base.global_failed_dmns, 1));
+    CHECK("a departure that was never broadcast is still not confirmed",
+          !pmix_bitmap_is_set_bit(&prte_rml_base.global_failed_dmns, 2));
+
+    /* the widths the subtraction needs.  200 daemons is four 64-bit words
+     * where 7 was one, so this fails if the set is carried forward as-is. */
+    CHECK("the two sets are the same width after the grow",
+          pmix_bitmap_size(&prte_rml_base.global_failed_dmns)
+              == pmix_bitmap_size(&prte_rml_base.failed_dmns));
+    CHECK("so the subtraction the notice path performs actually runs",
+          PMIX_SUCCESS == pmix_bitmap_bitwise_xor_inplace(
+                              &prte_rml_base.global_failed_dmns,
+                              &prte_rml_base.failed_dmns));
+
+    /* global_failed_dmns is a subset of failed_dmns, and the restore keeps it
+     * one: a rank whose absent mark the unheal path cleared is live again, so
+     * it must not come back as a confirmed failure either. */
+    bitmaps_reset();
+    build_dvm(2, 7, 0);
+    pmix_bitmap_set_bit(&prte_rml_base.absent_dmns, 3);
+    build_dvm(2, 7, 0);
+    pmix_bitmap_set_bit(&prte_rml_base.global_failed_dmns, 3);
+    pmix_bitmap_clear_bit(&prte_rml_base.absent_dmns, 3);
+    build_dvm(2, 9, 0);
+    CHECK("a revived rank is live again", prte_rml_is_node_up(3));
+    CHECK("and is not left behind in the globally-failed set",
+          !pmix_bitmap_is_set_bit(&prte_rml_base.global_failed_dmns, 3));
+
+    bitmaps_reset();
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_global_failures_survive_recompute\n");
+    }
+    return failures;
+}
+
+/*
  * Ancestry reconciliation -- prte_rml_reconcile_ancestry().
  *
  * Both notices that reshape the tree carry a peer's view of THIS daemon's
@@ -1175,6 +1252,7 @@ int main(void)
     failures += test_radix_traversal();
     failures += test_routing_tree();
     failures += test_departed_ranks_survive_recompute();
+    failures += test_global_failures_survive_recompute();
     failures += test_reconcile_ancestry();
     failures += test_dead_dmns_round_trip();
     failures += test_num_contributors();


### PR DESCRIPTION
### The problem

`prte_rml_compute_routing_tree()` re-initializes both failure bitmaps on every DVM resize and then restores only the permanent sets, `dead_dmns` and `absent_dmns`. A `TODO` there asked whether anything else ought to survive the recompute. This is the answer.

For `failed_dmns` the wipe is exactly right, and is not merely harmless: every path that sets a bit in it also records the rank as dead or absent (`repair_routing_tree`), and `reconcile_ancestry` undoes the provisional marks it makes while walking, so the two persistent sets reproduce it precisely — at the new, wider span, which a bitmap carried forward unchanged would not have. Ancestors, lifeline, children and `cur_node` are likewise rebuilt from the fault-free radix positions by design.

`global_failed_dmns` is the one thing thrown away that nothing else can reconstruct. It is the subset of the failures whose departure the HNP has already broadcast, and no other state in the daemon records that fact. Its only consumer is `send_failures_notice()`: when a daemon is re-homed onto a new parent it subtracts this set from `failed_dmns` and reports upward only the failures in its subtree that the new parent may not have heard about. Wiped, that subtraction yields everything, so the first parent change after any resize re-reported every departure the daemon knows, and the parent had to recognize and drop them one at a time.

The DVM converges either way — `report_new_departures()` and the repair both deduplicate on `failed_dmns` — so this is redundant traffic rather than a wrong answer. But it defeats the purpose the set exists for, which its own comment states as avoiding redundant failure notices up the tree.

### The fix

Hold the marks aside across the wipe and put them back.

There is a trap in the obvious version of this. Both bitmaps must still be re-initialized to the new span rather than simply not re-initialized the way `dead_dmns` is: the subtraction is `pmix_bitmap_bitwise_xor_inplace()`, which returns `PMIX_ERR_BAD_PARAM` and modifies **nothing at all** when its two operands hold different numbers of words. Leaving `global_failed_dmns` at its old width after a grow would silently defeat the very subtraction it was being preserved for.

Restoring the marks inside the dead-or-absent arm also makes the documented invariant — `global_failed_dmns` is a subset of `failed_dmns` — hold by construction rather than by every caller's good behavior.

### Tests

`test_global_failures_survive_recompute()` pins the contents, the widths (7 → 200 daemons, one 64-bit word to four), that the XOR the notice path performs actually returns `PMIX_SUCCESS`, and the case where the unheal path has revived a rank, which must not come back as a confirmed failure. Verified non-vacuous: stubbing out the restore fails it on "a broadcast departure is still globally confirmed".

`make check` is green and the `-Werror` debug build is clean.

### Docs

`src/rml/AGENTS.md` now carries the answer for the whole struct — the rule a future recompute has to follow ("re-derive everything derivable, preserve only what isn't") plus the width trap — rather than leaving it to be rediscovered. The `TODO` and its `docs/todo.rst` entry are removed.