### PR TITLE
Survive the loss of a daemon during file staging

### DIFF
--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -512,7 +512,7 @@ build_linux() {
             # all, so an assemblage that spans daemons is the only shape the
             # runtime ever sees - and the promise being checked (an event to
             # the assemblage when a member departs without disconnecting) is
-            # the runtime's to keep.
+            # one the runtime has to keep.
             # (No apostrophes here: see the note further down.)
             echo ">>>> connector (connect/disconnect assemblage) test client"
             gcc -O0 -g -o /opt/prte/prte/bin/connector \

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -6164,6 +6164,106 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     [ "$c" = 0 ] && ok "no daemons linger after the refused path" || bad "$c stray prted after refused path"
     for n in 1 2 3; do docker exec "$NODE$n" sh -c 'rm -rf /root/pfesc' >/dev/null 2>&1; done
 
+    banner "filem: a daemon loss after staging does not take the DVM down"
+    # Every daemon -- the HNP included, since it receives its own broadcast --
+    # keeps its staged files on incoming_files for the life of the DVM: that
+    # list is what link_local_files reads at fork time, so nothing removes an
+    # entry when a transfer finishes. The fault handler used to read "the list
+    # is not empty" as "a transfer is in flight" and activate a DVM-wide
+    # COMM_FAILED, which on the HNP terminates the DVM and on a prted kills
+    # every local proc and aborts the daemon. So one preload job anywhere in
+    # the DVM's history turned the next daemon loss -- an event the rest of
+    # PRRTE is built to absorb -- into the end of the DVM.
+    docker exec "${NODE}1" sh -c 'echo SURVIVOR-DATA-OK > /root/pfsurv.dat' >/dev/null 2>&1
+    for n in 2 3 4; do docker exec "$NODE$n" sh -c 'rm -f /root/pfsurv.dat' >/dev/null 2>&1; done
+    if prted_dvm_start 'node1:1,node2:1,node3:1,node4:1'; then
+        out=$(RUN 'cd /root && timeout 60 prun --host node2:1,node3:1 -np 2 --map-by node \
+                     --preload-files /root/pfsurv.dat -- sh -c "cat pfsurv.dat"' 2>&1); rc=$?
+        hits=$(echo "$out" | grep -c 'SURVIVOR-DATA-OK')
+        [ "$rc" = 0 ] && [ "$hits" = 2 ] \
+            && ok "the file staged to node2 and node3" \
+            || bad "staging failed before the daemon loss (rc=$rc, hits=$hits): $(echo "$out" | tr '\n' ' ')"
+        if ! ON 4 'pgrep -x prted' >/dev/null 2>&1; then
+            bad "node4 has no daemon to kill"
+        else
+            ON 4 'pkill -9 -x prted' >/dev/null 2>&1
+            sleep 6
+            RUN 'pgrep -x prte' >/dev/null 2>&1 \
+                && ok "the HNP survived a daemon loss after a completed staging" \
+                || bad "the HNP terminated the DVM over a staging that had already finished"
+            ON 2 'pgrep -x prted' >/dev/null 2>&1 \
+                && ok "...and so did the daemon that holds the staged file" \
+                || bad "node2's daemon aborted itself over an unrelated daemon loss"
+            # the DVM has to still be usable, and the same file has to still
+            # be deliverable through it -- positioned_files now covers one
+            # fewer daemon than it did
+            out=$(RUN 'cd /root && timeout 60 prun --host node2:1,node3:1 -np 2 --map-by node \
+                         --preload-files /root/pfsurv.dat -- sh -c "cat pfsurv.dat"' 2>&1); rc=$?
+            hits=$(echo "$out" | grep -c 'SURVIVOR-DATA-OK')
+            [ "$rc" = 0 ] && [ "$hits" = 2 ] \
+                && ok "a second staging job ran in the surviving DVM" \
+                || bad "the DVM could not stage again after the loss (rc=$rc, hits=$hits): $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        fi
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start a DVM for the post-staging daemon-loss test"
+    fi
+    c=$(prted_settle 10 1 2 3 4 5 6 7 8 9 10)
+    [ "$c" = 0 ] && ok "no daemons linger after the post-staging loss test" || bad "$c stray prted after post-staging loss test"
+    for n in 1 2 3 4; do docker exec "$NODE$n" sh -c 'rm -f /root/pfsurv.dat' >/dev/null 2>&1; done
+    cleanup_swarm
+
+    banner "filem: a daemon lost while files are in flight does not hang the job"
+    # The staging half of the same story. A transfer retires when every daemon
+    # it was broadcast to has acked, and nothing else ever revisits it -- so a
+    # daemon that dies still owing an ack leaves the job parked at VM_READY
+    # forever unless the fault handler settles the account for it. The file is
+    # large enough that the broadcast is still running when node4's daemon is
+    # killed; if the kill lands after the last ack instead, this degrades into
+    # the case above, and every assertion below still holds either way.
+    docker exec "${NODE}1" sh -c 'head -c 50331648 /dev/urandom > /root/pfbig.dat; echo INFLIGHT-OK > /root/pfsmall.dat' >/dev/null 2>&1
+    for n in 2 3 4; do docker exec "$NODE$n" sh -c 'rm -f /root/pfbig.dat /root/pfsmall.dat' >/dev/null 2>&1; done
+    if prted_dvm_start 'node1:1,node2:1,node3:1,node4:1'; then
+        # detached, like PRUN_BG -- but this one needs a working directory
+        # (that is where the staged files land), which PRUN_BG cannot take
+        docker exec -d -e PRTE_ALLOW_RUN_AS_ROOT=1 -e PRTE_ALLOW_RUN_AS_ROOT_CONFIRM=1 \
+            "${NODE}1" bash -lc ". /opt/prte/env.sh; cd /root && \
+                timeout 180 prun --dvm-uri file:$PRTED_URI --host node2:1,node3:1 \
+                  -np 2 --map-by node --preload-files /root/pfbig.dat,/root/pfsmall.dat \
+                  -- sh -c 'cat pfsmall.dat' > /tmp/filem-inflight.out 2>&1" >/dev/null 2>&1
+        # measured: a 48 MB stage to this swarm runs about 3-4s after a ~1s
+        # prun startup, so 2s lands inside the broadcast
+        sleep 2
+        if ! ON 4 'pgrep -x prted' >/dev/null 2>&1; then
+            bad "node4 has no daemon to kill"
+        else
+            ON 4 'pkill -9 -x prted' >/dev/null 2>&1
+            n=0
+            while [ "$n" -lt 120 ]; do
+                RUN 'pgrep -x prun' >/dev/null 2>&1 || break
+                sleep 1; n=$((n+1))
+            done
+            RUN 'pgrep -x prun' >/dev/null 2>&1 \
+                && bad "the staging job never finished after a daemon died mid-transfer" \
+                || ok "the staging job finished after a daemon died mid-transfer"
+            out=$(RUN 'tr -d "\000" < /tmp/filem-inflight.out' 2>&1)
+            hits=$(echo "$out" | grep -c 'INFLIGHT-OK')
+            [ "$hits" = 2 ] \
+                && ok "both surviving ranks got their staged file" \
+                || bad "$hits of 2 ranks read the staged file: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+            RUN 'pgrep -x prte' >/dev/null 2>&1 \
+                && ok "the HNP survived the loss during staging" \
+                || bad "the HNP died over a daemon lost during staging"
+        fi
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start a DVM for the mid-staging daemon-loss test"
+    fi
+    c=$(prted_settle 10 1 2 3 4 5 6 7 8 9 10)
+    [ "$c" = 0 ] && ok "no daemons linger after the mid-staging loss test" || bad "$c stray prted after mid-staging loss test"
+    for n in 1 2 3 4; do docker exec "$NODE$n" sh -c 'rm -f /root/pfbig.dat /root/pfsmall.dat' >/dev/null 2>&1; done
+    cleanup_swarm
+
     banner "iof: stdin forwarded to a REMOTE proc (HNP -> prted -> proc)"
     # Rank 0 is mapped onto node2, not the head node, so every stdin byte must
     # travel HNP -> RML(PRTE_RML_TAG_IOF_PROXY) -> prted -> the proc's stdin

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -32,13 +32,6 @@ Runtime behavior
 surface exists for SLURM only.  Everything above the component is
 RM-agnostic; what is missing is the Flux-side conversation.
 
-**``filem/raw`` does not survive losing a daemon mid-staging.**  Its fault
-handler is deliberately minimal (``src/mca/filem/raw/filem_raw_module.c``);
-the note in place observes that the real thing should be straightforward,
-since the transport it stages over (xcast) is already resilient.  Until then,
-a daemon lost while files are in flight fails the staging rather than
-re-driving it.
-
 **Only a command line can ask for a daemon on an allocated node.**  The
 command-line half of this is done: ``--activate`` (``prun`` and
 ``prterun``) takes node names, ``+all``, ``+n<K>`` and ``file=<hostfile>``,
@@ -245,8 +238,6 @@ the marker is stale.
 
    * - marker
      - entry above
-   * - ``mca/filem/raw/filem_raw_module.c``, ``raw_fault_handler``
-     - ``filem/raw`` does not survive losing a daemon mid-staging
    * - ``mca/odls/base/odls_base_default_fns.c``,
        ``prte_odls_base_default_get_add_procs_data``
      - a job cannot ask for a transport

--- a/src/grpcomm/grpcomm_xcast.c
+++ b/src/grpcomm/grpcomm_xcast.c
@@ -575,16 +575,6 @@ void prte_grpcomm_xcast_fault_handler(
         }
     }
 
-    /* Any exchange still running has lost a participant, and no rearrangement
-     * of the survivors can produce the block that participant owed. Give up on
-     * it and let the payload come down the repaired tree instead. Done after
-     * the tree work above so the replays it sends go to the new children. */
-    {
-        op_t* op;
-        op_t* next_op;
-        PMIX_LIST_FOREACH_SAFE(op, next_op, &XCAST.ops, op_t){
-        }
-    }
     drive_completions();
 }
 

--- a/src/mca/filem/AGENTS.md
+++ b/src/mca/filem/AGENTS.md
@@ -92,7 +92,7 @@ pointer:
 |-------|-----------|---------|--------|
 | `filem_init` | `int (void)` | Module init (called by `select` on the winner). | `PRTE_SUCCESS` |
 | `filem_finalize` | `int (void)` | Module teardown (called on framework close). | `PRTE_SUCCESS` |
-| `fault_handler` | `void (const prte_rml_recovery_status_t *)` | React to a daemon failure during transfer. | — |
+| `fault_handler` | `void (const prte_rml_recovery_status_t *)` | React to a routing-tree change — a daemon death, a shrink, or a revival. Called on **every** daemon, twice per death (LOCAL then GLOBAL scope); read `status->failed_ranks`/`->scope` before acting. | — |
 | `put` / `put_nb` | `int (prte_filem_base_request_t *)` | Push file(s) to remote proc(s), blocking / async. | `PRTE_SUCCESS`/`PRTE_ERROR` |
 | `get` / `get_nb` | `int (prte_filem_base_request_t *)` | Pull file(s) from remote proc(s), blocking / async. | `PRTE_SUCCESS`/`PRTE_ERROR` |
 | `rm` / `rm_nb` | `int (prte_filem_base_request_t *)` | Remove remote file(s), blocking / async. | `PRTE_SUCCESS`/`PRTE_ERROR` |

--- a/src/mca/filem/raw/AGENTS.md
+++ b/src/mca/filem/raw/AGENTS.md
@@ -67,7 +67,7 @@ the working directory instead of recreating their directory tree.
 | Class | Lives on | Role |
 |-------|----------|------|
 | `prte_filem_raw_outbound_t` | HNP | One preposition request. Holds the list of `xfers`, the aggregate `status`, and the caller's `cbfunc`/`cbdata`. When its `xfers` list drains, the callback fires. |
-| `prte_filem_raw_xfer_t` | HNP | One file being sent. Carries the read `fd`, the libevent `ev` (the caddy field — **named `ev`** as required), `src` (local path, for dup detection), `file` (remote-relative path), `type`, `mode` (the source file's permission bits), `nchunk` (next chunk index), and `nrecvd` (how many daemons have acked). |
+| `prte_filem_raw_xfer_t` | HNP | One file being sent. Carries the read `fd`, the libevent `ev` (the caddy field — **named `ev`** as required), `src` (local path, for dup detection), `file` (remote-relative path), `type`, `mode` (the source file's permission bits), `nchunk` (next chunk index), and the delivery accounting (`nexpected`, `nrecvd`, the `acked` bitmap, `horizon`) described under *completion accounting*. |
 | `prte_filem_raw_incoming_t` | daemon | One file being received. Carries the write `fd`, `ev`, `file`/`fullpath`, `type`, `mode`, the `outputs` list of pending write buffers, and `link_pts` (the paths, relative to the session dir, to place). |
 | `prte_filem_raw_output_t` | daemon | One received chunk: `numbytes` + a `PRTE_FILEM_RAW_CHUNK_MAX` data buffer, queued on an incoming file's `outputs` list for the write handler. |
 
@@ -193,16 +193,51 @@ zero-byte broadcast that tells receivers to close and finalize.
 ### `recv_ack` + `xfer_complete` — completion accounting
 
 Each daemon sends an ack `{file, status}` per file. `recv_ack` finds the
-matching `xfer` in `outbound_files`, records any non-success status, and
-bumps `xfer->nrecvd`. When `nrecvd >= prte_process_info.num_daemons` the
-file is fully positioned: `xfer_complete` moves the xfer from
-`outbound->xfers` to `positioned_files`. When an outbound's `xfers` list
-is empty, its `cbfunc` fires (this is the state machine's `files_ready`)
-and the outbound is released.
+matching `xfer` in `outbound_files`, records any non-success status, sets
+the sender's bit in `xfer->acked` and bumps `xfer->nrecvd`, then calls
+`xfer_check_complete()`. When `nrecvd >= xfer->nexpected` the file is
+fully positioned: `xfer_complete` moves the xfer from `outbound->xfers` to
+`positioned_files`. When an outbound's `xfers` list is empty, its `cbfunc`
+fires (this is the state machine's `files_ready`) and the outbound is
+released.
 
-`>=`, not `==`: `num_daemons` is read fresh on every ack, so a daemon
-leaving the DVM mid-transfer can lower it *past* a count already reached,
-and an exactly-equal test would then never fire.
+**Four fields, maintained together, and none of them is a live global.**
+
+| Field | Meaning |
+|-------|---------|
+| `nexpected` | How many daemons still owe an ack. Seeded from `prte_process_info.num_daemons` when the transfer starts; the fault handler decrements it as daemons depart. |
+| `nrecvd` | How many daemons have the file **and are still in the DVM** — a departure takes its ack back out again. |
+| `acked` | A `pmix_bitmap_t` of *which* daemons those are. |
+| `horizon` | The daemon job's `num_procs` when the transfer started, i.e. the vpid line above which a rank must have joined later. |
+
+The counting used to be a bare `nrecvd >= prte_process_info.num_daemons`
+re-read on every ack, and the reasons it cannot be are worth keeping:
+
+- **A daemon that dies owing an ack never sends one, and nothing revisits
+  the transfer.** Completion is driven only by arriving acks, so the
+  outbound hangs and the job wedges at `VM_READY`. The fault handler is
+  what settles this, which is only possible if the arithmetic does not
+  depend on a global it cannot trust at that instant — the shrink path
+  repairs the routing tree (and so calls the handler) *before* it
+  decrements `num_daemons`.
+- **A repeated ack from one daemon is not another daemon reporting in.**
+  Without `acked`, two acks for one file complete a transfer that some
+  daemon still has no copy of. `acked` also lets the handler tell "it died
+  before answering" from "it answered and then died", which need opposite
+  adjustments.
+- **A daemon that joins mid-transfer owes nothing.** `xcast` hands a late
+  joiner the ops it missed as already complete, so those chunks never
+  reach it and no ack will ever come. `horizon` is what keeps such a rank
+  from being credited (or expected) by either path — vpids are never
+  reused and a grow appends them, so "rank ≥ horizon" is exactly "joined
+  after this broadcast began".
+
+`xfer_check_complete()` also refuses to retire a transfer whose `fd` is
+still open. Under normal delivery that cannot trigger — a receiver acks
+only at EOF, which is broadcast in the same `send_chunk` call that closes
+the fd — but an *error* ack can arrive at chunk 0, and retiring on it would
+leave `send_chunk` pumping bytes for a file the job has been told is in
+place.
 
 **Every exit from a transfer goes through `xfer_retire()`**, which is the
 one place that unlinks the xfer from `outbound->xfers` and, when that list
@@ -290,8 +325,14 @@ listing failed, which is reported rather than acked as a delivery.
 
 ### `send_complete(file, status)`
 
-Packs `{file, status}` and `PRTE_RML_SEND`s it to the HNP on
+Packs `{file, status}` and sends it to the HNP on
 `PRTE_RML_TAG_FILEM_BASE_RESP` — the ack that `recv_ack` counts.
+
+It goes out with `PRTE_RML_RELIABLE_SEND`, not a plain send. The ack is the
+only thing that retires a transfer on the master, and a plain send in flight
+through a daemon that then dies is simply dropped — leaving the master
+waiting forever for an ack this daemon believes it has already given. RELM
+re-drives it over the repaired tree.
 
 ---
 
@@ -328,11 +369,59 @@ working directories gets each app's files in its own.
 
 ## Fault handling
 
-`raw_fault_handler` is intentionally minimal (marked TODO for real
-resilience): if a daemon fails while `incoming_files` or `outbound_files`
-is non-empty — i.e. a transfer is in flight — it activates
-`PRTE_JOB_STATE_COMM_FAILED`. It relies on the fact that `xcast` is
-already resilient for the not-in-flight case.
+`raw_fault_handler` has exactly one job: **settle the ack accounting for
+daemons that are never going to answer.** Everything else a transfer needs
+in order to survive a daemon loss is supplied by the layers underneath it.
+
+- The chunks ride `xcast`, which re-drives its in-flight ops over the
+  repaired tree, so a daemon whose parent died still receives the rest of
+  the file, in order, with no help from here.
+- The acks ride RELM (`send_complete` uses `PRTE_RML_RELIABLE_SEND`), so an
+  ack in flight through the daemon that died is re-driven rather than lost.
+- Neither can produce an ack from a daemon that is *gone*. That is the one
+  gap, and it is fatal on its own: completion is driven only by arriving
+  acks, so a transfer still owing one to a departed daemon holds its
+  outbound forever and the job wedges at `VM_READY`.
+
+So the handler walks `outbound_files` (and `positioned_files`, whose counts
+answer the "does this file still cover the whole DVM?" question the dedup
+check asks), drops each failed rank from what the transfer is owed via
+`credit_departures()`, and calls `xfer_check_complete()` on anything still
+in flight. It is master-only — `outbound_files` exists nowhere else — and
+does nothing at all on a daemon, whose incoming transfers need no repair.
+
+Three filters keep it from acting on things that are not daemon deaths:
+
+- **Non-master returns immediately.**
+- **`PRTE_RML_FAULT_SCOPE_LOCAL` only.** The local pass carries the news
+  first and is the *only* pass the elastic shrink path drives at all
+  (`shrink_campaign_complete` calls `prte_rml_repair_routing_tree` with
+  `global = false`), so keying on it runs this exactly once per departure
+  on both routes.
+- **An empty `failed_ranks` returns immediately.** A *revival* reaches this
+  same entry point (`prte_rml_revive_routing_tree` calls
+  `prte_filem.fault_handler` on the way back up) with nothing marked
+  failed, and so does a duplicate fault notice for a rank already recorded
+  as gone.
+
+### What this replaced, and why the old shape was worse than the TODO said
+
+The handler used to activate `PRTE_JOB_STATE_COMM_FAILED` whenever
+`incoming_files` or `outbound_files` was non-empty, on the theory that a
+non-empty list meant a transfer was in flight. It does not: **nothing ever
+removes an `incoming` entry on success.** It cannot — `raw_link_local_files`
+reads that list at fork time to find each file's link points — so after one
+preload job every daemon, the HNP included (it receives its own broadcast),
+holds a non-empty `incoming_files` for the life of the DVM.
+
+The consequence was not "staging fails" but "the DVM ends". On a prted,
+`PRTE_JOB_STATE_COMM_FAILED` kills every local proc and calls `prted_abort`
+(`errmgr/prted`); on the HNP it terminates the daemon job
+(`errmgr/dvm`, `job_errors`). So in any DVM that had *ever* staged a file,
+the next daemon loss — an event the rest of PRRTE is built to absorb — took
+the whole DVM down, as did an ordinary elastic **shrink** (which repairs the
+routing tree, and so calls this handler, on every survivor) and, on a
+bootstrap DVM, a daemon **revival**, where nothing had failed at all.
 
 ---
 
@@ -374,9 +463,18 @@ already resilient for the not-in-flight case.
 - **`raw_fault_handler` runs on daemons too**, where `outbound_files` was
   never constructed (`raw_init` only builds it on the master). Guard any
   new use of the HNP-only lists with `PRTE_PROC_IS_MASTER` —
-  `raw_preposition_files` now refuses outright off the master for the same
-  reason: appending to a list that was never constructed is not a failure
-  that announces itself.
+  `raw_fault_handler` returns immediately off the master, and
+  `raw_preposition_files` refuses outright, for the same reason: appending
+  to a list that was never constructed is not a failure that announces
+  itself.
+- **A non-empty `incoming_files` does not mean a transfer is in flight.**
+  Nothing removes an entry on success; the list is what `link_local_files`
+  reads at fork time, so it is non-empty from the first staged file until
+  the daemon exits. Any new "is staging active?" test must ask the
+  outbound side, on the master.
+- **The fault handler is also reached by a revival and by a shrink**, not
+  only by a death. Read `status->failed_ranks` and `status->scope` before
+  acting on anything.
 - **A PMIx status is not a PRTE status.** The receive path acks failures
   back to the HNP, where the value becomes the completion callback's
   status and then a job state; convert with `prte_pmix_convert_status()`
@@ -513,6 +611,14 @@ suffix classification; the collision case plants a *different* file of that
 name on one node and requires the launch to be refused with that node's
 data intact; and a `..` inside the delivered name must be refused rather
 than resolved. None of them can pass unless the bytes were actually staged
-and placed. Run them (or an equivalent multi-node test) after touching the
-send/receive/placement paths — the `test/unit/filem` unit test covers the
+and placed.
+
+Two further cases cover the fault path, and neither can be reproduced on
+one host: a daemon killed **after** a completed staging job, where the HNP,
+the daemon holding the staged file, and the DVM itself must all survive and
+a second staging job must still run; and a daemon killed **while** a large
+file is in flight, where the job must finish rather than park at `VM_READY`
+and the surviving ranks must still get their file. Run them (or an
+equivalent multi-node test) after touching the send/receive/placement paths
+or the fault handler — the `test/unit/filem` unit test covers the
 base classes, the "none" module, and the naming rules, but not delivery.

--- a/src/mca/filem/raw/filem_raw.h
+++ b/src/mca/filem/raw/filem_raw.h
@@ -18,6 +18,7 @@
 
 #include "prte_config.h"
 
+#include "src/class/pmix_bitmap.h"
 #include "src/class/pmix_object.h"
 #include "src/event/event-internal.h"
 #include "src/mca/mca.h"
@@ -60,7 +61,35 @@ typedef struct {
     uint32_t mode;
     int32_t nchunk;
     int status;
+    /* Delivery accounting, all four fields maintained together.
+     *
+     * "nexpected" is how many daemons still owe an ack.  It is seeded from
+     * the DVM's daemon count when the transfer starts and is decremented by
+     * the fault handler as daemons depart, rather than being re-read from
+     * prte_process_info.num_daemons on each ack: the handler has to settle
+     * the transfer at a moment when the daemon that just died may or may
+     * not have been subtracted from that global yet.
+     *
+     * "nrecvd" counts the daemons that have the file AND are still in the
+     * DVM, so a departure takes its ack back out again.  That is what makes
+     * "did this file reach the whole DVM?" answerable later, in
+     * raw_preposition_files' already-positioned check.
+     *
+     * "acked" records WHICH daemons those are.  A count alone cannot tell a
+     * repeated ack from one daemon apart from a first ack from another, and
+     * the fault handler must know whether the daemon that died had already
+     * answered.
+     */
+    pmix_rank_t nexpected;
     pmix_rank_t nrecvd;
+    pmix_bitmap_t acked;
+    /* the number of daemon vpids the DVM had assigned when this transfer
+     * began.  Daemon vpids are never reused and a grow appends new ones, so
+     * any rank at or above this line joined after the broadcast started,
+     * never saw its chunks, and therefore owes it nothing - a distinction
+     * the fault handler needs before it credits a departure.
+     */
+    pmix_rank_t horizon;
 } prte_filem_raw_xfer_t;
 PMIX_CLASS_DECLARATION(prte_filem_raw_xfer_t);
 

--- a/src/mca/filem/raw/filem_raw_module.c
+++ b/src/mca/filem/raw/filem_raw_module.c
@@ -96,6 +96,7 @@ static void recv_files(int status, pmix_proc_t *sender, pmix_data_buffer_t *buff
 static void recv_ack(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer,
                      prte_rml_tag_t tag, void *cbdata);
 static void write_handler(int fd, short event, void *cbdata);
+static void xfer_check_complete(prte_filem_raw_xfer_t *xfer);
 
 static int raw_init(void)
 {
@@ -149,20 +150,115 @@ static int raw_finalize(void)
     return PRTE_SUCCESS;
 }
 
+/* Drop a set of departed ranks from what one transfer is owed.
+ *
+ * A rank at or above the transfer's horizon joined after the broadcast began,
+ * never saw its chunks and owes it nothing, so it is skipped.  Below the
+ * horizon there are two cases and they need opposite adjustments: a daemon
+ * that had already acked is dropped from nrecvd as well, because the file no
+ * longer covers a daemon that is no longer here, while one that had not acked
+ * simply stops being expected.
+ */
+static void credit_departures(prte_filem_raw_xfer_t *xfer,
+                              const pmix_rank_t *failed, size_t nfailed)
+{
+    size_t n;
+    int r;
+
+    for (n = 0; n < nfailed; n++) {
+        r = (int) failed[n];
+        if ((pmix_rank_t) r >= xfer->horizon) {
+            /* joined after this broadcast began - it never owed us an ack */
+            continue;
+        }
+        if (pmix_bitmap_is_set_bit(&xfer->acked, r)) {
+            /* it took delivery before it died: the file no longer covers
+             * this daemon because the daemon is no longer here
+             */
+            pmix_bitmap_clear_bit(&xfer->acked, r);
+            if (0 < xfer->nrecvd) {
+                --xfer->nrecvd;
+            }
+        }
+        if (0 < xfer->nexpected) {
+            --xfer->nexpected;
+        }
+        PMIX_OUTPUT_VERBOSE((1, prte_filem_base_framework.framework_output,
+                             "%s filem:raw: daemon %s departed - file %s now"
+                             " delivered to %u of %u expected",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                             PRTE_VPID_PRINT(failed[n]), xfer->file,
+                             (unsigned) xfer->nrecvd, (unsigned) xfer->nexpected));
+    }
+}
+
+/* A daemon has left the DVM.  Everything a transfer needs to survive that is
+ * already in place elsewhere, so this handler has exactly one job: settle the
+ * ack accounting for the daemons that are never going to answer.
+ *
+ *  - The chunks themselves ride xcast, which re-drives its in-flight ops over
+ *    the repaired tree, so a daemon whose parent died still receives the rest
+ *    of the file, in order, without anything here.
+ *  - The acks travel back over RELM (PRTE_RML_RELIABLE_SEND in
+ *    send_complete), so an ack in flight through the daemon that died is
+ *    re-driven rather than lost.
+ *  - What neither of those can supply is an ack from a daemon that is gone.
+ *    Nothing else will ever revisit the transfer - completion is driven by
+ *    arriving acks - so a file still owing one to the departed daemon would
+ *    hang its outbound forever and wedge the job at VM_READY.  Drop the dead
+ *    ranks from what is owed here, and let any transfer that is thereby
+ *    finished retire.
+ *
+ * positioned_files is walked for the same reason, even though those transfers
+ * are long over: their counts are what the already-positioned check in
+ * raw_preposition_files reads to decide whether the file still covers the
+ * whole DVM, and a daemon that took its copy with it must stop counting.
+ *
+ * This is deliberately master-only and deliberately silent on the daemons:
+ * outbound_files exists only on the master (raw_init constructs it nowhere
+ * else), and a daemon's own incoming transfers need no repair.
+ */
 static void raw_fault_handler(const prte_rml_recovery_status_t *status){
-    PRTE_HIDE_UNUSED_PARAMS(status);
-    /* TODO: Make this actually resilient. Seems pretty trivial, since xcast is
-     * already resilient */
-    /* outbound_files only exists on the master - raw_init constructs it
-     * there and nowhere else - so it must not be read on a daemon
+    prte_filem_raw_outbound_t *outbound;
+    prte_filem_raw_xfer_t *xfer, *nxt_x;
+    pmix_list_item_t *item, *nxt;
+    pmix_rank_t *failed;
+
+    if (!PRTE_PROC_IS_MASTER) {
+        return;
+    }
+    /* the local pass is the one that carries the news first, and it is the
+     * only one the elastic shrink path drives at all - keying on it means
+     * this runs exactly once per departure, on both routes
      */
-    if (0 < pmix_list_get_size(&incoming_files) ||
-        (PRTE_PROC_IS_MASTER && 0 < pmix_list_get_size(&outbound_files))) {
-        PMIX_OUTPUT_VERBOSE((0, prte_filem_base_framework.framework_output,
-                             "%s filem:raw daemon failed during active file"
-                             " transfer operation(s)",
-                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
-        PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_COMM_FAILED);
+    if (PRTE_RML_FAULT_SCOPE_LOCAL != status->scope) {
+        return;
+    }
+    /* a revival reaches us through this same entry point with nothing marked
+     * failed (prte_rml_revive_routing_tree), and so does a fault notice whose
+     * ranks were all already recorded as gone.  Neither owes us anything.
+     */
+    if (0 == status->failed_ranks.size || NULL == status->failed_ranks.array) {
+        return;
+    }
+    failed = (pmix_rank_t *) status->failed_ranks.array;
+
+    PMIX_LIST_FOREACH_SAFE(xfer, nxt_x, &positioned_files, prte_filem_raw_xfer_t) {
+        credit_departures(xfer, failed, status->failed_ranks.size);
+    }
+
+    item = pmix_list_get_first(&outbound_files);
+    while (item != pmix_list_get_end(&outbound_files)) {
+        /* retiring the last xfer of an outbound releases the outbound, so
+         * take the next link before touching its contents
+         */
+        nxt = pmix_list_get_next(item);
+        outbound = (prte_filem_raw_outbound_t *) item;
+        PMIX_LIST_FOREACH_SAFE(xfer, nxt_x, &outbound->xfers, prte_filem_raw_xfer_t) {
+            credit_departures(xfer, failed, status->failed_ranks.size);
+            xfer_check_complete(xfer);
+        }
+        item = nxt;
     }
 }
 
@@ -278,6 +374,39 @@ static void xfer_complete(int status, prte_filem_raw_xfer_t *xfer)
     xfer_retire(status, xfer, true);
 }
 
+/* Has every daemon this file was broadcast to answered for it?
+ *
+ * The comparison is against the transfer's own frozen "nexpected", not the
+ * live prte_process_info.num_daemons: the DVM's size moves underneath a
+ * transfer in both directions, and neither direction says anything about
+ * who owes an ack for these bytes.  A daemon that joined after the
+ * broadcast never saw the chunks (xcast hands a late joiner the ops it
+ * missed as already complete), so it will never ack and must not be
+ * counted as owing; a daemon that departed is credited by the fault
+ * handler, whose arithmetic must not also be racing a num_daemons that
+ * may or may not have been decremented yet.
+ */
+static void xfer_check_complete(prte_filem_raw_xfer_t *xfer)
+{
+    if (0 <= xfer->fd) {
+        /* still reading and broadcasting this file.  An ack cannot mean
+         * "delivered" yet - a receiver only acks at EOF - so this is a
+         * receiver reporting an error, and retiring the transfer now would
+         * leave send_chunk pumping bytes for a file the job has already been
+         * told is in place.  The ack that does complete it always arrives
+         * after the last chunk went out.
+         */
+        return;
+    }
+    if (xfer->nrecvd < xfer->nexpected) {
+        return;
+    }
+    PMIX_OUTPUT_VERBOSE((1, prte_filem_base_framework.framework_output,
+                         "%s filem:raw: xfer complete for file %s status %d",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), xfer->file, xfer->status));
+    xfer_complete(xfer->status, xfer);
+}
+
 static void recv_ack(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer,
                      prte_rml_tag_t tag, void *cbdata)
 {
@@ -328,21 +457,17 @@ static void recv_ack(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer
                 if (0 != st) {
                     xfer->status = st;
                 }
-                /* track number of respondents */
-                xfer->nrecvd++;
-                /* if all daemons have responded, then this is complete.
-                 * Compare with >= rather than ==: num_daemons is read
-                 * fresh on every ack, so a daemon leaving the DVM
-                 * mid-transfer can lower it past a count we have already
-                 * reached - an exactly-equal test would then never fire
-                 * and the job would wedge at VM_READY
+                /* record WHICH daemon answered, and count it only the first
+                 * time it does: a repeated ack for the same file from the
+                 * same daemon must not be read as another daemon reporting
+                 * in, or the transfer completes while some daemon still has
+                 * no copy of the file
                  */
-                if (xfer->nrecvd >= prte_process_info.num_daemons) {
-                    PMIX_OUTPUT_VERBOSE((1, prte_filem_base_framework.framework_output,
-                                         "%s filem:raw: xfer complete for file %s status %d",
-                                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), file, xfer->status));
-                    xfer_complete(xfer->status, xfer);
+                if (!pmix_bitmap_is_set_bit(&xfer->acked, (int) sender->rank)) {
+                    pmix_bitmap_set_bit(&xfer->acked, (int) sender->rank);
+                    xfer->nrecvd++;
                 }
+                xfer_check_complete(xfer);
                 free(file);
                 return;
             }
@@ -370,6 +495,7 @@ static int raw_preposition_files(prte_job_t *jdata,
     pmix_list_t fsets;
     struct stat sbuf;
     bool already_sent;
+    prte_job_t *daemons;
 
     PMIX_OUTPUT_VERBOSE((1, prte_filem_base_framework.framework_output,
                          "%s filem:raw: preposition files for job %s",
@@ -697,6 +823,17 @@ static int raw_preposition_files(prte_job_t *jdata,
         }
 
         xfer = PMIX_NEW(prte_filem_raw_xfer_t);
+        /* every daemon in the DVM as it stands right now is a target of the
+         * broadcast about to start, and is therefore expected to ack.  The
+         * set is fixed here rather than re-read as acks arrive - see
+         * xfer_check_complete() - and the vpid horizon is taken from the same
+         * instant so a daemon that joins later can be told apart from one
+         * that was here all along
+         */
+        xfer->nexpected = prte_process_info.num_daemons;
+        daemons = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace);
+        xfer->horizon = (NULL == daemons) ? prte_process_info.num_daemons
+                                          : daemons->num_procs;
         /* save the source so we can avoid duplicate transfers */
         xfer->src = strdup(fs->local_target);
         xfer->fd = fd;
@@ -1351,7 +1488,13 @@ static void send_complete(char *file, int status)
         PMIX_DATA_BUFFER_RELEASE(buf);
         return;
     }
-    PRTE_RML_SEND(rc, PRTE_PROC_MY_HNP->rank, buf, PRTE_RML_TAG_FILEM_BASE_RESP);
+    /* send this reliably: the ack is the only thing that retires a transfer
+     * on the master, and a plain send that is in flight through a daemon
+     * which then dies is simply dropped - leaving the master waiting on an
+     * ack this daemon believes it has already given, and the job wedged at
+     * VM_READY.  RELM re-drives it over the repaired tree.
+     */
+    PRTE_RML_RELIABLE_SEND(rc, PRTE_PROC_MY_HNP->rank, buf, PRTE_RML_TAG_FILEM_BASE_RESP);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(buf);
@@ -1800,13 +1943,17 @@ static void xfer_construct(prte_filem_raw_xfer_t *ptr)
     ptr->file = NULL;
     ptr->nchunk = 0;
     ptr->status = PRTE_SUCCESS;
+    ptr->nexpected = 0;
     ptr->nrecvd = 0;
+    PMIX_CONSTRUCT(&ptr->acked, pmix_bitmap_t);
+    ptr->horizon = 0;
 }
 static void xfer_destruct(prte_filem_raw_xfer_t *ptr)
 {
     if (ptr->pending) {
         prte_event_del(&ptr->ev);
     }
+    PMIX_DESTRUCT(&ptr->acked);
     if (NULL != ptr->src) {
         free(ptr->src);
     }

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -461,6 +461,16 @@ Two things follow from that record, and they are the rest of the definition:
   prterun-style launch records the daemon) and against `PRTE_JOB_FLAG_TOOL`
   (a `prun` records its own tool procID, and a tool is not a member of a job).
   `PMIX_SPAWN_CHILD_SEP` opts out.
+
+  **The same screen governs `PMIX_PARENT_ID`** (`register_nspace()`), and for
+  the same reason: an app reads that key to ask "was I spawned by another
+  application process?". Publishing the launch proxy unscreened answers *yes*
+  to every ordinary `prun ./app`, so a program that branches on it — a spawned
+  child doing one thing and its parent another, which is what the key is for —
+  runs the wrong half of itself. That was live: the daemon screen was there
+  and the tool screen was not, and the swarm's `connect:` cases (whose client
+  detects its role exactly that way) all failed on it, every one of them with
+  the parent calling itself the child.
 - **A failure that terminates one member's job terminates the assemblage**
   (`connection_job_failed()`, from `_terminate_job()` in `errmgr/dvm` — the
   one place every failure-driven teardown goes through), each such job

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -247,7 +247,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
     gid_t gid;
     pmix_list_t *cache;
     hwloc_obj_t machine;
-    pmix_proc_t pproc, *parentproc, *procptr;
+    pmix_proc_t pproc, *parentproc = NULL, *procptr;
     pmix_status_t ret;
     pmix_info_t devinfo[2];
     prte_pmix_reg_caddy_t *cd;
@@ -665,12 +665,37 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
         PMIX_INFO_LIST_RELEASE(iarray);
     }
 
-    /* get the parent job that spawned this one */
+    /* Get the parent job that spawned this one, if a *process* did.
+     *
+     * The proxy is not automatically that: a prterun-style launch records the
+     * daemon itself, and a plain "prun ./app" records prun's own tool procID.
+     * Neither is a parent process - a tool is not a member of a job and has no
+     * procs to be spawned by - so PMIX_PARENT_ID must not be published for
+     * either. An app reads that key to ask "was I spawned by another
+     * application process?", and publishing prun's id answers yes to every
+     * ordinary launch, which is how a program that branches on it (a spawned
+     * child doing one thing, its parent another) ends up running the wrong
+     * half of itself. The identical screen, and the reasoning, is in
+     * prte_pmix_server_connection_spawned() (pmix_server_connect.c).
+     *
+     * strncmp, not PMIX_CHECK_NSPACE: that macro treats an empty nspace on
+     * either side as a wildcard match, and this test must answer only for the
+     * namespace it was actually given.
+     */
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_LAUNCH_PROXY, (void **) &parentproc, PMIX_PROC)) {
-        parent = prte_get_job_data_object(parentproc->nspace);
-        if (NULL != parent && PMIX_CHECK_NSPACE(PRTE_PROC_MY_NAME->nspace, parent->nspace)) {
-            PMIX_PROC_RELEASE(parentproc);
+        if (0 != strncmp(PRTE_PROC_MY_NAME->nspace, parentproc->nspace, PMIX_MAX_NSLEN)) {
+            parent = prte_get_job_data_object(parentproc->nspace);
+        }
+        if (NULL != parent && PRTE_FLAG_TEST(parent, PRTE_JOB_FLAG_TOOL)) {
             parent = NULL;
+        }
+        if (NULL == parent) {
+            /* release it here: the tail of this function only releases it
+             * when a parent was found, so every rejecting path must clean up
+             * its own copy or the proc object leaks once per job launched
+             */
+            PMIX_PROC_RELEASE(parentproc);
+            parentproc = NULL;
         }
     }
 


### PR DESCRIPTION
Closes the `docs/todo.rst` item "`filem/raw` does not survive losing a daemon mid-staging", plus three defects found while verifying it.

### The staging fix

`raw_fault_handler` activated `PRTE_JOB_STATE_COMM_FAILED` whenever `incoming_files` or `outbound_files` was non-empty, reading that as "a transfer is in flight". It is not: **nothing ever removes an `incoming` entry on success**, and nothing can, because `raw_link_local_files` reads that list at fork time to find each staged file's link points. The HNP receives its own broadcast, so after one `--preload-files` job every node in the DVM — the master included — holds a non-empty `incoming_files` for the rest of the session.

`COMM_FAILED` does not mean "the staging failed". On a prted it kills every local proc and calls `prted_abort`; on the HNP it terminates the daemon job. So in any DVM that had ever staged a file, the next daemon loss ended the DVM — as did an ordinary elastic **shrink** (it repairs the routing tree, so it runs this handler on every survivor) and, on a bootstrap DVM, a **revival**, which reaches the same entry point with nothing marked failed.

Measured on the dockerswarm harness, 4-node DVM, one completed `--preload-files` job, then `kill -9` on an uninvolved daemon:

| | before | after |
|---|---|---|
| HNP | **gone** | alive |
| the daemon holding the staged file | **gone** | alive |
| third daemon | **gone** | alive |
| a second staging job | — | runs, exit 0 |

The real gap underneath was that a transfer retires only when every daemon acks, and nothing else revisits it, so a daemon that dies owing an ack parks the job at `VM_READY` forever. `xcast` already re-drives in-flight ops over the repaired tree and RELM re-drives an ack that was in flight through the dying hop (`send_complete` now sends reliably), so the handler's whole remaining job is to drop departed ranks from what each transfer is owed. Accounting moved off the live `num_daemons` — the shrink path repairs the tree *before* it decrements it — onto per-transfer `nexpected`/`nrecvd`/an `acked` bitmap/a vpid `horizon`.

### Three fixes found on the way

- **`contrib/dockerswarm/build.sh` was a syntax error on master.** The builder body is one `bash -c '...'` string; a comment reading `the runtime's to keep` closes the quote, and `bash -n` refuses the whole file. The harness could not be built at all, which is also why the `connect:` cases below had never run — their client was never compiled.
- **`PMIX_PARENT_ID` was published for tool-launched jobs.** `register_nspace()` screened the launch proxy against our own namespace but not `PRTE_JOB_FLAG_TOOL`, though its own comment said "if we were spawned by a non-tool" and `prte_pmix_server_connection_spawned()` screens both. Every `prun ./app` therefore looked spawned, so a program that branches on that key runs the wrong half of itself — which is exactly what happened to the swarm's `connector` client: parent identified as child, never spawned, and all four `connect:` cases failed. Also fixes a `parentproc` leak on the reject path.
- **A dead empty loop** in `xcast_fault_handler`, left behind when the lateral movements were removed, along with a comment describing work that no longer happens.

### Testing

- `make check` 22/22; offline mapper harness unaffected; docs build clean.
- `contrib/dockerswarm/run-tests.sh linux`: **659 passed, 0 failed, 3 skipped** (the 3 skips are the usual "no network device in these topologies"). That is the 636/0/3 baseline plus 9 new `filem` assertions and the 14 `connect:` assertions that had never run before.
- Two new swarm cases, neither reproducible on one host: a daemon killed **after** a completed staging job, and a daemon killed **while** a 48 MB file is in flight (staging measured at 3–4 s on this swarm, so the kill at 2 s lands inside the broadcast).

Each commit stands alone and can be split out if you would rather they landed separately.
