### PR TITLE
Tell the user where a hostfile entry was refused

### DIFF
--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -99,17 +99,6 @@ which nodes, and the daemon-launch path would have to fan out through more
 than one.  At minimum it needs a launcher affinity recorded per node and
 honored by ``prte_plm_base_setup_virtual_machine``.
 
-**A hostfile line with more than one ``@`` stops the parse without saying
-where.**  ``hostfile_parse_line`` splits the value on ``@`` and takes one
-field as a hostname and two as ``user@host``; anything else prints
-``WARNING: Unhandled user@host-combination`` through ``pmix_output`` and
-returns ``PRTE_ERROR``, which abandons the rest of the file (two sites in
-``src/util/hostfile/hostfile.c``, one per token class that can carry a
-name).  Every other parse failure in that file goes through
-``hostfile_parse_error`` and ``help-hostfile.txt``, which name the file and
-the line number.  This one names neither, and it is the failure a user is
-most likely to reach by typo.
-
 **A peer whose socket cannot be created keeps its queued messages.**  In
 ``prte_oob_tcp_peer_try_connect`` (``src/rml/oob/oob_tcp_connection.c``), a
 failed ``tcp_peer_create_socket`` activates ``PRTE_JOB_STATE_COMM_FAILED``,
@@ -238,8 +227,6 @@ the marker is stale.
 
    * - marker
      - entry above
-   * - ``util/hostfile/hostfile.c``, ``hostfile_parse_line`` (two sites)
-     - a hostfile line with more than one ``@``
    * - ``util/stacktrace.c``, ``show_stackframe``
      - stack traces assume ``siginfo_t``
    * - ``rml/oob/oob_tcp_connection.c``,

--- a/src/docs/prrte-rst-content/detail-hostfiles.rst
+++ b/src/docs/prrte-rst-content/detail-hostfiles.rst
@@ -1,6 +1,6 @@
 .. -*- rst -*-
 
-   Copyright (c) 2022-2023 Nanook Consulting.  All rights reserved.
+   Copyright (c) 2022-2026 Nanook Consulting.  All rights reserved.
    Copyright (c) 2023      Jeffrey M. Squyres.  All rights reserved.
 
    $COPYRIGHT$
@@ -34,6 +34,16 @@ including a designated number of "slots":
    ...
 
 Blank lines and lines beginning with a ``#`` are ignored.
+
+A node name may carry the account PRRTE is to use when reaching that
+node, written in front of it and separated by a single ``@``:
+
+.. code:: sh
+
+   user01@node01  slots=4
+
+An entry may contain at most one ``@``; a second one is reported as a
+parse error naming the hostfile and the line it is on.
 
 A "slot" is the PRRTE term for an allocatable unit where we can launch
 a process.  See the section on definition of the term ``slot`` for a

--- a/src/util/hostfile/AGENTS.md
+++ b/src/util/hostfile/AGENTS.md
@@ -53,6 +53,33 @@ If you touch the hostname pattern, keep the leading `\^?` **outside** the
 
 ---
 
+## Every refusal names the file and the line, and says so only once
+
+A hostfile is user input, and every way of getting it wrong has to come back
+as a `prte_show_help()` message out of `help-hostfile.txt` carrying
+`cur_hostfile_name` and `prte_util_hostfile_line`. Two failures did not:
+
+- A value with more than one `@` — `hostfile_parse_username()` takes one
+  field as a hostname and two as `user@hostname`, and anything else is a
+  typo. It used to print `WARNING: Unhandled user@host-combination` through
+  `pmix_output` at two sites (the plain host entry and the `rank N=<host>`
+  form), naming neither the file nor the line, and it is the failure a user
+  is most likely to reach by typo. Both sites now go through the one helper
+  and the `user-host` topic.
+- A `rank N` whose `=` never arrives. The loop that skips to the `=` runs to
+  the end of the file, and the `done` arm returned a bare error with no
+  message at all.
+
+The other half of "says so only once": a path that has already shown help
+must return **`PRTE_ERR_SILENT`**, not `PRTE_ERROR`. `PRTE_ERROR_LOG()`
+drops `PRTE_ERR_SILENT` and prints everything else, and the callers
+(`prte_ras_base_allocate`, `prte_rmaps_base_filter_nodes`) log whatever they
+are handed — so a `PRTE_ERROR` return put `PRTE ERROR: Error in file
+ras_base_allocate.c at line 408` above the user's own diagnostic, pointing
+at our source for their typo.
+
+---
+
 ## The parser state is process-global
 
 `prte_util_hostfile_in` (the `FILE*`), `prte_util_hostfile_line` (the line
@@ -171,8 +198,9 @@ appearing more than once.
   framework opened.
 - `test/unit/util/test_util.c` writes temporary hostfiles and parses them:
   slot counts, `max_slots`, comments, the `^` exclusion (including a duplicated
-  excluded name), a malformed file, and a good file parsed straight after a
-  failed one.
+  excluded name), a `user@host` entry and the refusal of a second `@` in both
+  the plain and the `rank N=` form, a `rank` entry with no host, a malformed
+  file, and a good file parsed straight after a failed one.
 - `contrib/dockerswarm/run-tests.sh` `test_util` covers what a single node
   cannot: that a `^host` line removes *that* machine and no other, and that a
   failed parse does not poison the next one across a real launch.

--- a/src/util/hostfile/help-hostfile.txt
+++ b/src/util/hostfile/help-hostfile.txt
@@ -316,7 +316,7 @@ PRTE detected a parse error in the hostfile:
 
    %s
 
-It occured on line number %d on token %d:
+It occurred on line number %d on token %d:
 
    %s
 #
@@ -326,7 +326,7 @@ PRTE detected a parse error in the hostfile:
 
    %s
 
-It occured on line number %d on token %d:
+It occurred on line number %d on token %d:
 
    %d
 #
@@ -349,7 +349,7 @@ PRTE detected a parse error in the hostfile:
 
    %s
 
-It occured on line number %d on token %d.
+It occurred on line number %d on token %d.
 #
 [not-all-mapped-alloc]
 

--- a/src/util/hostfile/help-hostfile.txt
+++ b/src/util/hostfile/help-hostfile.txt
@@ -60,6 +60,14 @@ including a designated number of "slots":
 
 Blank lines and lines beginning with a "#" are ignored.
 
+A node name may carry the account PRRTE is to use when reaching that
+node, written in front of it and separated by a single "@":
+
+   user01@node01  slots=4
+
+An entry may contain at most one "@"; a second one is reported as a
+parse error naming the hostfile and the line it is on.
+
 A "slot" is the PRRTE term for an allocatable unit where we can launch
 a process.  See the section on definition of the term "slot" for a
 longer description of slots.
@@ -321,6 +329,19 @@ PRTE detected a parse error in the hostfile:
 It occured on line number %d on token %d:
 
    %d
+#
+[user-host]
+
+PRTE detected a parse error in the hostfile:
+
+   %s
+
+The entry on line number %d contains more than one "@" separator:
+
+   %s
+
+An entry may name at most one user, in the form "user@hostname". Please
+correct the hostfile and try again.
 #
 [parse_error]
 

--- a/src/util/hostfile/hostfile.c
+++ b/src/util/hostfile/hostfile.c
@@ -104,6 +104,37 @@ static char *hostfile_parse_string(void)
     return strdup(prte_util_hostfile_value.sval);
 }
 
+/*
+ * Split a host entry into its optional username and the node name.
+ *
+ * The lexer's string rule accepts '@' anywhere in a token, so a mistyped
+ * entry such as "a@b@c" arrives here as a single token that is neither a
+ * hostname nor a "user@hostname".  Refuse it the way every other parse
+ * failure in this file is refused - by naming the file, the line, and the
+ * entry - rather than printing a bare warning that says none of the three.
+ */
+static int hostfile_parse_username(const char *value, char **username, char **node_name)
+{
+    char **argv;
+    int cnt;
+
+    argv = PMIx_Argv_split(value, '@');
+    cnt = PMIx_Argv_count(argv);
+    if (1 == cnt) {
+        *node_name = strdup(argv[0]);
+    } else if (2 == cnt) {
+        *username = strdup(argv[0]);
+        *node_name = strdup(argv[1]);
+    } else {
+        prte_show_help("help-hostfile.txt", "user-host", true, cur_hostfile_name,
+                       prte_util_hostfile_line, value);
+        PMIx_Argv_free(argv);
+        return PRTE_ERR_SILENT;
+    }
+    PMIx_Argv_free(argv);
+    return PRTE_SUCCESS;
+}
+
 static int hostfile_parse_line(int token, pmix_list_t *updates,
                                pmix_list_t *exclude, bool keep_all)
 {
@@ -111,10 +142,8 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
     prte_node_t *node;
     bool got_max = false;
     char *value;
-    char **argv;
     char *node_name = NULL;
     char *username = NULL;
-    int cnt;
     char buff[64];
 
     if (PRTE_HOSTFILE_STRING == token || PRTE_HOSTFILE_HOSTNAME == token ||
@@ -127,20 +156,10 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
         } else {
             value = prte_util_hostfile_value.sval;
         }
-        argv = PMIx_Argv_split(value, '@');
-
-        cnt = PMIx_Argv_count(argv);
-        if (1 == cnt) {
-            node_name = strdup(argv[0]);
-        } else if (2 == cnt) {
-            username = strdup(argv[0]);
-            node_name = strdup(argv[1]);
-        } else {
-            pmix_output(0, "WARNING: Unhandled user@host-combination - %s\n", value); /* XXX */
-            PMIx_Argv_free(argv);
-            return PRTE_ERROR;
+        rc = hostfile_parse_username(value, &username, &node_name);
+        if (PRTE_SUCCESS != rc) {
+            return rc;
         }
-        PMIx_Argv_free(argv);
 
         /* if the first letter of the name is '^', then this is a node
          * to be excluded. Remove the ^ character so the nodename is
@@ -244,8 +263,11 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
             token = prte_util_hostfile_lex();
         }
         if (prte_util_hostfile_done) {
-            /* bad syntax somewhere */
-            return PRTE_ERROR;
+            /* the file ended before the '=' that must follow a rank, so we
+             * never got a node name - say so rather than returning an error
+             * the caller can only report as a line number in our own source */
+            hostfile_parse_error(token);
+            return PRTE_ERR_SILENT;
         }
         /* next position should be the node name */
         token = prte_util_hostfile_lex();
@@ -256,20 +278,10 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
             value = prte_util_hostfile_value.sval;
         }
 
-        argv = PMIx_Argv_split(value, '@');
-
-        cnt = PMIx_Argv_count(argv);
-        if (1 == cnt) {
-            node_name = strdup(argv[0]);
-        } else if (2 == cnt) {
-            username = strdup(argv[0]);
-            node_name = strdup(argv[1]);
-        } else {
-            pmix_output(0, "WARNING: Unhandled user@host-combination - %s\n", value); /* XXX */
-            PMIx_Argv_free(argv);
-            return PRTE_ERROR;
+        rc = hostfile_parse_username(value, &username, &node_name);
+        if (PRTE_SUCCESS != rc) {
+            return rc;
         }
-        PMIx_Argv_free(argv);
 
         /* Do we need to make a new node object? */
         if (NULL == (node = prte_node_match(updates, node_name))) {
@@ -310,7 +322,7 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
 
     } else {
         hostfile_parse_error(token);
-        return PRTE_ERROR;
+        return PRTE_ERR_SILENT;
     }
     free(username);
 
@@ -337,7 +349,7 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
             rc = hostfile_parse_int();
             if (rc < 0) {
                 prte_show_help("help-hostfile.txt", "port", true, cur_hostfile_name, rc);
-                return PRTE_ERROR;
+                return PRTE_ERR_SILENT;
             }
             prte_set_attribute(&node->attributes, PRTE_NODE_PORT, PRTE_ATTR_LOCAL, &rc, PMIX_INT);
             break;
@@ -350,7 +362,7 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
                 prte_show_help("help-hostfile.txt", "slots", true, cur_hostfile_name, rc);
                 pmix_list_remove_item(updates, &node->super);
                 PMIX_RELEASE(node);
-                return PRTE_ERROR;
+                return PRTE_ERR_SILENT;
             }
             if (PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_SLOTS_GIVEN)) {
                 /* multiple definitions were given for the
@@ -360,7 +372,7 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
                                node->name);
                 pmix_list_remove_item(updates, &node->super);
                 PMIX_RELEASE(node);
-                return PRTE_ERROR;
+                return PRTE_ERR_SILENT;
             }
             node->slots = rc;
             PRTE_FLAG_SET(node, PRTE_NODE_FLAG_SLOTS_GIVEN);
@@ -378,7 +390,7 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
                                ((size_t) rc));
                 pmix_list_remove_item(updates, &node->super);
                 PMIX_RELEASE(node);
-                return PRTE_ERROR;
+                return PRTE_ERR_SILENT;
             }
             /* Only take this update if it puts us >= node_slots */
             if (rc >= node->slots) {
@@ -389,10 +401,9 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
             } else {
                 prte_show_help("help-hostfile.txt", "max_slots_lt", true, cur_hostfile_name,
                                node->slots, rc);
-                PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
                 pmix_list_remove_item(updates, &node->super);
                 PMIX_RELEASE(node);
-                return PRTE_ERROR;
+                return PRTE_ERR_SILENT;
             }
             break;
 
@@ -405,7 +416,7 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
             hostfile_parse_error(token);
             pmix_list_remove_item(updates, &node->super);
             PMIX_RELEASE(node);
-            return PRTE_ERROR;
+            return PRTE_ERR_SILENT;
         }
     }
 
@@ -507,7 +518,7 @@ static int hostfile_parse(const char *hostfile, pmix_list_t *updates, pmix_list_
 
         default:
             hostfile_parse_error(token);
-            rc = PRTE_ERROR;
+            rc = PRTE_ERR_SILENT;
             goto unlock;
         }
     }

--- a/test/unit/util/test_util.c
+++ b/test/unit/util/test_util.c
@@ -954,6 +954,91 @@ static int test_hostfile(void)
     PMIX_LIST_DESTRUCT(&nodes);
     unlink(badpath);
 
+    /*
+     * "user@host" names a host and the account to reach it with. Anything
+     * carrying a second "@" is neither a hostname nor a "user@hostname",
+     * and it has to be refused - by name, file and line, like every other
+     * parse failure here. It used to print a bare "WARNING: Unhandled
+     * user@host-combination" through pmix_output and abandon the rest of
+     * the file, naming neither the file nor the line, which is the least
+     * that was said about any failure and the one a user is most likely to
+     * reach by typo. Both token classes that can carry a name have to
+     * refuse it, so check the plain entry and the "rank N=<host>" form.
+     */
+    if (NULL == write_hostfile("hostA\n"
+                               "someone@hostB\n",
+                               badpath, sizeof(badpath))) {
+        fprintf(stderr, "FAIL [hostfile]: could not write a temp hostfile\n");
+        unlink(path);
+        return failures + 1;
+    }
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    rc = prte_util_add_hostfile_nodes(&nodes, badpath);
+    CHECK("a user@host entry parses", PRTE_SUCCESS == rc);
+    nd = find_node(&nodes, "hostB");
+    CHECK("and the host is the part after the @", NULL != nd);
+    if (NULL != nd) {
+        char *uname = NULL;
+        CHECK("and the user is the part before it",
+              prte_get_attribute(&nd->attributes, PRTE_NODE_USERNAME, (void **) &uname,
+                                 PMIX_STRING)
+                  && NULL != uname && 0 == strcmp("someone", uname));
+        if (NULL != uname) {
+            free(uname);
+        }
+    }
+    PMIX_LIST_DESTRUCT(&nodes);
+    unlink(badpath);
+
+    if (NULL == write_hostfile("hostA\n"
+                               "someone@else@hostB\n"
+                               "hostC\n",
+                               badpath, sizeof(badpath))) {
+        fprintf(stderr, "FAIL [hostfile]: could not write a temp hostfile\n");
+        unlink(path);
+        return failures + 1;
+    }
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    rc = prte_util_add_hostfile_nodes(&nodes, badpath);
+    CHECK("a second @ in a host entry is refused", PRTE_SUCCESS != rc);
+    PMIX_LIST_DESTRUCT(&nodes);
+    unlink(badpath);
+
+    if (NULL == write_hostfile("rank 0=someone@else@hostB\n",
+                               badpath, sizeof(badpath))) {
+        fprintf(stderr, "FAIL [hostfile]: could not write a temp hostfile\n");
+        unlink(path);
+        return failures + 1;
+    }
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    rc = prte_util_add_hostfile_nodes(&nodes, badpath);
+    CHECK("a second @ in a rank entry is refused", PRTE_SUCCESS != rc);
+    PMIX_LIST_DESTRUCT(&nodes);
+    unlink(badpath);
+
+    /*
+     * A "rank N" that never reaches its "=" runs the lexer to the end of the
+     * file looking for one, and reported nothing at all when it got there -
+     * the user was handed an error logged against a line of our own source.
+     */
+    if (NULL == write_hostfile("rank 0\n", badpath, sizeof(badpath))) {
+        fprintf(stderr, "FAIL [hostfile]: could not write a temp hostfile\n");
+        unlink(path);
+        return failures + 1;
+    }
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    rc = prte_util_add_hostfile_nodes(&nodes, badpath);
+    CHECK("a rank entry with no host is refused", PRTE_SUCCESS != rc);
+    PMIX_LIST_DESTRUCT(&nodes);
+    unlink(badpath);
+
+    /* and the file the parser gave up on left nothing behind for the next */
+    PMIX_CONSTRUCT(&nodes, pmix_list_t);
+    rc = prte_util_add_hostfile_nodes(&nodes, path);
+    CHECK("a good hostfile still parses after a refused @", PRTE_SUCCESS == rc);
+    CHECK("and reads its three hosts", 3 == pmix_list_get_size(&nodes));
+    PMIX_LIST_DESTRUCT(&nodes);
+
     /* filtering an allocation down to what a hostfile names */
     PMIX_CONSTRUCT(&nodes, pmix_list_t);
     rc = prte_util_add_hostfile_nodes(&nodes, path);


### PR DESCRIPTION
A hostfile is user input, and every way of getting one wrong should come back naming the file and the line it happened on. Three refusals in the parser did not — the first of them is the `docs/todo.rst` item "A hostfile line with more than one `@` stops the parse without saying where", which this closes.

**More than one `@`.** A value carrying a second `@` is neither a hostname nor a `user@hostname`, and it is the mistake a user is most likely to reach by typo. It printed

```
WARNING: Unhandled user@host-combination - a@b@c
```

through `pmix_output` at two sites — the plain host entry and the `rank N=<host>` form — naming neither the hostfile nor the line, and then abandoned the rest of the file. Both sites now split through one helper and report through `help-hostfile.txt`:

```
PRTE detected a parse error in the hostfile:

   /home/me/hosts.txt

The entry on line number 2 contains more than one "@" separator:

   a@b@c

An entry may name at most one user, in the form "user@hostname". Please
correct the hostfile and try again.
```

**A `rank N` whose `=` never arrives.** The loop that skips to the `=` runs to the end of the file, and the `done` arm returned a bare error with no message at all.

**The internal error line printed over the user's diagnostic.** A path that has already shown help has to return `PRTE_ERR_SILENT` rather than `PRTE_ERROR`: `PRTE_ERROR_LOG()` drops the former and prints the latter, and the callers (`prte_ras_base_allocate`, `prte_rmaps_base_filter_nodes`) log whatever they are handed. So a mistyped slot count put

```
[node01:94656] PRTE ERROR: Error in file ../../../../src/mca/ras/base/ras_base_allocate.c at line 408
```

above the user's own diagnostic, pointing at our source for their typo. The rest of this file already returned `PRTE_ERR_SILENT` after showing help; these returns were the ones that did not. A stray `PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM)` in the `max_slots_lt` arm did the same thing directly and is gone.

The `user@hostname` form itself was documented nowhere, so `detail-hostfiles.rst` and the `[hostfile]` help text now describe it and the one-`@` rule the parser enforces.

The second commit is a standalone typo fix: the three `parse_error` topics all said "It occured on line number".

### Testing

`test/unit/util/test_util.c` gains: a `user@host` entry parses and records the username on the node, a second `@` is refused in **both** token classes, a `rank` entry with no host is refused, and a good hostfile still parses straight afterwards — the parser's state is process-global, so a refusal has to leave nothing behind.

Verified with a warning-free `--enable-debug` build, `make check`, `prte-convert-help.py --check-only`, a Sphinx `-W` docs build, each of the five refusals end-to-end against `prterun`, and a `prte --daemonize` → `prun -n 2` → `pterm` smoke test.