### PR TITLE
ras/slurm: bound expander jobs in time, serve PMIX_ALLOC_NEW, take node lists

### DIFF
--- a/contrib/dockerswarm/elastic.c
+++ b/contrib/dockerswarm/elastic.c
@@ -18,6 +18,7 @@
  *   elastic grow       <node[:slots],...>  # PMIX_ALLOC_NEW     + NODE_LIST
  *   elastic shrink     <node,...>          # PMIX_ALLOC_RELEASE + NODE_LIST
  *   elastic extend     <num-nodes>         # PMIX_ALLOC_EXTEND  + NUM_NODES
+ *   elastic new        <num-nodes>         # PMIX_ALLOC_NEW     + NUM_NODES
  *   elastic release    <num-nodes>         # PMIX_ALLOC_RELEASE + NUM_NODES
  *   elastic release-id <alloc-id>          # PMIX_ALLOC_RELEASE + ALLOC_ID
  *   elastic cancel     <req-id>            # PMIX_ALLOC_REQ_CANCEL
@@ -27,11 +28,12 @@
  *   --wait          wait for the phase-two completion event
  *   --no-wait       do not
  *
- * The last four forms exist for the resource managers that serve a size
+ * The last five forms exist for the resource managers that serve a size
  * change by talking to a scheduler rather than by naming nodes -- ras/slurm
  * is the one in tree, and NUM_NODES/ALLOC_ID/REQ_CANCEL are the only request
  * shapes its modify() accepts.  Which nodes such a request lands on is the
- * scheduler's choice, not the caller's.
+ * scheduler's choice, not the caller's.  The two grow directives may or may
+ * not differ to an RM; ras/slurm treats them as synonyms.
  *
  * Phase two is waited for by default, but not for "cancel", which is answered
  * in full by phase one.
@@ -248,6 +250,7 @@ static void usage(const char *me) {
             "  grow       <node[:slots],...>   PMIX_ALLOC_NEW     + NODE_LIST\n"
             "  shrink     <node,...>           PMIX_ALLOC_RELEASE + NODE_LIST\n"
             "  extend     <num-nodes>          PMIX_ALLOC_EXTEND  + NUM_NODES\n"
+            "  new        <num-nodes>          PMIX_ALLOC_NEW     + NUM_NODES\n"
             "  release    <num-nodes>          PMIX_ALLOC_RELEASE + NUM_NODES\n"
             "  release-id <alloc-id>           PMIX_ALLOC_RELEASE + ALLOC_ID\n"
             "  cancel     <req-id>             PMIX_ALLOC_REQ_CANCEL\n"
@@ -307,6 +310,9 @@ int main(int argc, char **argv) {
         directive = PMIX_ALLOC_RELEASE;
     } else if (0 == strcmp(op, "extend")) {
         directive = PMIX_ALLOC_EXTEND;
+        num_nodes = strtoull(arg, NULL, 10);
+    } else if (0 == strcmp(op, "new")) {
+        directive = PMIX_ALLOC_NEW;
         num_nodes = strtoull(arg, NULL, 10);
     } else if (0 == strcmp(op, "release")) {
         directive = PMIX_ALLOC_RELEASE;
@@ -368,7 +374,8 @@ int main(int argc, char **argv) {
         PMIX_INFO_CREATE(info, ninfo);
     } else {
         PMIX_INFO_CREATE(info, ninfo);
-        if (PMIX_ALLOC_EXTEND == directive || 0 == strcmp(op, "release")) {
+        if (PMIX_ALLOC_EXTEND == directive || 0 == strcmp(op, "new") ||
+            0 == strcmp(op, "release")) {
             PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_NUM_NODES, &num_nodes, PMIX_UINT64);
         } else if (0 == strcmp(op, "release-id")) {
             PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_ID, arg, PMIX_STRING);

--- a/contrib/dockerswarm/elastic.c
+++ b/contrib/dockerswarm/elastic.c
@@ -15,13 +15,13 @@
  * (success) or PMIX_ERR_DVM_MOD (failure) event so the two-phase completion
  * contract can be observed end to end.
  *
- *   elastic grow       <node[:slots],...>  # PMIX_ALLOC_NEW     + NODE_LIST
- *   elastic shrink     <node,...>          # PMIX_ALLOC_RELEASE + NODE_LIST
- *   elastic extend     <num-nodes>         # PMIX_ALLOC_EXTEND  + NUM_NODES
- *   elastic new        <num-nodes>         # PMIX_ALLOC_NEW     + NUM_NODES
- *   elastic release    <num-nodes>         # PMIX_ALLOC_RELEASE + NUM_NODES
- *   elastic release-id <alloc-id>          # PMIX_ALLOC_RELEASE + ALLOC_ID
- *   elastic cancel     <req-id>            # PMIX_ALLOC_REQ_CANCEL
+ *   elastic grow       <node[:slots],...>   # PMIX_ALLOC_NEW     + NODE_LIST
+ *   elastic shrink     <node,...>           # PMIX_ALLOC_RELEASE + NODE_LIST
+ *   elastic extend     <num-nodes|node,...> # PMIX_ALLOC_EXTEND  + NUM_NODES/NODE_LIST
+ *   elastic new        <num-nodes|node,...> # PMIX_ALLOC_NEW     + NUM_NODES/NODE_LIST
+ *   elastic release    <num-nodes>          # PMIX_ALLOC_RELEASE + NUM_NODES
+ *   elastic release-id <alloc-id>           # PMIX_ALLOC_RELEASE + ALLOC_ID
+ *   elastic cancel     <req-id>             # PMIX_ALLOC_REQ_CANCEL
  *
  *   --req-id <id>   request id to send (default "elastic-test"); "cancel"
  *                   names the request to cancel this way too
@@ -29,11 +29,11 @@
  *   --no-wait       do not
  *
  * The last five forms exist for the resource managers that serve a size
- * change by talking to a scheduler rather than by naming nodes -- ras/slurm
- * is the one in tree, and NUM_NODES/ALLOC_ID/REQ_CANCEL are the only request
- * shapes its modify() accepts.  Which nodes such a request lands on is the
- * scheduler's choice, not the caller's.  The two grow directives may or may
- * not differ to an RM; ras/slurm treats them as synonyms.
+ * change by talking to a scheduler -- ras/slurm is the one in tree.  A grow
+ * it serves may name a count, and then which nodes it lands on is the
+ * scheduler's choice, or the nodes themselves, and then the scheduler queues
+ * until they are free.  The two grow directives may or may not differ to an
+ * RM; ras/slurm treats them as synonyms.
  *
  * Phase two is waited for by default, but not for "cancel", which is answered
  * in full by phase one.
@@ -249,8 +249,8 @@ static void usage(const char *me) {
             "usage: %s <op> <arg> [--req-id <id>] [--wait|--no-wait] [-- <cmd> ...]\n"
             "  grow       <node[:slots],...>   PMIX_ALLOC_NEW     + NODE_LIST\n"
             "  shrink     <node,...>           PMIX_ALLOC_RELEASE + NODE_LIST\n"
-            "  extend     <num-nodes>          PMIX_ALLOC_EXTEND  + NUM_NODES\n"
-            "  new        <num-nodes>          PMIX_ALLOC_NEW     + NUM_NODES\n"
+            "  extend     <num-nodes|node,...> PMIX_ALLOC_EXTEND  + NUM_NODES/NODE_LIST\n"
+            "  new        <num-nodes|node,...> PMIX_ALLOC_NEW     + NUM_NODES/NODE_LIST\n"
             "  release    <num-nodes>          PMIX_ALLOC_RELEASE + NUM_NODES\n"
             "  release-id <alloc-id>           PMIX_ALLOC_RELEASE + ALLOC_ID\n"
             "  cancel     <req-id>             PMIX_ALLOC_REQ_CANCEL\n"
@@ -270,6 +270,7 @@ int main(int argc, char **argv) {
     const char *op, *arg, *req_id = "elastic-test";
     char **spawn_cmd = NULL;
     uint64_t num_nodes = 0;
+    bool by_count = false;
     bool wait_phase2 = true;
     int wait_opt = -1;          /* an explicit --wait/--no-wait, if given */
     int rcexit = 0, i;
@@ -302,20 +303,22 @@ int main(int argc, char **argv) {
     }
 
     /* A grow is a NEW reservation that names the nodes to add: PRRTE adds them
-     * to the pool and extends the DVM.  PMIX_ALLOC_EXTEND asks the resource
-     * manager for more nodes instead, and names a count rather than hosts. */
+     * to the pool and extends the DVM.  "extend" and "new" name either a count
+     * for the resource manager to fill or the nodes themselves, whichever the
+     * argument looks like. */
     if (0 == strcmp(op, "grow")) {
         directive = PMIX_ALLOC_NEW;
     } else if (0 == strcmp(op, "shrink")) {
         directive = PMIX_ALLOC_RELEASE;
-    } else if (0 == strcmp(op, "extend")) {
-        directive = PMIX_ALLOC_EXTEND;
-        num_nodes = strtoull(arg, NULL, 10);
-    } else if (0 == strcmp(op, "new")) {
-        directive = PMIX_ALLOC_NEW;
-        num_nodes = strtoull(arg, NULL, 10);
+    } else if (0 == strcmp(op, "extend") || 0 == strcmp(op, "new")) {
+        directive = (0 == strcmp(op, "new")) ? PMIX_ALLOC_NEW : PMIX_ALLOC_EXTEND;
+        by_count = (strspn(arg, "0123456789") == strlen(arg));
+        if (by_count) {
+            num_nodes = strtoull(arg, NULL, 10);
+        }
     } else if (0 == strcmp(op, "release")) {
         directive = PMIX_ALLOC_RELEASE;
+        by_count = true;
         num_nodes = strtoull(arg, NULL, 10);
     } else if (0 == strcmp(op, "release-id")) {
         directive = PMIX_ALLOC_RELEASE;
@@ -374,11 +377,10 @@ int main(int argc, char **argv) {
         PMIX_INFO_CREATE(info, ninfo);
     } else {
         PMIX_INFO_CREATE(info, ninfo);
-        if (PMIX_ALLOC_EXTEND == directive || 0 == strcmp(op, "new") ||
-            0 == strcmp(op, "release")) {
-            PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_NUM_NODES, &num_nodes, PMIX_UINT64);
-        } else if (0 == strcmp(op, "release-id")) {
+        if (0 == strcmp(op, "release-id")) {
             PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_ID, arg, PMIX_STRING);
+        } else if (by_count) {
+            PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_NUM_NODES, &num_nodes, PMIX_UINT64);
         } else {
             PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_NODE_LIST, arg, PMIX_STRING);
         }

--- a/contrib/slurmswarm/AGENTS.md
+++ b/contrib/slurmswarm/AGENTS.md
@@ -201,8 +201,14 @@ serves without consulting the ras. `ras/slurm`'s `modify()` accepts only
 `PMIX_ALLOC_REQ_CANCEL` — which nodes an extend lands on is the scheduler's
 choice. Hence `elastic extend|release|release-id|cancel`.
 
-Four cases are worth calling out:
+Five cases are worth calling out:
 
+- **The expander job's deadline.** `ras/slurm` asks for the parent's remaining
+  time and resets the limit once SLURM starts the job; both cases assert
+  SLURM's own `EndTime` for the expander is not later than the parent's. The
+  reset only does work when the parent's end moves while the expander queues,
+  so `elastic_trim_group` arranges that. `test_elastic` allocates with
+  `--time` because the partition's `MaxTime` is `INFINITE`.
 - **The in-place resize.** A partial release keeps the SLURM job and shrinks
   it with `scontrol update job <id> ReqNodeList=<survivors>`. Whether SLURM
   accepts that on a RUNNING job is precisely the assumption a fake scheduler

--- a/contrib/slurmswarm/AGENTS.md
+++ b/contrib/slurmswarm/AGENTS.md
@@ -194,9 +194,9 @@ a scheduler that can say no: `salloc` really allocates a job, `scontrol show job
 --json` really emits SLURM's own schema, `scontrol update` really has to be a
 resize SLURM accepts **on a running job**, and `scancel` really removes an
 allocation. Note the request shapes differ from a plain elastic grow:
-`elastic grow <nodes>` is `PMIX_ALLOC_NEW` naming hosts, which the *base*
-serves without consulting the ras. `ras/slurm`'s `modify()` accepts only
-(`PMIX_ALLOC_EXTEND`|`PMIX_ALLOC_NEW`)+`NUM_NODES`,
+`elastic grow <nodes>` names hosts with slot counts, which `ras/slurm`
+refuses — Slurm decides the slots. `ras/slurm`'s `modify()` accepts
+(`PMIX_ALLOC_EXTEND`|`PMIX_ALLOC_NEW`)+(`NUM_NODES`|`NODE_LIST`),
 `PMIX_ALLOC_RELEASE`+(`NODE_LIST`|`NUM_NODES`|`ALLOC_ID`) and
 `PMIX_ALLOC_REQ_CANCEL` — which nodes a grow lands on is the scheduler's
 choice. Hence `elastic extend|new|release|release-id|cancel`. The two grow

--- a/contrib/slurmswarm/AGENTS.md
+++ b/contrib/slurmswarm/AGENTS.md
@@ -196,10 +196,11 @@ resize SLURM accepts **on a running job**, and `scancel` really removes an
 allocation. Note the request shapes differ from a plain elastic grow:
 `elastic grow <nodes>` is `PMIX_ALLOC_NEW` naming hosts, which the *base*
 serves without consulting the ras. `ras/slurm`'s `modify()` accepts only
-`PMIX_ALLOC_EXTEND`+`NUM_NODES`,
+(`PMIX_ALLOC_EXTEND`|`PMIX_ALLOC_NEW`)+`NUM_NODES`,
 `PMIX_ALLOC_RELEASE`+(`NODE_LIST`|`NUM_NODES`|`ALLOC_ID`) and
-`PMIX_ALLOC_REQ_CANCEL` — which nodes an extend lands on is the scheduler's
-choice. Hence `elastic extend|release|release-id|cancel`.
+`PMIX_ALLOC_REQ_CANCEL` — which nodes a grow lands on is the scheduler's
+choice. Hence `elastic extend|new|release|release-id|cancel`. The two grow
+directives are one request to this component.
 
 Five cases are worth calling out:
 

--- a/contrib/slurmswarm/run-tests.sh
+++ b/contrib/slurmswarm/run-tests.sh
@@ -678,7 +678,9 @@ test_elastic() {
     fi
 
     cleanup_cluster
-    ALLOC new --tag dvm --nodes 3 --tasks-per-node 2 >/dev/null 2>&1
+    # --time is what makes the expander-job trim observable: the partition's
+    # MaxTime is INFINITE, and a parent with no end has nothing to align to.
+    ALLOC new --tag dvm --nodes 3 --tasks-per-node 2 --time 60 >/dev/null 2>&1
     jid=$(ALLOC jobid --tag dvm | tr -d ' \r')
     if ! dvm_start --prtemca prte_elastic_mode 1 --prtemca ras_base_verbose 5; then
         banner "ras/slurm: elastic modify surface"
@@ -707,7 +709,7 @@ test_elastic() {
 # The first extend, and everything that can only be asserted about a grant
 # that actually happened.
 elastic_grant_group() {
-    local jid=$1 out ajid nodes idx n
+    local jid=$1 out ajid nodes idx n p_end a_end
 
     banner "ras/slurm: PMIX_ALLOC_EXTEND submits a real job and absorbs it"
     out=$(SA 'timeout 180 elastic extend 2' 2>&1)
@@ -772,6 +774,23 @@ elastic_grant_group() {
     [ -n "$n" ] && [ "$n" -ge 16 ] \
         && ok "the expander job owns whole nodes ($n cpus for 2 nodes -- --exclusive)" \
         || bad "the granted job did not get whole nodes (NumCPUs=$n, want >= 16)"
+    # The salloc carried the parent's time LIMIT, not what is left of it, so
+    # counted from a later start the expander outlives the DVM it was grown
+    # for.  ras/slurm resets the limit once SLURM starts the job; whether
+    # SLURM accepts that on a RUNNING job only a real scheduler can settle.
+    p_end=$(SQ "squeue -h -j $jid -o '%e'" | tr -d ' \r')
+    a_end=$(SQ "squeue -h -j $ajid -o '%e'" | tr -d ' \r')
+    # ISO-8601 timestamps sort as strings, so no date arithmetic is needed
+    if [ -z "$p_end" ] || [ -z "$a_end" ]; then
+        bad "no end time for the parent ($p_end) or the expander ($a_end)"
+    elif [ "$a_end" \> "$p_end" ]; then
+        bad "job $ajid outlives the parent allocation ($a_end > $p_end)"
+    else
+        ok "the expander job was trimmed to the parent's end ($a_end <= $p_end)"
+    fi
+    SA "grep -q 'asking for .* what is left of parent job $jid' /tmp/prte.out" \
+        && ok "the salloc asked for the parent's remainder, not its whole limit" \
+        || bad "no remainder logged: $(SA 'grep -m3 "asking for" /tmp/prte.out' | tr '\n' ' ')"
 
     banner "ras/slurm: releasing one node resizes the SLURM job in place"
     # Removing SOME of a job's nodes keeps the job and resizes it with

--- a/contrib/slurmswarm/run-tests.sh
+++ b/contrib/slurmswarm/run-tests.sh
@@ -618,9 +618,10 @@ test_plm() {
 # The request shapes are not the same as a plain elastic grow.  `elastic grow
 # <nodes>` is PMIX_ALLOC_NEW naming hosts, which the base serves without ever
 # consulting the ras.  ras/slurm's modify() accepts only
-# PMIX_ALLOC_EXTEND+NUM_NODES, PMIX_ALLOC_RELEASE+(NODE_LIST|NUM_NODES|
-# ALLOC_ID) and PMIX_ALLOC_REQ_CANCEL -- which nodes an extend lands on is
-# the scheduler's choice.  Hence `elastic extend|release|release-id|cancel`.
+# (PMIX_ALLOC_EXTEND|PMIX_ALLOC_NEW)+NUM_NODES, PMIX_ALLOC_RELEASE+(NODE_LIST|
+# NUM_NODES|ALLOC_ID) and PMIX_ALLOC_REQ_CANCEL -- which nodes a grow lands on
+# is the scheduler's choice.  Hence `elastic extend|new|release|release-id|
+# cancel`.
 job_nodes() {   # $1 = slurm job id -> comma-separated hostnames
     local nl; nl=$(SQ "squeue -h -j $1 -o '%N'" | tr -d ' \r')
     [ -n "$nl" ] || return 1
@@ -691,6 +692,7 @@ test_elastic() {
     fi
 
     elastic_grant_group "$jid"
+    elastic_new_synonym_group "$jid"
     elastic_count_release_group "$jid"
     elastic_reextend_reuse_group "$jid"
     elastic_release_during_grow_group "$jid"

--- a/contrib/slurmswarm/run-tests.sh
+++ b/contrib/slurmswarm/run-tests.sh
@@ -616,12 +616,10 @@ test_plm() {
 # SLURM accepts on a RUNNING job, and scancel really removes an allocation.
 #
 # The request shapes are not the same as a plain elastic grow.  `elastic grow
-# <nodes>` is PMIX_ALLOC_NEW naming hosts, which the base serves without ever
-# consulting the ras.  ras/slurm's modify() accepts only
-# (PMIX_ALLOC_EXTEND|PMIX_ALLOC_NEW)+NUM_NODES, PMIX_ALLOC_RELEASE+(NODE_LIST|
-# NUM_NODES|ALLOC_ID) and PMIX_ALLOC_REQ_CANCEL -- which nodes a grow lands on
-# is the scheduler's choice.  Hence `elastic extend|new|release|release-id|
-# cancel`.
+# <nodes>` names hosts with slot counts, which ras/slurm refuses -- Slurm
+# decides the slots.  Its modify() accepts (PMIX_ALLOC_EXTEND|PMIX_ALLOC_NEW)+
+# (NUM_NODES|NODE_LIST), PMIX_ALLOC_RELEASE+(NODE_LIST|NUM_NODES|ALLOC_ID) and
+# PMIX_ALLOC_REQ_CANCEL.  Hence `elastic extend|new|release|release-id|cancel`.
 job_nodes() {   # $1 = slurm job id -> comma-separated hostnames
     local nl; nl=$(SQ "squeue -h -j $1 -o '%N'" | tr -d ' \r')
     [ -n "$nl" ] || return 1
@@ -693,6 +691,7 @@ test_elastic() {
 
     elastic_grant_group "$jid"
     elastic_new_synonym_group "$jid"
+    elastic_trim_group "$jid"
     elastic_count_release_group "$jid"
     elastic_reextend_reuse_group "$jid"
     elastic_release_during_grow_group "$jid"
@@ -850,6 +849,118 @@ elastic_grant_group() {
     [ "$(echo "$out" | tr -d '\r')" = node1 ] \
         && ok "DVM still responsive after the release" \
         || bad "DVM wedged after the release: $out"
+    drop_extra_jobs "$jid"
+}
+
+# The trim at the grant only has work to do when the parent's end moved after
+# the expander was submitted -- otherwise the request already carried the
+# remainder.  A pending extend plus a shortened parent is exactly that, and
+# needs no fault injection: park the free nodes so the extend queues, lower
+# the parent's limit while it waits, then hand the nodes back.
+elastic_trim_group() {
+    local jid=$1 ajid target elapsed start p_end a_end
+
+    banner "ras/slurm: a pending expander is trimmed to the parent's new end"
+    # Pend on ONE named node, not on the whole free pool.  Parking everything
+    # and handing it all back leaves the case waiting for the queue to drain
+    # (a released node can sit IDLE with its cores still accounted, see
+    # grantable_nodes); one node has to come back, and the request names it.
+    target=$(grantable_nodes | cut -d, -f1)
+    if [ -z "$target" ]; then
+        skp "no free node to park -- the trim case needs an extend that pends"
+        return
+    fi
+    ALLOC new --tag trimpark --nodelist "$target" >/dev/null 2>&1
+    SA "nohup timeout 240 elastic extend $target --req-id trim-req \
+            >/tmp/trim.out 2>&1 & sleep 2" >/dev/null 2>&1
+    sleep 8
+    ajid=$(SQ "squeue -h -t PENDING -o '%i'" | tr -d ' \r' | head -1)
+    if [ -z "$ajid" ]; then
+        bad "the extend never queued a job: $(SA 'tr "\n" " " < /tmp/trim.out' | tail -c 200)"
+        SA 'timeout 60 elastic cancel trim-req' >/dev/null 2>&1
+        ALLOC free --tag trimpark >/dev/null 2>&1
+        drop_extra_jobs "$jid"
+        return
+    fi
+    # Lower the parent to five minutes from now.  A user may always shorten
+    # their own job, so this is the scheduler doing what it is asked, not a
+    # fault the shim armed.
+    start=$(SQ "squeue -h -j $jid -o '%S'" | tr -d ' \r')
+    elapsed=$(SQ "echo \$(( ( \$(date +%s) - \$(date -d '$start' +%s) ) / 60 + 5 ))" | tr -d ' \r')
+    SQ "scontrol update job $jid TimeLimit=$elapsed" >/dev/null 2>&1
+    ALLOC free --tag trimpark >/dev/null 2>&1
+    # Nothing to assert until the node comes back and the job starts
+    for _ in $(seq 45); do
+        [ "$(SQ "squeue -h -j $ajid -o '%T'" | tr -d ' \r')" = RUNNING ] && break
+        sleep 1
+    done
+    if [ "$(SQ "squeue -h -j $ajid -o '%T'" | tr -d ' \r')" != RUNNING ]; then
+        skp "SLURM did not start job $ajid on $target within 45s -- nothing to trim"
+        SA 'timeout 60 elastic cancel trim-req' >/dev/null 2>&1
+        drop_extra_jobs "$jid"
+        return
+    fi
+    # The trim follows the job's START, and PRRTE acts on its salloc exiting --
+    # a moment after slurmctld reports RUNNING -- so give it that moment.
+    p_end=$(SQ "squeue -h -j $jid -o '%e'" | tr -d ' \r')
+    for _ in $(seq 30); do
+        a_end=$(SQ "squeue -h -j $ajid -o '%e'" | tr -d ' \r')
+        [ -n "$a_end" ] && [ -n "$p_end" ] && ! [ "$a_end" \> "$p_end" ] && break
+        sleep 1
+    done
+    if [ -z "$a_end" ] || [ -z "$p_end" ]; then
+        bad "no end time for the parent ($p_end) or the expander ($a_end)"
+    elif [ "$a_end" \> "$p_end" ]; then
+        # PRRTE asked and this SLURM said no.  Whether a TimeLimit update is
+        # allowed on a running job is site policy, and the refusal is handled
+        # (reported, extend proceeds), so this is not a PRRTE failure.
+        if SA "grep -q 'could not align job $ajid' /tmp/prte.out"; then
+            skp "this SLURM refuses a TimeLimit update on a running job"
+        else
+            bad "the granted job outlives the shortened parent ($a_end > $p_end;"\
+                " job $ajid is $(SQ "squeue -h -j $ajid -o '%T %l'" | tr -d '\r'),"\
+                " parent $(SQ "squeue -h -j $jid -o '%T %l'" | tr -d '\r'))"
+        fi
+    else
+        SA "grep -q 'trim_job: job $ajid now ends with parent job $jid' /tmp/prte.out" \
+            && ok "the late expander was trimmed to the parent's new end ($a_end <= $p_end)" \
+            || bad "job $ajid ends in time but PRRTE never trimmed it: $(SA 'grep -m3 trim_job /tmp/prte.out' | tr '\n' ' ')"
+    fi
+    # Release through PRRTE.  Cancelling the job from outside would leave its
+    # nodes in the pool with no daemon on them, and the next group's extend
+    # would be answered PMIX_ERR_EXISTS when SLURM re-granted one of them.
+    SA "timeout 120 elastic release-id $ajid" >/dev/null 2>&1
+    sleep 4
+    drop_extra_jobs "$jid"
+}
+
+# A counted PMIX_ALLOC_NEW is the same request as PMIX_ALLOC_EXTEND here:
+# Slurm cannot grow an allocation in place, so either becomes a second,
+# disjoint job the DVM spans.  A NEW naming its own NODES is still not this
+# component's request -- Slurm allocates them by name.
+elastic_new_synonym_group() {
+    local jid=$1 out ajid nodes idx
+
+    banner "ras/slurm: a counted PMIX_ALLOC_NEW is served as an extend"
+    out=$(SA 'timeout 180 elastic new 1' 2>&1)
+    ajid=$(echo "$out" | sed -n 's/^>>> ALLOC_ID \([0-9][0-9]*\).*/\1/p' | head -1)
+    if [ -z "$ajid" ]; then
+        bad "PMIX_ALLOC_NEW + NUM_NODES was refused: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        drop_extra_jobs "$jid"
+        return
+    fi
+    ok "PMIX_ALLOC_NEW accepted and reported PMIX_ALLOC_ID=$ajid"
+    SQ "squeue -h -j $ajid -o '%i'" | grep -q "$ajid" \
+        && ok "SLURM really has a job $ajid for the NEW request" \
+        || bad "no SLURM job $ajid exists -- the id PRRTE reported is not a job"
+    nodes=$(job_nodes "$ajid"); idx=$(idx_of "$nodes")
+    sleep 8
+    # shellcheck disable=SC2086
+    [ "$(prted_count $idx)" = 1 ] \
+        && ok "the DVM grew onto the node NEW brought in ($nodes)" \
+        || bad "no daemon on $nodes -- the NEW request never reached the DVM"
+    SA "timeout 120 elastic release-id $ajid" >/dev/null 2>&1
+    sleep 4
     drop_extra_jobs "$jid"
 }
 

--- a/contrib/slurmswarm/run-tests.sh
+++ b/contrib/slurmswarm/run-tests.sh
@@ -937,7 +937,7 @@ elastic_trim_group() {
 # A counted PMIX_ALLOC_NEW is the same request as PMIX_ALLOC_EXTEND here:
 # Slurm cannot grow an allocation in place, so either becomes a second,
 # disjoint job the DVM spans.  A NEW naming its own NODES is still not this
-# component's request -- Slurm allocates them by name.
+# component's request -- Slurm allocates them by name too.
 elastic_new_synonym_group() {
     local jid=$1 out ajid nodes idx
 

--- a/examples/slurm/README
+++ b/examples/slurm/README
@@ -8,8 +8,8 @@ Jansson support, and elastic mode enabled.
 
 elastic-coordination.c:
 A Slurm-specific PMIx client for exercising dynamic allocation changes. It
-accepts interactive requests to extend by node count and to shrink by node
-count, allocation ID, or node list. After every request it queries PRRTE's
+accepts interactive requests to extend by node count or node list, and to
+shrink by node count, allocation ID, or node list. After every request it queries PRRTE's
 allocation state and displays the corresponding Slurm jobs; a separate `dvm`
 command uses prun to verify reachability across the active DVM.
 
@@ -47,6 +47,7 @@ Then run inside a Slurm allocation with one initial node:
 At the coord prompt, available commands are:
 
     extend count N [as REQUEST_NAME]
+    extend list NODE1,NODE2 [as REQUEST_NAME]
     shrink count N
     shrink alloc SLURM_JOB_ID
     shrink list NODE1,NODE2

--- a/examples/slurm/elastic-coordination.c
+++ b/examples/slurm/elastic-coordination.c
@@ -1083,7 +1083,8 @@ typedef enum {
     VERIFY_NODES_AT_LEAST,
     VERIFY_NODES_AT_MOST,
     VERIFY_ALLOC_GONE,
-    VERIFY_NODES_ABSENT
+    VERIFY_NODES_ABSENT,
+    VERIFY_NODES_PRESENT
 } verify_kind_t;
 
 typedef struct {
@@ -1101,6 +1102,33 @@ typedef struct {
 } watch_t;
 
 static int wait_until_alloc_count_at_least(size_t min_count);
+static int wait_until_nodes_present(char **nodes)
+{
+    queries_quiet = 1;
+    for (int i = 0; i < VERIFY_TIMEOUT; i++) {
+        alloc_snapshot_t snap;
+        int present = 0;
+
+        if (0 == query_snapshot(&snap)) {
+            present = 1;
+            for (int n = 0; NULL != nodes[n]; n++) {
+                if (!snapshot_has_node(&snap, nodes[n])) {
+                    present = 0;
+                    break;
+                }
+            }
+            snapshot_free(&snap);
+        }
+        if (present) {
+            queries_quiet = 0;
+            return 0;
+        }
+        sleep(1);
+    }
+    queries_quiet = 0;
+    return -1;
+}
+
 static int wait_until_total_nodes_at_most(size_t max_count);
 static int wait_until_alloc_removed(const char *allocid);
 
@@ -1149,6 +1177,7 @@ static size_t current_total_nodes(void)
     return total;
 }
 static int wait_until_nodes_absent(char **nodes);
+static int wait_until_nodes_present(char **nodes);
 static int squeue_job_exists(const char *jobid);
 
 static void watch_finish(watch_t *ctx, pmix_status_t rc)
@@ -1225,6 +1254,18 @@ static void watch_finish(watch_t *ctx, pmix_status_t rc)
             record_message("VERIFY %s: %s (requested nodes %s in PRRTE)\n",
                            ctx->description, gone ? "PASS" : "WARN",
                            gone ? "absent" : "still present");
+            if (NULL != nodes) {
+                PMIx_Argv_free(nodes);
+            }
+            break;
+        }
+        case VERIFY_NODES_PRESENT: {
+            char **nodes = PMIx_Argv_split(ctx->subject, ',');
+            int here = (NULL != nodes && 0 == wait_until_nodes_present(nodes));
+
+            record_message("VERIFY %s: %s (requested nodes %s in PRRTE)\n",
+                           ctx->description, here ? "PASS" : "WARN",
+                           here ? "present" : "still missing");
             if (NULL != nodes) {
                 PMIx_Argv_free(nodes);
             }
@@ -1484,6 +1525,23 @@ static void handle_extend_count(uint64_t count, const char *name)
                    (size_t) count, NULL, 0, 1);
 }
 
+/* Name the nodes instead of a count. Slurm allocates them by name, so the
+ * request waits for those nodes rather than for any free ones - including
+ * for one this DVM still holds, since the job is exclusive. */
+static void handle_extend_list(const char *list, const char *name)
+{
+    pmix_info_t *info;
+    char reqid[REQID_LEN];
+
+    make_reqid(reqid, sizeof(reqid), "extend", name);
+    PMIX_INFO_CREATE(info, 2);
+    PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_NODE_LIST, list, PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_ALLOC_REQ_ID, reqid, PMIX_STRING);
+
+    submit_watched(PMIX_ALLOC_EXTEND, info, 2, "extend list", reqid,
+                   VERIFY_NODES_PRESENT, 0, 0, list, 0, 1);
+}
+
 static void handle_shrink_count(uint64_t count)
 {
     alloc_snapshot_t before;
@@ -1583,6 +1641,7 @@ static void usage(const char *argv0)
     printf("Usage: %s\n\n", argv0);
     printf("Run inside a Slurm job and under PRRTE/PMIx, then enter commands:\n");
     printf("  extend count N [as REQUEST_NAME]\n");
+    printf("  extend list NODE1,NODE2 [as REQUEST_NAME]\n");
     printf("  shrink count N\n");
     printf("  shrink alloc SLURM_JOB_ID\n");
     printf("  shrink list NODE1,NODE2\n");
@@ -1775,9 +1834,18 @@ int main(int argc, char **argv)
 
             type = strtok(NULL, " \t");
             arg = strtok(NULL, " \t");
-            if (NULL == type || NULL == arg || 0 != strcmp(type, "count") ||
-                0 != parse_u64(arg, &count)) {
-                printf("usage: extend count N [as REQUEST_NAME]\n");
+            if (NULL == type || NULL == arg) {
+                printf("usage: extend count N | extend list NODE1,NODE2"
+                       " [as REQUEST_NAME]\n");
+                continue;
+            }
+            if (0 == strcmp(type, "list")) {
+                handle_extend_list(arg, parse_as_name());
+                continue;
+            }
+            if (0 != strcmp(type, "count") || 0 != parse_u64(arg, &count)) {
+                printf("usage: extend count N | extend list NODE1,NODE2"
+                       " [as REQUEST_NAME]\n");
                 continue;
             }
             handle_extend_count(count, parse_as_name());

--- a/src/include/constants.h
+++ b/src/include/constants.h
@@ -227,6 +227,7 @@ enum {
     PRTE_ERR_SLURM_CANCEL_FAILURE = (PRTE_ERR_BASE - 154),
     PRTE_ERR_SLURM_SHRINK_FAILURE = (PRTE_ERR_BASE - 155),
     PRTE_ERR_PRELOAD_CONFLICT = (PRTE_ERR_BASE - 156),
+    PRTE_ERR_SLURM_UPDATE_FAILURE = (PRTE_ERR_BASE - 157),
 
     /* Not an error code.  Nothing returns it, nothing tests for it, and
      * prte_strerror() deliberately has no case for it: it is one past the
@@ -248,7 +249,7 @@ enum {
      * it evaluated to PRTE_SUCCESS.  This one has consumers, and a test
      * that notices when it lies.
      */
-    PRTE_ERR_MAX = (PRTE_ERR_BASE - 157)
+    PRTE_ERR_MAX = (PRTE_ERR_BASE - 158)
 };
 
 END_C_DECLS

--- a/src/mca/ras/slurm/AGENTS.md
+++ b/src/mca/ras/slurm/AGENTS.md
@@ -21,7 +21,7 @@ Files:
 |------|----------|
 | `ras_slurm_component.c` | Registration; `query` gates on `SLURM_JOBID`; many `propagate_*` MCA params. |
 | `ras_slurm_module.c` | `init`, `allocate`, `modify`, `finalize`; the `SLURM_NODELIST` regex parser; session/tagging helpers; jobid/hostname validation. |
-| `ras_slurm_modify_extend.c` | `PMIX_ALLOC_EXTEND`: build & launch a `salloc --no-shell` expander job, wait for it, absorb new nodes. |
+| `ras_slurm_modify_extend.c` | `PMIX_ALLOC_EXTEND`: build & launch a `salloc --no-shell` expander job, wait for it, trim its time limit, absorb new nodes. |
 | `ras_slurm_modify_release.c` | `PMIX_ALLOC_RELEASE`: `scontrol update job` to shrink; remove nodes by count. |
 | `ras_slurm_modify_cancel.c` | `PMIX_ALLOC_REQ_CANCEL`: track and cancel pending extend requests. |
 | `ras_slurm_modify_common.c` | Shared helpers: `kill_job`, control-char checks, command-output draining. |
@@ -83,13 +83,34 @@ deviation* and the framework guide.
   job's SLURM attributes (account, partition, qos, cwd, mem-per-cpu,
   mem-per-node, time, threads-per-core — each gated by a `propagate_*`
   MCA param, all default true), builds `salloc` args, launches an
-  **expander job**, waits for its `salloc` to exit, then adds the modified
-  resources. Answers in two phases — see below.
+  **expander job**, waits for its `salloc` to exit, trims its time limit to
+  the parent's end, then adds the modified resources. Answers in two
+  phases — see below.
 - **`PMIX_ALLOC_RELEASE`** → `serve_release_req`: shrinks the SLURM job
   with `scontrol update job`, removing nodes by count while protecting
   the launching node (`SLURMD_NODENAME`).
 - **`PMIX_ALLOC_REQ_CANCEL`** → `serve_cancel_req`: cancels a pending
   extend by request id, and answers it (see below).
+
+### The expander job ends with the parent allocation
+
+The expander must not outlive the allocation it was grown for, which takes two
+steps. At submit, `limit_to_parent_remainder` asks for the parent's remaining
+time instead of its whole limit. At the grant, `trim_job_to_parent` makes the
+window exact — `scontrol update job <id> TimeLimit=<minutes>` — because Slurm
+counts a limit from the job's own start, which a queued job does not have yet.
+
+- **Only ever shortens**, truncating to the minute. A parent with no end time
+  is left alone: Slurm prints one for such a job anyway (start plus a year),
+  which `get_job_times` reports as 0.
+- **Never zero minutes.** Slurm reads `TimeLimit=0` as *no limit*, so a window
+  under a minute becomes one minute.
+- **Neither step failing fails the extend.** A generous request is still a
+  valid one, granted nodes are usable, and the limit is site policy; both
+  report and carry on.
+- Only the trim is clock-safe: the submit step compares Slurm's end time
+  against the local clock.
+- Both are gated by `ras_slurm_propagate_time`.
 
 ### An extend is answered when the DVM has grown, not when Slurm has granted
 

--- a/src/mca/ras/slurm/AGENTS.md
+++ b/src/mca/ras/slurm/AGENTS.md
@@ -104,8 +104,9 @@ Either directive may carry `PMIX_ALLOC_NUM_NODES` or `PMIX_ALLOC_NODE_LIST`,
 never both: Slurm allocates named nodes (`--nodelist=`) as readily as a count,
 and queues until it can — including for a node the DVM already holds, which
 `--exclusive` keeps it from granting twice. Names are vetted before anything
-is submitted: no per-node slot counts, since Slurm sizes the node. A request
-naming neither selector is declined with `PMIX_ERR_TAKE_NEXT_OPTION`.
+is submitted: no per-node slot counts, since Slurm sizes the node. A grow
+naming neither selector is refused, not passed on — inside a Slurm allocation
+no other module could legitimately serve it.
 
 ### The expander job ends with the parent allocation
 

--- a/src/mca/ras/slurm/AGENTS.md
+++ b/src/mca/ras/slurm/AGENTS.md
@@ -21,7 +21,7 @@ Files:
 |------|----------|
 | `ras_slurm_component.c` | Registration; `query` gates on `SLURM_JOBID`; many `propagate_*` MCA params. |
 | `ras_slurm_module.c` | `init`, `allocate`, `modify`, `finalize`; the `SLURM_NODELIST` regex parser; session/tagging helpers; jobid/hostname validation. |
-| `ras_slurm_modify_extend.c` | `PMIX_ALLOC_EXTEND`/`PMIX_ALLOC_NEW`: build & launch a `salloc --no-shell` expander job, wait for it, trim its time limit, absorb new nodes. |
+| `ras_slurm_modify_extend.c` | `PMIX_ALLOC_EXTEND`/`PMIX_ALLOC_NEW`: vet the request, build & launch a `salloc --no-shell` expander job, wait for it, trim its time limit, absorb new nodes. |
 | `ras_slurm_modify_release.c` | `PMIX_ALLOC_RELEASE`: `scontrol update job` to shrink; remove nodes by count. |
 | `ras_slurm_modify_cancel.c` | `PMIX_ALLOC_REQ_CANCEL`: track and cancel pending extend requests. |
 | `ras_slurm_modify_common.c` | Shared helpers: `kill_job`, control-char checks, command-output draining. |
@@ -86,7 +86,7 @@ deviation* and the framework guide.
   **expander job**, waits for its `salloc` to exit, trims its time limit to
   the parent's end, then adds the modified resources. Answers in two
   phases — see below.
-- **`PMIX_ALLOC_NEW`** → the same, for a request naming a node **count**.
+- **`PMIX_ALLOC_NEW`** → the same request; see below.
 - **`PMIX_ALLOC_RELEASE`** → `serve_release_req`: shrinks the SLURM job
   with `scontrol update job`, removing nodes by count while protecting
   the launching node (`SLURMD_NODENAME`).
@@ -100,10 +100,12 @@ disjoint Slurm job — "new" to the scheduler. The DVM spans both, they share a
 deadline, and a release crosses them by node count, so the two directives name
 one request.
 
-The synonym covers what this component can ask Slurm for:
-`PMIX_ALLOC_NUM_NODES`. A `PMIX_ALLOC_NEW` naming its own nodes is declined
-with `PMIX_ERR_TAKE_NEXT_OPTION` and reaches `ras/hosts` and the base as
-before.
+Either directive may carry `PMIX_ALLOC_NUM_NODES` or `PMIX_ALLOC_NODE_LIST`,
+never both: Slurm allocates named nodes (`--nodelist=`) as readily as a count,
+and queues until it can — including for a node the DVM already holds, which
+`--exclusive` keeps it from granting twice. Names are vetted before anything
+is submitted: no per-node slot counts, since Slurm sizes the node. A request
+naming neither selector is declined with `PMIX_ERR_TAKE_NEXT_OPTION`.
 
 ### The expander job ends with the parent allocation
 
@@ -331,9 +333,9 @@ omitted) and can arm unparsable JSON or a failing `scancel`. Read
 adding a case. Two things that trip people up:
 
 - **The request shapes are not a plain grow.** `modify()` accepts only
-  `PMIX_ALLOC_EXTEND`/`PMIX_ALLOC_NEW`+`NUM_NODES`, `PMIX_ALLOC_RELEASE` with
-  one of `NODE_LIST`/`NUM_NODES`/`ALLOC_ID`, and `PMIX_ALLOC_REQ_CANCEL`. A
-  node-naming `PMIX_ALLOC_NEW` is declined here — the base serves it.
+  `PMIX_ALLOC_EXTEND`/`PMIX_ALLOC_NEW` with `NUM_NODES` or `NODE_LIST`,
+  `PMIX_ALLOC_RELEASE` with one of `NODE_LIST`/`NUM_NODES`/`ALLOC_ID`, and
+  `PMIX_ALLOC_REQ_CANCEL`.
 - **An extend answers in two phases, like a release.** Phase one reports
   `PMIX_OPERATION_IN_PROGRESS` with the allocation id once Slurm grants;
   `PMIX_DVM_IS_READY` (or `PMIX_ERR_DVM_MOD`) follows when the grow campaign

--- a/src/mca/ras/slurm/AGENTS.md
+++ b/src/mca/ras/slurm/AGENTS.md
@@ -21,7 +21,7 @@ Files:
 |------|----------|
 | `ras_slurm_component.c` | Registration; `query` gates on `SLURM_JOBID`; many `propagate_*` MCA params. |
 | `ras_slurm_module.c` | `init`, `allocate`, `modify`, `finalize`; the `SLURM_NODELIST` regex parser; session/tagging helpers; jobid/hostname validation. |
-| `ras_slurm_modify_extend.c` | `PMIX_ALLOC_EXTEND`: build & launch a `salloc --no-shell` expander job, wait for it, trim its time limit, absorb new nodes. |
+| `ras_slurm_modify_extend.c` | `PMIX_ALLOC_EXTEND`/`PMIX_ALLOC_NEW`: build & launch a `salloc --no-shell` expander job, wait for it, trim its time limit, absorb new nodes. |
 | `ras_slurm_modify_release.c` | `PMIX_ALLOC_RELEASE`: `scontrol update job` to shrink; remove nodes by count. |
 | `ras_slurm_modify_cancel.c` | `PMIX_ALLOC_REQ_CANCEL`: track and cancel pending extend requests. |
 | `ras_slurm_modify_common.c` | Shared helpers: `kill_job`, control-char checks, command-output draining. |
@@ -86,11 +86,24 @@ deviation* and the framework guide.
   **expander job**, waits for its `salloc` to exit, trims its time limit to
   the parent's end, then adds the modified resources. Answers in two
   phases — see below.
+- **`PMIX_ALLOC_NEW`** → the same, for a request naming a node **count**.
 - **`PMIX_ALLOC_RELEASE`** → `serve_release_req`: shrinks the SLURM job
   with `scontrol update job`, removing nodes by count while protecting
   the launching node (`SLURMD_NODENAME`).
 - **`PMIX_ALLOC_REQ_CANCEL`** → `serve_cancel_req`: cancels a pending
   extend by request id, and answers it (see below).
+
+### `PMIX_ALLOC_NEW` is a synonym for `PMIX_ALLOC_EXTEND`
+
+Slurm cannot grow an allocation in place, so an extend here is always a second,
+disjoint Slurm job — "new" to the scheduler. The DVM spans both, they share a
+deadline, and a release crosses them by node count, so the two directives name
+one request.
+
+The synonym covers what this component can ask Slurm for:
+`PMIX_ALLOC_NUM_NODES`. A `PMIX_ALLOC_NEW` naming its own nodes is declined
+with `PMIX_ERR_TAKE_NEXT_OPTION` and reaches `ras/hosts` and the base as
+before.
 
 ### The expander job ends with the parent allocation
 
@@ -318,10 +331,9 @@ omitted) and can arm unparsable JSON or a failing `scancel`. Read
 adding a case. Two things that trip people up:
 
 - **The request shapes are not a plain grow.** `modify()` accepts only
-  `PMIX_ALLOC_EXTEND`+`NUM_NODES`, `PMIX_ALLOC_RELEASE` with one of
-  `NODE_LIST`/`NUM_NODES`/`ALLOC_ID`, and `PMIX_ALLOC_REQ_CANCEL`. A
-  node-naming `PMIX_ALLOC_NEW` never reaches this component — the base
-  serves it.
+  `PMIX_ALLOC_EXTEND`/`PMIX_ALLOC_NEW`+`NUM_NODES`, `PMIX_ALLOC_RELEASE` with
+  one of `NODE_LIST`/`NUM_NODES`/`ALLOC_ID`, and `PMIX_ALLOC_REQ_CANCEL`. A
+  node-naming `PMIX_ALLOC_NEW` is declined here — the base serves it.
 - **An extend answers in two phases, like a release.** Phase one reports
   `PMIX_OPERATION_IN_PROGRESS` with the allocation id once Slurm grants;
   `PMIX_DVM_IS_READY` (or `PMIX_ERR_DVM_MOD`) follows when the grow campaign

--- a/src/mca/ras/slurm/ras_slurm.h
+++ b/src/mca/ras/slurm/ras_slurm.h
@@ -158,6 +158,7 @@ extern const char *const num_obj_subfields[NUM_OBJ_SUBFIELD_COUNT];
 
 enum record_job_data_field {
     PRTE_JOB_DATA_NODES,
+    PRTE_JOB_DATA_NODELIST,
     PRTE_JOB_DATA_JOB_ID,
     PRTE_JOB_DATA_COUNT
 };

--- a/src/mca/ras/slurm/ras_slurm.h
+++ b/src/mca/ras/slurm/ras_slurm.h
@@ -33,6 +33,9 @@
 #define PRTE_RAS_SLURM_H
 
 #include "prte_config.h"
+
+#include <time.h>
+
 #include "src/mca/ras/base/base.h"
 #include "src/mca/ras/ras.h"
 
@@ -60,6 +63,7 @@ int prte_ras_slurm_extract_job_fields(pmix_hash_table_t *values_table);
 int prte_ras_slurm_add_modified_resources(const char *slurm_jobid, pmix_list_t *node_list);
 int prte_ras_slurm_detach_nodes(const char *slurm_jobid, prte_session_t *session, pmix_pointer_array_t *removed_nodes);
 int prte_ras_slurm_check_resources(const char *slurm_jobid);
+int prte_ras_slurm_get_job_times(const char *slurm_jobid, time_t *start_time, time_t *end_time);
 
 /* Features to serve cancel requests */
 int prte_ras_slurm_add_pending_req(const char *request_id, const char *slurm_job_id);

--- a/src/mca/ras/slurm/ras_slurm_component.c
+++ b/src/mca/ras/slurm/ras_slurm_component.c
@@ -124,7 +124,7 @@ static int ras_slurm_register(void)
 
     prte_mca_ras_slurm_component.propagate_time = true;
     (void) pmix_mca_base_component_var_register(component, "propagate_time",
-                                                "Propagate original time limit when requesting additional resources",
+                                                "Propagate original time limit when requesting additional resources, and trim the resulting job to the end of the original allocation",
                                                 PMIX_MCA_BASE_VAR_TYPE_BOOL,
                                                 &prte_mca_ras_slurm_component.propagate_time);
 

--- a/src/mca/ras/slurm/ras_slurm_jansson.c
+++ b/src/mca/ras/slurm/ras_slurm_jansson.c
@@ -46,6 +46,7 @@
  * Local functions
  */
 static int prte_ras_slurm_get_json_numobj_field(json_t *job, const char *key, pmix_hash_table_t *values_table);
+static int prte_ras_slurm_get_json_numobj_value(json_t *job, const char *key, int64_t *out);
 static int prte_ras_slurm_get_jobinfo_json(const char *slurm_jobid, json_t **job_info_out);
 static size_t prte_ras_slurm_jansson_cbfunc(void *buffer, size_t buflen, void *data);
 
@@ -1054,4 +1055,128 @@ int prte_ras_slurm_check_resources(const char *slurm_jobid)
     }
 
     return err;
+}
+
+/*
+ * Read the value of one Slurm numeric object out of a job record.
+ *
+ * A field that is absent, unset or infinite reads back as 0; only a field of
+ * the wrong shape fails.
+ *
+ * @param[in]  job JSON job object.
+ * @param[in]  key Field name to read.
+ * @param[out] out The number, or 0.
+ */
+static int prte_ras_slurm_get_json_numobj_value(json_t *job, const char *key, int64_t *out)
+{
+    if (NULL == job || NULL == key || NULL == out) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    *out = 0;
+
+    json_t *field = json_object_get(job, key);
+    if (NULL == field || json_is_null(field)) {
+        return PRTE_SUCCESS;
+    }
+    if (!json_is_object(field)) {
+        return PRTE_ERR_JSON_PARSE_FAILURE;
+    }
+
+    json_t *set_flag = json_object_get(field, num_obj_subfields[NUM_OBJ_SUBFIELD_SET]);
+    if (NULL == set_flag || !json_is_boolean(set_flag)) {
+        return PRTE_ERR_JSON_PARSE_FAILURE;
+    }
+    if (!json_is_true(set_flag)) {
+        return PRTE_SUCCESS;
+    }
+
+    json_t *inf_flag = json_object_get(field, num_obj_subfields[NUM_OBJ_SUBFIELD_INFINITE]);
+    if (NULL == inf_flag || !json_is_boolean(inf_flag)) {
+        return PRTE_ERR_JSON_PARSE_FAILURE;
+    }
+    if (json_is_true(inf_flag)) {
+        return PRTE_SUCCESS;
+    }
+
+    json_t *num_field = json_object_get(field, num_obj_subfields[NUM_OBJ_SUBFIELD_NUMBER]);
+    if (NULL == num_field || !json_is_integer(num_field)) {
+        return PRTE_ERR_JSON_PARSE_FAILURE;
+    }
+
+    json_int_t num = json_integer_value(num_field);
+    if (0 > num) {
+        return PRTE_ERR_JSON_PARSE_FAILURE;
+    }
+
+    *out = (int64_t) num;
+
+    return PRTE_SUCCESS;
+}
+
+/*
+ * Read a job's start and end times, in seconds since the epoch.
+ *
+ * Either output may be NULL. A time Slurm does not report comes back as 0, as
+ * does the end of a job with no time limit: Slurm prints an end_time for one
+ * anyway - its start plus a year - which is a placeholder, not a deadline.
+ *
+ * end_time is the start plus the CURRENT time limit, so it answers "when does
+ * this allocation end" only once the job is running.
+ *
+ * @param[in]  slurm_jobid Slurm job ID to query.
+ * @param[out] start_time  Job start time, or 0.
+ * @param[out] end_time    Job end time, or 0 if it has none.
+ */
+int prte_ras_slurm_get_job_times(const char *slurm_jobid, time_t *start_time, time_t *end_time)
+{
+    int err = PRTE_SUCCESS;
+    json_t *job_info = NULL;
+    int64_t time_limit = 0;
+    int64_t start = 0;
+    int64_t end = 0;
+
+    if (NULL == slurm_jobid) {
+        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    err = prte_ras_slurm_get_jobinfo_json(slurm_jobid, &job_info);
+
+    if (PRTE_SUCCESS != err) {
+        return err;
+    }
+
+    err = prte_ras_slurm_get_json_numobj_value(job_info, "start_time", &start);
+
+    if (PRTE_SUCCESS == err) {
+        err = prte_ras_slurm_get_json_numobj_value(job_info, "end_time", &end);
+    }
+
+    if (PRTE_SUCCESS == err) {
+        err = prte_ras_slurm_get_json_numobj_value(job_info,
+                                                   num_obj_fields[NUM_OBJ_TIME_LIMIT],
+                                                   &time_limit);
+    }
+
+    json_decref(job_info);
+
+    if (PRTE_SUCCESS != err) {
+        PRTE_ERROR_LOG(err);
+        return err;
+    }
+
+    if (0 == time_limit) {
+        end = 0;
+    }
+
+    if (NULL != start_time) {
+        *start_time = (time_t) start;
+    }
+
+    if (NULL != end_time) {
+        *end_time = (time_t) end;
+    }
+
+    return PRTE_SUCCESS;
 }

--- a/src/mca/ras/slurm/ras_slurm_jansson_stub.c
+++ b/src/mca/ras/slurm/ras_slurm_jansson_stub.c
@@ -66,3 +66,14 @@ int prte_ras_slurm_check_resources(const char *slurm_jobid)
                 "Jansson support is required but not enabled in this build");
     return PRTE_ERR_NOT_AVAILABLE;
 }
+
+/**
+ * Read a job's start/end times; returns PRTE_ERR_NOT_AVAILABLE if built without Jansson.
+ */
+int prte_ras_slurm_get_job_times(const char *slurm_jobid, time_t *start_time, time_t *end_time)
+{
+    PRTE_HIDE_UNUSED_PARAMS(slurm_jobid, start_time, end_time);
+    pmix_output(0, "ras:slurm:get_job_times: "
+                "Jansson support is required but not enabled in this build");
+    return PRTE_ERR_NOT_AVAILABLE;
+}

--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -1830,7 +1830,8 @@ int prte_ras_slurm_serve_extend_req(prte_pmix_server_req_t *req)
     }
 
     if(!found) {
-        pmix_output(0, "ras:slurm:modify: modify request invalid or unsupported.");
+        pmix_output(0, "ras:slurm:modify: a grow must name what it wants -"
+                       " PMIX_ALLOC_NUM_NODES or PMIX_ALLOC_NODE_LIST.");
         err = PRTE_ERR_REQUEST;
         goto cleanup;
     }

--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -1700,9 +1700,10 @@ void prte_ras_slurm_extend_abort_request(const char *request_id)
 /**
  * @brief Coordinate a resource-extension request with Slurm
  *
- * Service a PMIx allocation request (PMIX_ALLOC_EXTEND) by requesting 
- * additional nodes from Slurm and adding the resulting resources to PRRTE.
- * Current implementation requires specifying PMIX_ALLOC_NUM_NODES as a PMIX_UINT64.
+ * Service a PMIx allocation request (PMIX_ALLOC_EXTEND, or the PMIX_ALLOC_NEW
+ * that modify() reads as its synonym) by requesting additional nodes from
+ * Slurm and adding the resulting resources to PRRTE. Current implementation
+ * requires specifying PMIX_ALLOC_NUM_NODES as a PMIX_UINT64.
  *
  * @param[in] req PMIx server request describing the resource extension.
  */

--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -14,6 +14,7 @@
 #include "types.h"
 
 #include <ctype.h>
+#include <errno.h>
 #include <limits.h>
 #include <signal.h>
 #include <string.h>
@@ -31,9 +32,13 @@
 #include "src/util/name_fns.h"
 
 #include "ras_slurm.h"
+#include "src/mca/common/slurm/common_slurm.h"
 #include "src/mca/ras/base/base.h"
 
 #define PRTE_SLURM_MAX_SALLOC_ARGS 32
+
+/* Slurm states a job's time limit in minutes */
+#define PRTE_SLURM_SECS_PER_MINUTE 60
 
 /* Retry budget for a job whose salloc has exited but whose state slurmctld has
  * not caught up with. Doubles from 1ms to a 1s cap, ~3s in total. */
@@ -109,6 +114,8 @@ static int prte_ras_slurm_extract_reused_nodes(const char *slurm_jobid,
 static int prte_ras_slurm_add_reused_nodes_to_session(const char *slurm_jobid,
                                                       pmix_pointer_array_t *reused_nodes);
 static void prte_ras_slurm_rollback_session(const char *slurm_jobid);
+static int prte_ras_slurm_limit_to_parent_remainder(pmix_hash_table_t *fields);
+static int prte_ras_slurm_trim_job_to_parent(const char *slurm_jobid);
 static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata);
 static void slurm_grant_check_cb(int fd, short args, void *cbdata);
 static prte_slurm_wait_tracker_t *prte_ras_slurm_tracker_for_child(const prte_slurm_salloc_child_t *child);
@@ -1162,6 +1169,221 @@ static void prte_ras_slurm_rollback_session(const char *slurm_jobid)
 }
 
 /**
+ * @brief Replace the propagated time limit with what is left of the parent.
+ *
+ * The parent's limit is what that job asked for; asking Slurm for the whole
+ * of it again would reserve time past the allocation the nodes are for. The
+ * remainder counted from now is an upper bound on what a job submitted now
+ * can use - the exact figure is only knowable once Slurm starts it, which is
+ * what trim_job_to_parent does.
+ *
+ * A parent with no end time leaves the propagated value alone.
+ *
+ * @param[in,out] fields Job fields to rewrite in place.
+ */
+static int prte_ras_slurm_limit_to_parent_remainder(pmix_hash_table_t *fields)
+{
+    const char *key = num_obj_fields[NUM_OBJ_TIME_LIMIT];
+    char *parent_jobid;
+    char *minutes_string = NULL;
+    void *old_value = NULL;
+    time_t parent_end = 0;
+    long minutes;
+    int err;
+    int pmix_err;
+
+    parent_jobid = prte_common_slurm_jobid();
+    if (NULL == parent_jobid) {
+        return PRTE_ERR_NOT_FOUND;
+    }
+
+    err = prte_ras_slurm_get_job_times(parent_jobid, NULL, &parent_end);
+    if (PRTE_SUCCESS != err) {
+        return err;
+    }
+
+    if (0 == parent_end) {
+        return PRTE_SUCCESS;
+    }
+
+    /* See trim_job_to_parent on the truncation and the one-minute floor */
+    minutes = (long) ((parent_end - time(NULL)) / PRTE_SLURM_SECS_PER_MINUTE);
+    if (1 > minutes) {
+        minutes = 1;
+    }
+
+    if (0 > asprintf(&minutes_string, "%ld", minutes)) {
+        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+
+    pmix_hash_table_get_value_ptr(fields, key, strlen(key), &old_value);
+
+    pmix_err = pmix_hash_table_set_value_ptr(fields, key, strlen(key),
+                                             (void *) minutes_string);
+
+    if (PMIX_SUCCESS != pmix_err) {
+        free(minutes_string);
+        err = prte_pmix_convert_status(pmix_err);
+        PRTE_ERROR_LOG(err);
+        return err;
+    }
+
+    free(old_value);
+
+    PMIX_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
+                         "%s ras:slurm:extend: asking for %ld minute(s), what is"
+                         " left of parent job %s",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), minutes, parent_jobid));
+
+    return PRTE_SUCCESS;
+}
+
+/**
+ * @brief Trim an expander job's time limit to the end of the parent allocation.
+ *
+ * The expander carries the parent's time limit, not what is left of it, so
+ * counted from a later start it outlives the allocation it was grown for.
+ * Both ends of the window are known once Slurm has started the job, so this
+ * resets the limit to the parent's remainder. Slurm counts a limit from the
+ * job's own start, hence the arithmetic rather than an end time.
+ *
+ * Only ever shortens. A parent with no end time, or an expander that already
+ * ends first, is left alone.
+ *
+ * @param[in] slurm_jobid Slurm job ID of the running expander job.
+ */
+static int prte_ras_slurm_trim_job_to_parent(const char *slurm_jobid)
+{
+    int err = PRTE_SUCCESS;
+    char *parent_jobid = NULL;
+    char *cmd = NULL;
+    FILE *fp = NULL;
+    time_t parent_end = 0;
+    time_t start = 0;
+    time_t end = 0;
+    long minutes;
+    static const char *cmd_format = "scontrol update job %s TimeLimit=%ld 2>&1";
+    char err_msg[PRTE_SLURM_ERR_STR_MAX_LEN + 1];
+
+    if (NULL == slurm_jobid) {
+        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    err = prte_ras_slurm_validate_jobid(slurm_jobid);
+    if (PRTE_SUCCESS != err) {
+        PRTE_ERROR_LOG(err);
+        return err;
+    }
+
+    parent_jobid = prte_common_slurm_jobid();
+    if (NULL == parent_jobid) {
+        return PRTE_ERR_NOT_FOUND;
+    }
+
+    err = prte_ras_slurm_get_job_times(slurm_jobid, &start, &end);
+    if (PRTE_SUCCESS != err) {
+        return err;
+    }
+
+    /* Slurm counts the limit from the start, so without one there is nothing
+     * to measure. */
+    if (0 == start) {
+        PMIX_OUTPUT_VERBOSE((10, prte_ras_base_framework.framework_output,
+                             "%s ras:slurm:trim_job: job %s reports no start time",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), slurm_jobid));
+        return PRTE_ERR_NOT_FOUND;
+    }
+
+    /* Read the parent last: nothing re-trims afterwards, so a parent shortened
+     * between the two queries must land on this side of the arithmetic. */
+    err = prte_ras_slurm_get_job_times(parent_jobid, NULL, &parent_end);
+    if (PRTE_SUCCESS != err) {
+        return err;
+    }
+
+    if (0 == parent_end) {
+        PMIX_OUTPUT_VERBOSE((10, prte_ras_base_framework.framework_output,
+                             "%s ras:slurm:trim_job: parent job %s has no end time;"
+                             " leaving job %s as submitted",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), parent_jobid,
+                             slurm_jobid));
+        return PRTE_SUCCESS;
+    }
+
+    /* Never lengthen */
+    if (0 != end && end <= parent_end) {
+        return PRTE_SUCCESS;
+    }
+
+    /* Truncate rather than round, so the trimmed job cannot end after the
+     * parent does. Slurm reads a limit of 0 as "no limit", the opposite of
+     * what is asked here, so a window under a minute becomes one minute. */
+    minutes = (long) ((parent_end - start) / PRTE_SLURM_SECS_PER_MINUTE);
+    if (1 > minutes) {
+        minutes = 1;
+    }
+
+    if (0 > asprintf(&cmd, cmd_format, slurm_jobid, minutes)) {
+        cmd = NULL;
+        err = PRTE_ERR_OUT_OF_RESOURCE;
+        PRTE_ERROR_LOG(err);
+        goto cleanup;
+    }
+
+    PMIX_OUTPUT_VERBOSE((10, prte_ras_base_framework.framework_output,
+                         "%s ras:slurm:trim_job: trim command is:\n%s",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), cmd));
+
+    fp = popen(cmd, "r");
+    if (NULL == fp) {
+        err = PRTE_ERR_FILE_OPEN_FAILURE;
+        PRTE_ERROR_LOG(err);
+        goto cleanup;
+    }
+
+    err = prte_ras_slurm_drain_cmd_output(fp, err_msg, sizeof(err_msg));
+    if (PRTE_SUCCESS != err) {
+        PRTE_ERROR_LOG(err);
+        goto cleanup;
+    }
+
+    int status = pclose(fp);
+    fp = NULL;
+
+    if (-1 == status) {
+        pmix_output(0, "ras:slurm:trim_job: pclose failed: %s.", strerror(errno));
+        err = PRTE_ERR_IN_ERRNO;
+        goto cleanup;
+    }
+
+    if (!WIFEXITED(status) || 0 != WEXITSTATUS(status)) {
+        pmix_output(0, "ras:slurm:trim_job: could not set the time limit of job %s"
+                       " to %ld minute(s): %s",
+                    slurm_jobid, minutes, err_msg);
+        err = PRTE_ERR_SLURM_UPDATE_FAILURE;
+        goto cleanup;
+    }
+
+    PMIX_OUTPUT_VERBOSE((1, prte_ras_base_framework.framework_output,
+                         "%s ras:slurm:trim_job: job %s now ends with parent job %s,"
+                         " %ld minute(s) from its start",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), slurm_jobid,
+                         parent_jobid, minutes));
+
+    cleanup:
+
+    if (NULL != fp) {
+        pclose(fp);
+    }
+
+    free(cmd);
+
+    return err;
+}
+
+/**
  * @brief Finalize a Slurm resource extension request.
  *
  * Processes newly allocated Slurm resources after the wait phase completes.
@@ -1198,6 +1420,19 @@ static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata
 
     if(PRTE_SUCCESS != err) {
         goto complete;
+    }
+
+    /* The job is running, so its window is known for the first time here. A
+     * failed trim is not fatal: the nodes are granted and usable, and the job
+     * is scancelled with its session either way. */
+    if (prte_mca_ras_slurm_component.propagate_time) {
+        int trim_err = prte_ras_slurm_trim_job_to_parent(job_id);
+
+        if (PRTE_SUCCESS != trim_err) {
+            pmix_output(0, "ras:slurm:modify: could not align job %s with the end of"
+                           " the parent allocation: %s. It may outlive the DVM.",
+                        job_id, prte_strerror(trim_err));
+        }
     }
 
     PMIX_CONSTRUCT(&added_nodes, pmix_list_t);
@@ -1535,6 +1770,20 @@ int prte_ras_slurm_serve_extend_req(prte_pmix_server_req_t *req)
 
     if(PRTE_SUCCESS != err) {
         goto cleanup;
+    }
+
+    /* Ask for what is left of the parent, not for its whole limit again.
+     * Failing to work that out is not fatal - the parent's limit is a valid,
+     * if generous, request, and the trim at the grant is what makes the
+     * window exact. */
+    if (prte_mca_ras_slurm_component.propagate_time) {
+        int limit_err = prte_ras_slurm_limit_to_parent_remainder(&slurm_jobfields);
+
+        if (PRTE_SUCCESS != limit_err) {
+            pmix_output(0, "ras:slurm:modify: could not reduce the requested time"
+                           " limit to what is left of the parent allocation: %s.",
+                        prte_strerror(limit_err));
+        }
     }
 
     int rc = asprintf(&nodes_string, "%" PRIu64, num_nodes);

--- a/src/mca/ras/slurm/ras_slurm_modify_extend.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_extend.c
@@ -114,6 +114,7 @@ static int prte_ras_slurm_extract_reused_nodes(const char *slurm_jobid,
 static int prte_ras_slurm_add_reused_nodes_to_session(const char *slurm_jobid,
                                                       pmix_pointer_array_t *reused_nodes);
 static void prte_ras_slurm_rollback_session(const char *slurm_jobid);
+static int prte_ras_slurm_vet_node_list(char **names, uint64_t *count);
 static int prte_ras_slurm_limit_to_parent_remainder(pmix_hash_table_t *fields);
 static int prte_ras_slurm_trim_job_to_parent(const char *slurm_jobid);
 static void prte_ras_slurm_extend_wait_complete(int fd, short args, void *cbdata);
@@ -149,6 +150,7 @@ const char *const num_obj_subfields[NUM_OBJ_SUBFIELD_COUNT] = {
 /* Fields for internal PRRTE record keeping */
 const char *const record_job_data_fields[PRTE_JOB_DATA_COUNT] = {
     [PRTE_JOB_DATA_NODES]  = "nodes",
+    [PRTE_JOB_DATA_NODELIST] = "nodelist",
     [PRTE_JOB_DATA_JOB_ID] = "job_id",
 };
 
@@ -165,6 +167,7 @@ static const char *mem_per_cpu_format  = "--mem-per-cpu=%s";
 static const char *mem_per_node_format = "--mem=%s";
 static const char *time_format = "--time=%s";
 static const char *nodes_format = "--nodes=%s";
+static const char *nodelist_format = "--nodelist=%s";
 static const char *threads_per_core_format = "--threads-per-core=%s";
 
 /*
@@ -869,6 +872,15 @@ static int prte_ras_slurm_launch_expander_job(pmix_hash_table_t *fields)
         goto cleanup;
     }
 
+    /* Only when the caller named the nodes; Slurm picks them otherwise */
+    err = prte_ras_slurm_make_salloc_arg(fields, record_job_data_fields[PRTE_JOB_DATA_NODELIST],
+                                         nodelist_format, false, &argc, argv);
+
+    if(PRTE_SUCCESS != err && PRTE_ERR_NOT_FOUND != err) {
+        PRTE_ERROR_LOG(err);
+        goto cleanup;
+    }
+
     if (prte_mca_ras_slurm_component.propagate_account) {
         err = prte_ras_slurm_make_salloc_arg(fields, str_fields[STR_ACCOUNT], account_format, false, &argc, argv);
 
@@ -1166,6 +1178,45 @@ static void prte_ras_slurm_rollback_session(const char *slurm_jobid)
     }
 
     PMIX_RELEASE(session);
+}
+
+/**
+ * @brief Vet a caller-supplied node list and count it.
+ *
+ * Slurm is asked for these nodes by name, so each has to be a name it could
+ * be given: no slot counts (Slurm decides those; --exclusive takes the whole
+ * node) and nothing tainted. A node the DVM already holds needs no check of
+ * its own - --exclusive means Slurm cannot grant it twice, so such a request
+ * simply pends until the node is released.
+ *
+ * @param[in]  names Node names from PMIX_ALLOC_NODE_LIST.
+ * @param[out] count Number of names.
+ */
+static int prte_ras_slurm_vet_node_list(char **names, uint64_t *count)
+{
+    int n;
+    int err;
+
+    for (n = 0; NULL != names[n]; n++) {
+        if (NULL != strchr(names[n], ':')) {
+            pmix_output(0, "ras:slurm:modify: slot counts cannot be requested per"
+                           " node (%s); Slurm allocates whole nodes here.", names[n]);
+            return PRTE_ERR_BAD_PARAM;
+        }
+
+        err = prte_ras_slurm_validate_hostname(names[n]);
+        if (PRTE_SUCCESS != err) {
+            return err;
+        }
+    }
+
+    if (0 == n) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    *count = (uint64_t) n;
+
+    return PRTE_SUCCESS;
 }
 
 /**
@@ -1727,17 +1778,46 @@ int prte_ras_slurm_serve_extend_req(prte_pmix_server_req_t *req)
 
     uint64_t num_nodes;
     bool found = false;
+    char *node_string = NULL;
+    char **node_names = NULL;
 
     for (size_t i = 0; i < req->ninfo; i++) {
 
         if (0 == strcmp(req->info[i].key, PMIX_ALLOC_NUM_NODES)) {
 
-            if (req->info[i].value.type != PMIX_UINT64) {
+            if (req->info[i].value.type != PMIX_UINT64 || found) {
                 err = PRTE_ERR_BAD_PARAM;
                 goto cleanup;
             }
         
             num_nodes = req->info[i].value.data.uint64;
+            found = true;
+        } else if (PMIx_Check_key(req->info[i].key, PMIX_ALLOC_NODE_LIST)) {
+
+            /* Naming the nodes is a request Slurm can serve: it allocates
+             * them by name, or queues until it can. One selector only. */
+            if (found) {
+                err = PRTE_ERR_BAD_PARAM;
+                goto cleanup;
+            }
+
+            err = prte_pmix_convert_status(
+                      prte_ras_base_parse_node_list(&req->info[i], &node_string));
+            if (PRTE_SUCCESS != err) {
+                goto cleanup;
+            }
+
+            node_names = PMIx_Argv_split(node_string, ',');
+            if (NULL == node_names) {
+                err = PRTE_ERR_BAD_PARAM;
+                goto cleanup;
+            }
+
+            err = prte_ras_slurm_vet_node_list(node_names, &num_nodes);
+            if (PRTE_SUCCESS != err) {
+                goto cleanup;
+            }
+
             found = true;
         } else if (0 == strcmp(req->info[i].key, PMIX_ALLOC_REQ_ID)) {
             if (req->info[i].value.type != PMIX_STRING) {
@@ -1806,6 +1886,28 @@ int prte_ras_slurm_serve_extend_req(prte_pmix_server_req_t *req)
 
     /* Now owned by hash table */
     nodes_string = NULL;
+
+    if (NULL != node_names) {
+        char *joined = PMIx_Argv_join(node_names, ',');
+
+        if (NULL == joined) {
+            err = PRTE_ERR_OUT_OF_RESOURCE;
+            PRTE_ERROR_LOG(err);
+            goto cleanup;
+        }
+
+        pmix_err = pmix_hash_table_set_value_ptr(&slurm_jobfields,
+                        record_job_data_fields[PRTE_JOB_DATA_NODELIST],
+                        strlen(record_job_data_fields[PRTE_JOB_DATA_NODELIST]),
+                        (void *) joined);
+
+        if(PMIX_SUCCESS != pmix_err) {
+            free(joined);
+            err = prte_pmix_convert_status(pmix_err);
+            PRTE_ERROR_LOG(err);
+            goto cleanup;
+        }
+    }
 
     err = prte_ras_slurm_launch_expander_job(&slurm_jobfields);
 
@@ -1898,6 +2000,8 @@ int prte_ras_slurm_serve_extend_req(prte_pmix_server_req_t *req)
     }
 
     free(nodes_string);
+    free(node_string);
+    PMIx_Argv_free(node_names);
 
     if(have_slurm_jobfields) {
         void *key;

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -302,15 +302,16 @@ static int prte_ras_slurm_allocate(prte_job_t *jdata, pmix_list_t *nodes)
 }
 
 /**
- * @brief Whether a request asks the scheduler for a number of nodes.
+ * @brief Whether a request names something for the scheduler to allocate.
  *
- * The only grow shape this component serves; one that names its own nodes
- * belongs to the module that adds hosts directly.
+ * A node count or a node list; anything else is not a grow this component
+ * can take to Slurm.
  */
-static bool request_asks_for_node_count(const prte_pmix_server_req_t *req)
+static bool request_names_a_grow(const prte_pmix_server_req_t *req)
 {
     for (size_t i = 0; i < req->ninfo; i++) {
-        if (PMIx_Check_key(req->info[i].key, PMIX_ALLOC_NUM_NODES)) {
+        if (PMIx_Check_key(req->info[i].key, PMIX_ALLOC_NUM_NODES) ||
+            PMIx_Check_key(req->info[i].key, PMIX_ALLOC_NODE_LIST)) {
             return true;
         }
     }
@@ -325,9 +326,9 @@ static pmix_status_t modify(prte_pmix_server_req_t *req)
     /* PMIX_ALLOC_NEW is a synonym for PMIX_ALLOC_EXTEND here: Slurm cannot
      * grow an allocation in place, so an extend is always a second, disjoint
      * job - "new" to the scheduler - that the DVM then spans. The synonym
-     * covers the shape this component can ask Slurm for, a node count; a
-     * PMIX_ALLOC_NEW naming its own nodes is left to the next module. */
-    if (PMIX_ALLOC_NEW == req->allocdir && !request_asks_for_node_count(req)) {
+     * covers both shapes this component can ask Slurm for, a node count and
+     * a node list; a request naming neither is left to the next module. */
+    if (PMIX_ALLOC_NEW == req->allocdir && !request_names_a_grow(req)) {
         return PMIX_ERR_TAKE_NEXT_OPTION;
     }
 

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -301,37 +301,17 @@ static int prte_ras_slurm_allocate(prte_job_t *jdata, pmix_list_t *nodes)
     return PRTE_SUCCESS;
 }
 
-/**
- * @brief Whether a request names something for the scheduler to allocate.
- *
- * A node count or a node list; anything else is not a grow this component
- * can take to Slurm.
- */
-static bool request_names_a_grow(const prte_pmix_server_req_t *req)
-{
-    for (size_t i = 0; i < req->ninfo; i++) {
-        if (PMIx_Check_key(req->info[i].key, PMIX_ALLOC_NUM_NODES) ||
-            PMIx_Check_key(req->info[i].key, PMIX_ALLOC_NODE_LIST)) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
 static pmix_status_t modify(prte_pmix_server_req_t *req)
 {
     int err = PRTE_SUCCESS;
 
     /* PMIX_ALLOC_NEW is a synonym for PMIX_ALLOC_EXTEND here: Slurm cannot
      * grow an allocation in place, so an extend is always a second, disjoint
-     * job - "new" to the scheduler - that the DVM then spans. The synonym
-     * covers both shapes this component can ask Slurm for, a node count and
-     * a node list; a request naming neither is left to the next module. */
-    if (PMIX_ALLOC_NEW == req->allocdir && !request_names_a_grow(req)) {
-        return PMIX_ERR_TAKE_NEXT_OPTION;
-    }
-
+     * job - "new" to the scheduler - that the DVM then spans.
+     *
+     * Both are claimed outright, and a grow this component cannot ask Slurm
+     * for is refused rather than passed on: inside a Slurm allocation there
+     * is no next module that could legitimately serve it. */
     if(PMIX_ALLOC_EXTEND == req->allocdir || PMIX_ALLOC_NEW == req->allocdir) {
         err = prte_ras_slurm_serve_extend_req(req);
         req->pstatus = prte_pmix_convert_rc(err);

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -301,11 +301,37 @@ static int prte_ras_slurm_allocate(prte_job_t *jdata, pmix_list_t *nodes)
     return PRTE_SUCCESS;
 }
 
+/**
+ * @brief Whether a request asks the scheduler for a number of nodes.
+ *
+ * The only grow shape this component serves; one that names its own nodes
+ * belongs to the module that adds hosts directly.
+ */
+static bool request_asks_for_node_count(const prte_pmix_server_req_t *req)
+{
+    for (size_t i = 0; i < req->ninfo; i++) {
+        if (PMIx_Check_key(req->info[i].key, PMIX_ALLOC_NUM_NODES)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 static pmix_status_t modify(prte_pmix_server_req_t *req)
 {
     int err = PRTE_SUCCESS;
 
-    if(PMIX_ALLOC_EXTEND == req->allocdir) {
+    /* PMIX_ALLOC_NEW is a synonym for PMIX_ALLOC_EXTEND here: Slurm cannot
+     * grow an allocation in place, so an extend is always a second, disjoint
+     * job - "new" to the scheduler - that the DVM then spans. The synonym
+     * covers the shape this component can ask Slurm for, a node count; a
+     * PMIX_ALLOC_NEW naming its own nodes is left to the next module. */
+    if (PMIX_ALLOC_NEW == req->allocdir && !request_asks_for_node_count(req)) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+
+    if(PMIX_ALLOC_EXTEND == req->allocdir || PMIX_ALLOC_NEW == req->allocdir) {
         err = prte_ras_slurm_serve_extend_req(req);
         req->pstatus = prte_pmix_convert_rc(err);
     } else if(PMIX_ALLOC_RELEASE == req->allocdir) {

--- a/src/util/error.c
+++ b/src/util/error.c
@@ -445,6 +445,9 @@ const char *prte_strerror(int errnum)
     case PRTE_ERR_PRELOAD_CONFLICT:
         retval = "A preloaded file would have overwritten a file in the working directory";
         break;
+    case PRTE_ERR_SLURM_UPDATE_FAILURE:
+        retval = "Request to update Slurm job failed";
+        break;
     default:
         retval = "Unknown error";
     }

--- a/test/unit/include/test_include.c
+++ b/test/unit/include/test_include.c
@@ -155,8 +155,8 @@ static int test_error_code_numbering(void)
      * must not itself be one. The check that it is not stale -- that the
      * offset just inside it is a real, named code -- needs prte_strerror()
      * and lives in test/unit/util; here we only pin the arithmetic. */
-    CHECK("the bound is below the last code", PRTE_ERR_MAX < PRTE_ERR_PRELOAD_CONFLICT);
-    CHECK("the bound is one past the end", (PRTE_ERR_MAX + 1) == PRTE_ERR_PRELOAD_CONFLICT);
+    CHECK("the bound is below the last code", PRTE_ERR_MAX < PRTE_ERR_SLURM_UPDATE_FAILURE);
+    CHECK("the bound is one past the end", (PRTE_ERR_MAX + 1) == PRTE_ERR_SLURM_UPDATE_FAILURE);
 
     /* PRTE_ERROR must NOT be PMIX_ERROR any more. They were both -1, which
      * made a PRRTE code handed to PMIx unconverted invisible in the one


### PR DESCRIPTION
## ras/slurm: bound expander jobs in time, serve PMIX_ALLOC_NEW, take node lists

Follows from the discussion in #2699.

`ras/slurm` answers a grow by allocating a second Slurm job — Slurm cannot grow
an allocation in place — and the DVM then spans both. Two things follow from
that, and this PR implements them.

### The expander job now ends with the parent allocation

Previously the expander inherited the parent job's whole time limit, so a grow
late in an allocation reserved wall time well past the DVM it was for. Now:

- at submit, the request carries what is **left** of the parent, not its
  original limit;
- once Slurm reports the job RUNNING, the limit is reset to the exact remainder
  with `scontrol update job <id> TimeLimit=<minutes>`, because Slurm counts a
  limit from a start that a queued job does not have yet.

It only ever shortens, never lengthens. A parent with no time limit is left
alone: Slurm prints an `end_time` for such a job anyway — its start plus a year
— which is a placeholder rather than a deadline. A window under a minute
becomes one minute, since Slurm reads `TimeLimit=0` as *no limit*. Both steps
are gated by the existing `ras_slurm_propagate_time` MCA parameter, and neither
failing fails the grow.

### `PMIX_ALLOC_NEW` is served as a synonym for `PMIX_ALLOC_EXTEND`

From Slurm's point of view every extend is a new, disjoint job, so the two
directives name one request here — which is the point raised in #2699. Both are
now claimed by `modify()`, and a grow the component cannot ask Slurm for is
refused rather than passed to a module that could not legitimately serve it
inside a Slurm allocation.

### A grow may name its nodes, not only a count

`PMIX_ALLOC_NODE_LIST` is accepted alongside `PMIX_ALLOC_NUM_NODES` (never
both) and becomes `salloc --nodelist=`. Slurm allocates the named nodes, or
queues until it can — including for a node the DVM already holds, which
`--exclusive` keeps it from granting twice. Names are vetted before anything is
submitted: hostnames are validated as usual, and per-node slot counts are
refused because Slurm sizes the node itself.

Those two selectors remain the whole of what a grow may ask for here; this adds
the second one, not everything a Slurm command line could express.

### Testing

- `contrib/slurmswarm` gains cases for the trimmed deadline (its allocation now
  carries `--time`, since the partition's `MaxTime` is `INFINITE`), for a
  counted `PMIX_ALLOC_NEW`, and for a pending expander whose parent is
  shortened while it waits — the shape where the reset at the grant does the
  work; that one parks a single named node, so it pends on exactly the node it
  names rather than on the whole free pool. The suite's `elastic` client learns
  `new`, and its `extend`/`new` ops now send whichever selector their argument
  looks like. 114 cases pass against the ten-container Slurm.
- `examples/slurm/elastic-coordination` gains `extend list NODE1,NODE2`,
  verifying the named nodes joined the DVM.
- Everything above was also exercised by hand against a live Slurm 24.05
  cluster: count and node-list grows under both directives, the trim against a
  shortened parent, and an unlimited parent left untouched.

`PRTE_ERR_SLURM_UPDATE_FAILURE` is added for a rejected `scontrol update`;
`make check` covers the error-code bound as usual.
