### PR TITLE
Complete a peer's queued sends when we give up on the peer

### DIFF
--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -99,15 +99,6 @@ which nodes, and the daemon-launch path would have to fan out through more
 than one.  At minimum it needs a launcher affinity recorded per node and
 honored by ``prte_plm_base_setup_virtual_machine``.
 
-**A peer whose socket cannot be created keeps its queued messages.**  In
-``prte_oob_tcp_peer_try_connect`` (``src/rml/oob/oob_tcp_connection.c``), a
-failed ``tcp_peer_create_socket`` activates ``PRTE_JOB_STATE_COMM_FAILED``,
-which is right — the failure spans every interface, so there is no other
-address to try.  What the note in place also asks for is that the peer's
-queued messages be marked and returned as unreachable, and they are not.
-This is a reconnect path as well as a first-connect one, so what is queued
-can be real work rather than a handshake.
-
 **Nothing records who is "connected".**  ``pmix_server_connect_fn`` and
 ``pmix_server_disconnect_fn`` (``src/prted/pmix/pmix_server_dyn.c``)
 implement both operations as a fence across the participants, which is
@@ -229,9 +220,6 @@ the marker is stale.
      - entry above
    * - ``util/stacktrace.c``, ``show_stackframe``
      - stack traces assume ``siginfo_t``
-   * - ``rml/oob/oob_tcp_connection.c``,
-       ``prte_oob_tcp_peer_try_connect``
-     - a peer whose socket cannot be created
    * - ``mca/filem/raw/filem_raw_module.c``, ``raw_fault_handler``
      - ``filem/raw`` does not survive losing a daemon mid-staging
    * - ``mca/odls/base/odls_base_default_fns.c``,

--- a/src/rml/oob/AGENTS.md
+++ b/src/rml/oob/AGENTS.md
@@ -245,6 +245,18 @@ a socket handler call has to be safe off the main thread or has to be shifted.
   default callback and a lost message for RELM. From inside the transport, use
   `PRTE_OOB_COMPLETE_SEND(peer, msg)` instead: it completes inline when the peer
   is on the main base and posts the completion there when it is not.
+- **Every path that gives up on a peer drains its queue**, through
+  `tcp_peer_fail_queued_sends()` — the one place that does it, so the rule above
+  cannot be honored in one arm and forgotten in the next. It is not only
+  `prte_oob_tcp_peer_close()`: `prte_oob_tcp_peer_try_connect()` gives up in
+  five places of its own (out of memory, `socket()` or an unrecoverable
+  `bind()` failing, no address succeeding, the IDENT handshake failing), and
+  all but one of those used to return without touching the queue. They are
+  reconnect paths as well as first-connect ones, so what is queued there can
+  be real work rather than a handshake. Collect the on-deck `peer->send_msg`
+  as well as `peer->send_queue` — it is not on the list and is the one most
+  easily missed — lift both under `peer->lock`, and complete them outside it,
+  since completion runs the originator's callback.
 - **The recv object owns its payload.** `prte_oob_tcp_recv_t`'s destructor
   frees `data`; the paths that hand the payload on (`PMIx_Data_load` for local
   delivery, the relay) null the pointer first. Add a third path and it has to
@@ -279,7 +291,12 @@ a socket handler call has to be safe off the main thread or has to be shifted.
 ## Testing
 
 `prte_oob_split_and_resolve` — the interface-selection parser — is covered by
-`test/unit/rml/test_rml`, which runs under `make check` with no DVM. Everything
+`test/unit/rml/test_rml`, which runs under `make check` with no DVM. So is the
+queued-send drain above (`test_queued_sends_complete_on_close`), driven through
+`prte_oob_tcp_peer_close()` because that is the one give-up path reachable
+without sockets; the arms in `prte_oob_tcp_peer_try_connect()` share the same
+drain but cannot be provoked from a unit test, since they need `socket()` or
+`bind()` to fail. Everything
 else in this directory needs sockets between real daemons and lives in the
 `test_rml` phase of `contrib/dockerswarm/run-tests.sh`: relaying through an
 intermediate hop (which needs `--prtemca rml_base_radix 2`, since a ten-node

--- a/src/rml/oob/oob_tcp_connection.c
+++ b/src/rml/oob/oob_tcp_connection.c
@@ -172,6 +172,47 @@ static void abort_handshake(prte_oob_tcp_peer_t *peer, int sd)
 }
 
 /*
+ * Nothing queued for a peer we are giving up on can ever go out, so finish
+ * each of those sends with the status that says why.  Completing them -
+ * rather than dropping them on the floor - is what lets the originator learn
+ * the message died; RELM in particular is waiting on exactly that callback,
+ * and PMIX_RELEASE on the send would free the buffer and tell nobody.
+ *
+ * Lift them off the peer in one guarded step, since a message can still be
+ * queued onto it from another thread, and complete them outside the lock,
+ * since completion runs the originator's callback.
+ */
+static void tcp_peer_fail_queued_sends(prte_oob_tcp_peer_t *peer, int status)
+{
+    prte_oob_tcp_send_t *snd;
+    pmix_list_t doomed;
+
+    PMIX_CONSTRUCT(&doomed, pmix_list_t);
+    pmix_mutex_lock(&peer->lock);
+    /* the on-deck message is not in the send queue, so it has to be
+     * collected separately */
+    if (NULL != peer->send_msg) {
+        pmix_list_append(&doomed, &peer->send_msg->super);
+        peer->send_msg = NULL;
+    }
+    while (NULL != (snd = (prte_oob_tcp_send_t *) pmix_list_remove_first(&peer->send_queue))) {
+        pmix_list_append(&doomed, &snd->super);
+    }
+    pmix_mutex_unlock(&peer->lock);
+
+    while (NULL != (snd = (prte_oob_tcp_send_t *) pmix_list_remove_first(&doomed))) {
+        if (NULL != snd->msg) {
+            prte_rml_send_t *m = snd->msg;
+            m->status = status;
+            snd->msg = NULL; // the completion owns it now
+            PRTE_OOB_COMPLETE_SEND(peer, m);
+        }
+        PMIX_RELEASE(snd);
+    }
+    PMIX_DESTRUCT(&doomed);
+}
+
+/*
  * Try connecting to a peer - cycle across all known addresses
  * until one succeeds.
  */
@@ -185,24 +226,23 @@ void prte_oob_tcp_peer_try_connect(int fd, short args, void *cbdata)
     prte_socklen_t addrlen = 0;
     prte_oob_tcp_peer_t *peer;
     prte_oob_tcp_addr_t *addr;
-    prte_oob_tcp_send_t *snd;
-    pmix_list_t doomed;
     bool connected = false;
     pmix_pif_t *intf;
     char *host;
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
 
+    PMIX_ACQUIRE_OBJECT(op);
+    peer = op->peer;
+
     remote_list = PMIX_NEW(pmix_list_t);
     if (NULL == remote_list) {
         pmix_output(0, "%s CANNOT CREATE SOCKET, OUT OF MEMORY",
                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
+        tcp_peer_fail_queued_sends(peer, PRTE_ERR_UNREACH);
         PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_COMM_FAILED);
         PMIX_RELEASE(op);
         return;
     }
-
-    PMIX_ACQUIRE_OBJECT(op);
-    peer = op->peer;
 
     /* Construct a list of remote pmix_pif_t from peer */
     PMIX_LIST_FOREACH(addr, &peer->addrs, prte_oob_tcp_addr_t)
@@ -211,6 +251,7 @@ void prte_oob_tcp_peer_try_connect(int fd, short args, void *cbdata)
         if (NULL == intf) {
             pmix_output(0, "%s CANNOT CREATE SOCKET, OUT OF MEMORY",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
+            tcp_peer_fail_queued_sends(peer, PRTE_ERR_UNREACH);
             PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_COMM_FAILED);
             goto cleanup;
         }
@@ -318,16 +359,14 @@ void prte_oob_tcp_peer_try_connect(int fd, short args, void *cbdata)
         rc = tcp_peer_create_socket(peer, addr->addr.ss_family);
 
         if (PRTE_SUCCESS != rc) {
-            /* FIXME: we cannot create a TCP socket - this spans
-             * all interfaces, so all we can do is report
-             * back to the component that this peer is
-             * unreachable so it can remove the peer
-             * from its list and report back to the base
-             * NOTE: this could be a reconnect attempt,
-             * so we also need to mark any queued messages
-             * and return them as "unreachable"
+            /* we cannot create a TCP socket - this spans all interfaces, so
+             * there is no other address to try and this peer is unreachable.
+             * This is a reconnect path as well as a first-connect one, so
+             * what is queued on the peer can be real work rather than a
+             * handshake: it has to be completed as unreachable, not dropped.
              */
             pmix_output(0, "%s CANNOT CREATE SOCKET", PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
+            tcp_peer_fail_queued_sends(peer, PRTE_ERR_UNREACH);
             PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_COMM_FAILED);
             goto cleanup;
         }
@@ -352,6 +391,7 @@ void prte_oob_tcp_peer_try_connect(int fd, short args, void *cbdata)
                         prte_socket_errno);
 
             CLOSE_THE_SOCKET(peer->sd);
+            tcp_peer_fail_queued_sends(peer, PRTE_ERR_UNREACH);
             PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_COMM_FAILED);
             goto cleanup;
         }
@@ -499,32 +539,7 @@ void prte_oob_tcp_peer_try_connect(int fd, short args, void *cbdata)
          * from us if we are in our own progress thread
          */
         PRTE_ACTIVATE_TCP_CMP_OP(peer, prte_mca_oob_tcp_component_failed_to_connect);
-        /* Nothing queued for this peer can ever go out, so finish each of
-         * those sends as unreachable.  Completing them - rather than dropping
-         * them on the floor, which is what this used to do - is what lets the
-         * originator learn the message died; RELM in particular is waiting on
-         * exactly that callback.  Lift them off the peer under its lock, then
-         * complete them outside it. */
-        PMIX_CONSTRUCT(&doomed, pmix_list_t);
-        pmix_mutex_lock(&peer->lock);
-        if (NULL != peer->send_msg) {
-            pmix_list_append(&doomed, &peer->send_msg->super);
-            peer->send_msg = NULL;
-        }
-        while (NULL != (snd = (prte_oob_tcp_send_t *) pmix_list_remove_first(&peer->send_queue))) {
-            pmix_list_append(&doomed, &snd->super);
-        }
-        pmix_mutex_unlock(&peer->lock);
-        while (NULL != (snd = (prte_oob_tcp_send_t *) pmix_list_remove_first(&doomed))) {
-            if (NULL != snd->msg) {
-                prte_rml_send_t *m = snd->msg;
-                m->status = PRTE_ERR_UNREACH;
-                snd->msg = NULL; // the completion owns it now
-                PRTE_OOB_COMPLETE_SEND(peer, m);
-            }
-            PMIX_RELEASE(snd);
-        }
-        PMIX_DESTRUCT(&doomed);
+        tcp_peer_fail_queued_sends(peer, PRTE_ERR_UNREACH);
         goto cleanup;
     }
 
@@ -568,6 +583,7 @@ void prte_oob_tcp_peer_try_connect(int fd, short args, void *cbdata)
                     pmix_net_get_port((struct sockaddr *) &addr->addr), prte_strerror(rc), rc);
         /* close the socket */
         CLOSE_THE_SOCKET(peer->sd);
+        tcp_peer_fail_queued_sends(peer, PRTE_ERR_UNREACH);
         PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_COMM_FAILED);
     }
 
@@ -1331,8 +1347,6 @@ static void tcp_peer_connected(prte_oob_tcp_peer_t *peer)
 void prte_oob_tcp_peer_close(prte_oob_tcp_peer_t *peer)
 {
     prte_oob_tcp_state_t old_state;
-    prte_oob_tcp_send_t *send;
-    pmix_list_t doomed;
     int err;
 
     /* Take the state transition under the peer lock so exactly one caller
@@ -1443,21 +1457,6 @@ void prte_oob_tcp_peer_close(prte_oob_tcp_peer_t *peer)
         peer->recv_msg = NULL;
     }
 
-    /* Lift everything still queued off the peer in one guarded step - a
-     * message can still be queued onto it from another thread - and complete
-     * it outside the lock, since completion runs the originator's callback. */
-    PMIX_CONSTRUCT(&doomed, pmix_list_t);
-    pmix_mutex_lock(&peer->lock);
-    if (NULL != peer->send_msg) {
-        /* Just add to the doomed list to handle w/ the rest */
-        pmix_list_append(&doomed, &peer->send_msg->super);
-        peer->send_msg = NULL;
-    }
-    while (NULL != (send = (prte_oob_tcp_send_t *) pmix_list_remove_first(&peer->send_queue))) {
-        pmix_list_append(&doomed, &send->super);
-    }
-    pmix_mutex_unlock(&peer->lock);
-
     /* inform rml of all queued sends' completion (as failures)
      * do not try to re-queue messages at this level - risking message loss is
      * unavoidable when a node in the communication tree dies, so safely
@@ -1465,16 +1464,7 @@ void prte_oob_tcp_peer_close(prte_oob_tcp_peer_t *peer)
      */
     err = prte_rml_is_node_up(peer->name.rank) ?
         PRTE_ERR_UNREACH : PRTE_ERR_NODE_DOWN;
-    while (NULL != (send = (prte_oob_tcp_send_t *) pmix_list_remove_first(&doomed))) {
-        if (NULL != send->msg) {
-            prte_rml_send_t *snd = send->msg;
-            snd->status = err;
-            send->msg = NULL; // the completion owns it now
-            PRTE_OOB_COMPLETE_SEND(peer, snd);
-        }
-        PMIX_RELEASE(send);
-    }
-    PMIX_DESTRUCT(&doomed);
+    tcp_peer_fail_queued_sends(peer, err);
 
     /* inform the component-level that we have lost a connection so
      * it can decide what to do about it.

--- a/test/unit/rml/test_rml.c
+++ b/test/unit/rml/test_rml.c
@@ -73,7 +73,9 @@
 #include "src/rml/oob/oob.h"
 #include "src/rml/oob/oob_tcp.h"
 #include "src/rml/oob/oob_tcp_hdr.h"
+#include "src/rml/oob/oob_tcp_connection.h"
 #include "src/rml/oob/oob_tcp_peer.h"
+#include "src/rml/oob/oob_tcp_sendrecv.h"
 
 #define CHECK(label, cond)                                    \
     do {                                                      \
@@ -605,6 +607,96 @@ static int test_wire_header(void)
     return failures;
 }
 
+/* Giving up on a peer must not take its queued messages with it.
+ *
+ * A send handed to the OOB is owed a callback: PRTE_RML_SEND_COMPLETE is how
+ * the originator learns the message went out or died, and RELM is waiting on
+ * exactly that to decide whether to replay.  PMIX_RELEASE on the send frees
+ * the buffer and tells nobody, which looks like nothing at all happening.
+ *
+ * Every path that gives up on a peer therefore has to drain the queue and
+ * complete each message with a failure status - the peer teardown here, and
+ * the arms of prte_oob_tcp_peer_try_connect that cannot get a socket at all
+ * (a create or bind failure spans every interface, so there is no other
+ * address to try).  Those arms are a reconnect path as well as a
+ * first-connect one, so what is queued can be real work rather than a
+ * handshake; they used to drop it.  They share this drain, so exercising it
+ * through the one entry point that needs no sockets covers them.
+ *
+ * The on-deck message is checked as well as the queue: it is held in
+ * peer->send_msg rather than on the list, and is the one most easily missed.
+ */
+static int completed_sends = 0;
+static int last_send_status = PRTE_SUCCESS;
+
+static void record_completion(int status, pmix_proc_t *peer,
+                              pmix_data_buffer_t *buffer,
+                              prte_rml_tag_t tag, void *cbdata)
+{
+    PRTE_HIDE_UNUSED_PARAMS(peer, tag, cbdata);
+    if (NULL != buffer) {
+        PMIX_DATA_BUFFER_RELEASE(buffer);
+    }
+    completed_sends++;
+    last_send_status = status;
+}
+
+static prte_oob_tcp_send_t *queued_send(prte_oob_tcp_peer_t *peer)
+{
+    prte_oob_tcp_send_t *snd;
+    prte_rml_send_t *msg;
+
+    msg = PMIX_NEW(prte_rml_send_t);
+    PMIX_XFER_PROCID(&msg->dst, &peer->name);
+    PMIX_XFER_PROCID(&msg->origin, PRTE_PROC_MY_NAME);
+    msg->tag = PRTE_RML_TAG_XCAST;
+    msg->cbfunc = record_completion;
+    PMIX_DATA_BUFFER_CREATE(msg->dbuf);
+
+    snd = PMIX_NEW(prte_oob_tcp_send_t);
+    snd->msg = msg;
+    return snd;
+}
+
+static int test_queued_sends_complete_on_close(void)
+{
+    int failures = 0, i;
+    prte_oob_tcp_peer_t *peer;
+
+    peer = PMIX_NEW(prte_oob_tcp_peer_t);
+    PMIX_LOAD_PROCID(&peer->name, PRTE_PROC_MY_NAME->nspace, 1);
+    peer->sd = -1;
+    /* a connection that was up: "established" is what keeps peer_close out of
+     * the rotate-to-the-next-address branch, which deliberately keeps the
+     * queue so it can go out over the next address */
+    peer->established = true;
+    peer->state = MCA_OOB_TCP_FAILED;
+
+    completed_sends = 0;
+    last_send_status = PRTE_SUCCESS;
+
+    peer->send_msg = queued_send(peer);
+    for (i = 0; i < 2; i++) {
+        prte_oob_tcp_send_t *snd = queued_send(peer);
+        pmix_list_append(&peer->send_queue, &snd->super);
+    }
+
+    prte_oob_tcp_peer_close(peer);
+
+    CHECK("every queued send was completed, on-deck message included",
+          3 == completed_sends);
+    CHECK("and completed as a failure", PRTE_SUCCESS != last_send_status);
+    CHECK("the on-deck slot was cleared", NULL == peer->send_msg);
+    CHECK("the queue was drained", 0 == pmix_list_get_size(&peer->send_queue));
+
+    PMIX_RELEASE(peer);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_queued_sends_complete_on_close\n");
+    }
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0;
@@ -625,6 +717,7 @@ int main(void)
     failures += test_subnet_resolves_and_dedupes();
     failures += test_payload_outlives_sends();
     failures += test_peer_base_assignment();
+    failures += test_queued_sends_complete_on_close();
     failures += test_wire_header();
 
     prte_finalize();


### PR DESCRIPTION
Closes the `docs/todo.rst` item "A peer whose socket cannot be created keeps its queued messages".

A message handed to the OOB is owed a callback. `PRTE_RML_SEND_COMPLETE` is how the originator learns whether it went out or died, and RELM decides whether to replay on exactly that; `PMIX_RELEASE` on the send frees the buffer and tells nobody, which from above looks like nothing happening at all. `src/rml/oob/AGENTS.md` already states the rule — "Finish a send, never just free it" — and `prte_oob_tcp_peer_try_connect()` broke it in four of the five places it gives up on a peer:

| arm | before |
|---|---|
| out of memory building the interface list | queue stranded |
| `socket()` fails (`tcp_peer_create_socket`) | queue stranded — the `FIXME` this item is about |
| an unrecoverable `bind()` fails | queue stranded |
| no address succeeded | drained (the only one) |
| the IDENT handshake fails | queue stranded |

The `socket()` arm is the clearest case, because a failure to create a socket spans every interface: there is no other address to try, so nothing will ever come back for what is queued. All four are reconnect paths as well as first-connect ones, so what is waiting there can be real work rather than a handshake.

Rather than repeat the drain at each arm, the block `prte_oob_tcp_peer_close()` already had becomes `tcp_peer_fail_queued_sends()` and every arm calls it — `peer_close` included, which keeps computing its own status (`PRTE_ERR_UNREACH` vs `PRTE_ERR_NODE_DOWN`). Draining is easy to get subtly wrong — the on-deck `peer->send_msg` is not on the queue; the lift has to be under `peer->lock` and the completion outside it, since completion runs the originator's callback — which is a second reason for it to exist once. Net effect on the file is 66 lines removed for 56 added.

`PMIX_ACQUIRE_OBJECT(op)` and the `peer` read move above the first give-up arm, which previously returned before either had happened.

### Testing

`test/unit/rml/test_rml` gains `test_queued_sends_complete_on_close`: three messages queued on a peer — one on deck, two on the list — and the peer torn down; every one must come back through its callback with a failure status, and the peer must be left with an empty queue and a clear on-deck slot. It runs under `make check` with no DVM. Confirmed it has teeth by removing the drain and watching it fail.

It drives `prte_oob_tcp_peer_close()` because that is the one give-up path reachable without sockets — the `try_connect` arms need `socket()` or `bind()` to fail, which a unit test cannot provoke. They share the same drain, which is part of why it is now one function.

Also verified: warning-free `--enable-debug` build, full `make check`, and a live `prte --daemonize` → `prun -n 2` / `prun -n 4 --map-by node` → `pterm` cycle.

**Not run:** the `contrib/dockerswarm` multi-node suite, which is where this directory's teardown path really gets exercised. The machine's swarm was in use by another job at the time, and that suite needs it to itself. Worth a run before merge.