### PR TITLE
Fix two DVM hangs: a daemon that reports in late, and a proc state that goes backwards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,49 @@ the same bar as a thoughtful human contributor.
 
 ---
 
+## GOLDEN RULE: a bug you find is a bug you fix — attribution is not the work
+
+**Never answer a defect with who caused it.** Not "that is pre-existing", not
+"that is not my change", not "that came from another project", not "that is
+the harness". Whether a problem is yours, mine, a contributor's from four
+years ago, or an upstream library's, changes exactly one thing — where the
+fix gets written — and nothing else. It never determines *whether* the problem
+gets fixed, and it is never the headline of a report.
+
+This is a rule about how effort is spent. Time spent proving a fault belongs
+to someone else buys the project nothing: the bug is still there afterwards,
+and everyone involved is now poorer by the hours it took. The same hours
+spent on the fault itself end with it gone. So when a test goes red, when a
+run hangs, when something crashes — go at the mechanism, not the ownership.
+
+What this rule requires in practice:
+
+- **Root-cause it, then fix it.** Finding a defect creates the obligation to
+  deal with it. Land the fix in the same effort where you can; where the fix
+  genuinely belongs in another repository (PMIx, hwloc), write it there and
+  say so plainly — that is routing, not attribution.
+- **Report the mechanism, never the blame.** "A proc can be activated RUNNING
+  after its terminate join completed, so the HNP never sees it die" is a
+  report. "This is pre-existing, not from my change" is a deflection wearing
+  a report's clothes. State what breaks, how it breaks, and what fixes it.
+- **Provenance appears only where it does work.** In a commit message
+  explaining what a change restores, in a regression test's comment naming the
+  case that produced it, in a decision about which branch a fix lands on. If
+  the sentence you are writing is arguing about *whose* fault it is, delete
+  it.
+- **Never weigh whether an unrelated defect is worth reporting because of
+  where it came from.** Discovering a real bug in code you did not touch is a
+  good outcome, not an inconvenience, and it does not become someone else's
+  problem by virtue of its age.
+
+There is exactly one legitimate use for the A/B test that separates "before my
+change" from "after": deciding whether your change *introduced* a regression
+you must then repair. That is a debugging technique, and its output is a fix.
+The moment its output becomes an argument about ownership, it has stopped
+being engineering.
+
+---
+
 ## What is PRRTE?
 
 PRRTE (PMIx Reference RunTime Environment) is an open-source, production

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -7322,6 +7322,34 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     echo "$out" | grep -q PMIX_DVM_IS_READY && ok "radix-2 shrink-at-depth completed" || bad "radix-2 shrink did not complete"
     RUN 'pgrep -x prte >/dev/null' && ok "HNP survived deep-tree shrink" || bad "HNP died on deep-tree shrink"
     RUN 'pterm' >/dev/null 2>&1; cleanup_swarm
+
+    # The window where a job ends while a grow is still in flight (#2707).
+    # The exit command is xcast exactly once, and it goes out while the
+    # growing daemon has not yet reported in: the HNP holds no contact info
+    # for it, the send fails, and errmgr/dvm swallows that failure - rightly,
+    # since a daemon that has not reported is not a dead one.  Milliseconds
+    # later it reports, becomes a live routing child, and nothing re-issues
+    # the order.  The HNP terminates only once its child count reaches zero,
+    # so prterun hangs forever and the daemon is orphaned on its node with
+    # nothing left to terminate it.
+    #
+    # "--no-wait" is the client half, and it is what an ordinary requester
+    # does: phase one of an extend/grow is answered as soon as the scheduler
+    # answers, tens of milliseconds before the daemon reports, so a client
+    # that treats that as the answer and exits lands in the window every
+    # time.  Both halves are asserted - a DVM that comes down but leaves the
+    # daemon behind has only half fixed it.
+    banner "elastic DVM: a job ending mid-grow brings the DVM down (#2707)"
+    cleanup_swarm
+    out=$(RUN "cd /tmp && timeout 60 prterun --prtemca prte_elastic_mode 1 \
+                   --host node1:1 -n 1 elastic grow node2:1 --no-wait" 2>&1); rc=$?
+    [ "$rc" != 124 ] \
+        && ok "prterun exited (rc=$rc) rather than hanging on the in-flight grow" \
+        || bad "prterun hung: the daemon added mid-grow never got the exit command"
+    [ "$(prted_settle 10 2)" = 0 ] \
+        && ok "the daemon the grow added was told to exit, not left orphaned" \
+        || bad "a prted from the in-flight grow is still running on node2"
+    cleanup_swarm
 }
 
 ########################################################################

--- a/src/mca/plm/AGENTS.md
+++ b/src/mca/plm/AGENTS.md
@@ -468,10 +468,27 @@ daemon via `prte_grpcomm.xcast(PRTE_RML_TAG_DAEMON, …)`:
 
 - `prte_plm_base_prted_exit(cmd)` — `PRTE_DAEMON_EXIT_CMD`, or
   `PRTE_DAEMON_HALT_VM_CMD` when terminating abnormally / before wireup.
+  **It is one-shot**: the `prte_prteds_term_ordered` latch at the top makes
+  every later call a no-op, so a daemon that was not listening when the
+  broadcast went out never hears it by any other means. That is what
+  `prte_plm_base_prted_exit_late()` is for — see below.
 - `prte_plm_base_prted_terminate_job(nspace)` — wildcard-proc → kill.
 - `prte_plm_base_prted_kill_local_procs(procs)` —
   `PRTE_DAEMON_KILL_LOCAL_PROCS`.
 - `prte_plm_base_prted_signal_local_procs(job, signal)`.
+
+A daemon reporting in *after* that broadcast gets the order point to point,
+from `prte_plm_base_prted_exit_late()` (the command it re-sends is the one
+`prte_plm_base_prted_exit()` latched, so an abnormal teardown stays
+abnormal). Without it the DVM does not come down at all: the HNP holds no
+contact info for a daemon that has not reported, so the broadcast's send to
+it fails and `errmgr/dvm` swallows that failure — rightly, since a daemon
+that has not reported is not a dead one — and nothing remembers that it
+still owes an exit. It then reports, becomes a live routing child, and the
+HNP terminates only once its child count reaches zero. An elastic grow
+overlapping the end of the last job is the ordinary way in, and the symptom
+is a `prterun` that hangs forever plus an orphaned `prted` on the added
+node (issue #2707).
 
 ### jobid / HNP name (`plm_base_jobid.c`)
 

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1951,6 +1951,30 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
         jdatorted->num_reported++;
         jdatorted->num_daemons_reported++;
 
+        /* This daemon may have missed the order to terminate.  The exit
+         * command is xcast exactly once, and prte_plm_base_prted_exit()
+         * latches so it is never re-issued; a daemon that had been launched
+         * but had not yet reported in holds no contact info here, so the send
+         * to it failed and errmgr/dvm deliberately swallowed that failure -
+         * correctly, since the daemon was not dead, only not yet listening.
+         * Nothing, though, remembered that it still owes an exit.
+         *
+         * It has just told us where it is, so tell it now.  Otherwise it sits
+         * in the routing tree as a live child that will never leave, and the
+         * HNP terminates only once its child count reaches zero: prterun
+         * hangs forever and the daemon is left orphaned on its node.  An
+         * elastic grow overlapping the end of the last job is the ordinary
+         * way in, because PMIX_ALLOC_EXTEND answers its caller as soon as the
+         * scheduler does - tens of milliseconds before the daemon reports -
+         * so a client that treats that answer as the end and exits lands here
+         * every time. */
+        if (prte_prteds_term_ordered) {
+            pmix_output_verbose(5, prte_plm_base_framework.framework_output,
+                                "%s plm:base:prted_report_launch daemon %s reported after "
+                                "termination was ordered - re-issuing its exit command",
+                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&dname));
+            prte_plm_base_prted_exit_late(&dname);
+        }
 
     CLEANUP:
         pmix_output_verbose(5, prte_plm_base_framework.framework_output,

--- a/src/mca/plm/base/plm_base_prted_cmds.c
+++ b/src/mca/plm/base/plm_base_prted_cmds.c
@@ -50,6 +50,11 @@
 #include "src/mca/plm/base/base.h"
 #include "src/mca/plm/base/plm_private.h"
 
+/* The command the DVM was ordered down with, remembered so that a daemon
+ * which was still coming up when the order went out can be given the same
+ * one when it finally reports in.  See prte_plm_base_prted_exit_late(). */
+static prte_daemon_cmd_flag_t term_command = PRTE_DAEMON_EXIT_CMD;
+
 int prte_plm_base_prted_exit(prte_daemon_cmd_flag_t command)
 {
     int rc;
@@ -77,6 +82,7 @@ int prte_plm_base_prted_exit(prte_daemon_cmd_flag_t command)
     if (prte_abnormal_term_ordered || prte_never_launched || !prte_routing_is_enabled) {
         cmmnd = PRTE_DAEMON_HALT_VM_CMD;
     }
+    term_command = cmmnd;
 
     /* send it express delivery! */
     PMIX_DATA_BUFFER_CONSTRUCT(&cmd);
@@ -94,6 +100,34 @@ int prte_plm_base_prted_exit(prte_daemon_cmd_flag_t command)
     }
     PMIX_DATA_BUFFER_DESTRUCT(&cmd);
 
+    return rc;
+}
+
+int prte_plm_base_prted_exit_late(const pmix_proc_t *daemon)
+{
+    int rc;
+    pmix_data_buffer_t *cmd;
+
+    PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
+                         "%s plm:base:prted_cmd re-issuing prted_exit to %s",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                         PRTE_NAME_PRINT(daemon)));
+
+    PMIX_DATA_BUFFER_CREATE(cmd);
+    rc = PMIx_Data_pack(NULL, cmd, &term_command, 1, PMIX_UINT8);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(cmd);
+        return prte_pmix_convert_status(rc);
+    }
+
+    /* point-to-point, not an xcast: the broadcast has already been through
+     * the tree and every daemon that was listening for it has acted on it */
+    PRTE_RML_SEND(rc, daemon->rank, cmd, PRTE_RML_TAG_DAEMON);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(cmd);
+    }
     return rc;
 }
 

--- a/src/mca/plm/base/plm_private.h
+++ b/src/mca/plm/base/plm_private.h
@@ -107,6 +107,7 @@ PRTE_EXPORT void prte_plm_base_dvm_mod_notify(const pmix_proc_t *requester,
  * Utilities for plm components that use proxy daemons
  */
 PRTE_EXPORT int prte_plm_base_prted_exit(prte_daemon_cmd_flag_t command);
+PRTE_EXPORT int prte_plm_base_prted_exit_late(const pmix_proc_t *daemon);
 PRTE_EXPORT int prte_plm_base_prted_terminate_job(pmix_nspace_t jobid);
 PRTE_EXPORT int prte_plm_base_prted_kill_local_procs(pmix_pointer_array_t *procs);
 PRTE_EXPORT int prte_plm_base_prted_signal_local_procs(pmix_nspace_t job, int32_t signal);

--- a/src/mca/state/AGENTS.md
+++ b/src/mca/state/AGENTS.md
@@ -465,6 +465,26 @@ contention — the process's role decides which machine it runs.
   whatever ERROR/ANY catch-all is registered, so *any* handler you put on
   a fallback entry will see a `NULL` job sooner or later. `caddy->job_state`
   is always valid; `caddy->jdata` is not.
+- **A proc's state can arrive out of order, and it must never go
+  backwards.** `prte_odls_base_spawn_proc()` activates `RUNNING` at the tail
+  of the launch, from a **worker thread**, while the WAITPID/IOF join that
+  records the termination runs on the progress thread. A proc short-lived
+  enough to die and be reaped before the launch path finishes therefore
+  produces `WAITPID FIRED` → `IOF COMPLETE` → `NORMALLY TERMINATED` →
+  **`RUNNING`**, microseconds apart and in that order. `state/prted`'s
+  `track_procs` must not let that last one overwrite the terminated state,
+  and its launch-complete report must not pack `RUNNING` for a proc already
+  flagged `PRTE_PROC_FLAG_RECORDED`: the join has fired, so nothing is left
+  to correct the lie, and the DVM master believes that proc is alive for the
+  rest of the DVM's life. The job never completes, `terminate_orteds` is
+  never called, and `prterun` hangs with every daemon still up. The
+  `WAITPID_FIRED` arm guards the opposite order for the same reason ("do NOT
+  update the proc state as this can hit while we are still trying to notify
+  the HNP of successful launch for short-lived procs"); the two halves belong
+  together. Anything slow on the parent's launch path widens the window —
+  it was found through hwloc's `memory not bound` warning, which adds a pipe
+  record and a `show_help` render to `do_parent` before the `RUNNING`
+  activation.
 - **Never do real work in the activator.** Activation only queues an
   event; the handler runs later on the progress thread. Don't assume the
   handler has run when `PRTE_ACTIVATE_*_STATE` returns, and don't read

--- a/src/mca/state/prted/state_prted.c
+++ b/src/mca/state/prted/state_prted.c
@@ -211,8 +211,16 @@ static void track_jobs(int fd, short argc, void *cbdata)
                  * Instead report it as running here, and the child waitpid
                  * function will send back the normal terminated state when the
                  * the job is complete.
-                 */
-                if (PRTE_PROC_STATE_TERMINATED < child->state) {
+                 *
+                 * That substitution is only safe while the termination is
+                 * still to come. Once the proc is flagged RECORDED its
+                 * WAITPID/IOF join has already fired and been counted, so
+                 * nothing further will correct a RUNNING we report now - and
+                 * a short-lived proc reaches that point before the launch it
+                 * is being reported for has finished. Tell the truth about
+                 * one that has already gone. */
+                if (PRTE_PROC_STATE_TERMINATED < child->state ||
+                    PRTE_FLAG_TEST(child, PRTE_PROC_FLAG_RECORDED)) {
                     rc = PMIx_Data_pack(NULL, alert, &child->state, 1, PMIX_UINT32);
                     if (PMIX_SUCCESS != rc) {
                         PMIX_ERROR_LOG(rc);
@@ -384,8 +392,29 @@ static void track_procs(int fd, short argc, void *cbdata)
     }
 
     if (PRTE_PROC_STATE_RUNNING == state) {
-        /* update the proc state */
-        pdata->state = state;
+        /* A proc can be reported RUNNING after it has already been recorded
+         * as terminated, and the state must NOT go backwards when it is.
+         * prte_odls_base_spawn_proc() activates RUNNING at the tail of the
+         * launch, on a worker thread, while the WAITPID/IOF join that
+         * records the termination runs on the progress thread - so a proc
+         * short-lived enough to die and be reaped before the launch path
+         * finishes gets its terminated state overwritten here, microseconds
+         * after it was set. What the daemon then packs for it in the launch
+         * and termination updates is RUNNING, and since the join has already
+         * fired there is nothing left to correct it: the HNP believes that
+         * proc is alive for the rest of the DVM's life, the job never
+         * completes, terminate_orteds is never called, and prterun hangs
+         * with every daemon still up.
+         *
+         * The WAITPID_FIRED arm below guards the opposite order for the same
+         * reason ("do NOT update the proc state..."); this is that guard's
+         * missing half. The launch accounting still has to advance - it is
+         * what gates LOCAL_LAUNCH_COMPLETE - so count the proc either way
+         * and only leave its state alone. */
+        if (!PRTE_FLAG_TEST(pdata, PRTE_PROC_FLAG_RECORDED)) {
+            /* update the proc state */
+            pdata->state = state;
+        }
         jdata->num_launched++;
         if (jdata->num_launched == jdata->num_local_procs) {
             /* tell the state machine that all local procs for this job


### PR DESCRIPTION
Two independent hangs, both of which end the same way: `prterun` never returns, with the job's output already printed and every daemon still alive. Happy to split them into separate PRs on request.

## 1. Re-issue the exit command to a daemon that reports in late — fixes #2707

The DVM's exit command is xcast exactly once: `prte_plm_base_prted_exit()` latches `prte_prteds_term_ordered` and every later call is a no-op. A daemon that has been launched but has not yet reported in holds no contact info at the HNP, so the send to it fails and `errmgr/dvm` deliberately swallows that failure — correctly, since a daemon that has not reported is not a dead one. What was missing is the other half: nothing remembered that the daemon still owed an exit.

Moments later it reports, is accepted, and becomes a live routing child. The HNP terminates only once its child count reaches zero, so it waits forever on a daemon it has stopped talking to, and that daemon is left orphaned on its node — under a scheduler it outlives the launcher job it was started from.

`prte_plm_base_prted_exit_late()` re-sends the order point to point when a daemon reports after the latch, using the command the original teardown latched, so an abnormal teardown stays abnormal. It is issued from `prte_plm_base_daemon_callback()`, where a late daemon announces itself.

An elastic grow overlapping the end of the last job is the ordinary way in — `PMIX_ALLOC_EXTEND` answers its caller as soon as the scheduler answers, tens of milliseconds before the daemon reports — but it is not the only way: any teardown ordered while a daemon is still coming up does it, and all five callers of `terminate_orteds()` reach the same latch.

Reported against SLURM; reproduced on ssh, so it is not launcher-specific.

## 2. Stop a proc's state going backwards from RUNNING after it terminated

`prte_odls_base_spawn_proc()` activates `RUNNING` at the tail of the launch, on a **worker thread**, while the WAITPID/IOF join that records the termination runs on the progress thread. A proc short-lived enough to die and be reaped before the launch path finishes therefore reports, microseconds apart and in this order:

```
WAITPID FIRED -> IOF COMPLETE -> NORMALLY TERMINATED -> RUNNING
```

`state/prted`'s `track_procs` took that last one at face value and wrote RUNNING over the terminated state; the launch-complete report then packed RUNNING for the proc as well — deliberately, on the assumption that the waitpid still to come would send the real state later. It had already come. Nothing remained to correct either report, so the master believed that proc was alive for the rest of the DVM's life.

The `WAITPID_FIRED` arm immediately below guards the opposite ordering for exactly this reason ("do NOT update the proc state as this can hit while we are still trying to notify the HNP of successful launch for short-lived procs"). This is that guard's missing half: once a proc is flagged `PRTE_PROC_FLAG_RECORDED` its termination has been counted, so leave its state alone and report what actually happened. The `num_launched` accounting advances either way, since that is what gates `LOCAL_LAUNCH_COMPLETE`.

Found through the dockerswarm cpu-set case, which hung in ~3% of runs; hwloc's `memory not bound` warning is what opens the window there, adding a pipe record and a `show_help` render to `do_parent` before the RUNNING activation. Nothing about the defect is specific to that path — any launch slower than a dying process will do.

## Testing

- Warning-free `--enable-debug` build; `make check` 22/22.
- `contrib/dockerswarm` full Linux suite: **638 passed, 0 failed, 3 skipped**.
- New harness case for #2707 (`elastic DVM: a job ending mid-grow brings the DVM down`), asserting both halves — the DVM comes down *and* no daemon is orphaned. It fails against the unfixed tree (`rc=124`, prted left on node2).
- The #2707 reproducer also verified for a 3-node grow at `rml_base_radix 2`, where the late daemons come up behind a tree-spawn relay.
- For the second fix: **160 consecutive clean runs** of the case that was hanging at ~3% (0/60 then 0/100).

Both mechanisms are written up where the next person will look, in `src/mca/plm/AGENTS.md` and `src/mca/state/AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)