### PR TITLE
Fix the stack trace's disabled build and buffer accounting; retire the siginfo_t FIXME

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -529,6 +529,13 @@ AC_CHECK_DECLS([AF_UNSPEC, PF_UNSPEC, AF_INET6, PF_INET6],
 #include <netinet/in.h>
 #endif])
 
+# The pretty-print stacktrace handler (src/util/stacktrace.c) reads siginfo_t
+# unconditionally, and nothing here probes for it: the type, the sa_sigaction
+# member and the SA_SIGINFO flag are all mandatory in POSIX.1-2001, well
+# below anything PRRTE can be built on.  These two *members* are the part
+# that genuinely varies -- si_fd is not in POSIX at all (a Solaris/Linux
+# extension, absent on macOS), and si_band belongs to the obsolescent XSI
+# SIGPOLL option.
 AC_CHECK_MEMBERS([siginfo_t.si_fd],,,[#include <signal.h>])
 
 AC_CHECK_MEMBERS([siginfo_t.si_band],,,[#include <signal.h>])

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -151,14 +151,6 @@ otherwise takes whatever transport the resource manager offers by default
 surface for saying which one, and the note there is the record that one was
 always intended.
 
-**Stack traces assume ``siginfo_t``.**  ``show_stackframe``
-(``src/util/stacktrace.c``) is installed as an ``sa_sigaction`` handler and
-prints ``si_code``, ``si_addr`` and their neighbors unconditionally.
-``configure`` probes for two *members* (``si_fd``, ``si_band``) but nothing
-probes for the structure itself, so a platform without it would fail to
-build rather than degrade to the plain handler.  Every platform PRRTE
-currently supports has it, which is why this has never been forced.
-
 Test coverage
 -------------
 
@@ -253,8 +245,6 @@ the marker is stale.
 
    * - marker
      - entry above
-   * - ``util/stacktrace.c``, ``show_stackframe``
-     - stack traces assume ``siginfo_t``
    * - ``mca/filem/raw/filem_raw_module.c``, ``raw_fault_handler``
      - ``filem/raw`` does not survive losing a daemon mid-staging
    * - ``mca/odls/base/odls_base_default_fns.c``,
@@ -534,6 +524,48 @@ so that the next person does not rediscover the idea and spend the effort
 again: each says what was measured and what the measurement decided.  Moving
 one back up the page takes new evidence, not a fresh reading of the same
 facts.
+
+**Guarding the stack-trace handler against a platform with no
+``siginfo_t``.**  ``show_stackframe`` (``src/util/stacktrace.c``) is
+installed as an ``sa_sigaction`` handler and reads ``si_code``, ``si_addr``
+and their neighbors unconditionally.  A ``FIXME`` carried over from the
+code's Open MPI ancestry asked for a second, plain ``sa_handler`` arm for
+"systems which don't have siginfo".  There are none.  ``siginfo_t``, the
+``sa_sigaction`` member of ``struct sigaction`` and the ``SA_SIGINFO`` flag
+are all mandatory in POSIX.1-2001 — not one of its option groups — and
+PRRTE's floor sits far above that: C11, PMIx 7, hwloc 2.1, libevent 2.0, and
+unguarded POSIX-2001 calls in every direction.  The comment dates from 2004,
+when the Unixes it was written for were still in the field.
+
+What the probes around it check is the part that genuinely is optional, and
+that division is the right one: ``si_fd`` is not in POSIX at all (a
+Solaris/Linux extension — macOS does not have it, as any build tree's
+``prte_config.h`` shows), and ``si_band`` belongs to the obsolescent XSI
+SIGPOLL option.  Both are probed, and both are guarded at their single use;
+so is every ``si_code`` value the switch decodes, and so is ``SIGPOLL``
+itself.  The only thing taken on faith is the structure.
+
+A second handler would therefore be code no compiler anywhere would ever be
+handed, living in a signal handler, where a mistake is untraceable.  Nor is
+a ``configure`` probe for the structure worth having: a check that can only
+ever answer yes is the same dead weight in a different file, and guessing at
+what a platform that has never existed would want is not portability.  The
+platform PRRTE cannot serve here already has its answer —
+``--disable-pretty-print-stacktrace`` compiles the handler out entirely and
+is used by several ``contrib/platform`` files.
+
+Checking that claim was worth more than the probe would have been: the arm
+did not build.  ``unable_to_print_msg`` and ``set_stacktrace_filename`` sat
+outside the switch their only users live behind, so with the feature off
+they were unreferenced and ``--enable-debug`` rejected the file.  Both now
+live inside the switch, and the disabled build compiles warning-free, passes
+``make check``, and launches.  That nobody had noticed is its own entry
+under **Test coverage**.
+
+So the ``FIXME`` is gone and nothing replaced it but a comment saying what is
+assumed and why.  If a platform without ``siginfo_t`` ever turns up, it will
+say so as a compile error naming the type in this one file, and the
+disable option is right there.
 
 **Giving RELM an MCA variable to choose between reliability modules.**  The
 marker in ``prte_relm_register`` asked for the enum variable that would select

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -168,6 +168,14 @@ sequence itself beyond a smoke test, and nothing configures with
 ``PRTE_WANT_HOME_CONFIG_FILES`` is never compiled in CI
 (``src/runtime/AGENTS.md``).
 
+**``--disable-pretty-print-stacktrace``.**  Nothing in CI configures with it,
+which is how the arm came to not build at all: with the feature off, two
+statics in ``src/util/stacktrace.c`` were unreferenced and ``--enable-debug``
+made that an error.  That is fixed, but the option is still compiled only
+when somebody thinks to try it, and the ``contrib/platform`` files that set
+it are not built either.  It is one more configuration in the same class as
+the ``#else`` arm above: cheap to break, and nothing watching.
+
 **Heterogeneous DVMs.**  The byte-order helpers (``prte_hton64`` /
 ``prte_ntoh64``) are exercised by every inter-daemon message, but the case
 they exist for — two daemons that disagree about endianness — cannot be built

--- a/src/util/stacktrace.c
+++ b/src/util/stacktrace.c
@@ -90,6 +90,38 @@ static void set_stacktrace_filename(void)
 
     return;
 }
+
+/*
+ * snprintf() returns the length its output *would* have had, which on
+ * truncation is larger than the space it was given, so nothing here may
+ * advance by it.  written_len() is what snprintf() actually put in the
+ * buffer, and advance_buffer() steps a print cursor by that.
+ *
+ * Stepping by the raw return instead walks the cursor past the end of the
+ * buffer and drives the remaining count negative -- and the next snprintf()
+ * takes that count as a size_t, reads it as enormous, and writes off the end
+ * of the stack.  A long node name is all it takes: the handler builds four
+ * host-prefixed lines in one 1 KB buffer, which a name of much over 200
+ * characters overruns.
+ */
+static int written_len(int ret, int cap)
+{
+    if (0 >= cap || 0 > ret) {
+        return 0;
+    }
+    if (ret >= cap) {
+        /* truncated: snprintf wrote cap - 1 characters plus the NUL */
+        return cap - 1;
+    }
+    return ret;
+}
+
+static void advance_buffer(char **tmp, int *size, int ret)
+{
+    ret = written_len(ret, *size);
+    *tmp += ret;
+    *size -= ret;
+}
 #endif /* PRTE_WANT_PRETTY_PRINT_STACKTRACE */
 
 /**
@@ -155,6 +187,7 @@ static void show_stackframe(int signo, siginfo_t *info, void *p)
     ret = snprintf(print_buffer, sizeof(print_buffer),
                    HOSTFORMAT "*** Process received signal ***\n", prte_process_info.nodename,
                    getpid());
+    ret = written_len(ret, (int) sizeof(print_buffer));
     if (-1 == write(prte_stacktrace_output_fileno, print_buffer, ret)) {
         return;
     }
@@ -168,8 +201,7 @@ static void show_stackframe(int signo, siginfo_t *info, void *p)
     ret = snprintf(tmp, size, HOSTFORMAT "Signal: %d\n", prte_process_info.nodename, getpid(),
                    signo);
 #    endif
-    size -= ret;
-    tmp += ret;
+    advance_buffer(&tmp, &size, ret);
 
     if (NULL != info) {
         switch (signo) {
@@ -426,14 +458,12 @@ static void show_stackframe(int signo, siginfo_t *info, void *p)
             ret = snprintf(tmp, size, HOSTFORMAT "Associated errno: %s (%d)\n",
                            prte_process_info.nodename, getpid(), strerror(info->si_errno),
                            info->si_errno);
-            size -= ret;
-            tmp += ret;
+            advance_buffer(&tmp, &size, ret);
         }
 
         ret = snprintf(tmp, size, HOSTFORMAT "Signal code: %s (%d)\n", prte_process_info.nodename,
                        getpid(), si_code_str, info->si_code);
-        size -= ret;
-        tmp += ret;
+        advance_buffer(&tmp, &size, ret);
 
         switch (signo) {
         case SIGILL:
@@ -442,16 +472,14 @@ static void show_stackframe(int signo, siginfo_t *info, void *p)
         case SIGBUS: {
             ret = snprintf(tmp, size, HOSTFORMAT "Failing at address: %p\n",
                            prte_process_info.nodename, getpid(), info->si_addr);
-            size -= ret;
-            tmp += ret;
+            advance_buffer(&tmp, &size, ret);
             break;
         }
         case SIGCHLD: {
             ret = snprintf(tmp, size, HOSTFORMAT "Sending PID: %d, Sending UID: %d, Status: %d\n",
                            prte_process_info.nodename, getpid(), info->si_pid, info->si_uid,
                            info->si_status);
-            size -= ret;
-            tmp += ret;
+            advance_buffer(&tmp, &size, ret);
             break;
         }
 #    ifdef SIGPOLL
@@ -465,8 +493,7 @@ static void show_stackframe(int signo, siginfo_t *info, void *p)
 #        else
             ret = 0;
 #        endif
-            size -= ret;
-            tmp += ret;
+            advance_buffer(&tmp, &size, ret);
             break;
         }
 #    endif
@@ -475,8 +502,7 @@ static void show_stackframe(int signo, siginfo_t *info, void *p)
         ret = snprintf(tmp, size,
                        HOSTFORMAT "siginfo is NULL, additional information unavailable\n",
                        prte_process_info.nodename, getpid());
-        size -= ret;
-        tmp += ret;
+        advance_buffer(&tmp, &size, ret);
     }
 
     /* write out the signal information generated above */
@@ -499,6 +525,7 @@ static void show_stackframe(int signo, siginfo_t *info, void *p)
     memset(print_buffer, 0, sizeof(print_buffer));
     ret = snprintf(print_buffer, sizeof(print_buffer), HOSTFORMAT "*** End of error message ***\n",
                    prte_process_info.nodename, getpid());
+    ret = written_len(ret, (int) sizeof(print_buffer));
     if (ret > 0) {
         if (-1 == write(prte_stacktrace_output_fileno, print_buffer, ret)) {
             return;

--- a/src/util/stacktrace.c
+++ b/src/util/stacktrace.c
@@ -104,7 +104,14 @@ static void set_stacktrace_filename(void)
  *  @param info with information regarding the reason/send of the signal
  *  @param p
  *
- * FIXME: Should distinguish for systems, which don't have siginfo...
+ * The handler is installed with SA_SIGINFO and reads siginfo_t without
+ * guarding for its absence.  That is deliberate, not an oversight: the
+ * type, the sa_sigaction member and the SA_SIGINFO flag are all mandatory
+ * in POSIX.1-2001, well below anything PRRTE can be built on.  The two
+ * *members* below that genuinely are optional -- si_fd, which is not in
+ * POSIX at all, and si_band, which belongs to the obsolescent XSI SIGPOLL
+ * option -- are probed for by configure and guarded individually, as is
+ * every si_code value the switch decodes.
  */
 #if PRTE_WANT_PRETTY_PRINT_STACKTRACE
 static void show_stackframe(int signo, siginfo_t *info, void *p)

--- a/src/util/stacktrace.c
+++ b/src/util/stacktrace.c
@@ -64,6 +64,14 @@
 #define HOSTFORMAT "[%s:%05d] "
 
 int prte_stacktrace_output_fileno = -1;
+
+/* Everything from here to the end of the file exists only to serve the
+ * handler, so it all lives behind the same switch: with the feature off,
+ * these are unreferenced, and --enable-debug turns an unused static into a
+ * build failure.
+ */
+#if PRTE_WANT_PRETTY_PRINT_STACKTRACE
+
 static char *prte_stacktrace_output_filename_base = NULL;
 static size_t prte_stacktrace_output_filename_max_len = 0;
 static char *unable_to_print_msg = "Unable to print stack trace!\n";
@@ -82,6 +90,7 @@ static void set_stacktrace_filename(void)
 
     return;
 }
+#endif /* PRTE_WANT_PRETTY_PRINT_STACKTRACE */
 
 /**
  * This function is being called as a signal-handler in response


### PR DESCRIPTION
Three separate problems in `src/util/stacktrace.c`, found while working the
"Stack traces assume `siginfo_t`" entry in `docs/todo.rst`.

### `--disable-pretty-print-stacktrace` does not build

The option compiles the signal handler out, but four things that exist only
to serve it — `unable_to_print_msg`, the two filename statics, and
`set_stacktrace_filename()` — sat outside the switch their only callers live
behind. With the feature off they are unreferenced, and `--enable-debug`
turns an unused static into an error:

```
stacktrace.c:77: error: 'set_stacktrace_filename' defined but not used
stacktrace.c:69: error: 'unable_to_print_msg' defined but not used
```

Nothing in CI configures with the option and the `contrib/platform` files
that set it are not built either, which is how this went unnoticed.
`docs/todo.rst` now records that coverage gap.

### The print cursor advances by the wrong length

`show_stackframe()` builds its report in a 1 KB stack buffer, stepping a
cursor after each `snprintf()` by that call's return — which is the length
the output *would* have had, not what it wrote. On truncation that walks the
cursor past the end of the buffer and drives the remaining count negative;
the next `snprintf()` takes that count as a `size_t`, reads it as enormous,
and writes off the end of the stack. Two `write()` calls hand the same raw
return over as a length.

Nothing bounds the input: the report is four host-prefixed lines, so the node
name is repeated four times, and a name of much over 200 characters overruns.
That is unusual but legal — an FQDN may be 253. Corrupting the stack while
already handling `SIGSEGV` is not a failure anyone could trace.

### The `siginfo_t` FIXME asked for something that cannot happen

The FIXME came from this code's Open MPI ancestry and dates to 2004.
`siginfo_t`, the `sa_sigaction` member of `struct sigaction` and the
`SA_SIGINFO` flag are all mandatory in POSIX.1-2001, not one of its option
groups, and PRRTE's floor sits far above that. What configure probes around
it is the part that genuinely varies — `si_fd` is not in POSIX at all and
`si_band` belongs to the obsolescent XSI SIGPOLL option — and both are
guarded at their single use, as is every `si_code` value the switch decodes.

So neither a second `sa_handler` arm nor a configure probe for the structure
is written: one is code no compiler would ever be handed, in a signal handler
where a mistake is untraceable, and the other is a check that can only answer
yes. The comment says what is assumed and why; `docs/todo.rst` moves the
entry to **Decided against**.

### Testing

With `--enable-debug` throughout, both the enabled and the disabled
configuration build warning-free, pass `make check`, install, and launch a
job; a `SIGSEGV` delivered to `prterun` prints the full trace in the first
and dies on the default disposition in the second. Each of the three commits
was built in both configurations. `sphinx-build -W` clean. The cursor
arithmetic was checked over node names of 1 to 250 characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GGakf7GCGwLDoEHBoy7ieX