### PR TITLE
Bind the forked child's memory with a syscall, not with hwloc

### DIFF
--- a/config/prte_check_mempolicy.m4
+++ b/config/prte_check_mempolicy.m4
@@ -1,0 +1,44 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2026      Nanook Consulting  All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+# See if we can issue set_mempolicy(2) directly.  glibc ships no wrapper
+# for it, so the only ways to reach it are libnuma (which allocates) or
+# the bare syscall - and the bare syscall is what hwloc itself does
+# underneath hwloc_set_membind().  When it is available, the odls child
+# can apply the job's memory-binding policy just before execve() without
+# calling into hwloc, which allocates and therefore cannot be used in the
+# async-signal-safe window after fork().  On platforms without it the
+# child falls back to hwloc.
+
+AC_DEFUN([PRTE_CHECK_SET_MEMPOLICY],[
+
+    PRTE_VAR_SCOPE_PUSH([prte_have_set_mempolicy])
+
+    prte_have_set_mempolicy=0
+
+    AC_MSG_CHECKING([for a usable set_mempolicy(2) syscall])
+    AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM(
+            [[#include <sys/syscall.h>
+              #include <unistd.h>]],
+            [[unsigned long mask = 1;
+              (void) syscall(__NR_set_mempolicy, 0, (void *) 0, 0UL);
+              (void) syscall(__NR_set_mempolicy, 2, &mask, 1UL);]])
+        ],
+        [AC_MSG_RESULT([yes])
+         prte_have_set_mempolicy=1],
+        [AC_MSG_RESULT([no])
+         prte_have_set_mempolicy=0])
+
+    AC_DEFINE_UNQUOTED([PRTE_HAVE_SET_MEMPOLICY], [$prte_have_set_mempolicy],
+        [Whether we can issue set_mempolicy(2) directly for async-signal-safe memory binding])
+
+    PRTE_VAR_SCOPE_POP
+])

--- a/configure.ac
+++ b/configure.ac
@@ -862,6 +862,12 @@ prte_show_title "CPU affinity (sched_setaffinity) support"
 
 PRTE_CHECK_SETAFFINITY
 
+# Check for async-signal-safe memory binding support (set_mempolicy)
+
+prte_show_title "Memory binding (set_mempolicy) support"
+
+PRTE_CHECK_SET_MEMPOLICY
+
 ############################################################################
 # Final top-level PRTE configuration
 ############################################################################

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -99,12 +99,6 @@ which nodes, and the daemon-launch path would have to fan out through more
 than one.  At minimum it needs a launcher affinity recorded per node and
 honored by ``prte_plm_base_setup_virtual_machine``.
 
-**The post-fork child still calls into hwloc once.**  ``odls`` was converted
-to async-signal-safe operations between ``fork`` and ``exec`` except for
-``hwloc_set_membind``, which allocates internally; replacing it with a bare
-``set_mempolicy``/``mbind`` means reproducing hwloc's NUMA nodeset handling
-and was left for later (``src/mca/odls/AGENTS.md``).
-
 **A hostfile line with more than one ``@`` stops the parse without saying
 where.**  ``hostfile_parse_line`` splits the value on ``@`` and takes one
 field as a hostname and two as ``user@host``; anything else prints
@@ -253,8 +247,6 @@ the marker is stale.
      - a peer whose socket cannot be created
    * - ``mca/filem/raw/filem_raw_module.c``, ``raw_fault_handler``
      - ``filem/raw`` does not survive losing a daemon mid-staging
-   * - ``mca/odls/base/odls_base_bind.c``, ``prte_odls_base_set``
-     - the post-fork child still calls into hwloc once
    * - ``mca/odls/base/odls_base_default_fns.c``,
        ``prte_odls_base_default_get_add_procs_data``
      - a job cannot ask for a transport

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -86,6 +86,40 @@ part that needs thought: an allocation request that is refused, or that
 times out, has to fail the spawn with something the caller can tell apart
 from a launch failure.
 
+**A child reaped before its pid is published is never accounted for.**
+``wait_signal_callback`` (``src/runtime/prte_wait.c``) reaps every available
+child with ``waitpid(-1, WNOHANG)`` and matches each pid against the
+registered trackers by ``t2->child->pid``.  That field is written by
+``fork_local`` on a **worker thread**, immediately after ``fork`` returns,
+while the reaper runs on the **progress thread** - so a process short-lived
+enough to exit before the store is made (or, on a weakly-ordered machine,
+before it is visible: neither side uses ``PMIX_POST_OBJECT`` /
+``PMIX_ACQUIRE_OBJECT`` here) matches no tracker, and its exit status is
+dropped on the floor.  Nothing retries: the tracker stays on ``pending_cbs``
+for the life of the daemon, ``PRTE_PROC_FLAG_WAITPID`` is never set, that
+proc never reaches ``TERMINATED``, and ``jdata->num_terminated`` stops one
+short of ``num_procs``.  The job therefore never completes,
+``terminate_orteds`` is never called, and ``prterun`` sits in its event loop
+with ``prte_event_base_active`` still true and every line of the job's
+output already printed.
+
+The registration is deliberately made *before* the fork "to ensure we can
+capture the callback on shortlived apps" (``prte_odls_base_default_launch_local``),
+and it is on the list in time - it is the **key** that arrives late, not the
+tracker.  Any fix has to give the reaper a way to attribute a pid it cannot
+yet resolve: park the unmatched ``(pid, status)`` and drain it once the pid
+is published, or publish the pid to the progress thread before the child can
+be reaped.
+
+Observed at roughly 0.3% of runs of ``prterun -n 8 --map-by :oversubscribe
+hostname`` in a container (about one hang per 250-350 launches); the state
+at the hang is one proc left at ``PRTE_PROC_STATE_RUNNING`` with
+``PRTE_PROC_FLAG_ALIVE`` still set and neither ``WAITPID`` nor ``RECORDED``,
+its siblings all at ``TERMINATED``.  It is the other half of the fork/worker-thread
+race that "Stop a proc's state going backwards from RUNNING after it
+terminated" addressed: there the termination arrived and was mis-ordered
+against the launch report, here it is lost outright.
+
 **Mixed allocators are not supported, and would need more than the ``ras``
 framework.**  The motivating case is a cloud/local combination: an allocation
 from a scheduler plus a set of unmanaged nodes outside it.  The ``ras``

--- a/src/mca/odls/AGENTS.md
+++ b/src/mca/odls/AGENTS.md
@@ -491,6 +491,18 @@ Three decisions the parent makes so the child has only the one call left:
   guessing. If a third memory policy is ever added, this is what has to
   grow with it.
 
+**A failure to apply the *default* policy is not a memory-binding failure.**
+With `mem_alloc_policy=none` — the default — the call is a reset to the
+system default, not a binding: nothing ends up bound to the wrong place and
+nothing is degraded, so it is not reported at all, whatever the errno and
+whatever `mem_bind_failure_action` says (that parameter governs an explicit
+binding, and its own help text says so). The rule used to be narrower —
+`ENOSYS` alone — which covered the platform that *cannot* bind memory but
+not the one that *refuses* to: Docker's default seccomp profile denies
+`set_mempolicy` with `EPERM`, and every bound launch inside a container
+announced that "the memory was left unbound", aborting the job outright
+under `mem_bind_failure_action=error`.
+
 ### 7. Reaping children — `prte_odls_base_default_wait_local_proc()`
 
 The `waitpid` callback, registered per child and fired by

--- a/src/mca/odls/AGENTS.md
+++ b/src/mca/odls/AGENTS.md
@@ -436,8 +436,9 @@ Binding is split across the fork so the child stays async-signal-safe:
   the async-signal-safe window before `execve`. It only *issues the bind
   syscalls*: a bare `sched_setaffinity` with the precomputed mask on Linux,
   or `hwloc_set_cpubind` as the `#else` fallback (macOS and other platforms
-  without `sched_setaffinity`), plus `hwloc_set_membind`. It allocates
-  nothing and renders nothing.
+  without `sched_setaffinity`), and a bare `set_mempolicy` with the
+  precomputed mode and nodemask (`hwloc_set_membind` as the `#else`). It
+  allocates nothing and renders nothing.
 
 Because the child is not a real PRTE process — and runs in that
 async-signal-safe window — **it cannot use normal error reporting or
@@ -453,10 +454,42 @@ warning depends on `PRTE_BINDING_REQUIRED` and `PRTE_BINDING_POLICY_IS_SET`
 defaulted one degrades to a warning). If the proc has no cpuset but the
 daemon itself is bound, the proc is "freed" to all allowed cpus.
 
-The one remaining hwloc call in the child is `hwloc_set_membind` (memory
-binding), which still allocates internally; converting it to a bare
-`set_mempolicy`/`mbind` syscall would mean reproducing hwloc's NUMA
-nodeset handling and is left for later.
+**The child calls into hwloc on no platform that has the syscalls.** Both
+bind calls hwloc offers allocate — `hwloc_set_membind` several times, on its
+way to the single `set_mempolicy(2)` it issues underneath — and a `malloc`
+in a forked child deadlocks whenever another thread of the daemon held the
+arena lock at `fork` time. The daemon is multi-threaded (the PMIx progress
+thread, plus the shared worker pool the forks themselves run on), so that
+window is real. `prte_odls_base_prepare_mempolicy()` therefore does hwloc's
+work in the parent: the cpuset→nodeset conversion (`hwloc_set_membind` →
+`hwloc_fix_membind_cpuset` → `hwloc_fix_membind`), the policy→`MPOL_*`
+translation, and the kernel nodemask
+(`hwloc_linux_membind_mask_from_nodeset`). It is compiled on every platform,
+not only the ones that can issue the syscall, so that the unit test covers
+it wherever it runs; `PRTE_HAVE_SET_MEMPOLICY` (`config/prte_check_mempolicy.m4`)
+gates only the syscall, with the old `hwloc_set_membind` left as the `#else`.
+
+Three decisions the parent makes so the child has only the one call left:
+
+- **A topology that is not this machine gets no memory binding at all.**
+  Under `hwloc_use_topo_file` the topology describes some *other* machine,
+  and hwloc gives such a topology no-op binding hooks that report success
+  without touching anything. Aiming a real `set_mempolicy` at another
+  machine's NUMA numbering would not be reproducing that — it would be
+  binding a process by numbers that mean nothing here — so `do_membind` is
+  cleared. (Note the asymmetry with *cpu* binding, which goes through
+  `sched_setaffinity` and *is* applied from such a topology.)
+- **A platform with no memory binding is answered as hwloc would**, with
+  `ENOSYS` recorded in `cd->membind_prep_errno` for the child to report.
+  The support bits are read through `hwloc_topology_get_support()` and are
+  only meaningful for a this-system topology — `set_topology()` in
+  [`src/hwloc/hwloc_base_util.c`](../../hwloc/hwloc_base_util.c) asserts
+  them back on for an imported one, so they say nothing there.
+- **Only `MPOL_DEFAULT` and `MPOL_BIND` are expressed**, because
+  `prte_hwloc_base_map` only ever asks for `HWLOC_MEMBIND_DEFAULT` or
+  `HWLOC_MEMBIND_BIND|STRICT`. Anything else records `ENOSYS` rather than
+  guessing. If a third memory policy is ever added, this is what has to
+  grow with it.
 
 ### 7. Reaping children — `prte_odls_base_default_wait_local_proc()`
 

--- a/src/mca/odls/base/base.h
+++ b/src/mca/odls/base/base.h
@@ -140,6 +140,11 @@ typedef struct {
     bool do_membind;                    /* also apply the memory binding policy */
     hwloc_membind_policy_t membind_policy;
     int membind_flags;
+    int membind_prep_errno;             /* nonzero: report this instead of
+                                           attempting the memory binding */
+    int membind_mode;                   /* MPOL_* mode for set_mempolicy() */
+    unsigned long *membind_nodemask;    /* NULL for MPOL_DEFAULT */
+    unsigned long membind_maxnode;      /* bits in membind_nodemask */
 #if PRTE_HAVE_SCHED_SETAFFINITY
     cpu_set_t *bind_mask;               /* CPU_ALLOC'd mask for sched_setaffinity */
     size_t bind_masksize;               /* CPU_ALLOC_SIZE of bind_mask */
@@ -206,6 +211,14 @@ PRTE_EXPORT int prte_odls_base_preload_files_app_context(prte_app_context_t *con
  * in the async-signal-safe window before execve(), and only issues the
  * bind syscalls, reporting failures up the pipe. */
 PRTE_EXPORT void prte_odls_base_prepare_binding(prte_odls_spawn_caddy_t *cd);
+
+/* Translate the caddy's cpu binding into the mode and kernel nodemask that
+ * set_mempolicy(2) takes, exactly as hwloc_set_membind() would - the child
+ * then has only the syscall left to issue. Called by
+ * prte_odls_base_prepare_binding in the parent; exported (and compiled on
+ * every platform, not just the ones that can issue the syscall) so the unit
+ * tests can drive it directly against a known topology. */
+PRTE_EXPORT void prte_odls_base_prepare_mempolicy(prte_odls_spawn_caddy_t *cd);
 PRTE_EXPORT void prte_odls_base_set(prte_odls_spawn_caddy_t *cd, int write_fd);
 
 /*

--- a/src/mca/odls/base/odls_base_bind.c
+++ b/src/mca/odls/base/odls_base_bind.c
@@ -60,6 +60,25 @@
 
 #include "src/mca/odls/base/base.h"
 
+#if PRTE_HAVE_SET_MEMPOLICY
+#    include <sys/syscall.h>
+#    include <unistd.h>
+#endif
+
+/* Mode values for set_mempolicy(2). These are kernel ABI constants, and
+   <linux/mempolicy.h> is not guaranteed to be installed, so define the two
+   we use if the headers did not - which is what hwloc does as well. The
+   nodemask that goes with them is computed on every platform, so that the
+   computation is exercised by the unit tests wherever they are run; only
+   issuing the syscall is conditional. */
+#ifndef MPOL_DEFAULT
+#    define MPOL_DEFAULT 0
+#endif
+#ifndef MPOL_BIND
+#    define MPOL_BIND 2
+#endif
+#define PRTE_BITS_PER_LONG (8 * (unsigned) sizeof(unsigned long))
+
 /* Runs in the parent. Renders, for --report-bindings, the binding we are
    about to apply to the child (the cpuset requested by the mapper).  It
    cannot read the child's actual applied binding - the child does not
@@ -127,6 +146,120 @@ void prte_odls_base_child_warn(int write_fd, prte_odls_child_err_t which, int er
 
     /* best effort */
     (void) pmix_fd_write(write_fd, sizeof(msg), &msg);
+}
+
+/* Does this platform bind memory at all?  hwloc answers ENOSYS when neither
+   membind hook is present (macOS, for one), and the caller reproduces that
+   answer rather than making the child find out.  Only meaningful for a
+   topology that describes *this* machine - hwloc zeroes the support bits of
+   an imported one, and PRRTE asserts them back (see set_topology() in
+   src/hwloc/hwloc_base_util.c), so they say nothing there. */
+static bool membind_supported(void)
+{
+    const struct hwloc_topology_support *support;
+
+    support = hwloc_topology_get_support(prte_hwloc_topology);
+    if (NULL == support || NULL == support->membind) {
+        return false;
+    }
+    return support->membind->set_thisproc_membind
+           || support->membind->set_thisthread_membind;
+}
+
+/* Runs in the PARENT.  Reproduces, on this side of the fork, everything
+   hwloc_set_membind() does on its way to the single set_mempolicy(2) call it
+   ultimately issues: the cpuset-to-nodeset conversion (hwloc_set_membind() ->
+   hwloc_fix_membind_cpuset() -> hwloc_fix_membind()), the translation of the
+   hwloc policy into an MPOL_* mode, and the kernel nodemask
+   (hwloc_linux_membind_mask_from_nodeset()).  All of that allocates, which is
+   precisely why it cannot happen in the child; what is left for the child is
+   one syscall with no arguments to compute.
+
+   On failure this records the errno hwloc would have produced in
+   cd->membind_prep_errno, and the child reports it exactly as if the call had
+   been made and failed. */
+void prte_odls_base_prepare_mempolicy(prte_odls_spawn_caddy_t *cd)
+{
+    hwloc_topology_t topo = prte_hwloc_topology;
+    hwloc_const_bitmap_t complete_cpuset, topo_cpuset;
+    hwloc_const_bitmap_t complete_nodeset, topo_nodeset;
+    hwloc_nodeset_t nodeset;
+    unsigned max_os_index, i;
+    unsigned long *mask;
+    int last;
+
+    if (HWLOC_MEMBIND_DEFAULT == cd->membind_policy) {
+        /* hwloc issues set_mempolicy(MPOL_DEFAULT, NULL, 0) - some kernels
+           refuse a nodemask with this mode - so no nodeset is involved */
+        cd->membind_mode = MPOL_DEFAULT;
+        return;
+    }
+    if (HWLOC_MEMBIND_BIND != cd->membind_policy
+        || 0 == (cd->membind_flags & HWLOC_MEMBIND_STRICT)) {
+        /* prepare_binding() only ever asks for DEFAULT or BIND|STRICT.
+           Anything else would need the rest of hwloc's policy translation,
+           so refuse it the way hwloc refuses a policy it cannot express. */
+        cd->membind_prep_errno = ENOSYS;
+        return;
+    }
+    cd->membind_mode = MPOL_BIND;
+
+    complete_cpuset = hwloc_topology_get_complete_cpuset(topo);
+    topo_cpuset = hwloc_topology_get_topology_cpuset(topo);
+    complete_nodeset = hwloc_topology_get_complete_nodeset(topo);
+    topo_nodeset = hwloc_topology_get_topology_nodeset(topo);
+
+    /* hwloc_fix_membind_cpuset() */
+    if (hwloc_bitmap_iszero(cd->bind_cpuset)
+        || !hwloc_bitmap_isincluded(cd->bind_cpuset, complete_cpuset)) {
+        cd->membind_prep_errno = EINVAL;
+        return;
+    }
+    nodeset = hwloc_bitmap_alloc();
+    if (NULL == nodeset) {
+        cd->membind_prep_errno = ENOMEM;
+        return;
+    }
+    if (hwloc_bitmap_isincluded(topo_cpuset, cd->bind_cpuset)) {
+        /* the cpuset covers the whole topology - take every node */
+        hwloc_bitmap_copy(nodeset, complete_nodeset);
+    } else {
+        hwloc_cpuset_to_nodeset(topo, cd->bind_cpuset, nodeset);
+    }
+
+    /* hwloc_fix_membind() */
+    if (hwloc_bitmap_iszero(nodeset)
+        || !hwloc_bitmap_isincluded(nodeset, complete_nodeset)) {
+        hwloc_bitmap_free(nodeset);
+        cd->membind_prep_errno = EINVAL;
+        return;
+    }
+    if (hwloc_bitmap_isincluded(topo_nodeset, nodeset)) {
+        hwloc_bitmap_copy(nodeset, complete_nodeset);
+    }
+
+    /* hwloc_linux_membind_mask_from_nodeset(): an infinite nodeset has no
+       kernel representation, and hwloc passes node 0 alone for it */
+    if (hwloc_bitmap_isfull(nodeset)) {
+        hwloc_bitmap_only(nodeset, 0);
+    }
+    last = hwloc_bitmap_last(nodeset);
+    max_os_index = (0 > last) ? 0 : (unsigned) last;
+    /* add one to turn the last index into a count, then round up to a whole
+       number of longs */
+    max_os_index = (max_os_index + 1 + PRTE_BITS_PER_LONG - 1) & ~(PRTE_BITS_PER_LONG - 1);
+    mask = calloc(max_os_index / PRTE_BITS_PER_LONG, sizeof(unsigned long));
+    if (NULL == mask) {
+        hwloc_bitmap_free(nodeset);
+        cd->membind_prep_errno = ENOMEM;
+        return;
+    }
+    for (i = 0; i < max_os_index / PRTE_BITS_PER_LONG; i++) {
+        mask[i] = hwloc_bitmap_to_ith_ulong(nodeset, i);
+    }
+    hwloc_bitmap_free(nodeset);
+    cd->membind_nodemask = mask;
+    cd->membind_maxnode = max_os_index + 1;
 }
 
 /* Runs in the PARENT, before the fork. Does everything that requires
@@ -224,6 +357,22 @@ void prte_odls_base_prepare_binding(prte_odls_spawn_caddy_t *cd)
             cd->membind_flags = 0;
             break;
         }
+        /* settle here what the child will be able to do, so that all it has
+           left is to issue the call */
+        if (!hwloc_topology_is_thissystem(prte_hwloc_topology)) {
+            /* the topology describes some other machine (hwloc_use_topo_file):
+               hwloc gives such a topology no-op binding hooks and reports
+               success without touching anything, so do nothing rather than
+               aim a real syscall at another machine's NUMA numbering */
+            cd->do_membind = false;
+        } else if (!membind_supported()) {
+            /* hwloc would answer ENOSYS - let the child report exactly that */
+            cd->membind_prep_errno = ENOSYS;
+        } else {
+#if PRTE_HAVE_SET_MEMPOLICY
+            prte_odls_base_prepare_mempolicy(cd);
+#endif
+        }
     }
 
 #if PRTE_HAVE_SCHED_SETAFFINITY
@@ -294,23 +443,40 @@ void prte_odls_base_set(prte_odls_spawn_caddy_t *cd, int write_fd)
         return;
     }
 
-    /* Apply the memory-binding policy, if one was requested. hwloc is used
-       on all platforms here; converting this to a bare syscall would mean
-       reproducing hwloc's NUMA nodeset handling and is left for later. */
+    /* Apply the memory-binding policy, if one was requested. Where the
+       set_mempolicy(2) syscall is reachable we issue it directly with the
+       mode and nodemask the parent precomputed - that is async-signal-safe,
+       and it is the one call hwloc_set_membind() makes underneath after
+       several allocations we cannot afford here. Elsewhere we fall back to
+       hwloc, which allocates internally, for want of anything better. */
     if (cd->do_membind) {
-        rc = hwloc_set_membind(prte_hwloc_topology, cd->bind_cpuset, cd->membind_policy,
-                               cd->membind_flags);
-        if (0 != rc && PRTE_BINDING_POLICY_IS_SET(jobdat->map->binding)) {
-            /* hwloc failing with ENOSYS when no explicit policy was set is
-               not really an error (mirrors the historical membind path) */
-            if (ENOSYS == errno && PRTE_HWLOC_BASE_MAP_NONE == prte_hwloc_base_map) {
+        int err = cd->membind_prep_errno;
+
+        if (0 == err) {
+#if PRTE_HAVE_SET_MEMPOLICY
+            if (0 > syscall(__NR_set_mempolicy, cd->membind_mode, cd->membind_nodemask,
+                            cd->membind_maxnode)) {
+                err = errno;
+            }
+#else
+            if (0 != hwloc_set_membind(prte_hwloc_topology, cd->bind_cpuset,
+                                       cd->membind_policy, cd->membind_flags)) {
+                err = errno;
+            }
+#endif
+        }
+        if (0 != err && PRTE_BINDING_POLICY_IS_SET(jobdat->map->binding)) {
+            /* memory binding being unavailable when no memory policy was
+               actually requested is not really an error (mirrors the
+               historical membind path) */
+            if (ENOSYS == err && PRTE_HWLOC_BASE_MAP_NONE == prte_hwloc_base_map) {
                 return;
             }
             if (PRTE_HWLOC_BASE_MBFA_ERROR == prte_hwloc_base_mbfa) {
-                prte_odls_base_child_fail(write_fd, 1, PRTE_ODLS_CHILD_ERR_BIND_MEM, errno);
+                prte_odls_base_child_fail(write_fd, 1, PRTE_ODLS_CHILD_ERR_BIND_MEM, err);
                 /* does not return */
             }
-            prte_odls_base_child_warn(write_fd, PRTE_ODLS_CHILD_WARN_MEM_NOT_BOUND, errno);
+            prte_odls_base_child_warn(write_fd, PRTE_ODLS_CHILD_WARN_MEM_NOT_BOUND, err);
             return;
         }
     }

--- a/src/mca/odls/base/odls_base_bind.c
+++ b/src/mca/odls/base/odls_base_bind.c
@@ -466,10 +466,24 @@ void prte_odls_base_set(prte_odls_spawn_caddy_t *cd, int write_fd)
 #endif
         }
         if (0 != err && PRTE_BINDING_POLICY_IS_SET(jobdat->map->binding)) {
-            /* memory binding being unavailable when no memory policy was
-               actually requested is not really an error (mirrors the
-               historical membind path) */
-            if (ENOSYS == err && PRTE_HWLOC_BASE_MAP_NONE == prte_hwloc_base_map) {
+            /* With mem_alloc_policy=none - the default - the job asked for no
+               memory policy at all, and the call just made was a reset to the
+               system default rather than a binding. Failing it leaves nothing
+               bound to the wrong place and degrades nothing, so there is
+               nothing to report: mem_bind_failure_action governs an explicit
+               memory binding, and says so. The rule used to be narrower
+               (ENOSYS alone), which covered the platform that cannot bind
+               memory but not the one that refuses to - a container whose
+               seccomp policy denies set_mempolicy, which is the default under
+               Docker, answers EPERM, and every bound launch inside one
+               announced that "the memory was left unbound" (and aborted the
+               job outright under mem_bind_failure_action=error). */
+            if (PRTE_HWLOC_BASE_MAP_NONE == prte_hwloc_base_map) {
+                return;
+            }
+            if (PRTE_HWLOC_BASE_MBFA_SILENT == prte_hwloc_base_mbfa) {
+                /* "silent" means proceed without comment - and it was being
+                   answered with the same warning as "warn" */
                 return;
             }
             if (PRTE_HWLOC_BASE_MBFA_ERROR == prte_hwloc_base_mbfa) {

--- a/src/mca/odls/base/odls_base_frame.c
+++ b/src/mca/odls/base/odls_base_frame.c
@@ -251,6 +251,10 @@ static void sccon(prte_odls_spawn_caddy_t *p)
     p->bind_cpuset = NULL;
     p->bind_fatal = false;
     p->do_membind = false;
+    p->membind_prep_errno = 0;
+    p->membind_mode = 0;
+    p->membind_nodemask = NULL;
+    p->membind_maxnode = 0;
 #if PRTE_HAVE_SCHED_SETAFFINITY
     p->bind_mask = NULL;
     p->bind_masksize = 0;
@@ -272,6 +276,9 @@ static void scdes(prte_odls_spawn_caddy_t *p)
     }
     if (NULL != p->bind_cpuset) {
         hwloc_bitmap_free(p->bind_cpuset);
+    }
+    if (NULL != p->membind_nodemask) {
+        free(p->membind_nodemask);
     }
 #if PRTE_HAVE_SCHED_SETAFFINITY
     if (NULL != p->bind_mask) {

--- a/test/unit/odls/Makefile.am
+++ b/test/unit/odls/Makefile.am
@@ -5,7 +5,8 @@
 AM_CPPFLAGS = \
     -I$(top_srcdir)/src \
     -I$(top_srcdir)/include \
-    -I$(top_srcdir)
+    -I$(top_srcdir) \
+    -DPRTE_TEST_TOPO_DIR=\"$(top_srcdir)/test/topologies\"
 
 check_PROGRAMS = test_odls
 

--- a/test/unit/odls/test_odls.c
+++ b/test/unit/odls/test_odls.c
@@ -641,6 +641,172 @@ static int test_signal_skips_dead_procs(void)
     return failures;
 }
 
+/*
+ * The memory-binding translation (odls_base_bind.c).
+ *
+ * The child applies the job's memory policy with a bare set_mempolicy(2),
+ * because hwloc_set_membind() allocates several times on its way there and
+ * the child is in the async-signal-safe window before execve().  What the
+ * parent has to hand it is exactly what hwloc would have computed: an MPOL_*
+ * mode and a kernel nodemask derived from the proc's cpuset.  That
+ * derivation is where a mistake would silently bind a process to the wrong
+ * NUMA node, so drive it directly against a topology whose NUMA layout we
+ * know.
+ *
+ * This runs on every platform, including ones that cannot issue the syscall
+ * - the translation is pure bitmap arithmetic and does not need the kernel
+ * to have it.
+ */
+#ifndef MPOL_DEFAULT
+#    define MPOL_DEFAULT 0
+#endif
+#ifndef MPOL_BIND
+#    define MPOL_BIND 2
+#endif
+#define TEST_BITS_PER_LONG (8 * (unsigned) sizeof(unsigned long))
+
+/* is bit `n` - and nothing else - set in the caddy's nodemask? */
+static bool only_node_set(prte_odls_spawn_caddy_t *cd, unsigned n)
+{
+    unsigned i, nlongs;
+
+    if (NULL == cd->membind_nodemask || 0 == cd->membind_maxnode) {
+        return false;
+    }
+    nlongs = (unsigned) (cd->membind_maxnode - 1) / TEST_BITS_PER_LONG;
+    for (i = 0; i < nlongs; i++) {
+        unsigned long want = (i == n / TEST_BITS_PER_LONG)
+                                 ? (1UL << (n % TEST_BITS_PER_LONG))
+                                 : 0UL;
+        if (cd->membind_nodemask[i] != want) {
+            return false;
+        }
+    }
+    return true;
+}
+
+static int test_mempolicy(void)
+{
+    int failures = 0;
+    hwloc_topology_t topo, save;
+    hwloc_obj_t numa;
+    prte_odls_spawn_caddy_t *cd;
+    char path[1024];
+    unsigned nnuma, n;
+
+    snprintf(path, sizeof(path), "%s/%s", PRTE_TEST_TOPO_DIR, "test-topo.xml");
+    if (0 != hwloc_topology_init(&topo)) {
+        fprintf(stdout, "  SKIP test_mempolicy (topology init failed)\n");
+        return 0;
+    }
+    if (0 != hwloc_topology_set_xml(topo, path) || 0 != hwloc_topology_load(topo)) {
+        hwloc_topology_destroy(topo);
+        fprintf(stdout, "  SKIP test_mempolicy (cannot load %s)\n", path);
+        return 0;
+    }
+    nnuma = (unsigned) hwloc_get_nbobjs_by_type(topo, HWLOC_OBJ_NUMANODE);
+    if (2 > nnuma) {
+        hwloc_topology_destroy(topo);
+        fprintf(stdout, "  SKIP test_mempolicy (topology has no NUMA nodes)\n");
+        return 0;
+    }
+    /* the translation reads the process-wide topology, as it does in a
+     * daemon; put ours in place and restore whatever was there */
+    save = prte_hwloc_topology;
+    prte_hwloc_topology = topo;
+
+    /* the default policy names no nodes at all: hwloc issues
+     * set_mempolicy(MPOL_DEFAULT, NULL, 0) because some kernels refuse a
+     * nodemask with that mode */
+    cd = PMIX_NEW(prte_odls_spawn_caddy_t);
+    cd->membind_policy = HWLOC_MEMBIND_DEFAULT;
+    cd->membind_flags = 0;
+    cd->bind_cpuset = hwloc_bitmap_dup(hwloc_topology_get_allowed_cpuset(topo));
+    prte_odls_base_prepare_mempolicy(cd);
+    CHECK("default policy prepares", 0 == cd->membind_prep_errno);
+    CHECK("default policy mode", MPOL_DEFAULT == cd->membind_mode);
+    CHECK("default policy has no nodemask", NULL == cd->membind_nodemask);
+    CHECK("default policy has no maxnode", 0 == cd->membind_maxnode);
+    PMIX_RELEASE(cd);
+
+    /* a cpuset inside one NUMA node must yield that node, and only it */
+    for (n = 0; n < nnuma; n++) {
+        char label[64];
+
+        numa = hwloc_get_obj_by_type(topo, HWLOC_OBJ_NUMANODE, n);
+        if (NULL == numa || NULL == numa->cpuset || hwloc_bitmap_iszero(numa->cpuset)) {
+            continue;
+        }
+        cd = PMIX_NEW(prte_odls_spawn_caddy_t);
+        cd->membind_policy = HWLOC_MEMBIND_BIND;
+        cd->membind_flags = HWLOC_MEMBIND_STRICT;
+        cd->bind_cpuset = hwloc_bitmap_alloc();
+        /* one cpu of that node - the narrowest binding a mapper produces */
+        hwloc_bitmap_only(cd->bind_cpuset, (unsigned) hwloc_bitmap_first(numa->cpuset));
+        prte_odls_base_prepare_mempolicy(cd);
+        snprintf(label, sizeof(label), "numa %u prepares", numa->os_index);
+        CHECK(label, 0 == cd->membind_prep_errno);
+        snprintf(label, sizeof(label), "numa %u mode", numa->os_index);
+        CHECK(label, MPOL_BIND == cd->membind_mode);
+        snprintf(label, sizeof(label), "numa %u nodemask", numa->os_index);
+        CHECK(label, only_node_set(cd, numa->os_index));
+        snprintf(label, sizeof(label), "numa %u maxnode covers it", numa->os_index);
+        CHECK(label, cd->membind_maxnode > (unsigned long) numa->os_index);
+        PMIX_RELEASE(cd);
+    }
+
+    /* a cpuset spanning the whole machine must yield every node, not one */
+    cd = PMIX_NEW(prte_odls_spawn_caddy_t);
+    cd->membind_policy = HWLOC_MEMBIND_BIND;
+    cd->membind_flags = HWLOC_MEMBIND_STRICT;
+    cd->bind_cpuset = hwloc_bitmap_dup(hwloc_topology_get_topology_cpuset(topo));
+    prte_odls_base_prepare_mempolicy(cd);
+    CHECK("whole-machine prepares", 0 == cd->membind_prep_errno);
+    if (NULL != cd->membind_nodemask) {
+        unsigned set = 0, i, bit;
+        for (i = 0; i < (unsigned) (cd->membind_maxnode - 1) / TEST_BITS_PER_LONG; i++) {
+            for (bit = 0; bit < TEST_BITS_PER_LONG; bit++) {
+                if (cd->membind_nodemask[i] & (1UL << bit)) {
+                    set++;
+                }
+            }
+        }
+        CHECK("whole-machine names every node", set == nnuma);
+    } else {
+        CHECK("whole-machine has a nodemask", false);
+    }
+    PMIX_RELEASE(cd);
+
+    /* an empty cpuset is the EINVAL hwloc_fix_membind_cpuset() answers with,
+     * and it must be reported rather than turned into a bind to node 0 */
+    cd = PMIX_NEW(prte_odls_spawn_caddy_t);
+    cd->membind_policy = HWLOC_MEMBIND_BIND;
+    cd->membind_flags = HWLOC_MEMBIND_STRICT;
+    cd->bind_cpuset = hwloc_bitmap_alloc();
+    prte_odls_base_prepare_mempolicy(cd);
+    CHECK("empty cpuset refused", EINVAL == cd->membind_prep_errno);
+    CHECK("empty cpuset yields no nodemask", NULL == cd->membind_nodemask);
+    PMIX_RELEASE(cd);
+
+    /* a policy the translation does not express must say so, not guess */
+    cd = PMIX_NEW(prte_odls_spawn_caddy_t);
+    cd->membind_policy = HWLOC_MEMBIND_INTERLEAVE;
+    cd->membind_flags = 0;
+    cd->bind_cpuset = hwloc_bitmap_dup(hwloc_topology_get_allowed_cpuset(topo));
+    prte_odls_base_prepare_mempolicy(cd);
+    CHECK("unsupported policy refused", ENOSYS == cd->membind_prep_errno);
+    CHECK("unsupported policy yields no nodemask", NULL == cd->membind_nodemask);
+    PMIX_RELEASE(cd);
+
+    prte_hwloc_topology = save;
+    hwloc_topology_destroy(topo);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_mempolicy\n");
+    }
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0;
@@ -669,6 +835,7 @@ int main(void)
     failures += test_process_envars();
     failures += test_child_pipe_protocol();
     failures += test_signal_skips_dead_procs();
+    failures += test_mempolicy();
 
     (void) pmix_mca_base_framework_close(&prte_odls_base_framework);
     prte_finalize();


### PR DESCRIPTION
Closes the `docs/todo.rst` item "The post-fork child still calls into hwloc once".

### The problem

`odls`' fork child was made async-signal-safe between `fork` and `execve`
except for one call: `hwloc_set_membind`. That call allocates several times on
its way to the single `set_mempolicy(2)` it issues underneath, and a `malloc`
in a forked child deadlocks whenever another thread of the daemon held the
arena lock at `fork` time. The daemon is multi-threaded — the PMIx progress
thread, plus the shared worker pool the forks themselves run on — so the
window is real, and a child that deadlocks there never execs and never
reports: the daemon sees a process that simply never started.

What kept the call was the belief that replacing it meant reproducing hwloc's
NUMA nodeset handling. It does, but only the part that leads to the two
policies PRRTE actually asks for: `HWLOC_MEMBIND_DEFAULT` and
`HWLOC_MEMBIND_BIND|STRICT`, which are `MPOL_DEFAULT` with no nodemask and
`MPOL_BIND` with one. None of hwloc's other policies, none of its
`MPOL_PREFERRED_MANY` fallback, and none of its migration handling is
reachable from here.

### What this does

`prte_odls_base_prepare_mempolicy()` does hwloc's work in the parent, where
allocating is safe — the cpuset→nodeset conversion (`hwloc_set_membind` →
`hwloc_fix_membind_cpuset` → `hwloc_fix_membind`), the policy translation, and
the kernel nodemask (`hwloc_linux_membind_mask_from_nodeset`) — and the child
is left with a bare syscall, which is all hwloc was going to do with it.

Three things the parent settles rather than the child:

- **A topology that describes some other machine gets no memory binding at
  all.** hwloc gives a non-`is_thissystem` topology no-op binding hooks that
  report success without touching anything, and aiming a real `set_mempolicy`
  at another machine's NUMA numbering would not be reproducing that. Gated on
  `hwloc_topology_is_thissystem()`, deliberately **not** on the support bits —
  PRRTE asserts those back on for an imported topology (`set_topology()` in
  `src/hwloc/hwloc_base_util.c`), so they say nothing there.
- **A platform with no memory binding** is answered with the `ENOSYS` hwloc
  would have returned.
- **A policy the translation does not express** records `ENOSYS` rather than
  guessing. If a third memory policy is ever added, that is what has to grow
  with it.

`PRTE_HAVE_SET_MEMPOLICY` (`config/prte_check_mempolicy.m4`) gates only the
syscall; `hwloc_set_membind` stays as the fallback for a platform without it.
The translation itself is compiled everywhere, not just where the syscall can
be issued, so the unit test covers it wherever it runs.

### Second commit: a failure to *not* bind memory was being reported

With `mem_alloc_policy=none` — the default — the child's call is a reset to
the system default, not a binding. Failing it leaves nothing bound to the
wrong place and degrades nothing, and `mem_bind_failure_action`'s own help
text says it governs an explicit memory binding ("this is a different case
than the general allocation policy described by `mem_alloc_policy`").

The code came close to saying that but keyed on the errno instead of the
question: `ENOSYS` was excused, and only `ENOSYS`. That covers the platform
that *cannot* bind memory and misses the one that *refuses* to. Docker's
default seccomp profile denies `set_mempolicy` with `EPERM`, so every launch
of a bound process inside a container announced "PRTE tried to bind memory …
the memory was left unbound", and under `mem_bind_failure_action=error` killed
the job for failing to not bind memory.

In the same block, `silent` was being answered with the warning `warn` asks
for — the value was never tested, so the two settings behaved identically.

### Third commit: a hang found while testing, recorded not fixed

`wait_signal_callback` (`src/runtime/prte_wait.c`) reaps with
`waitpid(-1, WNOHANG)` and attributes each pid by walking `pending_cbs` for
`t2->child->pid`. That field is stored by `fork_local` on a worker thread
right after `fork` returns, while the reaper runs on the progress thread, with
no `PMIX_POST_OBJECT`/`PMIX_ACQUIRE_OBJECT` pairing. A process short-lived
enough to exit before that store is made — or, on a weakly-ordered machine,
before it is visible — matches no tracker and has its exit status discarded.
Nothing retries: that proc never reaches `TERMINATED`, `num_terminated` stops
one short of `num_procs`, the job never completes, `terminate_orteds` is never
called, and `prterun` sits in its event loop with its job's output already
printed.

Roughly 0.3% of runs of `prterun -n 8 --map-by :oversubscribe hostname`;
confirmed under gdb with one proc left `RUNNING`/`ALIVE` and `num_term` at 7 of
8 while its siblings were all `TERMINATED`. It is the other half of the
fork/worker-thread race that 78df6ec ("Stop a proc's state going backwards
from RUNNING after it terminated") closed — there the termination arrived and
was mis-ordered against the launch report, here it is lost outright.

Recorded in `docs/todo.rst` rather than fixed because the repair is a design
choice about where a reap that arrives before its key can be drained, and that
decision sits next to the in-flight work on the sibling race.

### Testing

- macOS and Linux builds, `--enable-debug`, warning-free.
- `make check`: 20/20 suites pass. The new `test_mempolicy` case in
  `test/unit/odls/test_odls.c` drives the translation against the 4-NUMA
  `test/topologies/test-topo.xml` and checks that a cpuset inside one node
  yields that node and no other, that the whole machine yields every node,
  that an empty cpuset is refused with `EINVAL`, and that a policy the
  translation does not express is refused with `ENOSYS`. Verified it fails
  when the conversion is deliberately broken.
- A probe linking hwloc confirms `hwloc_set_membind` and the bare syscall
  agree exactly, in both errno regimes a container produces (`EPERM` under
  Docker's seccomp, `ENOSYS` with it lifted, since the Docker Desktop kernel
  has no `CONFIG_NUMA`).
- `contrib/dockerswarm` suite: **636 passed, 2 failed, 3 skipped** — the 636
  matching the current green baseline. Both failures are the concurrent
  `prun --tag-output` case, which A/Bs at 1/25 on an unmodified HEAD build and
  0/25 with this branch, i.e. a pre-existing intermittent (and a real one —
  one job's output goes missing entirely).

**Not verified:** a *successful* memory binding. No NUMA-capable Linux was
available — the Docker Desktop kernel reports a single node and no
`/sys/devices/system/node` — so the syscall was only exercised through its
failure paths. The nodemask arithmetic is covered by the unit test against
synthetic multi-NUMA topologies, and by the probe's agreement with hwloc, but
a run on real NUMA hardware would be worth having before this lands.
