### PR TITLE
Hold a forked child until its pid has been recorded

### DIFF
--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -86,40 +86,6 @@ part that needs thought: an allocation request that is refused, or that
 times out, has to fail the spawn with something the caller can tell apart
 from a launch failure.
 
-**A child reaped before its pid is published is never accounted for.**
-``wait_signal_callback`` (``src/runtime/prte_wait.c``) reaps every available
-child with ``waitpid(-1, WNOHANG)`` and matches each pid against the
-registered trackers by ``t2->child->pid``.  That field is written by
-``fork_local`` on a **worker thread**, immediately after ``fork`` returns,
-while the reaper runs on the **progress thread** - so a process short-lived
-enough to exit before the store is made (or, on a weakly-ordered machine,
-before it is visible: neither side uses ``PMIX_POST_OBJECT`` /
-``PMIX_ACQUIRE_OBJECT`` here) matches no tracker, and its exit status is
-dropped on the floor.  Nothing retries: the tracker stays on ``pending_cbs``
-for the life of the daemon, ``PRTE_PROC_FLAG_WAITPID`` is never set, that
-proc never reaches ``TERMINATED``, and ``jdata->num_terminated`` stops one
-short of ``num_procs``.  The job therefore never completes,
-``terminate_orteds`` is never called, and ``prterun`` sits in its event loop
-with ``prte_event_base_active`` still true and every line of the job's
-output already printed.
-
-The registration is deliberately made *before* the fork "to ensure we can
-capture the callback on shortlived apps" (``prte_odls_base_default_launch_local``),
-and it is on the list in time - it is the **key** that arrives late, not the
-tracker.  Any fix has to give the reaper a way to attribute a pid it cannot
-yet resolve: park the unmatched ``(pid, status)`` and drain it once the pid
-is published, or publish the pid to the progress thread before the child can
-be reaped.
-
-Observed at roughly 0.3% of runs of ``prterun -n 8 --map-by :oversubscribe
-hostname`` in a container (about one hang per 250-350 launches); the state
-at the hang is one proc left at ``PRTE_PROC_STATE_RUNNING`` with
-``PRTE_PROC_FLAG_ALIVE`` still set and neither ``WAITPID`` nor ``RECORDED``,
-its siblings all at ``TERMINATED``.  It is the other half of the fork/worker-thread
-race that "Stop a proc's state going backwards from RUNNING after it
-terminated" addressed: there the termination arrived and was mis-ordered
-against the launch report, here it is lost outright.
-
 **Mixed allocators are not supported, and would need more than the ``ras``
 framework.**  The motivating case is a cloud/local combination: an allocation
 from a scheduler plus a set of unmanaged nodes outside it.  The ``ras``

--- a/src/mca/odls/AGENTS.md
+++ b/src/mca/odls/AGENTS.md
@@ -171,7 +171,13 @@ have its "you decide" sentinel restored by a teardown path, or a call arriving
 during finalize builds a whole new set of real threads on the way out.
 
 MCA params, all under `prte odls base`: `signal_direct_children_only`,
-`exec_agent`, `scatter_cpusets`. Framework open also **unblocks `SIGCHLD`**
+`exec_agent`, `scatter_cpusets`, and `fork_publish_delay` — a
+fault-injection hook, like `prte_daemon_fail`, that stalls between the
+fork and the store of the child's pid so the launch/reap race described
+below can be reproduced deterministically from a single `prterun`. It is
+**not** restricted to a debug build, on purpose: an optimized build is a
+different race, so a hook that exists only in a debug one cannot say
+anything about the build that ships. Framework open also **unblocks `SIGCHLD`**
 (odls must see child deaths) and builds the xterm command vector. Framework
 close releases the global `prte_local_children` array.
 
@@ -670,6 +676,14 @@ computed proc state.
   a bare `return` in the middle — a stray `return` there both leaks and, on
   the daemon side, skips the `NEVER_LAUNCHED` activation that keeps the HNP
   from hanging.
+- **A child must not be able to die before its pid is recorded.** The fork
+  happens on a worker thread, and the `SIGCHLD` reaper on the progress
+  thread has nothing but `child->pid` with which to attribute what it
+  reaps — a status it cannot attribute is discarded, and the proc then
+  never leaves `RUNNING` and the job never completes. `fork_local_proc`
+  holds the child on a second pipe until the store is done; see
+  [`pdefault/AGENTS.md`](pdefault/AGENTS.md), "The gate". A fork primitive
+  added to a new component owes the same.
 - **A launch that never forked owes a `prte_wait_cb_cancel`.**
   `launch_local` flags a child `ALIVE` and registers its waitpid *before*
   the IOF setup and the dispatch to `spawn_proc`, so anything that fails in

--- a/src/mca/odls/base/base.h
+++ b/src/mca/odls/base/base.h
@@ -63,6 +63,9 @@ typedef struct {
     bool scatter_cpusets;
     /* launches and cpuset slices that are waiting for each other */
     pmix_list_t pending_slices;
+    /* microseconds to stall between fork() and the store of the child's
+     * pid - a fault-injection hook, see odls_base_frame.c */
+    int fork_publish_delay;
 } prte_odls_globals_t;
 
 PRTE_EXPORT extern prte_odls_globals_t prte_odls_globals;

--- a/src/mca/odls/base/odls_base_frame.c
+++ b/src/mca/odls/base/odls_base_frame.c
@@ -101,6 +101,30 @@ static int prte_odls_base_register(pmix_mca_base_register_flag_t flags)
                                       PMIX_MCA_BASE_VAR_TYPE_BOOL,
                                       &prte_odls_globals.scatter_cpusets);
 
+    /* A fault-injection hook, in the same spirit as prte_daemon_fail.  The
+     * daemon forks its children on a worker thread and records each child's
+     * pid there, while the SIGCHLD reaper runs on the progress thread and
+     * has nothing but that pid with which to attribute what it reaps.  A
+     * child short-lived enough to run between the fork and the store used to
+     * be reaped unattributably, and the job then never completed.  The child
+     * is now held until the store is done, and stalling here is what widens
+     * a window that is otherwise microseconds wide and fails in a fraction
+     * of a percent of launches.
+     *
+     * Deliberately NOT restricted to a debug build.  A timing defect has to
+     * be demonstrable in the build that ships, and an optimized build is a
+     * different race from a debug one; a hook that exists only in the latter
+     * cannot say anything about the former.  It costs a load and a
+     * predictable branch per fork(), against a fork/exec pair, and every
+     * launched proc pays the stall itself only if somebody sets it. */
+    prte_odls_globals.fork_publish_delay = 0;
+    (void) pmix_mca_base_var_register("prte", "odls", "base", "fork_publish_delay",
+                                      "Microseconds to stall between forking a child and recording "
+                                      "its pid, to exercise the launch/reap race "
+                                      "[default: 0 => no delay]",
+                                      PMIX_MCA_BASE_VAR_TYPE_INT,
+                                      &prte_odls_globals.fork_publish_delay);
+
     return PRTE_SUCCESS;
 }
 

--- a/src/mca/odls/pdefault/AGENTS.md
+++ b/src/mca/odls/pdefault/AGENTS.md
@@ -76,13 +76,16 @@ child-side pre-exec sequence.
 This is the function the base calls (as `cd->fork_local(cd)`) from inside
 `prte_odls_base_spawn_proc`, once per child, on whichever event base the
 base picked. The design, spelled out in the long header comment, is a
-**pipe-synchronized fork**:
+**pipe-synchronized fork**, with a pipe running each way:
 
-1. Open a pipe `p[2]`.
+1. Open a pipe `p[2]` (child→parent errors) and a pipe `gate[2]`
+   (parent→child release).
 2. `fork()`. Record `child->pid` (in *both* parent and child copies).
-3. **Child** (`pid == 0`): close the read end, call `do_child(cd, p[1])` —
-   which never returns (it either `execve`s or `_exit`s).
-4. **Parent**: close the write end, return `do_parent(cd, p[0])`.
+3. **Child** (`pid == 0`): close `p[0]` and `gate[1]`, call
+   `do_child(cd, p[1], gate[0])` — which never returns (it either
+   `execve`s or `_exit`s).
+4. **Parent**: close `gate[0]`, `PMIX_POST_OBJECT(child)`, write one byte
+   to `gate[1]` and close it, close `p[1]`, return `do_parent(cd, p[0])`.
 
 The pipe is the child→parent error channel: the child sets it
 close-on-exec, so if `execve` succeeds the pipe simply **closes with no
@@ -92,22 +95,73 @@ parent renders and prints the diagnostic.
 
 `pipe()` or `fork()` failure sets `child->state =
 PRTE_PROC_STATE_FAILED_TO_START` and returns `PMIX_ERR_SYS_LIMITS_PIPES` /
-`PMIX_ERR_SYS_LIMITS_CHILDREN`.
+`PMIX_ERR_SYS_LIMITS_CHILDREN`.  All four descriptors have to be closed on
+those paths — the gate pair is easy to forget, and leaking it leaks two
+fds per failed launch.
+
+### The gate — why the child waits to be released
+
+**The child must not be able to die before its pid has been recorded.**
+We fork on a *worker* thread, so `child->pid` is stored there, while the
+`SIGCHLD` reaper (`wait_signal_callback`,
+[`src/runtime/prte_wait.c`](../../../runtime/prte_wait.c)) runs on the
+progress thread and attributes every pid it reaps by scanning the wait
+trackers for that same field.  A process short-lived enough to run to
+completion between `fork()` returning and that store — or merely a worker
+thread descheduled right there — therefore matched **no tracker at all**,
+and `waitpid` had already consumed the status, so nothing could retry: the
+proc never left `RUNNING`, `PRTE_PROC_FLAG_WAITPID` was never set,
+`jdata->num_terminated` stopped one short of `num_procs`, the job never
+completed, `terminate_orteds` was never called, and `prterun` sat in its
+event loop with every line of the job's output already printed.  It
+reproduced in roughly 0.3% of `prterun -n 8 --map-by :oversubscribe
+hostname` runs.
+
+Registering the tracker earlier cannot fix it — the registration is
+already made *before* the fork, deliberately, "to ensure we can capture
+the callback on shortlived apps".  It is the **key** that arrives late,
+not the tracker.
+
+So `do_child()` blocks on `gate_fd` as its very first act, before
+anything that can `_exit()` — including `prte_odls_base_child_fail()`.
+The parent writes that byte only after storing the pid, which orders the
+store ahead of anything the child can do, the child's exit included.  EOF
+releases the child too, so a parent that dies mid-fork cannot strand it.
+`PMIX_POST_OBJECT`/`PMIX_ACQUIRE_OBJECT` pair the store with the reaper's
+read for the weakly-ordered case.
+
+`odls_base_fork_publish_delay` (an MCA parameter, present in **every**
+build — see the note in `odls_base_frame.c`) stalls the daemon in exactly
+that window, which turns a fraction of a percent into a certainty:
+
+```sh
+prterun --prtemca odls_base_fork_publish_delay 200000 \
+        -n 8 --map-by :oversubscribe hostname
+```
+
+That is the whole reproducer — one node, one daemon, no harness, because
+the race is between one daemon's worker thread and its own progress
+thread and nothing else participates.  Remove the gate read and it hangs
+on the first run; with the gate it is 8 lines of output and exit 0 every
+time.  Run it after touching anything in this fork path.
 
 ### `do_child()` — everything between fork and exec
 
 Runs in the forked child; `__prte_attribute_noreturn__`. In order:
 
-1. `setpgid(0,0)` — new process group so later signals reach grandchildren.
-2. Make the pipe write-fd close-on-exec.
-3. If this is a real child with output forwarding: `prte_iof_base_setup_child`
+1. Block reading `gate_fd` until the parent releases us, then close it —
+   see "The gate" above.  This is first for a reason: nothing below it may
+   run before our pid has been recorded.
+2. `setpgid(0,0)` — new process group so later signals reach grandchildren.
+3. Make the pipe write-fd close-on-exec.
+4. If this is a real child with output forwarding: `prte_iof_base_setup_child`
    to hook up stdout/stderr, then **`prte_odls_base_set(cd, write_fd)`** —
    the child half of the base binding routine, which only *issues* the
    cpu/memory bind syscalls the parent already prepared
    (`prte_odls_base_prepare_binding`, run pre-fork in `spawn_proc`) and
    proxies any binding error up the pipe. (If there is no child and no
    output forwarding, stdio is tied to `/dev/null`.)
-4. Close every inherited descriptor except stdio and the pipe. It
+5. Close every inherited descriptor except stdio and the pipe. It
    deliberately does **not** call `pmix_close_open_file_descriptors()`,
    which scans `/proc/self/fd` with `opendir`/`readdir` and so allocates —
    unsafe in the post-fork child.
@@ -131,13 +185,13 @@ Runs in the forked child; `__prte_attribute_noreturn__`. In order:
    arm also falls back on a runtime failure: the syscall can be present
    at build time and refused at run time by an older kernel or a seccomp
    policy.
-5. Restore default signal handlers (`SIGTERM/INT/HUP/PIPE/CHLD`) and
+6. Restore default signal handlers (`SIGTERM/INT/HUP/PIPE/CHLD`) and
    unblock all signals — the event library may have left them altered, and
    an app must not inherit a blocked SIGTERM.
-6. `chdir(cd->wdir)` to the app's working directory.
-7. If `PRTE_JOB_STOP_ON_EXEC`: `ptrace(PRTE_TRACEME, …)` so the app stops at
+7. `chdir(cd->wdir)` to the app's working directory.
+8. If `PRTE_JOB_STOP_ON_EXEC`: `ptrace(PRTE_TRACEME, …)` so the app stops at
    `execve` for a debugger to attach.
-8. **`execve(cd->cmd, cd->argv, cd->env)`.** On return (always an error) it
+9. **`execve(cd->cmd, cd->argv, cd->env)`.** On return (always an error) it
    simply reports `PRTE_ODLS_CHILD_ERR_EXEC` plus `errno`; the *parent*
    inspects `errno` and `stat`s the app to distinguish a bad interpreter
    (`ENOENT` but the file exists) from a missing/failed executable and

--- a/src/mca/odls/pdefault/odls_pdefault_module.c
+++ b/src/mca/odls/pdefault/odls_pdefault_module.c
@@ -150,7 +150,8 @@ static int restart_proc(prte_proc_t *child);
  * Explicitly declared functions so that we can get the noreturn
  * attribute registered with the compiler.
  */
-static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd) __prte_attribute_noreturn__;
+static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd,
+                     int gate_fd) __prte_attribute_noreturn__;
 
 /*
  * Module
@@ -234,11 +235,29 @@ static void set_handler_default(int sig)
     sigaction(sig, &act, (struct sigaction *) 0);
 }
 
-static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd)
+static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd, int gate_fd)
 {
     int i;
     long fd;
+    char byte;
     sigset_t sigs;
+
+    /* Wait for the parent to release us.  Our pid is recorded by the
+       thread that forked us - a worker thread - while the SIGCHLD reaper
+       runs on the progress thread and attributes each pid it reaps by
+       scanning the wait trackers for that same field.  A process that can
+       run to completion before the store lands therefore matches no
+       tracker at all, and its exit status is discarded: the proc never
+       leaves RUNNING, the job never counts it terminated, and the launch
+       hangs with all of its output already printed.  Nothing below this
+       point - not even a failure report, which _exit()s - can happen until
+       the parent has written the gate byte, so there is no window in which
+       we can die unattributably.  A closed gate (EOF) releases us too, so
+       a parent that dies mid-fork cannot strand us here. */
+    while (0 > read(gate_fd, &byte, 1) && EINTR == errno) {
+        continue;
+    }
+    close(gate_fd);
 
 #if HAVE_SETPGID
     /* Set a new process group for this child, so that any
@@ -576,8 +595,9 @@ static int do_parent(prte_odls_spawn_caddy_t *cd, int read_fd)
 static int fork_local_proc(void *cdptr)
 {
     prte_odls_spawn_caddy_t *cd = (prte_odls_spawn_caddy_t *) cdptr;
-    int p[2];
+    int p[2], gate[2];
     pid_t pid;
+    char byte = 0;
     prte_proc_t *child = cd->child;
 
     /* Default the argv if the app didn't provide one.  Do this here in
@@ -615,8 +635,33 @@ static int fork_local_proc(void *cdptr)
         return PMIX_ERR_SYS_LIMITS_PIPES;
     }
 
+    /* A second pipe runs the other way and gates the child.  We fork on a
+       worker thread, so the store of the child's pid races the progress
+       thread's SIGCHLD reaper - which has nothing but that pid with which
+       to attribute a reaped child to its wait tracker.  Holding the child
+       at the far end of this pipe until we have stored its pid means the
+       child cannot exit - or even fail - before the reaper is able to
+       recognize it.  See the comment at the head of do_child(). */
+    if (pipe(gate) < 0) {
+        PRTE_ERROR_LOG(PMIX_ERR_SYS_LIMITS_PIPES);
+        close(p[0]);
+        close(p[1]);
+        if (NULL != child) {
+            child->state = PRTE_PROC_STATE_FAILED_TO_START;
+            child->exit_code = PMIX_ERR_SYS_LIMITS_PIPES;
+        }
+        return PMIX_ERR_SYS_LIMITS_PIPES;
+    }
+
     /* Fork off the child */
     pid = fork();
+    if (0 < pid && 0 < prte_odls_globals.fork_publish_delay) {
+        /* Fault injection: widen the window between the fork and the store
+           below, which is the window a child used to be able to die in
+           without the reaper being able to attribute it.  The gate makes
+           that harmless, and a launch under this delay is what proves it. */
+        usleep((useconds_t) prte_odls_globals.fork_publish_delay);
+    }
     if (NULL != child) {
         child->pid = pid;
     }
@@ -625,6 +670,8 @@ static int fork_local_proc(void *cdptr)
         PRTE_ERROR_LOG(PMIX_ERR_SYS_LIMITS_CHILDREN);
         /* nobody inherited these - the fork is what failed - and nothing
            downstream will close them: do_parent() is never reached */
+        close(gate[0]);
+        close(gate[1]);
         close(p[0]);
         close(p[1]);
         if (NULL != child) {
@@ -636,9 +683,22 @@ static int fork_local_proc(void *cdptr)
 
     if (pid == 0) {
         close(p[0]);
-        do_child(cd, p[1]);
+        close(gate[1]);
+        do_child(cd, p[1], gate[0]);
         /* Does not return */
     }
+
+    close(gate[0]);
+    /* the pid is stored above; make it visible before the write that
+       releases the child, so the reaper - which sees the child's exit no
+       earlier than the child sees this byte - cannot read a stale field */
+    if (NULL != child) {
+        PMIX_POST_OBJECT(child);
+    }
+    while (0 > write(gate[1], &byte, 1) && EINTR == errno) {
+        continue;
+    }
+    close(gate[1]);
 
     close(p[1]);
     return do_parent(cd, p[0]);

--- a/src/mca/odls/pdefault/odls_pdefault_module.c
+++ b/src/mca/odls/pdefault/odls_pdefault_module.c
@@ -623,6 +623,10 @@ static int fork_local_proc(void *cdptr)
 
     if (pid < 0) {
         PRTE_ERROR_LOG(PMIX_ERR_SYS_LIMITS_CHILDREN);
+        /* nobody inherited these - the fork is what failed - and nothing
+           downstream will close them: do_parent() is never reached */
+        close(p[0]);
+        close(p[1]);
         if (NULL != child) {
             child->state = PRTE_PROC_STATE_FAILED_TO_START;
             child->exit_code = PMIX_ERR_SYS_LIMITS_CHILDREN;

--- a/src/runtime/AGENTS.md
+++ b/src/runtime/AGENTS.md
@@ -232,6 +232,31 @@ round-robin cursor. They now both call `prte_worker_pool_assign()`.
   `prte_worker_pool_size()` is the answer; `prte_num_worker_threads` is only
   the request.
 
+### The SIGCHLD reaper, and what a worker thread owes it
+
+`wait_signal_callback` (`prte_wait.c`) is on `prte_event_base` and reaps
+with `waitpid(-1, WNOHANG)` — every child the process has, not just the
+one whose death raised the signal, because SIGCHLDs coalesce. It
+attributes each pid it reaps by scanning `pending_cbs` for a tracker whose
+`child->pid` matches, and **a pid it cannot attribute is gone**: `waitpid`
+has consumed the status and nothing retries.
+
+So a forker owes the reaper the pid *before the child can die*, and where
+that costs nothing — `plm/ssh`, `plm/slurm`, `ras/slurm` all fork on the
+progress thread itself, so the reaper cannot run in between — it is free.
+The one forker that does not is `odls/pdefault`, which forks on a worker
+thread precisely so the launch does not serialize on this one; it holds
+the child on a pipe until the store is done. See
+[`src/mca/odls/pdefault/AGENTS.md`](../mca/odls/pdefault/AGENTS.md), "The
+gate". Any *new* off-thread fork owes the same, and getting it wrong is
+not a crash: it is a proc stuck in `RUNNING`, a job that never counts it
+terminated, and a launch that hangs with all of its output printed.
+
+The reaper says so, at verbosity 5 on `prte_debug_output`, when it reaps a
+pid no tracker claims. That is routine — the `popen()` helpers scattered
+around the tree are our children too and `waitpid(-1)` takes whichever
+exits first — but it is the only trace such a hang leaves.
+
 ---
 
 ## Gotchas before you edit

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -176,6 +176,21 @@ int prte_register_params(void)
         return ret;
     }
 
+    /* Verbosity of prte_debug_output, the general PRRTE debug stream that
+     * prte_dt_init() opens.  Nothing set this, so the variable sat at its
+     * -1 initializer for the life of the process and the stream could only
+     * ever reach verbosity 1, and then only as a side effect of
+     * --debug-daemons.  Every message the tree writes to it above that
+     * level was unreachable.  Registered here, in phase two, so a parameter
+     * file can set it - and ahead of prte_init(), which is where
+     * prte_dt_init() reads it. */
+    prte_debug_verbosity = -1;
+    (void) pmix_mca_base_var_register("prte", "prte", NULL, "debug_verbose",
+                                      "Verbosity of the general PRRTE debug output stream "
+                                      "(-1 = off)",
+                                      PMIX_MCA_BASE_VAR_TYPE_INT,
+                                      &prte_debug_verbosity);
+
     /*
      * This string is going to be used in prte/util/stacktrace.c
      */

--- a/src/runtime/prte_wait.c
+++ b/src/runtime/prte_wait.c
@@ -226,6 +226,7 @@ static void wait_signal_callback(int fd, short event, void *arg)
     int status;
     pid_t pid;
     prte_wait_tracker_t *t2;
+    bool found;
     PRTE_HIDE_UNUSED_PARAMS(fd, event);
 
     PMIX_ACQUIRE_OBJECT(signal);
@@ -248,11 +249,18 @@ static void wait_signal_callback(int fd, short event, void *arg)
             return;
         }
 
+        /* A child forked by one of the worker threads had its pid stored
+         * by that thread; pair the reads below with the barrier it issues
+         * before it lets the child run. */
+        PMIX_ACQUIRE_OBJECT(&pending_cbs);
+
         /* we are already in an event, so it is safe to access the list */
+        found = false;
         PMIX_LIST_FOREACH(t2, &pending_cbs, prte_wait_tracker_t)
         {
             if (pid == t2->child->pid) {
                 /* found it! */
+                found = true;
                 t2->child->exit_code = status;
                 pmix_list_remove_item(&pending_cbs, &t2->super);
                 if (NULL != t2->cbfunc) {
@@ -263,6 +271,18 @@ static void wait_signal_callback(int fd, short event, void *arg)
                 }
                 break;
             }
+        }
+        if (!found) {
+            /* This is expected for a child nobody registered - the popen()
+             * helpers scattered around the tree are ours too, and waitpid(-1)
+             * takes whichever of them exits first.  It is a lost termination
+             * for anything that *was* registered, though, so say which pid
+             * went unclaimed rather than leaving a hang with no trace of why:
+             * whoever forked it either never recorded its pid or recorded it
+             * too late to be found here. */
+            PMIX_OUTPUT_VERBOSE((5, prte_debug_output,
+                                 "%s wait_signal_callback: reaped unregistered pid %d status %d",
+                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) pid, status));
         }
     }
 }


### PR DESCRIPTION
### The problem

`prte_odls_base_spawn_proc()` dispatches each fork to a worker thread, so
`fork_local_proc()` stores `child->pid` there. `wait_signal_callback()` reaps on the
progress thread with `waitpid(-1, WNOHANG)` and attributes each pid it takes by
scanning the wait trackers for that same field.

A process short-lived enough to run to completion between `fork()` returning and that
store - or a worker thread merely descheduled right there - therefore matched **no
tracker at all**. `waitpid` had already consumed the status, so nothing could retry:
the tracker stayed on `pending_cbs` for the life of the daemon, `PRTE_PROC_FLAG_WAITPID`
was never set, that proc never reached `TERMINATED`, and `jdata->num_terminated` stopped
one short of `num_procs`. The job never completed, `terminate_orteds` was never called,
and `prterun` sat in its event loop with every line of the job's output already printed.

This is the `docs/todo.rst` item *"A child reaped before its pid is published is never
accounted for"*, which this PR removes. It is the other half of the race that
`78df6ec2b9` closed: there the termination arrived and was mis-ordered against the
launch report, here it was lost outright.

Registering the tracker earlier is not the fix - the registration is already made
*before* the fork, deliberately, "to ensure we can capture the callback on shortlived
apps". It is the **key** that arrives late, not the tracker.

### The fix

Make the pid arrive first. A second pipe now runs parent-to-child; `do_child()` blocks
on it as its very first act, and the parent writes the byte only after storing the pid.
Nothing the child can do - not even `prte_odls_base_child_fail()`, which `_exit()`s -
happens before that store, so there is no window left in which a child can die
unattributably. EOF releases the child as well, so a parent that dies mid-fork cannot
strand it.

This is the only fork in the tree that needed it: `plm/ssh`, `plm/slurm`, `plm/pals` and
`ras/slurm` all fork on the progress thread itself, where the reaper cannot interleave.

The reaper now also reports, at verbosity 5, a pid no tracker claims. That is routine -
the `popen()` helpers around the tree are our children too, and `waitpid(-1)` takes
whichever exits first - but it is the only trace a lost termination would otherwise leave.

### How it is tested

A race this narrow cannot be tested by running the launch and hoping, so
`odls_base_fork_publish_delay` stalls the daemon in exactly that window. It is a
fault-injection parameter in the same spirit as `prte_daemon_fail`, and like that one it
is present in **every** build rather than only a debug one.

That last point is deliberate and is the reason the numbers below exist. An optimized
build is a different race from a debug build, so a hook compiled only into the latter can
say nothing about the former. In an `-O2` build with the delay at 200ms:

| gate | injected | unaided |
|---|---|---|
| removed | **15 hangs / 15 runs** | 0 / 3000 |
| present | **0 / 40** | 0 / 3000 |

(`prterun -n 8 --map-by :oversubscribe hostname`; each injected hang printed all 8 lines
of output first, the signature of the defect.)

Note the unaided column: the same optimized build did not fail once in 3000 runs **with
the fix removed**. The defect is fully present - the 15/15 says so - it simply does not
surface on its own on that machine. Without the hook in a release build there would be no
way to demonstrate it there at all. The 0.3% figure in the removed todo entry was measured
in a container on aarch64 and does not transfer.

Also verified in release: exit status survives the injected window; 16 procs at a 1s stall
complete in 2.4s total, so the stall parallelizes across worker threads rather than
serializing the launch; and with the parameter unset the launch time is unchanged.

The single-node scope is the point - the race is between one daemon's worker thread and
its own progress thread - so this is reproduced by one `prterun` and needs no multi-node
harness. The one-line recipe is in `src/mca/odls/pdefault/AGENTS.md`.

### The other two commits

- **Close the launch pipe when the fork that would have used it fails.** `fork_local_proc()`
  leaked both pipe descriptors when the `fork()` itself failed: no child inherited either
  end and `do_parent()` - which is what closes the read end - is never reached. A leak that
  compounds precisely when the daemon is already out of processes.

- **Make `prte_debug_verbosity` settable.** `prte_dt_init()` reads it to set the verbosity
  of `prte_debug_output`, but nothing anywhere writes it - no MCA parameter, no CLI option -
  so it held its `-1` initializer for the life of every process and the stream could only
  ever reach verbosity 1, and then only as a side effect of `--debug-daemons`. Three
  existing messages at level 2 (`prted_comm.c` x2, `ess_hnp_module.c`) were unreachable by
  any combination of options a user could give, as was the new one above. Registered as
  `prte_debug_verbose` in phase two, so a parameter file can set it.

### Verification

Debug and non-debug builds warning-free; `make check` clean; `make -C test/offline
check-offline` 2449 pass / 0 fail; live DVM smoke test (`prte --daemonize` -> `prun` ->
`pterm`, plain and under injection).
