### PR TITLE
Implement the PMIx definition of "connected"

### DIFF
--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -505,6 +505,20 @@ build_linux() {
                 /prrte-src/contrib/dockerswarm/groupcon.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
+            # connector: a bare PMIx client that connects a spawned child job
+            # to its parent and then has the child leave, with or without
+            # disconnecting first.  The PMIx server library runs a connect
+            # whose participants are all local without telling the host at
+            # all, so an assemblage that spans daemons is the only shape the
+            # runtime ever sees - and the promise being checked (an event to
+            # the assemblage when a member departs without disconnecting) is
+            # the runtime's to keep.
+            # (No apostrophes here: see the note further down.)
+            echo ">>>> connector (connect/disconnect assemblage) test client"
+            gcc -O0 -g -o /opt/prte/prte/bin/connector \
+                /prrte-src/contrib/dockerswarm/connector.c \
+                -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
+
             # groupinv: a bare PMIx client that forms a group by INVITATION
             # and asks for a context id.  That method runs no server
             # collective, so its leader requests the id through job control,

--- a/contrib/dockerswarm/connector.c
+++ b/contrib/dockerswarm/connector.c
@@ -12,12 +12,18 @@
  * real, multi-node DVM, and see whether the runtime keeps the one promise
  * that "connected" makes.
  *
- *   connector [--child-host <node>] [--disconnect] [--wait <s>]
+ *   connector [--child-host <node>] [--disconnect] [--abort] [--wait <s>]
  *
  * The parent (no PMIX_PARENT_ID in its job info) spawns one copy of itself,
  * registers for PMIX_ERR_PROC_TERM_WO_SYNC, and connects to the child.  The
- * child connects back and then leaves - either by calling PMIx_Disconnect
- * first (--disconnect) or by simply exiting.
+ * child connects back and then leaves - either after both halves call
+ * PMIx_Disconnect (--disconnect) or by simply exiting.
+ *
+ * With --abort the child instead dies on a signal after connecting, which
+ * asks the other half of the definition: "connected" means the host treats
+ * the assemblage as one application, so a failure that terminates the child
+ * is to terminate the parent along with it.  The parent prints nothing more
+ * in that case - it is killed - which is exactly what the harness checks.
  *
  * That difference is the whole test.  The PMIx definition of "connected" is
  * that the host environment must generate PMIX_ERR_PROC_TERM_WO_SYNC to the
@@ -48,6 +54,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <signal.h>
 #include <unistd.h>
 
 #include <pmix.h>
@@ -100,6 +107,7 @@ int main(int argc, char **argv)
     pmix_nspace_t child;
     pmix_status_t code = PMIX_ERR_PROC_TERM_WO_SYNC;
     bool disconnect = false;
+    bool doabort = false;
     bool ischild = false;
     int wait_secs = 15;
     char *child_host = NULL;
@@ -109,6 +117,8 @@ int main(int argc, char **argv)
     for (i = 1; i < argc; i++) {
         if (0 == strcmp(argv[i], "--disconnect")) {
             disconnect = true;
+        } else if (0 == strcmp(argv[i], "--abort")) {
+            doabort = true;
         } else if (0 == strcmp(argv[i], "--child-host") && i + 1 < argc) {
             child_host = argv[++i];
         } else if (0 == strcmp(argv[i], "--wait") && i + 1 < argc) {
@@ -157,6 +167,9 @@ int main(int argc, char **argv)
         if (disconnect) {
             PMIx_Argv_append_nosize(&app.argv, "--disconnect");
         }
+        if (doabort) {
+            PMIx_Argv_append_nosize(&app.argv, "--abort");
+        }
         /* the child says where it landed, so a run that never left this node
          * cannot pass as one that did */
         if (NULL != child_host) {
@@ -194,13 +207,27 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    /* Leaving the assemblage the sanctioned way is a COLLECTIVE over the set
+     * that was connected, so both halves have to call it - a disconnect that
+     * only the departing side issues never completes.  Whether it happens at
+     * all is what the two runs of this program differ in. */
+    if (disconnect) {
+        rc = PMIx_Disconnect(procs, 2, NULL, 0);
+        printf("CNCT %s %u DISCONNECT %s\n", role, myproc.rank, PMIx_Error_string(rc));
+        fflush(stdout);
+    }
+
+    if (ischild && doabort) {
+        /* fail, rather than leave - the assemblage is supposed to come down
+         * with us */
+        printf("CNCT %s %u ABORTING\n", role, myproc.rank);
+        fflush(stdout);
+        raise(SIGSEGV);
+        sleep(5);
+        return 1;
+    }
+
     if (ischild) {
-        /* leave the assemblage the sanctioned way, or just walk out of it */
-        if (disconnect) {
-            rc = PMIx_Disconnect(procs, 2, NULL, 0);
-            printf("CNCT %s %u DISCONNECT %s\n", role, myproc.rank, PMIx_Error_string(rc));
-            fflush(stdout);
-        }
         printf("CNCT %s %u DONE 0\n", role, myproc.rank);
         fflush(stdout);
         PMIx_Finalize(NULL, 0);

--- a/contrib/dockerswarm/connector.c
+++ b/contrib/dockerswarm/connector.c
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * connector -- drive PMIx_Connect / PMIx_Disconnect between two jobs across a
+ * real, multi-node DVM, and see whether the runtime keeps the one promise
+ * that "connected" makes.
+ *
+ *   connector [--child-host <node>] [--disconnect] [--wait <s>]
+ *
+ * The parent (no PMIX_PARENT_ID in its job info) spawns one copy of itself,
+ * registers for PMIX_ERR_PROC_TERM_WO_SYNC, and connects to the child.  The
+ * child connects back and then leaves - either by calling PMIx_Disconnect
+ * first (--disconnect) or by simply exiting.
+ *
+ * That difference is the whole test.  The PMIx definition of "connected" is
+ * that the host environment must generate PMIX_ERR_PROC_TERM_WO_SYNC to the
+ * assemblage should any member terminate without disconnecting first; a
+ * member that DID disconnect owes nobody anything.  So the parent must see
+ * the event in the first case and must not in the second, and the difference
+ * can only come from the runtime having recorded who connected to whom.
+ *
+ * Output lines, all prefixed CNCT so the harness can grep:
+ *
+ *   CNCT <role> <rank> HOST <hostname>
+ *   CNCT <role> <rank> CHILD <nspace>
+ *   CNCT <role> <rank> CONNECT <status>
+ *   CNCT <role> <rank> DISCONNECT <status>
+ *   CNCT <role> <rank> EVENT <status> FROM <nspace>:<rank>
+ *   CNCT <role> <rank> EVENTS <n>
+ *   CNCT <role> <rank> DONE <rc>
+ *
+ * Why this cannot be a unit test, or even a single-node run: the PMIx server
+ * library executes a connect whose participants are ALL local by itself and
+ * never calls the host at all ("if all the participants are local, then we
+ * don't need the host").  The host only hears about an assemblage that spans
+ * nodes - so a DVM with at least two daemons, with the child mapped away from
+ * the parent, is the smallest thing that exercises any of this.
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <pmix.h>
+
+static pmix_proc_t myproc;
+static const char *role = "parent";
+static volatile bool handler_done = false;
+static volatile int nevents = 0;
+
+static void evhandler(size_t evhdlr_registration_id, pmix_status_t status,
+                      const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
+                      pmix_info_t results[], size_t nresults,
+                      pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+{
+    (void) evhdlr_registration_id;
+    (void) info;
+    (void) ninfo;
+    (void) results;
+    (void) nresults;
+
+    if (PMIX_ERR_PROC_TERM_WO_SYNC == status) {
+        ++nevents;
+    }
+    printf("CNCT %s %u EVENT %s FROM %s:%u\n", role, myproc.rank,
+           PMIx_Error_string(status),
+           NULL == source ? "unknown" : source->nspace,
+           NULL == source ? 0 : source->rank);
+    fflush(stdout);
+
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+static void reg_cb(pmix_status_t status, size_t errhandler_ref, void *cbdata)
+{
+    (void) status;
+    (void) errhandler_ref;
+    (void) cbdata;
+    handler_done = true;
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_value_t *val = NULL;
+    pmix_proc_t parent, procs[2];
+    pmix_app_t app;
+    pmix_info_t jobinfo[2];
+    pmix_nspace_t child;
+    pmix_status_t code = PMIX_ERR_PROC_TERM_WO_SYNC;
+    bool disconnect = false;
+    bool ischild = false;
+    int wait_secs = 15;
+    char *child_host = NULL;
+    char host[256];
+    int i;
+
+    for (i = 1; i < argc; i++) {
+        if (0 == strcmp(argv[i], "--disconnect")) {
+            disconnect = true;
+        } else if (0 == strcmp(argv[i], "--child-host") && i + 1 < argc) {
+            child_host = argv[++i];
+        } else if (0 == strcmp(argv[i], "--wait") && i + 1 < argc) {
+            wait_secs = atoi(argv[++i]);
+        }
+    }
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "CNCT init failed: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    /* a spawned job is told who spawned it, and that is what tells us which
+     * half of this program we are */
+    rc = PMIx_Get(&myproc, PMIX_PARENT_ID, NULL, 0, &val);
+    if (PMIX_SUCCESS == rc && NULL != val && PMIX_PROC == val->type) {
+        memcpy(&parent, val->data.proc, sizeof(pmix_proc_t));
+        ischild = true;
+        role = "child";
+    }
+    if (NULL != val) {
+        PMIX_VALUE_RELEASE(val);
+    }
+
+    if (0 != gethostname(host, sizeof(host))) {
+        strcpy(host, "unknown");
+    }
+    printf("CNCT %s %u HOST %s\n", role, myproc.rank, host);
+    fflush(stdout);
+
+    /* both halves want to hear about a member departing */
+    PMIx_Register_event_handler(&code, 1, NULL, 0, evhandler, reg_cb, NULL);
+    while (!handler_done) {
+        usleep(10000);
+    }
+
+    if (!ischild) {
+        /* spawn the other half, and keep it off this node so the assemblage
+         * genuinely spans daemons - which is the only shape the host is
+         * asked about */
+        PMIX_APP_CONSTRUCT(&app);
+        app.cmd = strdup(argv[0]);
+        app.maxprocs = 1;
+        PMIx_Argv_append_nosize(&app.argv, argv[0]);
+        if (disconnect) {
+            PMIx_Argv_append_nosize(&app.argv, "--disconnect");
+        }
+        /* the child says where it landed, so a run that never left this node
+         * cannot pass as one that did */
+        if (NULL != child_host) {
+            PMIX_INFO_CREATE(app.info, 1);
+            PMIX_INFO_LOAD(&app.info[0], PMIX_HOST, child_host, PMIX_STRING);
+            app.ninfo = 1;
+        }
+
+        PMIX_INFO_LOAD(&jobinfo[0], PMIX_NOTIFY_COMPLETION, NULL, PMIX_BOOL);
+        rc = PMIx_Spawn(jobinfo, 1, &app, 1, child);
+        PMIX_INFO_DESTRUCT(&jobinfo[0]);
+        PMIX_APP_DESTRUCT(&app);
+        if (PMIX_SUCCESS != rc) {
+            printf("CNCT %s %u DONE %d\n", role, myproc.rank, rc);
+            fflush(stdout);
+            PMIx_Finalize(NULL, 0);
+            return 1;
+        }
+        printf("CNCT %s %u CHILD %s\n", role, myproc.rank, child);
+        fflush(stdout);
+        PMIX_LOAD_PROCID(&procs[0], myproc.nspace, PMIX_RANK_WILDCARD);
+        PMIX_LOAD_PROCID(&procs[1], child, PMIX_RANK_WILDCARD);
+    } else {
+        PMIX_LOAD_PROCID(&procs[0], parent.nspace, PMIX_RANK_WILDCARD);
+        PMIX_LOAD_PROCID(&procs[1], myproc.nspace, PMIX_RANK_WILDCARD);
+    }
+
+    rc = PMIx_Connect(procs, 2, NULL, 0);
+    printf("CNCT %s %u CONNECT %s\n", role, myproc.rank, PMIx_Error_string(rc));
+    fflush(stdout);
+    if (PMIX_SUCCESS != rc) {
+        printf("CNCT %s %u DONE %d\n", role, myproc.rank, rc);
+        fflush(stdout);
+        PMIx_Finalize(NULL, 0);
+        return 1;
+    }
+
+    if (ischild) {
+        /* leave the assemblage the sanctioned way, or just walk out of it */
+        if (disconnect) {
+            rc = PMIx_Disconnect(procs, 2, NULL, 0);
+            printf("CNCT %s %u DISCONNECT %s\n", role, myproc.rank, PMIx_Error_string(rc));
+            fflush(stdout);
+        }
+        printf("CNCT %s %u DONE 0\n", role, myproc.rank);
+        fflush(stdout);
+        PMIx_Finalize(NULL, 0);
+        return 0;
+    }
+
+    /* the parent waits to be told - or not - that the child has gone */
+    for (i = 0; i < wait_secs * 10 && 0 == nevents; i++) {
+        usleep(100000);
+    }
+    printf("CNCT %s %u EVENTS %d\n", role, myproc.rank, nevents);
+    printf("CNCT %s %u DONE 0\n", role, myproc.rank);
+    fflush(stdout);
+
+    PMIx_Finalize(NULL, 0);
+    return 0;
+}

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -3745,6 +3745,29 @@ test_connect() {
         && ok "...and heard nothing when the child disconnected before leaving" \
         || bad "an event was sent about a child that had disconnected: $(echo "$out" | grep CNCT | tr '\n' ' ' | tail -c 400)"
 
+    banner "connect: a failure in one member terminates the assemblage"
+    # The other half of the definition: the host is to treat the assemblage
+    # as a single application, so a failure that terminates one member's job
+    # terminates the rest of it.  The child aborts on a signal while still
+    # connected; the parent, on another node, must not survive it.
+    out=$(PRUN "--host node1:1 -n 1 $CN --child-host node2 --abort --wait 20" 2>&1)
+    echo "$out" | grep -q 'A job is being terminated because a job it was connected to has failed' \
+        && ok "the parent's job was terminated with the child that failed" \
+        || bad "the assemblage survived a member's failure: $(echo "$out" | tr '\n' ' ' | tail -c 400)"
+    echo "$out" | grep -q 'CNCT parent 0 DONE' \
+        && bad "the parent ran to completion despite the failure" \
+        || ok "...and it did not reach the end of its own run"
+
+    banner "connect: a member that disconnected first is left out of that"
+    # ...and the same failure, after both halves have disconnected, is the
+    # child's own business.  This is what shows the teardown is driven by the
+    # recorded membership rather than by the parent/child relationship, which
+    # a disconnect does not change.
+    out=$(PRUN "--host node1:1 -n 1 $CN --child-host node2 --disconnect --abort --wait 10" 2>&1)
+    echo "$out" | grep -q 'CNCT parent 0 DONE' \
+        && ok "the parent survived the failure of a job it had disconnected from" \
+        || bad "the parent was taken down anyway: $(echo "$out" | tr '\n' ' ' | tail -c 400)"
+
     RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     cleanup_swarm
 }

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -3686,6 +3686,69 @@ test_hwloc() {
 }
 
 # Absolute path, deliberately -- see the note above DS.
+########################################################################
+# Absolute path, deliberately -- see the note on DS above.
+CN=/opt/prte/prte/bin/connector
+
+test_connect() {
+    local out n host
+
+    banner "connect: a member that leaves without disconnecting is reported"
+    # PMIx_Connect asks the host to treat a set of processes as one
+    # assemblage, and the one obligation that creates is that a member which
+    # terminates WITHOUT calling PMIx_Disconnect first owes the rest of the
+    # assemblage a PMIX_ERR_PROC_TERM_WO_SYNC event.  Nothing recorded who
+    # had connected to whom, so there was nothing to consult when a member
+    # died and the event was never sent.
+    #
+    # This cannot be tested on one host at any level.  The PMIx server
+    # library executes a connect whose participants are ALL local itself and
+    # never calls the host ("if all the participants are local, then we do
+    # not need the host"), so a single-node run exercises none of the
+    # runtime's half.  connector therefore spawns its child onto another
+    # node, and the assemblage spans two daemons.
+    cleanup_swarm
+    if ! RUN "test -x $CN"; then
+        skp "connector client not installed -- re-run ./build.sh"
+        return
+    fi
+    if ! prted_dvm_start 'node1:2,node2:2,node3:2,node4:2'; then
+        bad "could not start a DVM for the connect tests"
+        cleanup_swarm
+        return
+    fi
+
+    out=$(PRUN "--host node1:1 -n 1 $CN --child-host node2 --wait 20" 2>&1)
+    echo "$out" | grep -q 'CNCT parent 0 CONNECT PMIX_SUCCESS' \
+        && ok "the parent connected to the job it spawned" \
+        || bad "the connect did not complete: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    host=$(echo "$out" | awk '$1=="CNCT" && $2=="child" && $4=="HOST" {print $5}')
+    [ -n "$host" ] && [ "$host" != "node1" ] \
+        && ok "...to a child on $host, so the assemblage spans daemons" \
+        || skp "child host not reported ($host) -- spawned-job output may not be forwarded"
+    n=$(echo "$out" | awk '$1=="CNCT" && $2=="parent" && $4=="EVENTS" {print $5}')
+    [ "${n:-0}" -ge 1 ] \
+        && ok "...and the parent was told when the child left without disconnecting" \
+        || bad "no PMIX_ERR_PROC_TERM_WO_SYNC reached the parent: $(echo "$out" | grep CNCT | tr '\n' ' ' | tail -c 400)"
+
+    banner "connect: a member that disconnects first owes nobody an event"
+    # The other half of the same promise, and the one that shows the registry
+    # is consulted rather than the event being fired at every departure: a
+    # child that calls PMIx_Disconnect has left the assemblage, so its exit
+    # is nobody else's business.
+    out=$(PRUN "--host node1:1 -n 1 $CN --child-host node2 --disconnect --wait 10" 2>&1)
+    echo "$out" | grep -q 'CNCT parent 0 CONNECT PMIX_SUCCESS' \
+        && ok "the parent connected again" \
+        || bad "the second connect did not complete: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    n=$(echo "$out" | awk '$1=="CNCT" && $2=="parent" && $4=="EVENTS" {print $5}')
+    [ "${n:-1}" = 0 ] \
+        && ok "...and heard nothing when the child disconnected before leaving" \
+        || bad "an event was sent about a child that had disconnected: $(echo "$out" | grep CNCT | tr '\n' ' ' | tail -c 400)"
+
+    RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    cleanup_swarm
+}
+
 GC=/opt/prte/prte/bin/groupcon
 GINV=/opt/prte/prte/bin/groupinv
 FENCER=/opt/prte/prte/bin/fencer
@@ -7242,6 +7305,8 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     test_odls
 
     test_grpcomm
+
+    test_connect
 
     test_pmix_cycling
 

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -99,32 +99,6 @@ which nodes, and the daemon-launch path would have to fan out through more
 than one.  At minimum it needs a launcher affinity recorded per node and
 honored by ``prte_plm_base_setup_virtual_machine``.
 
-**A connected assemblage is remembered, but not yet treated as one
-application.**  The membership of a ``PMIx_Connect`` is now recorded on the
-DVM master (``src/prted/pmix/pmix_server_connect.c``) and a member that
-terminates without disconnecting first draws the
-``PMIX_ERR_PROC_TERM_WO_SYNC`` the PMIx definition requires.  Three things
-that definition also asks for are not there yet:
-
-- **The fault response.**  "Connected" is defined as the host treating the
-  assemblage as a single application: an environment that terminates an
-  application when one of its processes fails should terminate every member
-  of the assemblage.  PRRTE terminates only the failed process's own job, and
-  generates no ``PMIX_ERR_JOB_TERM_WO_SYNC`` for the jobs a member's death
-  ought to have taken with it.  The registry is what such a policy would be
-  written against.
-- **An assemblage on a single node is invisible to us.**  The PMIx server
-  library executes a connect whose participants are all local without calling
-  the host at all, so PRRTE never learns of one and cannot keep the promise
-  for it.  Nothing PRRTE does can cover that; it is a question for the PMIx
-  server library, which is the only thing that knows those procs connected.
-- **Spawn does not connect the child to its parent.**  The PMIx definition
-  says the processes created by ``PMIx_Spawn`` are connected to the parent by
-  default; PRRTE records nothing, so a spawned job that dies notifies its
-  parent only through the ordinary job-level channels.  Doing this properly
-  means deciding what ``PMIX_SPAWN_CONNECTED`` should mean for a DVM that has
-  always let a parent outlive its children.
-
 **The bootstrap configuration parses two options it deliberately does not
 publish.**  ``SessionTmpDir`` and the ``Log*`` options are read into the
 bootstrap configuration and then left there

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -99,13 +99,31 @@ which nodes, and the daemon-launch path would have to fan out through more
 than one.  At minimum it needs a launcher affinity recorded per node and
 honored by ``prte_plm_base_setup_virtual_machine``.
 
-**Nothing records who is "connected".**  ``pmix_server_connect_fn`` and
-``pmix_server_disconnect_fn`` (``src/prted/pmix/pmix_server_dyn.c``)
-implement both operations as a fence across the participants, which is
-enough to make them return.  The bookkeeping is what is missing: the set of
-processes a ``PMIx_Connect`` joined is recorded nowhere, so when one of them
-terminates or fails there is nothing to consult for who was promised a
-notification.
+**A connected assemblage is remembered, but not yet treated as one
+application.**  The membership of a ``PMIx_Connect`` is now recorded on the
+DVM master (``src/prted/pmix/pmix_server_connect.c``) and a member that
+terminates without disconnecting first draws the
+``PMIX_ERR_PROC_TERM_WO_SYNC`` the PMIx definition requires.  Three things
+that definition also asks for are not there yet:
+
+- **The fault response.**  "Connected" is defined as the host treating the
+  assemblage as a single application: an environment that terminates an
+  application when one of its processes fails should terminate every member
+  of the assemblage.  PRRTE terminates only the failed process's own job, and
+  generates no ``PMIX_ERR_JOB_TERM_WO_SYNC`` for the jobs a member's death
+  ought to have taken with it.  The registry is what such a policy would be
+  written against.
+- **An assemblage on a single node is invisible to us.**  The PMIx server
+  library executes a connect whose participants are all local without calling
+  the host at all, so PRRTE never learns of one and cannot keep the promise
+  for it.  Nothing PRRTE does can cover that; it is a question for the PMIx
+  server library, which is the only thing that knows those procs connected.
+- **Spawn does not connect the child to its parent.**  The PMIx definition
+  says the processes created by ``PMIx_Spawn`` are connected to the parent by
+  default; PRRTE records nothing, so a spawned job that dies notifies its
+  parent only through the ordinary job-level channels.  Doing this properly
+  means deciding what ``PMIX_SPAWN_CONNECTED`` should mean for a DVM that has
+  always let a parent outlive its children.
 
 **The bootstrap configuration parses two options it deliberately does not
 publish.**  ``SessionTmpDir`` and the ``Log*`` options are read into the
@@ -228,8 +246,6 @@ the marker is stale.
    * - ``mca/ess/base/ess_base_bootstrap.c``,
        ``prte_ess_base_bootstrap_params``
      - two bootstrap options are parsed and not plumbed
-   * - ``prted/pmix/pmix_server_dyn.c``, ``pmix_server_disconnect_fn``
-     - nothing records who is "connected"
    * - ``mca/ras/flux/ras_flux_module.c``, ``modify``
      - ``ras/flux`` has no ``modify()``
 

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -55,6 +55,7 @@
 #include "src/util/pmix_show_help.h"
 #include "src/util/prte_show_help.h"
 
+#include "src/prted/pmix/pmix_server_internal.h"
 #include "src/runtime/prte_globals.h"
 #include "src/runtime/prte_locks.h"
 #include "src/runtime/prte_quit.h"
@@ -107,10 +108,18 @@ static int finalize(void)
     return PRTE_SUCCESS;
 }
 
+/* Every path into here is a failure taking a job down - job_errors and the
+ * unrecoverable arms of proc_errors - which is exactly the event a connected
+ * assemblage is defined by: the host is to treat its members as one
+ * application, so a failure that costs this job its life costs every job
+ * connected to it too.  Doing it here rather than at each call site is what
+ * keeps the two from drifting apart. */
 static void _terminate_job(pmix_nspace_t jobid)
 {
     pmix_pointer_array_t procs;
     prte_proc_t pobj;
+
+    prte_pmix_server_connection_job_failed(jobid);
 
     PMIX_CONSTRUCT(&procs, pmix_pointer_array_t);
     pmix_pointer_array_init(&procs, 1, 1, 1);

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -44,6 +44,7 @@
 #include "src/hwloc/hwloc-internal.h"
 #include "src/pmix/pmix-internal.h"
 #include "src/prted/pmix/pmix_server.h"
+#include "src/prted/pmix/pmix_server_internal.h"
 
 #include "src/mca/errmgr/errmgr.h"
 #include "src/mca/ess/ess.h"
@@ -1235,6 +1236,12 @@ int prte_plm_base_spawn_response(int32_t status, prte_job_t *jdata)
      * so tell it what actually happened while it is still listening */
     if (PMIX_SUCCESS != status) {
         report_launch_failure(jdata);
+    } else {
+        /* the PMIx definition says the processes created by PMIx_Spawn are
+         * connected to the parent process upon successful launch - which is
+         * what makes a parent and its child hear about each other's failures.
+         * Whether this launch has such a parent at all is decided there. */
+        prte_pmix_server_connection_spawned(jdata);
     }
 
     /* If the requestor was a tool, use PMIx to notify them of launch

--- a/src/mca/schizo/prte/help-prted.txt
+++ b/src/mca/schizo/prte/help-prted.txt
@@ -273,3 +273,19 @@ executable does not meet the minimum supported version:
 
 Please check your LD_LIBRARY_PATH and ensure we are pointed to a
 version that meets the minimum requirement.
+#
+[connected-term]
+
+A job is being terminated because a job it was connected to has failed:
+
+   Failed job:      %s
+   Terminated job:  %s
+
+Processes that call PMIx_Connect ask the runtime to treat them as a
+single application for fault purposes, so the failure of any member is
+taken as a failure of them all. A job leaves an assemblage by calling
+PMIx_Disconnect; a job that is still connected when another member fails
+is terminated with it.
+
+Run with "--prtemca pmix_terminate_connected 0" to confine a failure to
+the job it happened in.

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -686,6 +686,15 @@ void prte_state_base_track_procs(int fd, short argc, void *cbdata)
         }
         PRTE_FLAG_SET(pdata, PRTE_PROC_FLAG_RECORDED);
 
+        /* If this proc was connected to others, they are owed an event: the
+         * PMIx definition of "connected" is that a member which departs
+         * without first calling PMIx_Disconnect is a reportable event for
+         * the rest of the assemblage.  This is the one place that sees every
+         * proc in the DVM stop, whether it exited, failed, or was on a node
+         * whose daemon died, and the RECORDED flag just set above is what
+         * makes it exactly once per proc. */
+        prte_pmix_server_connection_terminated(pdata);
+
         /* update the proc state */
         PRTE_FLAG_UNSET(pdata, PRTE_PROC_FLAG_ALIVE);
         if (pdata->state < PRTE_PROC_STATE_TERMINATED) {

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -449,12 +449,49 @@ design:
   (`prte_pmix_server_connection_purge()`, from
   `prte_pmix_server_job_departed()`).
 
-What this cannot see: the PMIx server library executes a connect whose
-participants are **all local** without calling the host at all, so PRRTE
-never learns of a single-node assemblage and cannot keep the promise for
-one. Neither is the *fault response* half of the definition implemented —
-terminating the assemblage when a member fails. Both are recorded in
-[`docs/todo.rst`](../../../docs/todo.rst).
+Two things follow from that record, and they are the rest of the definition:
+
+- **A spawn connects the child to the parent process** (`connection_spawned()`,
+  from `prte_plm_base_spawn_response()`), because the PMIx definition makes
+  that the default for `PMIx_Spawn`. Which launches have a parent process at
+  all is the delicate part: `jdata->originator` does *not* answer it, since
+  `plm_base_receive` overwrites it with the daemon that relayed the request.
+  `PRTE_JOB_LAUNCH_PROXY` survives from the requestor's own daemon and is the
+  process that actually asked — screened against our own namespace (a
+  prterun-style launch records the daemon) and against `PRTE_JOB_FLAG_TOOL`
+  (a `prun` records its own tool procID, and a tool is not a member of a job).
+  `PMIX_SPAWN_CHILD_SEP` opts out.
+- **A failure that terminates one member's job terminates the assemblage**
+  (`connection_job_failed()`, from `_terminate_job()` in `errmgr/dvm` — the
+  one place every failure-driven teardown goes through), each such job
+  announced with `PMIX_ERR_JOB_TERM_WO_SYNC` and explained to the user with
+  the `connected-term` help topic. `pmix_terminate_connected=0` turns it off.
+  The assemblage is marked `terminating` as it goes, so the failures its own
+  teardown produces do not drive it again.
+
+**Dissolving is more generous than recording, deliberately.** Recording
+compares memberships exactly; a disconnect dissolves any assemblage all of
+whose members it *names*, wildcards covering ranks. That asymmetry is what
+lets an application out of the assemblage a spawn created for it: the spawn
+connects the child to the parent **process**, while an application that wants
+out disconnects the two **jobs** — the shape `MPI_Comm_disconnect` has — and
+under an exact-set rule that request would match nothing and the implicit
+assemblage could never be left. It cannot dissolve anything by accident: a
+request only covers a member it names, and a wildcard member is covered only
+by a wildcard.
+
+A proc in more than one assemblage — a spawned child that also connects
+explicitly — produces **one** event, addressed to the union of the
+memberships, not one per assemblage.
+
+Note what this depends on: PMIx used to execute a connect or disconnect whose
+participants were **all local** without calling the host at all, which left
+PRRTE unable to see a single-node assemblage — and, worse, unable to see the
+disconnect that would dissolve one it had created itself at spawn. That is
+fixed in the PMIx server library (openpmix: the host is called whenever it
+offers the entry point; locality alone is no longer a reason to skip it).
+Against a PMIx without that fix, a single-node spawn assemblage cannot be
+dissolved.
 
 ---
 
@@ -668,9 +705,10 @@ only exist with more than one daemon:
   driven by `examples/sessionctrl.c`, which `build.sh` installs;
 - **connect/disconnect** (`test_connect`, driven by
   `contrib/dockerswarm/connector.c`) — a spawned child connected to its
-  parent on another node, leaving with and without disconnecting first. This
-  one is *only* testable here: a connect whose participants are all local is
-  executed inside the PMIx server library and never reaches PRRTE at all.
+  parent on another node, leaving with and without disconnecting first, and
+  failing with and without having disconnected first. The single-node run of
+  the same client covers the same ground once the PMIx fix above is in place;
+  what only the swarm shows is an assemblage that genuinely spans daemons.
 
 ---
 

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -402,6 +402,62 @@ onto PRRTE job and app attributes. Notes for extending them:
 
 ---
 
+## Connected assemblages (`pmix_server_connect.c`)
+
+`PMIx_Connect` is not a communication operation — the fence it runs is a
+means, not the point. What it asks for is that the host **treat the
+participants as one application for fault purposes**, and the concrete
+obligation that creates is one event: a member that terminates, or calls
+`PMIx_Finalize`, without first calling `PMIx_Disconnect` owes the rest of
+the assemblage a `PMIX_ERR_PROC_TERM_WO_SYNC`. A connect never followed by a
+disconnect is therefore not an untidy loose end; it is the case the event
+exists for.
+
+Keeping that promise needs the membership, and where it is held is the whole
+design:
+
+- **The DVM master holds it, alone.** It is the one process that learns of
+  every proc termination in the DVM — including the procs of a node whose
+  daemon has died, which is exactly when an assemblage most wants telling,
+  and exactly when a record kept on that daemon would have died with it.
+- **Each participating daemon reports it**, on `PRTE_RML_TAG_CONNECTED`,
+  from the *completion* of the connect collective (`connect_release`) rather
+  than from its start — so a connect that failed is never recorded. Every
+  such daemon reports, and the master takes the first and ignores the rest:
+  there is no cheap election here that does not depend on one particular
+  daemon still being alive, and the reports are a few dozen bytes on an
+  operation that has just paid for a DVM-wide collective.
+- **Termination is noticed in one place**: the `PRTE_PROC_STATE_TERMINATED`
+  arm of `prte_state_base_track_procs()`, behind the `PRTE_PROC_FLAG_RECORDED`
+  guard that makes it exactly once per proc. Every death reaches it, whether
+  the proc exited, failed, or was force-marked terminated by the errmgr
+  because its daemon is gone.
+- **A member entry may be a wildcard rank**, and usually is — a connect
+  between two jobs is written `{A/WILDCARD, B/WILDCARD}`. It stands for
+  every proc of that namespace both when matching a departure and when
+  addressing the event, where `PMIX_EVENT_CUSTOM_RANGE` carries the member
+  array as-is and PMIx's own `PMIX_CHECK_PROCID` does the covering.
+- **Matching a *set* is literal, though.** Two assemblages are the same one
+  if they name the same participants, order disregarded; but `A/0` and
+  `A/WILDCARD` are different participants, because PMIx will not pair a
+  connect expressed one way with a connect expressed the other. A disconnect
+  naming a set that was never recorded must fail to find it rather than drop
+  somebody else's.
+- **A record outlives one member's job.** The survivors are still connected
+  to each other and still owed an event apiece, so a record is dropped only
+  by a disconnect or when nothing named in it exists any more
+  (`prte_pmix_server_connection_purge()`, from
+  `prte_pmix_server_job_departed()`).
+
+What this cannot see: the PMIx server library executes a connect whose
+participants are **all local** without calling the host at all, so PRRTE
+never learns of a single-node assemblage and cannot keep the promise for
+one. Neither is the *fault response* half of the definition implemented —
+terminating the assemblage when a member fails. Both are recorded in
+[`docs/todo.rst`](../../../docs/todo.rst).
+
+---
+
 ## Session control (`pmix_server_session.c`)
 
 `PMIx_Session_control` is the scheduler's API for creating, operating on and
@@ -586,10 +642,12 @@ it is enforced here:
 ## Testing
 
 **Unit — `test/unit/prted/`.** The directive translators
-(`prte_pmix_xfer_job_info`, `prte_pmix_xfer_app`), the job-info cache, and
-the session time-limit parser (`prte_pmix_server_parse_session_time`) are
-pure data transforms and are covered there. Most of the rest of this
-directory needs a live PMIx server and at least one peer daemon.
+(`prte_pmix_xfer_job_info`, `prte_pmix_xfer_app`), the job-info cache, the
+session time-limit parser (`prte_pmix_server_parse_session_time`), the
+departed-jobs list, and the connected-assemblage registry
+(`test_connections` — set matching, wildcard coverage, and when a record is
+purged) are pure data transforms and are covered there. Most of the rest of
+this directory needs a live PMIx server and at least one peer daemon.
 
 **Live smoke test.** `prte --daemonize && prun -n 4 hostname && pterm`
 exercises register_nspace, register_client, fence, and the spawn path on
@@ -607,7 +665,12 @@ only exist with more than one daemon:
 - **session control** (`test_session`) — a reservation actually withholding
   its nodes from a general job, a request relayed from a non-master daemon,
   and a session signal reaching the jobs on every node they occupy. It is
-  driven by `examples/sessionctrl.c`, which `build.sh` installs.
+  driven by `examples/sessionctrl.c`, which `build.sh` installs;
+- **connect/disconnect** (`test_connect`, driven by
+  `contrib/dockerswarm/connector.c`) — a spawned child connected to its
+  parent on another node, leaving with and without disconnecting first. This
+  one is *only* testable here: a connect whose participants are all local is
+  executed inside the PMIx server library and never reaches PRRTE at all.
 
 ---
 

--- a/src/prted/pmix/Makefile.am
+++ b/src/prted/pmix/Makefile.am
@@ -1,7 +1,7 @@
 #
 # Copyright (c) 2014-2020 Intel, Inc.  All rights reserved.
 # Copyright (c) 2014-2020 Cisco Systems, Inc.  All rights reserved
-# Copyright (c) 2022-2025 Nanook Consulting  All rights reserved.
+# Copyright (c) 2022-2026 Nanook Consulting  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -18,6 +18,7 @@ libprrte_la_SOURCES += \
           prted/pmix/pmix_server_fence.c \
           prted/pmix/pmix_server_register_fns.c \
           prted/pmix/pmix_server_dyn.c \
+          prted/pmix/pmix_server_connect.c \
           prted/pmix/pmix_server_pub.c \
           prted/pmix/pmix_server_gen.c \
           prted/pmix/pmix_server_queries.c \

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -437,6 +437,17 @@ void pmix_server_register_params(void)
                                       PMIX_MCA_BASE_VAR_TYPE_BOOL,
                                       &prte_pmix_server_globals.remote_connections);
 
+    /* whether a failure that terminates one job of a connected assemblage
+     * terminates the rest of it.  The PMIx definition of "connected" asks a
+     * host that terminates an application when one of its processes fails to
+     * do the same to the whole assemblage; this is a switch because it
+     * changes the fate of a job the failure did not happen in. */
+    prte_pmix_server_globals.terminate_connected = true;
+    (void) pmix_mca_base_var_register("prte", "pmix", NULL, "terminate_connected",
+                                      "Terminate every job in a connected assemblage when a failure terminates one of them",
+                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                                      &prte_pmix_server_globals.terminate_connected);
+
     /* whether or not to require client pid to match */
     prte_pmix_server_globals.require_pid_match = false;
     (void) pmix_mca_base_var_register("prte", "pmix", NULL, "require_pid_match",

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -806,6 +806,7 @@ int pmix_server_init(void)
     PMIX_CONSTRUCT(&prte_pmix_server_globals.psets, pmix_list_t);
     PMIX_CONSTRUCT(&prte_pmix_server_globals.departed_jobs, pmix_list_t);
     PMIX_CONSTRUCT(&prte_pmix_server_globals.groups, pmix_list_t);
+    PMIX_CONSTRUCT(&prte_pmix_server_globals.connections, pmix_list_t);
     PMIX_CONSTRUCT(&prte_pmix_server_globals.local_reqs, pmix_pointer_array_t);
     pmix_pointer_array_init(&prte_pmix_server_globals.local_reqs, 128, INT_MAX, 2);
     PMIX_CONSTRUCT(&prte_pmix_server_globals.remote_reqs, pmix_pointer_array_t);
@@ -1251,6 +1252,11 @@ void pmix_server_start(void)
         /* setup recv for scheduler requests */
         PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_SCHED,
                       PRTE_RML_PERSISTENT, pmix_server_sched, NULL);
+        /* setup recv for the membership of connected assemblages, which is
+         * held here because we are the one process that sees every proc in
+         * the DVM terminate */
+        PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_CONNECTED,
+                      PRTE_RML_PERSISTENT, prte_pmix_server_connection_recv, NULL);
     }
 }
 
@@ -1278,6 +1284,7 @@ void pmix_server_finalize(void)
     if (PRTE_PROC_IS_MASTER) {
         PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_LOGGING);
         PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_SCHED);
+        PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_CONNECTED);
     }
 
     /* finalize our local data server */
@@ -1304,6 +1311,7 @@ void pmix_server_finalize(void)
     PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.psets);
     PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.departed_jobs);
     PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.groups);
+    PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.connections);
 
     /* shutdown the local server */
     prte_pmix_server_globals.initialized = false;
@@ -1354,6 +1362,9 @@ static void send_error(int status, pmix_proc_t *idreq, pmix_proc_t *remote, int 
 void prte_pmix_server_job_departed(const pmix_nspace_t nspace)
 {
     prte_namelist_t *nm;
+
+    /* an assemblage this job belonged to may now have nobody left in it */
+    prte_pmix_server_connection_purge(nspace);
 
     if (prte_pmix_server_job_has_departed(nspace)) {
         return;
@@ -2825,6 +2836,8 @@ static void rqcon(prte_pmix_server_req_t *p)
     p->range = PMIX_RANGE_SESSION;
     p->proxy = *PRTE_NAME_INVALID;
     p->target = *PRTE_NAME_INVALID;
+    p->procs = NULL;
+    p->nprocs = 0;
     p->jdata = NULL;
     PMIX_DATA_BUFFER_CONSTRUCT(&p->msg);
     p->timeout = prte_pmix_server_globals.timeout;
@@ -2842,6 +2855,9 @@ static void rqdes(prte_pmix_server_req_t *p)
 {
     if (NULL != p->operation) {
         free(p->operation);
+    }
+    if (NULL != p->procs) {
+        PMIX_PROC_FREE(p->procs, p->nprocs);
     }
     if (NULL != p->info && p->copy) {
         PMIX_INFO_FREE(p->info, p->ninfo);

--- a/src/prted/pmix/pmix_server_connect.c
+++ b/src/prted/pmix/pmix_server_connect.c
@@ -37,10 +37,12 @@
 #include "src/util/pmix_output.h"
 
 #include "src/grpcomm/grpcomm.h"
+#include "src/mca/plm/plm.h"
 #include "src/mca/state/state.h"
 #include "src/rml/rml.h"
 #include "src/runtime/prte_globals.h"
 #include "src/util/name_fns.h"
+#include "src/util/prte_show_help.h"
 
 #include "src/prted/pmix/pmix_server_internal.h"
 
@@ -48,6 +50,7 @@ static void cncon(prte_pmix_server_connection_t *p)
 {
     p->members = NULL;
     p->nmembers = 0;
+    p->terminating = false;
 }
 static void cndes(prte_pmix_server_connection_t *p)
 {
@@ -156,38 +159,78 @@ void prte_pmix_server_connection_record(const pmix_proc_t *members, size_t nmemb
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) nmembers);
 }
 
+/* Does this disconnect request name every member of this assemblage?
+ *
+ * Dissolving is deliberately more generous than recording.  Recording
+ * compares sets exactly, because that is how PMIx itself decides whether two
+ * connects are the same operation; but an assemblage exists to be told about
+ * departures, and once every process in it has said it is leaving there is
+ * nobody left the record serves.  The generosity is one-directional and
+ * cannot dissolve something by accident: a request only covers a member it
+ * names, and a wildcard member is covered only by a wildcard.
+ *
+ * The case that needs it is the one PRRTE creates itself.  A spawn connects
+ * the child to the parent *process*, while an application that then wants
+ * out disconnects the two *jobs* - the shape MPI_Comm_disconnect has - and
+ * under an exact-set rule that request would match nothing and the implicit
+ * assemblage could never be left. */
+static bool membership_covered(prte_pmix_server_connection_t *cptr,
+                               const pmix_proc_t *members, size_t nmembers)
+{
+    size_t i, j;
+    bool found;
+
+    for (i = 0; i < cptr->nmembers; i++) {
+        found = false;
+        for (j = 0; j < nmembers; j++) {
+            if (member_covers(&members[j], &cptr->members[i])) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            return false;
+        }
+    }
+    return true;
+}
+
 void prte_pmix_server_connection_drop(const pmix_proc_t *members, size_t nmembers)
 {
-    prte_pmix_server_connection_t *cptr;
+    prte_pmix_server_connection_t *cptr, *next;
 
     if (!registry_live() || NULL == members || 0 == nmembers) {
         return;
     }
 
-    PMIX_LIST_FOREACH(cptr, &prte_pmix_server_globals.connections,
-                      prte_pmix_server_connection_t) {
-        if (same_membership(cptr, members, nmembers)) {
+    PMIX_LIST_FOREACH_SAFE(cptr, next, &prte_pmix_server_globals.connections,
+                           prte_pmix_server_connection_t) {
+        if (membership_covered(cptr, members, nmembers)) {
             pmix_list_remove_item(&prte_pmix_server_globals.connections, &cptr->super);
             PMIX_RELEASE(cptr);
             pmix_output_verbose(2, prte_pmix_server_globals.output,
                                 "%s connection dropped across %d participants",
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) nmembers);
-            return;
         }
     }
 }
 
-/* Broadcast the event to the assemblage.
+/* Broadcast an event to the assemblage.
  *
  * The targets are the members as named, wildcards and all, which is what the
  * custom range wants: PMIx delivers to whoever registered for the code and
  * falls within it, so a member that has already gone simply matches nothing.
- * The source is the departed proc rather than ourselves - naming ourselves
- * would have our own PMIx server upcall the event straight back to us. */
-static void notify_assemblage(prte_pmix_server_connection_t *cptr,
-                              prte_proc_t *proc)
+ * The source is the affected proc rather than ourselves - naming ourselves
+ * would have our own PMIx server upcall the event straight back to us.
+ *
+ * "affected" is a proc for a departure and <nspace>/WILDCARD for a job that
+ * was terminated because of one; exit_code is passed as -1 where there is
+ * none to report. */
+static void notify_assemblage(const pmix_proc_t *members, size_t nmembers,
+                              pmix_status_t event,
+                              const pmix_proc_t *affected,
+                              int exit_code)
 {
-    pmix_status_t event = PMIX_ERR_PROC_TERM_WO_SYNC;
     pmix_data_range_t range = PMIX_RANGE_CUSTOM;
     pmix_data_array_t darray;
     pmix_info_t *info;
@@ -196,15 +239,15 @@ static void notify_assemblage(prte_pmix_server_connection_t *cptr,
     pmix_status_t rc;
     int ret;
 
-    ninfo = (0 <= proc->exit_code) ? 3 : 2;
+    ninfo = (0 <= exit_code) ? 3 : 2;
     PMIX_INFO_CREATE(info, ninfo);
-    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_AFFECTED_PROC, &proc->name, PMIX_PROC);
+    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_AFFECTED_PROC, (pmix_proc_t *) affected, PMIX_PROC);
     darray.type = PMIX_PROC;
-    darray.array = cptr->members;
-    darray.size = cptr->nmembers;
+    darray.array = (pmix_proc_t *) members;
+    darray.size = nmembers;
     PMIX_INFO_LOAD(&info[1], PMIX_EVENT_CUSTOM_RANGE, &darray, PMIX_DATA_ARRAY);
-    if (0 <= proc->exit_code) {
-        PMIX_INFO_LOAD(&info[2], PMIX_EXIT_CODE, &proc->exit_code, PMIX_INT);
+    if (0 <= exit_code) {
+        PMIX_INFO_LOAD(&info[2], PMIX_EXIT_CODE, &exit_code, PMIX_INT);
     }
 
     PMIX_DATA_BUFFER_CONSTRUCT(&pbkt);
@@ -217,7 +260,7 @@ static void notify_assemblage(prte_pmix_server_connection_t *cptr,
         rc = PMIx_Data_pack(NULL, &pbkt, &event, 1, PMIX_STATUS);
     }
     if (PMIX_SUCCESS == rc) {
-        rc = PMIx_Data_pack(NULL, &pbkt, &proc->name, 1, PMIX_PROC);
+        rc = PMIx_Data_pack(NULL, &pbkt, (pmix_proc_t *) affected, 1, PMIX_PROC);
     }
     if (PMIX_SUCCESS == rc) {
         rc = PMIx_Data_pack(NULL, &pbkt, &range, 1, PMIX_DATA_RANGE);
@@ -236,8 +279,9 @@ static void notify_assemblage(prte_pmix_server_connection_t *cptr,
     }
 
     pmix_output_verbose(2, prte_pmix_server_globals.output,
-                        "%s notifying connected assemblage of the loss of %s",
-                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&proc->name));
+                        "%s notifying connected assemblage of %s affecting %s",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PMIx_Error_string(event),
+                        PRTE_NAME_PRINT(affected));
 
     ret = prte_grpcomm_xcast(PRTE_RML_TAG_NOTIFICATION, &pbkt);
     if (PRTE_SUCCESS != ret) {
@@ -278,6 +322,9 @@ bool prte_pmix_server_is_connected(const pmix_proc_t *proc)
 void prte_pmix_server_connection_terminated(prte_proc_t *proc)
 {
     prte_pmix_server_connection_t *cptr;
+    pmix_proc_t *targets = NULL;
+    size_t ntargets = 0, cap = 0, i, j;
+    bool have;
 
     if (!registry_live() ||
         0 == pmix_list_get_size(&prte_pmix_server_globals.connections)) {
@@ -288,10 +335,194 @@ void prte_pmix_server_connection_terminated(prte_proc_t *proc)
         return;
     }
 
+    /* A proc can belong to more than one assemblage - a spawned job is
+     * connected to its parent by the spawn itself, and the two may then
+     * connect explicitly as well - and its departure is one event, not one
+     * per assemblage.  Address it to the union of the memberships, so
+     * everyone who was promised the news gets it exactly once. */
     PMIX_LIST_FOREACH(cptr, &prte_pmix_server_globals.connections,
                       prte_pmix_server_connection_t) {
-        if (connection_covers(cptr, &proc->name)) {
-            notify_assemblage(cptr, proc);
+        if (!connection_covers(cptr, &proc->name)) {
+            continue;
+        }
+        if (ntargets + cptr->nmembers > cap) {
+            cap = ntargets + cptr->nmembers;
+            targets = (pmix_proc_t *) realloc(targets, cap * sizeof(pmix_proc_t));
+        }
+        for (i = 0; i < cptr->nmembers; i++) {
+            have = false;
+            for (j = 0; j < ntargets; j++) {
+                if (same_proc(&targets[j], &cptr->members[i])) {
+                    have = true;
+                    break;
+                }
+            }
+            if (!have) {
+                memcpy(&targets[ntargets], &cptr->members[i], sizeof(pmix_proc_t));
+                ++ntargets;
+            }
+        }
+    }
+
+    if (0 < ntargets) {
+        notify_assemblage(targets, ntargets, PMIX_ERR_PROC_TERM_WO_SYNC,
+                          &proc->name, proc->exit_code);
+    }
+    if (NULL != targets) {
+        free(targets);
+    }
+}
+
+/* A job has launched successfully.  If it was spawned by an application
+ * process, the PMIx definition connects the two by default - "the parent
+ * process is given a copy of the new job's job-level information ... and both
+ * the parent and the members of the child job receive notification of errors
+ * arising anywhere in their combined assemblage".
+ *
+ * Whether there is a parent process at all is the whole question here, and
+ * three launches that are not a dynamic spawn arrive by the same route.
+ *
+ * jdata->originator does NOT answer it.  By the time the job reaches us it
+ * names the daemon that relayed the request - plm_base_receive overwrites it
+ * with the sender, because that is who the response has to go back to.  What
+ * survives from the requestor's own daemon is PRTE_JOB_LAUNCH_PROXY, which
+ * is set from the originator before the request is packed and is therefore
+ * the process that actually asked.
+ *
+ * That still has to be screened.  A prterun-style launch records the daemon
+ * itself as the proxy, and a "prun ./app" records prun's own tool procID - a
+ * tool is not a member of a job, has no processes to connect to or to
+ * terminate, and is not what "the parent process" means.  So a proxy in our
+ * own namespace is rejected, as is one whose job object carries
+ * PRTE_JOB_FLAG_TOOL.
+ *
+ * PMIX_SPAWN_CHILD_SEP is honored as the opt-out: a spawn that asked for the
+ * child to be independent of its parent has said in as many words that the
+ * two jobs' fates are not to be linked. */
+void prte_pmix_server_connection_spawned(prte_job_t *jdata)
+{
+    prte_job_t *parent;
+    pmix_proc_t *proxy = NULL, members[2];
+    bool sep = false, *sepptr = &sep;
+
+    if (!registry_live() || NULL == jdata) {
+        return;
+    }
+    if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_LAUNCH_PROXY,
+                            (void **) &proxy, PMIX_PROC) || NULL == proxy) {
+        return;
+    }
+    if (PMIX_NSPACE_INVALID(proxy->nspace) || PMIX_RANK_INVALID == proxy->rank ||
+        same_nspace(proxy->nspace, PRTE_PROC_MY_NAME->nspace)) {
+        /* no requestor, or one of our own daemons - either way there is no
+         * parent process to connect to */
+        goto done;
+    }
+    parent = prte_get_job_data_object(proxy->nspace);
+    if (NULL == parent || PRTE_FLAG_TEST(parent, PRTE_JOB_FLAG_TOOL)) {
+        goto done;
+    }
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_CHILD_SEP,
+                           (void **) &sepptr, PMIX_BOOL) && sep) {
+        goto done;
+    }
+
+    PMIX_XFER_PROCID(&members[0], proxy);
+    PMIX_LOAD_PROCID(&members[1], jdata->nspace, PMIX_RANK_WILDCARD);
+    prte_pmix_server_connection_record(members, 2);
+
+done:
+    PMIX_PROC_RELEASE(proxy);
+}
+
+/* Does this assemblage name this job at all? */
+static bool connection_names_job(prte_pmix_server_connection_t *cptr,
+                                 const pmix_nspace_t nspace)
+{
+    size_t n;
+
+    for (n = 0; n < cptr->nmembers; n++) {
+        if (same_nspace(cptr->members[n].nspace, nspace)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void prte_pmix_server_connection_job_failed(const pmix_nspace_t nspace)
+{
+    prte_pmix_server_connection_t *cptr;
+    prte_job_t *jptr;
+    pmix_proc_t target;
+    pmix_pointer_array_t procs;
+    prte_proc_t *pobj;
+    size_t n, m;
+    bool done;
+    int i;
+
+    if (!registry_live() || !prte_pmix_server_globals.terminate_connected) {
+        return;
+    }
+    if (prte_finalizing || prte_dvm_abort_ordered || prte_prteds_term_ordered) {
+        /* everything is going down anyway */
+        return;
+    }
+
+    PMIX_LIST_FOREACH(cptr, &prte_pmix_server_globals.connections,
+                      prte_pmix_server_connection_t) {
+        if (cptr->terminating || !connection_names_job(cptr, nspace)) {
+            continue;
+        }
+        /* the rest of this assemblage is coming down with it, and each of
+         * those jobs will report its own procs failing as it goes - none of
+         * which should drive this again */
+        cptr->terminating = true;
+
+        for (n = 0; n < cptr->nmembers; n++) {
+            if (same_nspace(cptr->members[n].nspace, nspace)) {
+                continue;
+            }
+            /* a namespace can appear more than once in a membership - one
+             * entry per rank - and it is to be killed once */
+            done = false;
+            for (m = 0; m < n; m++) {
+                if (same_nspace(cptr->members[m].nspace, cptr->members[n].nspace)) {
+                    done = true;
+                    break;
+                }
+            }
+            if (done) {
+                continue;
+            }
+            jptr = prte_get_job_data_object(cptr->members[n].nspace);
+            if (NULL == jptr || PRTE_FLAG_TEST(jptr, PRTE_JOB_FLAG_ABORTED) ||
+                PRTE_JOB_STATE_TERMINATED <= jptr->state) {
+                /* already gone, or already on its way */
+                continue;
+            }
+
+            /* the user is about to lose a job they did not ask about, so say
+             * why - "connected" is not a property they can see in ps */
+            prte_show_help("help-prted.txt", "connected-term", true,
+                           nspace, jptr->nspace);
+
+            PMIX_LOAD_PROCID(&target, jptr->nspace, PMIX_RANK_WILDCARD);
+            notify_assemblage(cptr->members, cptr->nmembers,
+                              PMIX_ERR_JOB_TERM_WO_SYNC, &target, -1);
+
+            PMIX_CONSTRUCT(&procs, pmix_pointer_array_t);
+            pmix_pointer_array_init(&procs, 1, 1, 1);
+            pobj = PMIX_NEW(prte_proc_t);
+            PMIX_XFER_PROCID(&pobj->name, &target);
+            pmix_pointer_array_add(&procs, pobj);
+            prte_plm.terminate_procs(&procs);
+            for (i = 0; i < procs.size; i++) {
+                pobj = (prte_proc_t *) pmix_pointer_array_get_item(&procs, i);
+                if (NULL != pobj) {
+                    PMIX_RELEASE(pobj);
+                }
+            }
+            PMIX_DESTRUCT(&procs);
         }
     }
 }

--- a/src/prted/pmix/pmix_server_connect.c
+++ b/src/prted/pmix/pmix_server_connect.c
@@ -1,0 +1,438 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+/*
+ * The registry of "connected" assemblages.
+ *
+ * PMIx_Connect asks the host to treat a set of processes as one application
+ * for fault and event-notification purposes.  The obligation that creates is
+ * narrow and specific: should any member terminate - or call PMIx_Finalize -
+ * without first calling PMIx_Disconnect, the host must generate a
+ * PMIX_ERR_PROC_TERM_WO_SYNC event to the assemblage.  A connect that is
+ * never followed by a disconnect is therefore not an omission to be tidied
+ * away; it is the case the event exists for.
+ *
+ * The membership is what makes that promise keepable, and it is held here,
+ * on the DVM master alone.  The master is the one process that learns of
+ * every proc termination in the DVM, including the procs of a node whose
+ * daemon has died - which is exactly when an assemblage most wants telling,
+ * and exactly when a record held on the dead daemon would have gone with it.
+ */
+
+#include "prte_config.h"
+#include "constants.h"
+#include "types.h"
+
+#include <string.h>
+
+#include "src/class/pmix_list.h"
+#include "src/pmix/pmix-internal.h"
+#include "src/util/pmix_output.h"
+
+#include "src/grpcomm/grpcomm.h"
+#include "src/mca/state/state.h"
+#include "src/rml/rml.h"
+#include "src/runtime/prte_globals.h"
+#include "src/util/name_fns.h"
+
+#include "src/prted/pmix/pmix_server_internal.h"
+
+static void cncon(prte_pmix_server_connection_t *p)
+{
+    p->members = NULL;
+    p->nmembers = 0;
+}
+static void cndes(prte_pmix_server_connection_t *p)
+{
+    if (NULL != p->members) {
+        PMIX_PROC_FREE(p->members, p->nmembers);
+    }
+}
+PMIX_CLASS_INSTANCE(prte_pmix_server_connection_t,
+                    pmix_list_item_t,
+                    cncon, cndes);
+
+/* The registry exists on the DVM master, and only while its PMIx server is
+ * up: every one of these entry points is also reachable from a unit test, and
+ * from teardown, where the list has never been constructed. */
+static bool registry_live(void)
+{
+    return (PRTE_PROC_IS_MASTER && prte_pmix_server_globals.initialized);
+}
+
+/* Do these two namespaces name the same job?
+ *
+ * NOT PMIX_CHECK_NSPACE, which answers "true" the moment either side is
+ * empty - wildcard semantics that are right for matching a request and wrong
+ * for deciding who is in an assemblage, where an empty nspace would put a
+ * proc in every one of them. */
+static bool same_nspace(const pmix_nspace_t a, const pmix_nspace_t b)
+{
+    return (0 == strncmp(a, b, PMIX_MAX_NSLEN));
+}
+
+/* Does this member entry cover this proc?  An entry naming a wildcard rank
+ * stands for every proc of that namespace, which is how a connect between
+ * two jobs is almost always expressed. */
+static bool member_covers(const pmix_proc_t *member, const pmix_proc_t *proc)
+{
+    if (!same_nspace(member->nspace, proc->nspace)) {
+        return false;
+    }
+    return (PMIX_RANK_WILDCARD == member->rank || member->rank == proc->rank);
+}
+
+/* Two assemblages are the same one if they name the same participants.  The
+ * order carries no meaning - the PMIx definition says so explicitly - so this
+ * compares them as sets.
+ *
+ * The comparison of a single entry is literal, deliberately: PMIX_CHECK_PROCID
+ * would call "nspace/0" and "nspace/WILDCARD" a match, and the two are
+ * different participant lists.  PMIx itself will not match a connect
+ * expressed one way with a connect expressed the other, so neither may we -
+ * a disconnect naming a set we never recorded must fail to find it rather
+ * than drop somebody else's. */
+static bool same_proc(const pmix_proc_t *a, const pmix_proc_t *b)
+{
+    return (a->rank == b->rank && same_nspace(a->nspace, b->nspace));
+}
+
+static bool same_membership(prte_pmix_server_connection_t *cptr,
+                            const pmix_proc_t *members, size_t nmembers)
+{
+    size_t i, j;
+    bool found;
+
+    if (cptr->nmembers != nmembers) {
+        return false;
+    }
+    for (i = 0; i < nmembers; i++) {
+        found = false;
+        for (j = 0; j < cptr->nmembers; j++) {
+            if (same_proc(&members[i], &cptr->members[j])) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void prte_pmix_server_connection_record(const pmix_proc_t *members, size_t nmembers)
+{
+    prte_pmix_server_connection_t *cptr;
+
+    if (!registry_live() || NULL == members || 0 == nmembers) {
+        return;
+    }
+
+    /* a repeat is not an error - it just means the same set connected again
+     * without having disconnected, which changes nothing */
+    PMIX_LIST_FOREACH(cptr, &prte_pmix_server_globals.connections,
+                      prte_pmix_server_connection_t) {
+        if (same_membership(cptr, members, nmembers)) {
+            return;
+        }
+    }
+
+    cptr = PMIX_NEW(prte_pmix_server_connection_t);
+    cptr->nmembers = nmembers;
+    PMIX_PROC_CREATE(cptr->members, cptr->nmembers);
+    memcpy(cptr->members, members, nmembers * sizeof(pmix_proc_t));
+    pmix_list_append(&prte_pmix_server_globals.connections, &cptr->super);
+
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s connection recorded across %d participants",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) nmembers);
+}
+
+void prte_pmix_server_connection_drop(const pmix_proc_t *members, size_t nmembers)
+{
+    prte_pmix_server_connection_t *cptr;
+
+    if (!registry_live() || NULL == members || 0 == nmembers) {
+        return;
+    }
+
+    PMIX_LIST_FOREACH(cptr, &prte_pmix_server_globals.connections,
+                      prte_pmix_server_connection_t) {
+        if (same_membership(cptr, members, nmembers)) {
+            pmix_list_remove_item(&prte_pmix_server_globals.connections, &cptr->super);
+            PMIX_RELEASE(cptr);
+            pmix_output_verbose(2, prte_pmix_server_globals.output,
+                                "%s connection dropped across %d participants",
+                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (int) nmembers);
+            return;
+        }
+    }
+}
+
+/* Broadcast the event to the assemblage.
+ *
+ * The targets are the members as named, wildcards and all, which is what the
+ * custom range wants: PMIx delivers to whoever registered for the code and
+ * falls within it, so a member that has already gone simply matches nothing.
+ * The source is the departed proc rather than ourselves - naming ourselves
+ * would have our own PMIx server upcall the event straight back to us. */
+static void notify_assemblage(prte_pmix_server_connection_t *cptr,
+                              prte_proc_t *proc)
+{
+    pmix_status_t event = PMIX_ERR_PROC_TERM_WO_SYNC;
+    pmix_data_range_t range = PMIX_RANGE_CUSTOM;
+    pmix_data_array_t darray;
+    pmix_info_t *info;
+    size_t ninfo;
+    pmix_data_buffer_t pbkt;
+    pmix_status_t rc;
+    int ret;
+
+    ninfo = (0 <= proc->exit_code) ? 3 : 2;
+    PMIX_INFO_CREATE(info, ninfo);
+    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_AFFECTED_PROC, &proc->name, PMIX_PROC);
+    darray.type = PMIX_PROC;
+    darray.array = cptr->members;
+    darray.size = cptr->nmembers;
+    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_CUSTOM_RANGE, &darray, PMIX_DATA_ARRAY);
+    if (0 <= proc->exit_code) {
+        PMIX_INFO_LOAD(&info[2], PMIX_EXIT_CODE, &proc->exit_code, PMIX_INT);
+    }
+
+    PMIX_DATA_BUFFER_CONSTRUCT(&pbkt);
+
+    /* the originator field: an invalid rank says "this did not come from a
+     * daemon", so every daemon - ourselves included - hands it to its own
+     * PMIx server rather than assuming it has already been delivered */
+    rc = PMIx_Data_pack(NULL, &pbkt, &PRTE_NAME_INVALID->rank, 1, PMIX_PROC_RANK);
+    if (PMIX_SUCCESS == rc) {
+        rc = PMIx_Data_pack(NULL, &pbkt, &event, 1, PMIX_STATUS);
+    }
+    if (PMIX_SUCCESS == rc) {
+        rc = PMIx_Data_pack(NULL, &pbkt, &proc->name, 1, PMIX_PROC);
+    }
+    if (PMIX_SUCCESS == rc) {
+        rc = PMIx_Data_pack(NULL, &pbkt, &range, 1, PMIX_DATA_RANGE);
+    }
+    if (PMIX_SUCCESS == rc) {
+        rc = PMIx_Data_pack(NULL, &pbkt, &ninfo, 1, PMIX_SIZE);
+    }
+    if (PMIX_SUCCESS == rc) {
+        rc = PMIx_Data_pack(NULL, &pbkt, info, ninfo, PMIX_INFO);
+    }
+    PMIX_INFO_FREE(info, ninfo);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+        return;
+    }
+
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s notifying connected assemblage of the loss of %s",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(&proc->name));
+
+    ret = prte_grpcomm_xcast(PRTE_RML_TAG_NOTIFICATION, &pbkt);
+    if (PRTE_SUCCESS != ret) {
+        PRTE_ERROR_LOG(ret);
+    }
+    PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
+}
+
+static bool connection_covers(prte_pmix_server_connection_t *cptr,
+                              const pmix_proc_t *proc)
+{
+    size_t n;
+
+    for (n = 0; n < cptr->nmembers; n++) {
+        if (member_covers(&cptr->members[n], proc)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool prte_pmix_server_is_connected(const pmix_proc_t *proc)
+{
+    prte_pmix_server_connection_t *cptr;
+
+    if (!registry_live() || NULL == proc) {
+        return false;
+    }
+    PMIX_LIST_FOREACH(cptr, &prte_pmix_server_globals.connections,
+                      prte_pmix_server_connection_t) {
+        if (connection_covers(cptr, proc)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void prte_pmix_server_connection_terminated(prte_proc_t *proc)
+{
+    prte_pmix_server_connection_t *cptr;
+
+    if (!registry_live() ||
+        0 == pmix_list_get_size(&prte_pmix_server_globals.connections)) {
+        return;
+    }
+    /* nobody is left to hear it, and the DVM is on its way out */
+    if (prte_finalizing || prte_dvm_abort_ordered || prte_prteds_term_ordered) {
+        return;
+    }
+
+    PMIX_LIST_FOREACH(cptr, &prte_pmix_server_globals.connections,
+                      prte_pmix_server_connection_t) {
+        if (connection_covers(cptr, &proc->name)) {
+            notify_assemblage(cptr, proc);
+        }
+    }
+}
+
+void prte_pmix_server_connection_purge(const pmix_nspace_t nspace)
+{
+    prte_pmix_server_connection_t *cptr, *next;
+    size_t n;
+    bool live;
+
+    if (!registry_live()) {
+        return;
+    }
+
+    /* An assemblage outlives the departure of one member's job: the members
+     * that remain are still connected to each other, and still owed an event
+     * apiece when they go.  It is only once nothing named in it exists any
+     * more that the record has no one left to serve. */
+    PMIX_LIST_FOREACH_SAFE(cptr, next, &prte_pmix_server_globals.connections,
+                           prte_pmix_server_connection_t) {
+        live = false;
+        for (n = 0; n < cptr->nmembers; n++) {
+            if (same_nspace(cptr->members[n].nspace, nspace)) {
+                continue;
+            }
+            if (NULL != prte_get_job_data_object(cptr->members[n].nspace)) {
+                live = true;
+                break;
+            }
+        }
+        if (!live) {
+            pmix_list_remove_item(&prte_pmix_server_globals.connections, &cptr->super);
+            PMIX_RELEASE(cptr);
+        }
+    }
+}
+
+/* Tell the DVM master what just connected (or disconnected).
+ *
+ * Every daemon holding a participant runs this, and the master takes the
+ * first report and ignores the rest - deliberately, rather than electing one
+ * daemon to speak for the others.  There is no cheap election here that does
+ * not depend on some particular daemon still being alive, and the reports are
+ * a few dozen bytes each on an operation that has just paid for a DVM-wide
+ * collective.  Reporting from the completion of that collective, rather than
+ * from its start, is what keeps a connect that failed from being recorded.
+ */
+static void report_connection(const pmix_proc_t *members, size_t nmembers, bool connected)
+{
+    pmix_data_buffer_t *buf;
+    pmix_status_t rc;
+    uint8_t flag;
+    int ret;
+
+    if (NULL == members || 0 == nmembers) {
+        return;
+    }
+
+    if (PRTE_PROC_IS_MASTER) {
+        /* no need to send it to ourselves */
+        if (connected) {
+            prte_pmix_server_connection_record(members, nmembers);
+        } else {
+            prte_pmix_server_connection_drop(members, nmembers);
+        }
+        return;
+    }
+
+    PMIX_DATA_BUFFER_CREATE(buf);
+    flag = connected ? 1 : 0;
+    rc = PMIx_Data_pack(NULL, buf, &flag, 1, PMIX_UINT8);
+    if (PMIX_SUCCESS == rc) {
+        rc = PMIx_Data_pack(NULL, buf, &nmembers, 1, PMIX_SIZE);
+    }
+    if (PMIX_SUCCESS == rc) {
+        rc = PMIx_Data_pack(NULL, buf, (pmix_proc_t *) members, nmembers, PMIX_PROC);
+    }
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        return;
+    }
+
+    PRTE_RML_SEND(ret, PRTE_PROC_MY_HNP->rank, buf, PRTE_RML_TAG_CONNECTED);
+    if (PRTE_SUCCESS != ret) {
+        PRTE_ERROR_LOG(ret);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+    }
+}
+
+void prte_pmix_server_connection_report(const pmix_proc_t *members, size_t nmembers)
+{
+    report_connection(members, nmembers, true);
+}
+
+void prte_pmix_server_connection_report_drop(const pmix_proc_t *members, size_t nmembers)
+{
+    report_connection(members, nmembers, false);
+}
+
+/* Receive a report from a daemon.  Runs on the DVM master, on the PRRTE
+ * progress thread. */
+void prte_pmix_server_connection_recv(int status, pmix_proc_t *sender,
+                                      pmix_data_buffer_t *buffer,
+                                      prte_rml_tag_t tag, void *cbdata)
+{
+    pmix_proc_t *members = NULL;
+    size_t nmembers;
+    uint8_t flag;
+    int32_t cnt;
+    pmix_status_t rc;
+    PRTE_HIDE_UNUSED_PARAMS(status, sender, tag, cbdata);
+
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &flag, &cnt, PMIX_UINT8);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return;
+    }
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &nmembers, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return;
+    }
+    if (0 == nmembers) {
+        return;
+    }
+    PMIX_PROC_CREATE(members, nmembers);
+    cnt = nmembers;
+    rc = PMIx_Data_unpack(NULL, buffer, members, &cnt, PMIX_PROC);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_PROC_FREE(members, nmembers);
+        return;
+    }
+
+    if (0 != flag) {
+        prte_pmix_server_connection_record(members, nmembers);
+    } else {
+        prte_pmix_server_connection_drop(members, nmembers);
+    }
+    PMIX_PROC_FREE(members, nmembers);
+}

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -1305,6 +1305,11 @@ static void connect_release(pmix_status_t status,
     }
 
 release:
+    /* the assemblage exists only if the collective that formed it succeeded */
+    if (PMIX_SUCCESS == status) {
+        prte_pmix_server_connection_report(md->procs, md->nprocs);
+    }
+
     /* now release the connect call */
     if (NULL != md->opcbfunc) {
         md->opcbfunc(rc, md->cbdata);
@@ -1340,6 +1345,12 @@ pmix_status_t pmix_server_connect_fn(const pmix_proc_t procs[], size_t nprocs,
      * for "remote" scope */
 
     cd = PMIX_NEW(prte_pmix_server_req_t);
+    /* keep the membership: once the fence says the connect completed, the DVM
+     * master has to be told who is now connected to whom, since it is the one
+     * that owes them an event if a member departs without disconnecting */
+    cd->nprocs = nprocs;
+    PMIX_PROC_CREATE(cd->procs, cd->nprocs);
+    memcpy(cd->procs, procs, nprocs * sizeof(pmix_proc_t));
     for (n=0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_PROC_INFO_ARRAY) ||
             PMIX_CHECK_KEY(&info[n], PMIX_JOB_INFO_ARRAY)) {
@@ -1394,6 +1405,15 @@ static void mdxcbfunc(pmix_status_t status,
     PRTE_HIDE_UNUSED_PARAMS(data, ndata, relcbfunc, relcbdata);
 
     PMIX_ACQUIRE_OBJECT(cd);
+    /* these procs have left the assemblage in the sanctioned way, so the
+     * promise made when they connected is discharged */
+    if (PMIX_SUCCESS == status && NULL != cd->procs) {
+        prte_pmix_server_connection_report_drop(cd->procs, cd->nprocs);
+    }
+    if (NULL != cd->procs) {
+        PMIX_PROC_FREE(cd->procs, cd->nprocs);
+        cd->procs = NULL;
+    }
     /* ack the call */
     if (NULL != cd->cbfunc) {
         cd->cbfunc(status, cd->cbdata);
@@ -1411,18 +1431,28 @@ pmix_status_t pmix_server_disconnect_fn(const pmix_proc_t procs[], size_t nprocs
     pmix_output_verbose(2, prte_pmix_server_globals.output, "%s disconnect called",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
 
-    /* at some point, we need to add bookeeping to track which
-     * procs are "connected" so we know who to notify upon
-     * termination or failure. For now, just execute a fence
-     * Note that we do not need to thread-shift here as the
-     * fence function will do it for us */
+    /* Execute a fence across the participants, and - once it says they all
+     * arrived - tell the DVM master to forget the assemblage they formed.
+     * Leaving it this way is what discharges the connect's promise: a member
+     * that departs afterwards owes nobody an event.
+     * Note that we do not need to thread-shift here as the fence function
+     * will do it for us */
     cd = PMIX_NEW(prte_pmix_server_op_caddy_t);
     cd->cbfunc = cbfunc;
     cd->cbdata = cbdata;
+    if (NULL != procs && 0 < nprocs) {
+        cd->nprocs = nprocs;
+        PMIX_PROC_CREATE(cd->procs, cd->nprocs);
+        memcpy(cd->procs, procs, nprocs * sizeof(pmix_proc_t));
+    }
 
     rc = pmix_server_fencenb_fn(procs, nprocs, info, ninfo, NULL, 0, mdxcbfunc, cd);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
+        if (NULL != cd->procs) {
+            PMIX_PROC_FREE(cd->procs, cd->nprocs);
+            cd->procs = NULL;
+        }
         PMIX_RELEASE(cd);
     }
 

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -499,6 +499,9 @@ typedef struct {
     pmix_list_item_t super;
     pmix_proc_t *members;
     size_t nmembers;
+    /* this assemblage is already being torn down after a member's failure,
+     * so a second failure inside it must not drive the teardown again */
+    bool terminating;
 } prte_pmix_server_connection_t;
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_pmix_server_connection_t);
 
@@ -519,6 +522,17 @@ PRTE_EXPORT bool prte_pmix_server_is_connected(const pmix_proc_t *proc);
  * plainly did not disconnect first.  Called once per proc from the DVM
  * master's proc-termination path. */
 PRTE_EXPORT void prte_pmix_server_connection_terminated(prte_proc_t *proc);
+
+/* A job has launched successfully: connect it to the process that spawned
+ * it, if it was spawned by a process at all.  The PMIx definition makes that
+ * the default for PMIx_Spawn; PMIX_SPAWN_CHILD_SEP opts out. */
+PRTE_EXPORT void prte_pmix_server_connection_spawned(prte_job_t *jdata);
+
+/* A failure has cost this job its life.  "Connected" means the host treats
+ * the assemblage as a single application, so every other job connected to it
+ * goes too - each one announced with PMIX_ERR_JOB_TERM_WO_SYNC.  Called from
+ * the DVM master's error manager as it terminates the job that failed. */
+PRTE_EXPORT void prte_pmix_server_connection_job_failed(const pmix_nspace_t nspace);
 
 /* A job's data object is going away: forget any assemblage that has nothing
  * left in it to notify. */
@@ -583,6 +597,12 @@ typedef struct {
     /* assemblages formed by PMIx_Connect - see prte_pmix_server_connection_t.
      * Populated on the DVM master only. */
     pmix_list_t connections;
+    /* whether a failure that terminates one job of an assemblage terminates
+     * the rest of it, which is what the PMIx definition of "connected" asks
+     * of a host that terminates an application when one of its processes
+     * fails.  An MCA parameter because it changes what happens to a job the
+     * user did not ask about. */
+    bool terminate_connected;
     /* jobs whose local procs have all departed, so that a direct modex for
      * one of them can be told "not found" instead of waiting for a job
      * object that is never coming back - see prte_pmix_server_job_departed() */

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -96,6 +96,9 @@ typedef struct {
     pmix_proc_t proxy;
     pmix_proc_t target;
     pmix_proc_t tproc;
+    /* a copy of an operation's participant list, owned by this request */
+    pmix_proc_t *procs;
+    size_t nprocs;
     prte_job_t *jdata;
     pmix_data_buffer_t msg;
     pmix_op_cbfunc_t opcbfunc;
@@ -479,6 +482,61 @@ typedef struct {
 } prte_pmix_server_pset_t;
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_pmix_server_pset_t);
 
+/* A set of processes recorded as "connected" by PMIx_Connect.
+ *
+ * "Connected" means only that the host is to treat the members as one
+ * assemblage for fault and event-notification purposes: any member that
+ * terminates without first calling PMIx_Disconnect owes the others a
+ * PMIX_ERR_PROC_TERM_WO_SYNC event.  Holding the membership is what makes
+ * that promise keepable, and it is held on the DVM master alone, because
+ * that is the one process that sees every proc in the DVM terminate -
+ * including the procs of a node whose daemon died, which no one else is
+ * left to report.
+ *
+ * The members are the participant array exactly as the connect named it, so
+ * an entry may be a wildcard rank standing for a whole namespace. */
+typedef struct {
+    pmix_list_item_t super;
+    pmix_proc_t *members;
+    size_t nmembers;
+} prte_pmix_server_connection_t;
+PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_pmix_server_connection_t);
+
+/* Record/forget an assemblage.  Both are driven by the connect and disconnect
+ * collectives as they complete on the DVM master, and both are no-ops
+ * anywhere else.  Recording an assemblage that is already recorded, or
+ * dropping one that is not, is not an error: the two collectives are the only
+ * things that call these, and a repeat of either is harmless. */
+PRTE_EXPORT void prte_pmix_server_connection_record(const pmix_proc_t *members, size_t nmembers);
+PRTE_EXPORT void prte_pmix_server_connection_drop(const pmix_proc_t *members, size_t nmembers);
+
+/* Is this proc a member of any recorded assemblage?  A member entry naming a
+ * wildcard rank covers every proc of that namespace, which is how a connect
+ * between two jobs is almost always expressed. */
+PRTE_EXPORT bool prte_pmix_server_is_connected(const pmix_proc_t *proc);
+
+/* A proc has terminated.  Tell every assemblage it belonged to, since it
+ * plainly did not disconnect first.  Called once per proc from the DVM
+ * master's proc-termination path. */
+PRTE_EXPORT void prte_pmix_server_connection_terminated(prte_proc_t *proc);
+
+/* A job's data object is going away: forget any assemblage that has nothing
+ * left in it to notify. */
+PRTE_EXPORT void prte_pmix_server_connection_purge(const pmix_nspace_t nspace);
+
+/* Report a completed connect/disconnect to the DVM master, which is where the
+ * membership is held.  Called on each daemon that had a participant, from the
+ * completion of the collective that carried the operation. */
+PRTE_EXPORT void prte_pmix_server_connection_report(const pmix_proc_t *members, size_t nmembers);
+PRTE_EXPORT void prte_pmix_server_connection_report_drop(const pmix_proc_t *members,
+                                                         size_t nmembers);
+
+/* Receive such a report - registered on PRTE_RML_TAG_CONNECTED by the DVM
+ * master. */
+PRTE_EXPORT void prte_pmix_server_connection_recv(int status, pmix_proc_t *sender,
+                                                  pmix_data_buffer_t *buffer,
+                                                  prte_rml_tag_t tag, void *cbdata);
+
 typedef struct {
     bool initialized;
     int verbosity;
@@ -522,6 +580,9 @@ typedef struct {
     bool lazy_procdata;
     pmix_list_t psets;
     pmix_list_t groups;
+    /* assemblages formed by PMIx_Connect - see prte_pmix_server_connection_t.
+     * Populated on the DVM master only. */
+    pmix_list_t connections;
     /* jobs whose local procs have all departed, so that a direct modex for
      * one of them can be told "not found" instead of waiting for a job
      * object that is never coming back - see prte_pmix_server_job_departed() */

--- a/src/rml/rml_types.h
+++ b/src/rml/rml_types.h
@@ -218,6 +218,10 @@ typedef void (*prte_rml_buffer_callback_fn_t)(int status, pmix_proc_t *peer,
  * src/util/prte_show_help.c for why a prted cannot emit its own */
 #define PRTE_RML_TAG_SHOW_HELP            82
 
+/* the membership of a PMIx_Connect assemblage, on its way to the DVM master,
+ * which is where it is held - see src/prted/pmix/pmix_server_connect.c */
+#define PRTE_RML_TAG_CONNECTED            83
+
 #define PRTE_RML_TAG_MAX                 100
 
 #define PRTE_RML_TAG_NTOH(t) ntohl(t)

--- a/test/unit/prted/test_prted.c
+++ b/test/unit/prted/test_prted.c
@@ -1435,6 +1435,32 @@ static int test_connections(void)
     CHECK("a disconnect drops the connection",
           0 == pmix_list_get_size(&prte_pmix_server_globals.connections));
 
+    /*
+     * Dissolving is deliberately more generous than recording: a request
+     * that names every member of an assemblage dissolves it, whether or not
+     * it names them the same way.  The case that needs it is the one the
+     * runtime creates itself - a spawn connects the child to the parent
+     * PROCESS, while an application that wants out disconnects the two JOBS,
+     * which is the shape MPI_Comm_disconnect has.  Under an exact-set rule
+     * that request matches nothing and the implicit assemblage can never be
+     * left, so a child's later failure would take a parent with it that had
+     * said in as many words that it was done.
+     */
+    PMIX_LOAD_PROCID(&other[0], "unit-test-conn@1", 0);
+    other[1] = members[1];
+    prte_pmix_server_connection_record(other, 2);
+    prte_pmix_server_connection_drop(members, 2);
+    CHECK("a disconnect of the jobs dissolves a connection to one rank of one",
+          0 == pmix_list_get_size(&prte_pmix_server_globals.connections));
+
+    /* ...and the generosity only goes that way: naming one rank does not
+     * dissolve an assemblage that named the whole job */
+    prte_pmix_server_connection_record(members, 2);
+    prte_pmix_server_connection_drop(other, 2);
+    CHECK("a disconnect of one rank leaves a whole-job connection alone",
+          1 == pmix_list_get_size(&prte_pmix_server_globals.connections));
+    prte_pmix_server_connection_drop(members, 2);
+
     /* a proc that belongs to nothing is not connected, and reporting its
      * termination is a no-op rather than a walk off the end of an empty list */
     PMIX_CONSTRUCT(&pdata, prte_proc_t);

--- a/test/unit/prted/test_prted.c
+++ b/test/unit/prted/test_prted.c
@@ -1344,6 +1344,119 @@ static int test_departed_jobs(void)
     return failures;
 }
 
+/* The registry of connected assemblages.
+ *
+ * PMIx_Connect asks the host to treat a set of processes as one application
+ * for fault purposes, and the one obligation that creates is narrow: a member
+ * that terminates without first calling PMIx_Disconnect owes the rest of the
+ * assemblage a PMIX_ERR_PROC_TERM_WO_SYNC event.  Nothing recorded the
+ * membership, so there was nothing to consult when a member died.
+ *
+ * The membership is held on the DVM master, and what is testable without a
+ * DVM is the bookkeeping itself: that the same set is recognized however it
+ * is ordered, that a set is matched literally rather than loosely, who a
+ * wildcard member covers, and that a record is neither leaked nor dropped
+ * while somebody named in it still exists.  Sending the event needs daemons.
+ */
+static int test_connections(void)
+{
+    int failures = 0;
+    pmix_proc_t members[2], other[2], proc;
+    prte_proc_t pdata;
+    prte_job_t *jdata;
+    bool made_array = false;
+
+    /* the registry lives in the server globals, which a full
+     * pmix_server_init() would have constructed - and it declines to record
+     * anything until that has happened, which is what keeps every other test
+     * in this binary out of it */
+    PMIX_CONSTRUCT(&prte_pmix_server_globals.connections, pmix_list_t);
+    prte_pmix_server_globals.initialized = true;
+    if (NULL == prte_job_data) {
+        prte_job_data = PMIX_NEW(pmix_pointer_array_t);
+        pmix_pointer_array_init(prte_job_data, 8, INT32_MAX, 8);
+        made_array = true;
+    }
+
+    PMIX_LOAD_PROCID(&members[0], "unit-test-conn@1", PMIX_RANK_WILDCARD);
+    PMIX_LOAD_PROCID(&members[1], "unit-test-conn@2", PMIX_RANK_WILDCARD);
+
+    prte_pmix_server_connection_record(members, 2);
+    CHECK("a connect is recorded",
+          1 == pmix_list_get_size(&prte_pmix_server_globals.connections));
+
+    /* the PMIx definition says the order of the participants carries no
+     * meaning, so the same set given the other way round is the same set */
+    other[0] = members[1];
+    other[1] = members[0];
+    prte_pmix_server_connection_record(other, 2);
+    CHECK("the same set in another order is the same connection",
+          1 == pmix_list_get_size(&prte_pmix_server_globals.connections));
+
+    /* a wildcard member stands for every proc of that namespace - which is
+     * how a connect between two jobs is nearly always expressed, so getting
+     * this wrong means never notifying anybody */
+    PMIX_LOAD_PROCID(&proc, "unit-test-conn@1", 3);
+    CHECK("a wildcard member covers a rank of that job",
+          prte_pmix_server_is_connected(&proc));
+    PMIX_LOAD_PROCID(&proc, "unit-test-conn@9", 0);
+    CHECK("and covers nothing outside it", !prte_pmix_server_is_connected(&proc));
+
+    /* Matching a set is literal.  PMIx will not pair a connect expressed with
+     * wildcards with one that named the ranks, so a disconnect naming a set
+     * we never recorded must leave the record we do hold alone rather than
+     * drop it in somebody else's name. */
+    PMIX_LOAD_PROCID(&other[0], "unit-test-conn@1", 0);
+    PMIX_LOAD_PROCID(&other[1], "unit-test-conn@2", 0);
+    prte_pmix_server_connection_drop(other, 2);
+    CHECK("a different set does not drop this one",
+          1 == pmix_list_get_size(&prte_pmix_server_globals.connections));
+
+    /* a job of the assemblage ends, but the other is still running: the
+     * survivors are still connected to each other and still owed an event
+     * apiece, so the record has to stay */
+    jdata = PMIX_NEW(prte_job_t);
+    PMIX_LOAD_NSPACE(jdata->nspace, "unit-test-conn@2");
+    CHECK("the surviving job registers", PRTE_SUCCESS == prte_set_job_data_object(jdata));
+    prte_pmix_server_connection_purge(members[0].nspace);
+    CHECK("a connection outlives one member's job",
+          1 == pmix_list_get_size(&prte_pmix_server_globals.connections));
+
+    /* ...and once nothing named in it is left, it has nobody to serve */
+    pmix_pointer_array_set_item(prte_job_data, jdata->index, NULL);
+    PMIX_RELEASE(jdata);
+    prte_pmix_server_connection_purge(members[1].nspace);
+    CHECK("and is forgotten when nothing named in it is left",
+          0 == pmix_list_get_size(&prte_pmix_server_globals.connections));
+
+    /* a disconnect of the set that was recorded does drop it */
+    prte_pmix_server_connection_record(members, 2);
+    prte_pmix_server_connection_drop(members, 2);
+    CHECK("a disconnect drops the connection",
+          0 == pmix_list_get_size(&prte_pmix_server_globals.connections));
+
+    /* a proc that belongs to nothing is not connected, and reporting its
+     * termination is a no-op rather than a walk off the end of an empty list */
+    PMIX_CONSTRUCT(&pdata, prte_proc_t);
+    PMIX_LOAD_PROCID(&pdata.name, "unit-test-conn@1", 0);
+    pdata.exit_code = 0;
+    CHECK("an unconnected proc is not connected", !prte_pmix_server_is_connected(&pdata.name));
+    prte_pmix_server_connection_terminated(&pdata);
+    PMIX_DESTRUCT(&pdata);
+
+    prte_pmix_server_globals.initialized = false;
+    PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.connections);
+    if (made_array) {
+        PMIX_RELEASE(prte_job_data);
+        prte_job_data = NULL;
+    }
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_connections\n");
+    }
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0, skipped = 0;
@@ -1405,6 +1518,7 @@ int main(void)
     }
 
     failures += test_departed_jobs();
+    failures += test_connections();
     failures += test_prefix_normalization();
     failures += test_singleton_id();
     failures += test_xfer_job_info();


### PR DESCRIPTION
Closes the `docs/todo.rst` item "Nothing records who is \"connected\"", and the three follow-on gaps that item's first draft left behind.

**Pairs with openpmix/openpmix#4187**, which is what makes the single-node case work; see the last section.

`PMIx_Connect` is not a communication operation. The fence PRRTE ran was enough to make the call *return*, but what connect asks of the host is that the participants be treated as **one application for fault purposes**. Per `PMIx_Connect(3)`, that means two concrete obligations, and PRRTE met neither because it recorded nothing:

> Once processes are connected, the host environment is required to generate a `PMIX_ERR_PROC_TERM_WO_SYNC` event should any process in the assemblage terminate or call `PMIx_Finalize` without first disconnecting

> ...if the environment defaults to terminating an application upon failure of any process in that application, then it should terminate all processes in the connected assemblage upon failure of any member. If a job is terminated as a result of that action, the host environment is also required to generate `PMIX_ERR_JOB_TERM_WO_SYNC` for all jobs that were terminated as a result.

### Commit 1 — record who is connected, and tell them when a member leaves

- Membership lives **on the DVM master alone** — the one process that sees every proc in the DVM stop, including procs of a node whose daemon died (exactly when the assemblage most wants telling, and exactly when a record held on that daemon would have died with it).
- Each participating daemon reports the set on a new `PRTE_RML_TAG_CONNECTED`, from the **completion** of the connect collective, so a failed connect is never recorded; the master takes the first report and ignores the rest.
- Termination is noticed in one place: the `TERMINATED` arm of `prte_state_base_track_procs()`, behind the flag that makes it once per proc — so an exit, a failure, and a proc force-marked terminated because its daemon died all reach it.
- Wildcard member entries (`{A/*, B/*}`, how a two-job connect is nearly always written) cover a whole namespace both when matching a departure and when addressing the event.

### Commit 2 — treat the assemblage as one application

- **The fault response.** A failure that terminates one member's job now terminates the rest of the assemblage, from `_terminate_job()` in `errmgr/dvm` — the one place every failure-driven teardown passes through. Each job that dies as a result is announced with `PMIX_ERR_JOB_TERM_WO_SYNC` and explained to the user by name (new `connected-term` help topic), rather than leaving them to infer why a job they did not ask about went away. The assemblage is marked terminating on the way, so the failures its own teardown produces cannot drive it again. `--prtemca pmix_terminate_connected 0` confines a failure to the job it happened in.
- **Spawn connects the child to the parent process**, as the `PMIx_Spawn` default requires. Which launches have a parent process at all needs care: `jdata->originator` does *not* answer it, because `plm_base_receive` overwrites it with the daemon that relayed the request. `PRTE_JOB_LAUNCH_PROXY` survives from the requestor's own daemon and is the process that actually asked — screened against our own namespace (a prterun-style launch records the daemon) and against `PRTE_JOB_FLAG_TOOL` (a `prun ./app` records prun's own tool procID, and a tool is not a member of a job). `PMIX_SPAWN_CHILD_SEP` opts out.
- **Dissolving is deliberately more generous than recording.** A disconnect dissolves any assemblage all of whose members it *names*, wildcards covering ranks. Without that asymmetry an application could never leave the assemblage a spawn created for it: the spawn connects the child to the parent **process**, while an application that wants out disconnects the two **jobs** — the shape `MPI_Comm_disconnect` has. It cannot dissolve anything by accident: a request only covers a member it names, and a wildcard member is covered only by a wildcard.
- A proc in more than one assemblage (a spawned child that also connects explicitly) draws **one** event, addressed to the union of the memberships.

### Testing

**Unit** — `test_connections` in `test/unit/prted/`: set matching however ordered, literal matching of a *set* (`A/0` and `A/*` are different participant lists, because PMIx will not pair them either), the coverage rule for dissolution in both directions, wildcard coverage of a departure, and the purge rules. Verified it has teeth by breaking each rule in turn.

**End-to-end, single node** — `contrib/dockerswarm/connector.c` spawns a child, connects, and leaves in four ways. With openpmix#4187 in place:

| case | result |
|---|---|
| child exits without disconnecting | parent gets `PMIX_ERR_PROC_TERM_WO_SYNC`, once |
| both disconnect, child exits | parent gets nothing |
| child aborts while connected | parent's job terminated, with the help text naming both jobs |
| child aborts after disconnecting | parent survives, gets nothing |
| `pmix_terminate_connected 0` | parent survives the abort, still gets the event |

**Multi-node** — `test_connect()` in `run-tests.sh` runs the same client with the child mapped to another node, which is the only shape that exercises a genuinely distributed assemblage. **Not yet run**: the machine's swarm is in use by another job, and that suite needs it to itself. I will run it and report before this merges.

Also: warning-free `--enable-debug` build, full `make check`, Sphinx `-W` docs build, live DVM smoke test.

### Why openpmix#4187 is needed

The PMIx server library used to complete a connect *or a disconnect* whose participants were all local without calling the host at all. That left PRRTE unable to see a single-node assemblage — and, worse, unable to see the disconnect that would dissolve one it had created itself at spawn, so a later failure in the child would take down a parent that had explicitly disconnected. Against a PMIx without that fix, everything here still works for assemblages that span nodes, and a single-node spawn assemblage cannot be dissolved.