### PR TITLE
Serve PMIX_ALLOC_ACTIVATE: a daemon on a node we already hold

### DIFF
--- a/contrib/dockerswarm/elastic.c
+++ b/contrib/dockerswarm/elastic.c
@@ -22,9 +22,12 @@
  *   elastic release    <num-nodes>          # PMIX_ALLOC_RELEASE + NUM_NODES
  *   elastic release-id <alloc-id>           # PMIX_ALLOC_RELEASE + ALLOC_ID
  *   elastic cancel     <req-id>             # PMIX_ALLOC_REQ_CANCEL
+ *   elastic activate   <host-spec>          # PMIX_ALLOC_ACTIVATE + HOST
  *
  *   --req-id <id>   request id to send (default "elastic-test"); "cancel"
  *                   names the request to cancel this way too
+ *   --hostfile <f>  hostfile to send as PMIX_HOSTFILE (activate only; may be
+ *                   given with or instead of the host spec, which is then "")
  *   --wait          wait for the phase-two completion event
  *   --no-wait       do not
  *
@@ -48,6 +51,16 @@
  * PMIX_DVM_IS_READY is the answer, exactly as it is for a grow.  Outside
  * elastic mode no campaign is recorded and phase one stays terminal; use
  * --no-wait there rather than burning the timeout.
+ *
+ * "activate" is the odd one out: it asks for nothing new at all, only that a
+ * daemon be started on nodes the DVM's allocation ALREADY holds but is not
+ * spanning (a --prtemca prte_max_vm_size cap leaves such nodes behind, and so
+ * does a shrink).  It is therefore the one size change permitted where a
+ * scheduler owns the allocation.  Its nodes are named with PMIX_HOST -- the
+ * same syntax "--activate" takes on a command line, including "+all", "+n<K>"
+ * and "file=<path>" -- and/or with PMIX_HOSTFILE.  Like an extend it answers
+ * phase one as soon as the request is granted and reports the daemons through
+ * the phase-two event, so it is waited for the same way.
  *
  * A grow may be followed by "-- <cmd> [args...]", in which case the tool
  * spawns that command INTO THE RESERVATION the grow just created, using the
@@ -254,6 +267,7 @@ static void usage(const char *me) {
             "  release    <num-nodes>          PMIX_ALLOC_RELEASE + NUM_NODES\n"
             "  release-id <alloc-id>           PMIX_ALLOC_RELEASE + ALLOC_ID\n"
             "  cancel     <req-id>             PMIX_ALLOC_REQ_CANCEL\n"
+            "  activate   <host-spec>          PMIX_ALLOC_ACTIVATE + HOST\n"
             "\n"
             "Every op but 'cancel' waits for the phase-two completion event;\n"
             "--no-wait is what a DVM outside elastic mode needs.\n", me);
@@ -268,6 +282,7 @@ int main(int argc, char **argv) {
     lock_t reglock;
     lock_t alloclock;
     const char *op, *arg, *req_id = "elastic-test";
+    const char *hostfile = NULL;
     char **spawn_cmd = NULL;
     uint64_t num_nodes = 0;
     bool by_count = false;
@@ -291,6 +306,8 @@ int main(int argc, char **argv) {
         }
         if (0 == strcmp(argv[i], "--req-id") && i + 1 < argc) {
             req_id = argv[++i];
+        } else if (0 == strcmp(argv[i], "--hostfile") && i + 1 < argc) {
+            hostfile = argv[++i];
         } else if (0 == strcmp(argv[i], "--wait")) {
             wait_opt = 1;
         } else if (0 == strcmp(argv[i], "--no-wait")) {
@@ -326,6 +343,8 @@ int main(int argc, char **argv) {
         directive = PMIX_ALLOC_REQ_CANCEL;
         req_id = arg;
         wait_phase2 = false;
+    } else if (0 == strcmp(op, "activate")) {
+        directive = PMIX_ALLOC_ACTIVATE;
     } else {
         fprintf(stderr, "unknown op '%s'\n", op);
         usage(argv[0]);
@@ -372,7 +391,16 @@ int main(int argc, char **argv) {
      * request id: the node list, the node count, or the allocation id -- the
      * RM modules reject a request that carries more than one. */
     lock_init(&alloclock);
-    if (0 == strcmp(op, "cancel")) {
+    if (0 == strcmp(op, "activate")) {
+        /* the nodes are named as hosts, not as an allocation request: they
+         * are already allocated, and nothing is being asked of a scheduler */
+        ninfo = (NULL != hostfile) ? 3 : 2;
+        PMIX_INFO_CREATE(info, ninfo);
+        PMIX_INFO_LOAD(&info[0], PMIX_HOST, arg, PMIX_STRING);
+        if (NULL != hostfile) {
+            PMIX_INFO_LOAD(&info[1], PMIX_HOSTFILE, hostfile, PMIX_STRING);
+        }
+    } else if (0 == strcmp(op, "cancel")) {
         ninfo = 1;
         PMIX_INFO_CREATE(info, ninfo);
     } else {

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -7398,7 +7398,7 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
         # and names both the host and the file
         RUN 'printf "node9\n" > /tmp/activate-bad.txt'
         out=$(RUN 'timeout 60 prun --activate file=/tmp/activate-bad.txt -n 1 hostname' 2>&1)
-        echo "$out" | grep -q 'hostfile given to "--activate" names a host' \
+        echo "$out" | grep -q 'hostfile given to an activation request names a host' \
             && ok "a hostfile naming an unallocated host is refused" \
             || bad "activate accepted an unallocated host from a file: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
         [ "$(prted_count 9)" = 0 ] && ok "no daemon launched from the refused file" \
@@ -7406,6 +7406,79 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
         RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     else
         bad "could not start an elastic DVM for the --activate re-admit test"
+    fi
+    cleanup_swarm
+
+    banner "ras: PMIX_ALLOC_ACTIVATE activates a node programmatically"
+    # The library form of the same operation: a tool that holds nodes the DVM
+    # is not spanning asks for daemons on them with PMIX_ALLOC_ACTIVATE,
+    # naming them with PMIX_HOST and/or PMIX_HOSTFILE. It is parsed by the
+    # same resolver "--activate" uses, so the two cannot drift apart - the
+    # cases below are deliberately the command-line ones, asked for through
+    # the API instead.
+    #
+    # Unlike the command line there is no job behind the request to make the
+    # completion observable, so the answer comes in two phases exactly as a
+    # grow's does: the request is granted at once, and the daemons are
+    # reported by the directed PMIX_DVM_IS_READY when they are up. That needs
+    # elastic mode, which is what records the campaign the event comes from.
+    cleanup_swarm
+    RUN 'nohup prte --daemonize --prtemca prte_elastic_mode 1 --prtemca prte_max_vm_size 2 --host node1:2,node2:2,node3:2,node4:2 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    if RUN 'pgrep -x prte >/dev/null'; then
+        [ "$(prted_count 3 4)" = 0 ] \
+            && ok "max_vm_size left node3+node4 allocated with no daemon" \
+            || bad "they already have daemons - the test premise is gone"
+
+        out=$(RUN 'timeout 90 elastic activate node3' 2>&1)
+        echo "$out" | grep -q PMIX_DVM_IS_READY \
+            && ok "PMIX_ALLOC_ACTIVATE node3 reported phase-two completion" \
+            || bad "no completion event for the activation: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        [ "$(prted_count 3)" = 1 ] && ok "a daemon started on the activated node" \
+                                   || bad "the activated node has no daemon"
+        [ "$(prted_count 4)" = 0 ] && ok "and only that node - node4 was not swept in" \
+                                   || bad "naming node3 also started a daemon on node4"
+        # the point of the exercise: the node is now usable
+        out=$(RUN 'timeout 60 prun --host node3:2 -n 2 --map-by node hostname' 2>&1)
+        c=$(echo "$out" | grep -c '^node3$')
+        [ "$c" = 2 ] && ok "a job then ran on the activated node (2 procs)" \
+                     || bad "launch on the activated node produced $c/2 procs: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+
+        # the hostfile half: PMIX_HOSTFILE instead of PMIX_HOST, with the
+        # host spec left empty. Its "slots=" must NOT be applied, for the
+        # same reason the command line refuses a ":N" - activation has no
+        # authority over what the allocation grants.
+        RUN 'printf "node4 slots=99\n" > /tmp/pactivate.txt'
+        out=$(RUN 'timeout 90 elastic activate "" --hostfile /tmp/pactivate.txt' 2>&1)
+        echo "$out" | grep -q PMIX_DVM_IS_READY \
+            && ok "PMIX_HOSTFILE activated the node the file named" \
+            || bad "no completion event for the hostfile activation: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        [ "$(prted_count 4)" = 1 ] && ok "a daemon started on the node from the file" \
+                                   || bad "the node named in the file has no daemon"
+        alloc=$(RUN 'timeout 30 prun --display allocation -n 1 hostname' 2>&1)
+        echo "$alloc" | grep -qE '^[[:space:]]*node4:[[:space:]]+slots=2' \
+            && ok "the file's slots=99 was not applied to node4" \
+            || bad "activation applied a slot count from its hostfile: $(echo "$alloc" | grep node4 | tr '\n' ' ')"
+
+        # ...and it can name nothing the allocation does not hold. This is the
+        # property that lets the directive be served under a scheduler at all,
+        # so the refusal is the feature. node5 is outside this DVM's four.
+        out=$(RUN 'timeout 60 elastic activate node5 --no-wait' 2>&1)
+        echo "$out" | grep -q 'REJECTED' \
+            && ok "an unallocated host is refused, and the refusal reaches the caller" \
+            || bad "the API accepted an unallocated host: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        [ "$(prted_count 5)" = 0 ] && ok "no daemon launched on the refused host" \
+                                   || bad "a daemon was launched on node5"
+
+        # with the DVM now spanning the whole allocation "+all" has nothing to
+        # do: that is success, answered in phase one, and NOT a promise of a
+        # completion event nobody will send
+        out=$(RUN 'timeout 60 elastic activate +all --no-wait' 2>&1)
+        echo "$out" | grep -q 'PHASE 1 (acceptance): allocation request returned PMIX_SUCCESS' \
+            && ok "+all is satisfied, and answered outright, with nothing left to activate" \
+            || bad "+all did not answer at phase one: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start an elastic DVM for the PMIX_ALLOC_ACTIVATE test"
     fi
     cleanup_swarm
 

--- a/contrib/slurmswarm/AGENTS.md
+++ b/contrib/slurmswarm/AGENTS.md
@@ -201,6 +201,16 @@ it. Several cases here cannot exist anywhere else:
   applied, since PRRTE has no more authority over a scheduler's slot count
   than over its node list.
 
+  The same case then asks for the same thing through the API, with
+  `PMIX_ALLOC_ACTIVATE` (`elastic activate`). That is a property of its own
+  rather than a repeat: the directive reaches `ras` through
+  `prte_ras_base_modify`, where `ras/slurm` owns the allocation and would have
+  to refuse anything needing the scheduler's consent, so "served under a
+  scheduler" has to be shown for the request as well as for the command line
+   — and, again, nowhere else can show it. The DVM here is not in elastic
+  mode, so no campaign is recorded and the grant is the whole answer; the
+  two-phase completion is exercised by the sibling harness instead.
+
 - **SLURM's compressed node list.** SLURM hands out `node[2,4,6]`, and
   `ras/slurm` has its own parser for that notation — a fake scheduler handing
   out comma-separated names never reaches it. The allocation is deliberately non-contiguous: a

--- a/contrib/slurmswarm/run-tests.sh
+++ b/contrib/slurmswarm/run-tests.sh
@@ -507,10 +507,10 @@ test_ras_alloc() {
     cleanup_cluster
     # four nodes, two in the DVM: node3 for the named form and node4 for the
     # hostfile form, so neither is already in the DVM when its case runs
-    ALLOC new --tag dvm --nodes 4 --tasks-per-node 2 >/dev/null 2>&1
+    ALLOC new --tag dvm --nodes 5 --tasks-per-node 2 >/dev/null 2>&1
     if dvm_start --host node1:2,node2:2; then
-        [ "$(prted_count 3 4)" = 0 ] \
-            && ok "node3 and node4 are allocated but not in the DVM" \
+        [ "$(prted_count 3 4 5)" = 0 ] \
+            && ok "node3, node4 and node5 are allocated but not in the DVM" \
             || bad "they already have daemons - the test premise is gone"
         out=$(SA 'timeout 90 prun --activate node3 --host node3:2 -n 2 --map-by node hostname 2>&1 | tr -d "\0"')
         c=$(echo "$out" | grep -c '^node3$')
@@ -551,6 +551,38 @@ test_ras_alloc() {
             || bad "--activate accepted an unallocated node: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
         [ "$(prted_count 9)" = 0 ] \
             && ok "no daemon was launched outside the allocation" \
+            || bad "a daemon was launched on node9"
+
+        # The same authority question asked through the API instead of the
+        # command line.  PMIX_ALLOC_ACTIVATE reaches ras by a different path -
+        # prte_ras_base_modify, where ras/slurm owns the allocation and would
+        # have to refuse anything that needed the scheduler's consent - so it
+        # being served here is a property of its own, and this is the only
+        # harness that can show it.  No elastic mode on this DVM, so no
+        # campaign is recorded and the grant is the whole answer.
+        out=$(SA 'timeout 90 elastic activate node5 --no-wait 2>&1 | tr -d "\0"')
+        echo "$out" | grep -q 'PHASE 1 (acceptance): allocation request returned PMIX_SUCCESS' \
+            && ok "PMIX_ALLOC_ACTIVATE was granted under SLURM" \
+            || bad "the activation request was not granted: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        # Run the job before counting daemons rather than sleeping for one:
+        # granting the request marks the DVM not-ready, so this prun is parked
+        # until the grow reaches VM_READY - which makes its completion the
+        # signal that the daemon is up, and its output the proof.
+        out=$(SA 'timeout 90 prun --host node5:2 -n 2 --map-by node hostname 2>&1 | tr -d "\0"')
+        c=$(echo "$out" | grep -c '^node5$')
+        [ "$c" = 2 ] \
+            && ok "a job then ran on the API-activated node (2 procs)" \
+            || bad "launch on the API-activated node produced $c/2 procs: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        [ "$(prted_count 5)" = 1 ] \
+            && ok "a daemon is running on the node the request named" \
+            || bad "no daemon on the node PMIX_ALLOC_ACTIVATE named"
+        # ...and it reaches no further than the command line does
+        out=$(SA 'timeout 60 elastic activate node9 --no-wait 2>&1 | tr -d "\0"')
+        echo "$out" | grep -q 'REJECTED' \
+            && ok "PMIX_ALLOC_ACTIVATE refuses a node SLURM never granted" \
+            || bad "the API accepted an unallocated node: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        [ "$(prted_count 9)" = 0 ] \
+            && ok "and launched no daemon outside the allocation" \
             || bad "a daemon was launched on node9"
         dvm_stop
     else

--- a/docs/how-things-work/schedulers/flow_of_control.rst
+++ b/docs/how-things-work/schedulers/flow_of_control.rst
@@ -20,9 +20,24 @@ via the ``PMIx_Session_control`` API - i.e., the RM cannot guarantee
 its ability to intercept and process an allocation response to learn
 of a session that needs to be instantiated.
 
-PRRTE's role in the ``PMIx_Allocation_request`` flow is simply to
+PRRTE's role in the ``PMIx_Allocation_request`` flow is generally to
 pass the request on to the scheduler, and transport the reply back
 to the requestor.
+
+``PMIX_ALLOC_ACTIVATE`` is the exception: PRRTE answers it itself,
+without involving any resource manager. It asks for a daemon on nodes
+the requestor **already holds** - an allocated node the DVM is not
+spanning, because a ``--host``/``--hostfile`` given at startup narrowed
+which nodes got one, or because a released reservation handed it back
+without one. Nothing is added to the allocation and no slot count
+changes, so there is nothing to ask a scheduler for and nothing a
+scheduler could refuse; for the same reason the request is served even
+where the scheduler owns the allocation, which is where a request for
+new resources cannot be. The nodes are named with ``PMIX_HOST`` and/or
+``PMIX_HOSTFILE``, in the same syntax the ``--activate`` command line
+option takes, and the request is answered when it is granted - the
+daemons themselves are reported by the ``PMIX_DVM_IS_READY`` event that
+completes any DVM size change.
 
 PRRTE only creates a session object as a result of a call from the
 scheduler via ``PMIx_Session_control``. What it does with each directive

--- a/docs/plans/elastic_dvm/elastic_dvm_spec.rst
+++ b/docs/plans/elastic_dvm/elastic_dvm_spec.rst
@@ -344,7 +344,11 @@ the DVM reflects the requested size: a grow's new nodes are available to
 spawn onto, a shrink's removed nodes are gone.  The event payload carries:
 
 * ``PMIX_ALLOC_ID`` (``char*``) — the allocation whose operation
-  completed; always present.
+  completed; present whenever the operation named one.  A
+  ``PMIX_ALLOC_ACTIVATE`` names none — it starts daemons on nodes the
+  requester already held, and creates no reservation — so the key is
+  omitted there rather than sent empty, and such a requester matches the
+  event by its own request id.
 * ``PMIX_ALLOC_REQ_ID`` (``char*``) — the requester's own request id,
   included whenever one was supplied on the original request, so the
   recipient can match the event by either identifier.
@@ -360,7 +364,8 @@ requester.  The event states that **no (further) DVM modification will be
 made** for this request and that the DVM has been returned to a stable
 state (for a failed grow, its pre-grow membership).  The payload carries:
 
-* ``PMIX_ALLOC_ID`` (``char*``) — always present.
+* ``PMIX_ALLOC_ID`` (``char*``) — when the operation named an allocation
+  (see the success event above).
 * ``PMIX_ALLOC_REQ_ID`` (``char*``) — when one was supplied.
 * The **underlying cause** — the specific ``pmix_status_t`` that prevented
   the modification (for example a daemon-launch failure versus a resource

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -32,41 +32,16 @@ Runtime behavior
 surface exists for SLURM only.  Everything above the component is
 RM-agnostic; what is missing is the Flux-side conversation.
 
-**Only a command line can ask for a daemon on an allocated node.**  The
-command-line half of this is done: ``--activate`` (``prun`` and
-``prterun``) takes node names, ``+all``, ``+n<K>`` and ``file=<hostfile>``,
-resolves them against the node pool, marks the chosen entries
-``PRTE_NODE_STATE_ADDED`` and calls ``prte_ras_base_activate_dvm_grow()``
-(``prte_ras_base_activate_hosts``).  It needs no ``ras`` module, touches no
-scheduler, and is safe by construction since it can only name nodes the
-allocation already contains - which is why it is allowed where
-``--add-host`` is refused.  A *programmatic* requester has no equivalent:
-the directive travels as a PRRTE-private spawn key
-(``prte.activate.hosts``) precisely because PMIx has no standard way to say
-"start a daemon on a node I already hold".
-
-The intended shape is a new **allocation directive**, not an extension of
-some existing attribute's meaning.  Add ``PMIX_ALLOC_ACTIVATE`` to
-``pmix_alloc_directive_t`` (``pmix_common.h``, next unused value after
-``PMIX_ALLOC_REQ_CANCEL``), naming its nodes with ``PMIX_HOST`` and/or
-``PMIX_HOSTFILE`` - the attributes that already mean "these hosts" and
-"this hostfile" everywhere else - and parsed **identically** to the command
-line, so a request and a ``--activate`` spec cannot drift apart.  That
-means factoring the resolver out of ``ras_base_activate_hosts`` rather than
-writing a second one; note the command line folds the hostfile into its own
-list as ``file=<path>`` while the PMIx form carries it as a separate
-attribute, so the shared entry point wants a host-syntax string and a
-hostfile path as two arguments.  On PRRTE's side the directive is another
-arm in ``prte_ras_base_complete_request()``/``ras/hosts``' ``modify()``
-beside ``NEW``/``EXTEND``/``RELEASE``, and - as with the command line - it
-must **not** be gated on ``prte_ras_base.scheduler_owned``, since it can
-name nothing the scheduler has not already granted.
-
-The second half is more general than activation and is worth having on its
-own: **there is no way to put an allocation directive into a**
-``PMIx_Spawn`` **call.**  Today a caller that needs resources before it can
-launch has to issue ``PMIx_Allocation_request`` itself, wait for it, and
-then spawn - the library equivalent of running ``salloc`` before ``srun``.
+**There is no way to put an allocation directive into a** ``PMIx_Spawn``
+**call.**  This was the second half of the activation item, which is now
+done: a programmatic requester asks for a daemon on a node it already holds
+with ``PMIX_ALLOC_ACTIVATE``, naming its nodes with ``PMIX_HOST`` and/or
+``PMIX_HOSTFILE``, and ``prte_ras_base_modify`` serves it through the same
+``prte_ras_base_activate_nodes`` the ``--activate`` command line resolves
+through.  What remains is more general than activation and is worth having
+on its own.  Today a caller that needs resources before it can launch has to
+issue ``PMIx_Allocation_request`` itself, wait for it, and then spawn - the
+library equivalent of running ``salloc`` before ``srun``.
 An attribute carrying an allocation request on the spawn would let the host
 do what ``srun`` does when invoked outside an allocation: obtain the
 allocation per the directive, wait for it to complete, and only then

--- a/src/mca/plm/AGENTS.md
+++ b/src/mca/plm/AGENTS.md
@@ -454,6 +454,17 @@ rather than reading `map->daemon_vpid_start`: a target whose session is gone
 would otherwise leave the campaign with no requester, and a successful grow
 would emit no phase-two completion event at all.
 
+That scan resolves a requester through the *session* owning each target,
+which an **activation** (`--activate`, `PMIX_ALLOC_ACTIVATE`) has none of —
+it names nodes the allocation already held, which stay in the general pool.
+Such a requester is carried instead by
+`prte_plm_base_add_grow_requester()`, held in a short-lived pending list
+that the campaign adopts when it is recorded. Anything the pass does not
+hand to a campaign is answered by the wrapper around
+`setup_virtual_machine()` — success where the launch ran and simply had
+nothing to record, failure where it did not run at all — so a requester is
+never stranded, and never answered by some later grow's campaign.
+
 `map->num_new_daemons` is the key output: `== 0` means every node
 already has a daemon, so the component fast-forwards to
 `DAEMONS_REPORTED`. It also records elastic **grow campaigns** and the

--- a/src/mca/plm/base/plm_base_frame.c
+++ b/src/mca/plm/base/plm_base_frame.c
@@ -134,6 +134,10 @@ static int prte_plm_base_close(void)
         }
     }
 
+    /* a size change granted but never launched still owes its requester an
+     * answer, and this is the last chance to give one */
+    prte_plm_base_flush_grow_requesters();
+
     if (NULL != prte_plm_globals.base_nspace) {
         free(prte_plm_globals.base_nspace);
         /* the tool-attach path in plm_base_receive reads this to mint a

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -2433,7 +2433,106 @@ static int campaign_add_requester(prte_grow_campaign_t *camp, prte_session_t *se
     return PRTE_SUCCESS;
 }
 
-int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
+/*
+ * Requesters waiting on the NEXT grow campaign.
+ *
+ * A campaign normally finds its requesters through the nodes it is launching
+ * on: a grow that was granted resources put those nodes in a session, and the
+ * session records who asked for them.  An ACTIVATION has no such session -
+ * it names nodes the allocation already held, which sit in the general pool
+ * exactly as they did before - so the requester has to be carried here
+ * instead, from the point the request was granted to the point a campaign
+ * exists to answer it.
+ *
+ * The list is short-lived by construction: activating a grow posts
+ * LAUNCH_DAEMONS, and setup_virtual_machine - which runs on the very next
+ * turn of the event loop - either hands the entries to the campaign it
+ * records or answers them itself because there is nothing to launch.
+ */
+static prte_grow_requester_t *pending_requesters = NULL;
+static int npending_requesters = 0;
+
+int prte_plm_base_add_grow_requester(const pmix_proc_t *requester,
+                                     const char *alloc_id,
+                                     const char *req_id)
+{
+    prte_grow_requester_t *tmp;
+
+    tmp = (prte_grow_requester_t *) realloc(pending_requesters,
+                                            (npending_requesters + 1) * sizeof(*tmp));
+    if (NULL == tmp) {
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+    pending_requesters = tmp;
+    tmp = &pending_requesters[npending_requesters];
+    PMIX_XFER_PROCID(&tmp->requester, requester);
+    tmp->alloc_id = (NULL != alloc_id) ? strdup(alloc_id) : NULL;
+    tmp->req_id = (NULL != req_id) ? strdup(req_id) : NULL;
+    npending_requesters++;
+
+    return PRTE_SUCCESS;
+}
+
+/* Give the pending requesters to this campaign, which then owns answering
+ * them - and owns their strings, so nothing is freed here. */
+static void adopt_pending_requesters(prte_grow_campaign_t *camp)
+{
+    prte_grow_requester_t *tmp;
+    int r;
+
+    if (0 == npending_requesters) {
+        return;
+    }
+    tmp = (prte_grow_requester_t *) realloc(camp->requesters,
+                                            (camp->nrequesters + npending_requesters)
+                                                * sizeof(*tmp));
+    if (NULL == tmp) {
+        /* keep what the campaign had rather than losing the launch; the
+         * pending requesters are answered here instead of never */
+        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+        for (r = 0; r < npending_requesters; r++) {
+            prte_plm_base_dvm_mod_notify(&pending_requesters[r].requester,
+                                         pending_requesters[r].alloc_id,
+                                         pending_requesters[r].req_id,
+                                         false, PMIX_ERR_NOMEM);
+            free(pending_requesters[r].alloc_id);
+            free(pending_requesters[r].req_id);
+        }
+        goto done;
+    }
+    camp->requesters = tmp;
+    memcpy(&camp->requesters[camp->nrequesters], pending_requesters,
+           npending_requesters * sizeof(*pending_requesters));
+    camp->nrequesters += npending_requesters;
+
+done:
+    free(pending_requesters);
+    pending_requesters = NULL;
+    npending_requesters = 0;
+}
+
+/* Answer every pending requester now.  Reached when the grow they were
+ * recorded for launches no daemon - nothing will report, so no campaign is
+ * recorded and grow_drain() would never run - and, defensively, wherever a
+ * launch ends without recording one. */
+static void notify_pending_requesters(bool success, pmix_status_t cause)
+{
+    int r;
+
+    for (r = 0; r < npending_requesters; r++) {
+        prte_plm_base_dvm_mod_notify(&pending_requesters[r].requester,
+                                     pending_requesters[r].alloc_id,
+                                     pending_requesters[r].req_id,
+                                     success, cause);
+        free(pending_requesters[r].alloc_id);
+        free(pending_requesters[r].req_id);
+    }
+    free(pending_requesters);
+    pending_requesters = NULL;
+    npending_requesters = 0;
+}
+
+static int setup_virtual_machine(prte_job_t *jdata)
 {
     prte_node_t *node, *nptr;
     prte_proc_t *proc, *pptr;
@@ -3140,12 +3239,44 @@ process:
                 }
             }
         }
+        /* an activation records its requester here rather than on a session,
+         * because it created none - see pending_requesters */
+        adopt_pending_requesters(gcamp);
         pmix_list_append(&prte_grow_campaigns, &gcamp->super);
         /* raise the fence by exactly what this campaign will drain */
         prte_dvm_launch_fence += gcamp->ntargets;
     }
 
     return PRTE_SUCCESS;
+}
+
+void prte_plm_base_flush_grow_requesters(void)
+{
+    /* The DVM is going away with a request still pending - it was granted,
+     * but the launch it was waiting on will not now happen.  Say so: a
+     * requester of a size change is answered exactly once, and silence is
+     * the one answer the contract does not have. */
+    notify_pending_requesters(false, PMIX_ERR_UNREACH);
+}
+
+int prte_plm_base_setup_virtual_machine(prte_job_t *jdata)
+{
+    int rc;
+
+    rc = setup_virtual_machine(jdata);
+
+    /* Answer any requester the pass did not hand to a campaign.  Success
+     * means the DVM already reflects what they asked for - either their nodes
+     * needed no daemon, or this launch is one no campaign tracks (a DVM
+     * outside elastic mode raises no fence).  A failure means the launch was
+     * never computed at all, and saying so here is what keeps them from being
+     * answered by some later grow's campaign instead.  Where a campaign did
+     * adopt them this is a no-op: the campaign owns the answer, and delivers
+     * it when its daemons report. */
+    notify_pending_requesters(PRTE_SUCCESS == rc,
+                              (PRTE_SUCCESS == rc) ? PMIX_SUCCESS
+                                                   : prte_pmix_convert_rc(rc));
+    return rc;
 }
 
 void prte_plm_base_dvm_mod_notify(const pmix_proc_t *requester,
@@ -3164,17 +3295,20 @@ void prte_plm_base_dvm_mod_notify(const pmix_proc_t *requester,
 
     /* Assemble a directed (custom-range) notification to the requester only,
      * mirroring the PMIX_ALLOC_TIMEOUT_WARNING delivery: custom range plus the
-     * allocation id, the requester's own request id when one was supplied, and
-     * — on failure — the underlying cause so the requester can distinguish
-     * what went wrong rather than only that something did.  The event also
-     * carries "prte.notify.donotloop" so our own notify_event server upcall
+     * allocation id and the requester's own request id where the operation had
+     * them, and — on failure — the underlying cause so the requester can
+     * distinguish what went wrong rather than only that something did.  The
+     * event also carries "prte.notify.donotloop" so our own notify_event server upcall
      * short-circuits instead of thread-shifting and re-xcasting it: the
      * requester is a tool local to this HNP, so PMIx delivers the event
      * locally and no broadcast is needed.  Without the marker the upcall
      * would defer its work onto this progress thread while the blocking
      * PMIx_Notify_event below is parked here waiting for it -- a self-deadlock
      * (see the AGENTS.md rule on locally-originated event notifications). */
-    nrinfo = 3;  /* custom range + alloc id + donotloop marker */
+    nrinfo = 2;  /* custom range + donotloop marker */
+    if (NULL != alloc_id) {
+        nrinfo++;
+    }
     if (NULL != req_id) {
         nrinfo++;
     }
@@ -3189,7 +3323,11 @@ void prte_plm_base_dvm_mod_notify(const pmix_proc_t *requester,
     parray.array = &ptarg;
     /* PMIX_INFO_LOAD deep-copies the data, so the stack copies are fine */
     PMIX_INFO_LOAD(&rinfo[idx++], PMIX_EVENT_CUSTOM_RANGE, &parray, PMIX_DATA_ARRAY);
-    PMIX_INFO_LOAD(&rinfo[idx++], PMIX_ALLOC_ID, (void *) alloc_id, PMIX_STRING);
+    if (NULL != alloc_id) {
+        /* omitted rather than sent empty when the operation named no
+         * allocation - an activation asks for none */
+        PMIX_INFO_LOAD(&rinfo[idx++], PMIX_ALLOC_ID, (void *) alloc_id, PMIX_STRING);
+    }
     /* keep delivery local: do not loop back through our own server upcall */
     PMIX_INFO_LOAD(&rinfo[idx++], "prte.notify.donotloop", NULL, PMIX_BOOL);
     if (NULL != req_id) {

--- a/src/mca/plm/base/plm_private.h
+++ b/src/mca/plm/base/plm_private.h
@@ -94,6 +94,21 @@ PRTE_EXPORT bool prte_plm_base_grow_target_failed(pmix_rank_t rank);
 PRTE_EXPORT void prte_plm_base_reset_dvm_node(prte_node_t *node);
 PRTE_EXPORT bool prte_plm_base_job_needs_remap(prte_job_t *jdata);
 PRTE_EXPORT void prte_plm_base_reset_proc_map(prte_job_t *jdata);
+/* Record a requester for the NEXT grow campaign to answer.  A grow normally
+ * resolves its requesters from the session that owns the nodes it launches
+ * on; an activation creates no session (it names nodes the allocation already
+ * held), so its requester is carried here from the moment the request is
+ * granted until a campaign exists to answer it.  Only worth calling where a
+ * campaign is expected - i.e. in elastic mode - though an entry no campaign
+ * adopts is answered rather than stranded. */
+PRTE_EXPORT int prte_plm_base_add_grow_requester(const pmix_proc_t *requester,
+                                                 const char *alloc_id,
+                                                 const char *req_id);
+
+/* Answer, with failure, every requester still waiting for a campaign that
+ * will now never be recorded.  Called when the framework closes. */
+PRTE_EXPORT void prte_plm_base_flush_grow_requesters(void);
+
 /* emit the spec's phase-two completion event to the size-change requester:
  * PMIX_DVM_IS_READY when success, else PMIX_ERR_DVM_MOD carrying `cause`.
  * Compiles to a no-op when PMIx lacks the DVM modification event codes. */

--- a/src/mca/ras/AGENTS.md
+++ b/src/mca/ras/AGENTS.md
@@ -232,6 +232,32 @@ cannot name anything the allocation does not already contain. A `:N` slot
 extension is **refused** rather than ignored for the same reason: activate
 has no authority to set slot counts.
 
+**The same operation, asked for programmatically.** `PMIX_ALLOC_ACTIVATE`
+is the allocation directive that says exactly this, naming its nodes with
+`PMIX_HOST` and/or `PMIX_HOSTFILE`. `prte_ras_base_modify()` serves it
+**itself**, before the module loop, for the same reason `scheduler_owned`
+does not gate the command line: there is nothing for a module to do, and
+routing it to whichever component owns the allocation would make the answer
+depend on the RM in play — refusing under a scheduler the one size change
+that is always safe under one. Both forms resolve through
+`prte_ras_base_activate_nodes()`, so the syntax, the refusals and the
+treatment of an already-joined node are one implementation and cannot drift
+apart. The two differ only in how the hostfile arrives: the command line
+folds it into the host list as `file=<path>`, the PMIx form carries it as
+its own attribute, which is why the shared entry point takes a host
+specification and a hostfile path as two arguments.
+
+The programmatic form answers in **two phases**, as an extend does, because
+there is no job behind it to make completion observable: the grant is
+returned at once and the daemons are reported by the directed
+`PMIX_DVM_IS_READY` (or `PMIX_ERR_DVM_MOD`) when the grow campaign drains.
+The requester is recorded with `prte_plm_base_add_grow_requester()` rather
+than on a session — an activation creates none — and the campaign adopts it
+when it is recorded. Where no campaign will exist (outside elastic mode, or
+when every named node is already in the DVM) the grant stays the answer and
+`PMIX_SUCCESS` is returned at phase one, so nothing waits on an event no one
+will send.
+
 Two things about it are load-bearing:
 
 - It runs **after** `prte_ras_base_add_hosts()` in `plm_base_receive.c`, and
@@ -396,6 +422,7 @@ elastic-DVM or PMIx_Allocation code:
 | `prte_ras_base_modify()` | The `modify` driver (also a state callback). Cycles modules (keyed by `req->key`) to serve a `prte_pmix_server_req_t`; on `PMIX_SUCCESS` calls `prte_ras_base_complete_request`, then invokes the requester's `infocbfunc`. |
 | `prte_ras_base_add_hosts()` | Collect `PRTE_APP_ADD_HOSTFILE`/`PRTE_APP_ADD_HOST` directives across apps into a `PMIX_ALLOC_EXTEND` request and hand it to `prte_ras_base_modify`. Sets `prte_dvm_ready = false` until processed. |
 | `prte_ras_base_activate_hosts()` | Collect `PRTE_APP_ACTIVATE_HOSTS` directives across apps, resolve them against the node pool, mark the resolved entries `PRTE_NODE_STATE_ADDED` and activate a grow. Adds nothing to the allocation, so it is permitted under a scheduler; must run after `prte_ras_base_add_hosts()`. Sets `prte_dvm_ready = false` when it activates a grow of its own. |
+| `prte_ras_base_activate_nodes()` | Resolve one activation — a host specification, a hostfile, or both — against the node pool and mark the resolved entries `PRTE_NODE_STATE_ADDED`, reporting how many entries that changed. Shared by `--activate` and `PMIX_ALLOC_ACTIVATE`. Resolves and marks only: activating the grow is the caller's. |
 | `prte_ras_base_complete_request()` | The heavy reservation router. For `PMIX_ALLOC_NEW`/`EXTEND` it resolves the destination `prte_session_t` (honoring `PMIX_ALLOC_TARGET`/`SHARE`/`INHERITANCE`/`ID`/`REQ_ID`), parses `PMIX_ALLOC_NODE_LIST`, inserts the nodes, and attaches them to the reservation (`add_nodes_to_session`). For `PMIX_ALLOC_RELEASE` it tears down a named reservation or xcasts a `PRTE_DAEMON_SHRINK_CMD`. Marks `PRTE_JOB_EXTEND_DVM` and re-launches daemons for grows. |
 | `prte_ras_base_release_allocation()` | Session-destruct hook: cycles modules whose `release_allocation` matches `session->alloc_module`. |
 | `prte_ras_base_shrink_complete()` | Offers a drained `prte_shrink_campaign_t` to every module's `shrink_complete`. |
@@ -598,7 +625,7 @@ prototype here compiles and then mismatches the real library.
 | Layer | What it covers |
 |-------|----------------|
 | [`test/unit/ras/test_ras.c`](../../../test/unit/ras/) (`make check`) | `prte_ras_base_node_insert` (dedup, drain, slot accounting, `ADD_SLOTS` clamping, FQDN normalization, HNP dedup, pre-assigned pool slots), the module vtable contract for every static component, `prte_ras_base_select` priority ordering, `prte_ras_base_flag_string`, and `ras/slurm`'s detect-and-report half — query gating on `SLURM_JOBID` at priority 50, then `allocate()` expanding a compressed `SLURM_NODELIST` and refusing a tainted jobid or an over-length nodelist. That last part is driven **through the framework** (find the component, query it, call the module it returns) rather than by naming its symbols, because `ras-slurm` is a plugin and has none in `libprrte`; keep it that way. It skips with a printed reason when the component is not there to be found. |
-| [`contrib/dockerswarm/run-tests.sh`](../../../contrib/dockerswarm/) (`linux`) | The multi-node paths: grow/shrink/re-grow leaving exactly one daemon per node (a duplicated pool entry launches two), `--add-hostfile` growing a live DVM through `add_hosts → ras/pmix defer → ras/hosts` including the `slots=+N` in-place adjust, `--activate` bringing an allocated-but-idle node into the DVM (one left out by `prte_max_vm_size`, and two a shrink handed back, named through `file=`) while refusing a host the allocation does not contain and refusing to apply the hostfile's `slots=`, and **`ras/slurm`'s whole modify surface** against a faked scheduler (below). |
+| [`contrib/dockerswarm/run-tests.sh`](../../../contrib/dockerswarm/) (`linux`) | The multi-node paths: grow/shrink/re-grow leaving exactly one daemon per node (a duplicated pool entry launches two), `--add-hostfile` growing a live DVM through `add_hosts → ras/pmix defer → ras/hosts` including the `slots=+N` in-place adjust, `--activate` bringing an allocated-but-idle node into the DVM (one left out by `prte_max_vm_size`, and two a shrink handed back, named through `file=`) while refusing a host the allocation does not contain and refusing to apply the hostfile's `slots=`, the same operation asked for through `PMIX_ALLOC_ACTIVATE` (`elastic activate`, both the `PMIX_HOST` and the `PMIX_HOSTFILE` form, including its two-phase completion), and **`ras/slurm`'s whole modify surface** against a faked scheduler (below). |
 | Live RM | PBS/LSF/Flux discovery still needs a real scheduler; there is no substitute. |
 
 **`ras/slurm`'s `modify` surface is covered in `contrib/dockerswarm`, not

--- a/src/mca/ras/base/base.h
+++ b/src/mca/ras/base/base.h
@@ -153,6 +153,23 @@ PRTE_EXPORT int prte_ras_base_add_hosts(prte_job_t *jdata);
  * of its own. */
 PRTE_EXPORT int prte_ras_base_activate_hosts(prte_job_t *jdata);
 
+/* Resolve an activation request - a host specification, a hostfile, or both -
+ * against the node pool and mark the resolved entries PRTE_NODE_STATE_ADDED,
+ * reporting in nactivated how many entries that changed (zero meaning every
+ * named node is already in the DVM or already on its way in, so there is
+ * nothing to launch).  Either argument may be NULL, but not both; the
+ * hostfile argument may name several files, comma-delimited.  The host
+ * specification is "--host" syntax, including the "file=<path>" form, and is
+ * parsed by the same code that parses "--activate".
+ *
+ * This resolves and marks only: activating the grow is the caller's, since
+ * only the caller knows whether another request is already about to launch
+ * one.  Refusals are reported through show_help and returned as
+ * PRTE_ERR_SILENT. */
+PRTE_EXPORT int prte_ras_base_activate_nodes(const char *hosts,
+                                             const char *hostfile,
+                                             int *nactivated);
+
 /* Render the node specification carried by a PMIX_ALLOC_NODE_LIST-style info
  * (a string, a regex, or a regex2) into a comma-delimited node-name string the
  * caller must free. Returns PMIX_ERR_BAD_PARAM for any other value type. */

--- a/src/mca/ras/base/help-ras-base.txt
+++ b/src/mca/ras/base/help-ras-base.txt
@@ -80,17 +80,21 @@ support adding to them after the fact - a bootstrapped DVM, for instance,
 takes its membership from the configuration file every daemon reads.
 
 [ras-base:activate-unknown]
-An "--activate" directive named a host that is not part of this DVM's
+An activation request named a host that is not part of this DVM's
 allocation:
 
   Host: %s
 
-"--activate" can only start a daemon on a node the allocation already
+Activation can only start a daemon on a node the allocation already
 contains; it cannot add one. Check the name, or use "--add-host" if PRRTE
 owns this allocation and you mean to enlarge it.
 
+The request came either from the "--activate" command line option or from a
+PMIX_ALLOC_ACTIVATE allocation request; both name their hosts the same way
+and both are held to this rule.
+
 [ras-base:activate-unavailable]
-An "--activate" directive named a host that is not available for use:
+An activation request named a host that is not available for use:
 
   Host:     %s
   State:    %s
@@ -101,7 +105,7 @@ been marked unusable. Starting a daemon on it would fail, and a daemon that
 fails to start takes the whole DVM down with it.
 
 [ras-base:activate-empty]
-An "--activate" directive used the "empty node" syntax:
+An activation request used the "empty node" syntax:
 
   Given as: %s
 
@@ -114,28 +118,37 @@ also name the nodes you want, use "+n<K>" to name one by its position in the
 allocation, or use "file=<hostfile>" to read them from a file.
 
 [ras-base:activate-nofile]
-An "--activate" directive gave "file=" with no filename after it.
+An activation request gave "file=" with no filename after it.
 
 The form is "--activate file=<hostfile>", naming a file in the same format
-"--hostfile" reads.
+"--hostfile" reads. A PMIX_ALLOC_ACTIVATE request may instead give the file
+as its own PMIX_HOSTFILE attribute.
+
+[ras-base:activate-nothing-named]
+A PMIX_ALLOC_ACTIVATE allocation request named nothing to activate.
+
+The request must carry PMIX_HOST, PMIX_HOSTFILE, or both, saying which of
+the nodes this DVM already holds are to have a daemon started on them.
+There is no default: activating everything the allocation holds is asked for
+explicitly, with a host specification of "+all".
 
 [ras-base:activate-unknown-in-file]
-A hostfile given to "--activate" names a host that is not part of this DVM's
-allocation:
+A hostfile given to an activation request names a host that is not part of
+this DVM's allocation:
 
   Host: %s
   File: %s
 
-"--activate" can only start a daemon on a node the allocation already
+Activation can only start a daemon on a node the allocation already
 contains; it cannot add one. Check the file, or use "--add-hostfile" if PRRTE
 owns this allocation and you mean to enlarge it.
 
 [ras-base:activate-slots]
-An "--activate" directive carried a slot count:
+An activation request carried a slot count:
 
   Given as: %s
 
-"--activate" cannot change what the allocation grants - it only starts a
+Activation cannot change what the allocation grants - it only starts a
 daemon on a node the allocation already contains - so a slot count here
 could not be honored and is refused rather than silently ignored. Drop the
 ":N" extension, or use "--add-host" where PRRTE owns the allocation and the

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -715,6 +715,106 @@ void prte_ras_base_flush_deferred_releases(pmix_status_t status)
     }
 }
 
+#if defined(PMIX_ALLOC_ACTIVATE)
+/*
+ * PMIX_ALLOC_ACTIVATE - the programmatic form of the "--activate" command
+ * line option: start daemons on nodes the requester already holds.
+ *
+ * This is served here, at the driver, rather than by a ras module, because
+ * there is nothing for a module to do.  The directive adds nothing to the
+ * allocation, changes no slot count and asks no scheduler for anything - it
+ * can only name nodes the node pool already contains - so it is neither
+ * gated on prte_ras_base.scheduler_owned nor routed to whichever component
+ * owns the allocation.  Sending it around the module loop would make the
+ * answer depend on which RM is in play, and refuse under a scheduler exactly
+ * the request that is always safe under one.
+ *
+ * The nodes are named with PMIX_HOST and/or PMIX_HOSTFILE and resolved by
+ * the same code that resolves an "--activate" specification, so the two
+ * cannot drift apart: the syntax, the refusals, and the treatment of a node
+ * that is already in the DVM are one implementation.
+ */
+static void ras_base_activate_request(prte_pmix_server_req_t *req)
+{
+    const char *hosts = NULL, *hostfile = NULL, *req_id = NULL;
+    int rc, nactivated = 0;
+    size_t n;
+
+    for (n = 0; n < req->ninfo; n++) {
+        if (PMIx_Check_key(req->info[n].key, PMIX_HOST)) {
+            /* the value arrived over the wire, so it may be anything */
+            if (PMIX_STRING != req->info[n].value.type) {
+                req->pstatus = PMIX_ERR_BAD_PARAM;
+                return;
+            }
+            hosts = req->info[n].value.data.string;
+
+        } else if (PMIx_Check_key(req->info[n].key, PMIX_HOSTFILE)) {
+            if (PMIX_STRING != req->info[n].value.type) {
+                req->pstatus = PMIX_ERR_BAD_PARAM;
+                return;
+            }
+            hostfile = req->info[n].value.data.string;
+
+        } else if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_REQ_ID)) {
+            if (PMIX_STRING == req->info[n].value.type) {
+                /* echoed back in the completion event so a requester with
+                 * several requests in flight can tell them apart */
+                req_id = req->info[n].value.data.string;
+            }
+        }
+    }
+
+    if ((NULL == hosts || '\0' == *hosts) &&
+        (NULL == hostfile || '\0' == *hostfile)) {
+        prte_show_help("help-ras-base.txt", "ras-base:activate-nothing-named", true);
+        req->pstatus = PMIX_ERR_BAD_PARAM;
+        return;
+    }
+
+    rc = prte_ras_base_activate_nodes(hosts, hostfile, &nactivated);
+    if (PRTE_SUCCESS != rc) {
+        /* the resolver reports what it refused, and why, through show_help;
+         * a refusal is always the specification's fault (a host this DVM
+         * does not hold, a slot count activate may not grant, a hostfile it
+         * cannot read), so it comes back as a bad parameter */
+        req->pstatus = (PRTE_ERR_SILENT == rc) ? PMIX_ERR_BAD_PARAM
+                                               : prte_pmix_convert_rc(rc);
+        return;
+    }
+
+    req->pstatus = PMIX_SUCCESS;
+    if (0 == nactivated) {
+        /* every named node is already in the DVM, or already on its way in.
+         * The request is met and nothing will be launched, so answer now -
+         * promising a completion event here would leave the requester
+         * waiting on a grow that never runs. */
+        PMIX_OUTPUT_VERBOSE((5, prte_ras_base_framework.framework_output,
+                             "%s ras:base:activate request had nothing to activate",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+        return;
+    }
+
+    /* hold the DVM not-ready until the new daemons are up, so a job submitted
+     * behind this request waits for them - the VM_READY re-entry at the end
+     * of the grow marks it ready again and releases the cached jobs */
+    prte_dvm_ready = false;
+
+#if PRTE_HAVE_DVM_MOD_EVENTS
+    if (prte_elastic_mode &&
+        PRTE_SUCCESS == prte_plm_base_add_grow_requester(&req->tproc, NULL, req_id)) {
+        /* An activated node is not usable until its daemon is up, so the
+         * campaign's PMIX_DVM_IS_READY is the answer - as it is for an
+         * extend.  Only where that event can arrive: outside elastic mode no
+         * campaign is recorded, and there the grant stays the answer. */
+        req->pstatus = PMIX_OPERATION_IN_PROGRESS;
+    }
+#endif
+
+    prte_ras_base_activate_dvm_grow();
+}
+#endif /* defined(PMIX_ALLOC_ACTIVATE) */
+
 void prte_ras_base_modify(int fd, short args, void *cbdata)
 {
     prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
@@ -751,6 +851,15 @@ void prte_ras_base_modify(int fd, short args, void *cbdata)
 
     // set the default response
     req->pstatus = PMIX_ERR_NOT_SUPPORTED;
+
+#if defined(PMIX_ALLOC_ACTIVATE)
+    if (PMIX_ALLOC_ACTIVATE == req->allocdir) {
+        /* served here rather than by a module - see the note on
+         * ras_base_activate_request */
+        ras_base_activate_request(req);
+        goto respond;
+    }
+#endif
 
     // cycle across the modules and give each a chance to execute request
     PMIX_LIST_FOREACH(mod, &prte_ras_base.selected_modules, prte_ras_base_selected_module_t) {
@@ -2144,7 +2253,7 @@ static int ras_base_activate_select(pmix_pointer_array_t *sel, prte_node_t *node
  * what the file said; what goes into the selection is the pool's own entry
  * for each, which is the only thing a grow can act on.
  */
-static int ras_base_activate_hostfile(char *hostfile, pmix_pointer_array_t *sel)
+static int ras_base_activate_hostfile(const char *hostfile, pmix_pointer_array_t *sel)
 {
     pmix_list_t nodes;
     prte_node_t *nd, *node;
@@ -2158,7 +2267,7 @@ static int ras_base_activate_hostfile(char *hostfile, pmix_pointer_array_t *sel)
     PMIX_CONSTRUCT(&nodes, pmix_list_t);
     /* the parser reports its own failures - a file it cannot open, a bad
      * line, relative syntax inside a file - through show_help */
-    rc = prte_util_add_hostfile_nodes(&nodes, hostfile);
+    rc = prte_util_add_hostfile_nodes(&nodes, (char *) hostfile);
     if (PRTE_SUCCESS != rc) {
         PMIX_LIST_DESTRUCT(&nodes);
         return (PRTE_ERR_SILENT == rc) ? rc : PRTE_ERR_SILENT;
@@ -2197,7 +2306,7 @@ static int ras_base_activate_hostfile(char *hostfile, pmix_pointer_array_t *sel)
  * A ":<slots>" modifier is refused rather than ignored (see below), and so
  * is "+e" - see there for why it cannot mean anything useful here.
  */
-static int ras_base_activate_spec(char *spec, pmix_pointer_array_t *sel)
+static int ras_base_activate_spec(const char *spec, pmix_pointer_array_t *sel)
 {
     char **tokens;
     int rc = PRTE_SUCCESS;
@@ -2320,12 +2429,108 @@ done:
     return rc;
 }
 
+/*
+ * Resolve one activation request - a host specification, a hostfile, or both -
+ * into the selection.  This is the single entry point both requesters share:
+ * the command line folds its hostfile into the host list as "file=<path>"
+ * while the PMIx form carries it as a separate attribute, so the two arrive
+ * differently and are parsed identically from here on.  Either argument may be
+ * NULL; the hostfile argument may name several files, comma-delimited, as
+ * every other hostfile attribute may.
+ */
+static int ras_base_activate_resolve(const char *hosts, const char *hostfile,
+                                     pmix_pointer_array_t *sel)
+{
+    char **files;
+    int k, rc = PRTE_SUCCESS;
+
+    if (NULL != hosts && '\0' != *hosts) {
+        rc = ras_base_activate_spec(hosts, sel);
+        if (PRTE_SUCCESS != rc) {
+            return rc;
+        }
+    }
+
+    if (NULL == hostfile || '\0' == *hostfile) {
+        return PRTE_SUCCESS;
+    }
+    files = PMIx_Argv_split(hostfile, ',');
+    if (NULL == files) {
+        return PRTE_SUCCESS;
+    }
+    for (k = 0; NULL != files[k]; k++) {
+        rc = ras_base_activate_hostfile(files[k], sel);
+        if (PRTE_SUCCESS != rc) {
+            break;
+        }
+    }
+    PMIx_Argv_free(files);
+
+    return rc;
+}
+
+/*
+ * Commit a resolved selection: mark every entry PRTE_NODE_STATE_ADDED so the
+ * next DVM extension launches a daemon there, and report how many entries that
+ * actually changed.  A count of zero means every named node is already in the
+ * DVM or already on its way in - nothing to launch, and nothing to wait for.
+ *
+ * Committing is separate from resolving so that a request naming several
+ * specifications is all-or-nothing: a bad token in a later one cannot leave
+ * nodes marked for a grow that never happens.
+ */
+static int ras_base_activate_commit(pmix_pointer_array_t *sel)
+{
+    int i, nactivated = 0;
+    prte_node_t *node;
+
+    for (i = 0; i < sel->size; i++) {
+        node = (prte_node_t *) pmix_pointer_array_get_item(sel, i);
+        if (NULL == node) {
+            continue;
+        }
+        if (PRTE_NODE_STATE_ADDED == node->state) {
+            /* already claimed by a pending grow, which will launch it */
+            continue;
+        }
+        node->state = PRTE_NODE_STATE_ADDED;
+        ++nactivated;
+    }
+
+    return nactivated;
+}
+
+int prte_ras_base_activate_nodes(const char *hosts, const char *hostfile,
+                                 int *nactivated)
+{
+    pmix_pointer_array_t sel;
+    int rc;
+
+    *nactivated = 0;
+    if ((NULL == hosts || '\0' == *hosts) &&
+        (NULL == hostfile || '\0' == *hostfile)) {
+        /* nothing named at all - the caller asked for an activation without
+         * saying what to activate */
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    PMIX_CONSTRUCT(&sel, pmix_pointer_array_t);
+    pmix_pointer_array_init(&sel, 8, INT_MAX, 8);
+
+    rc = ras_base_activate_resolve(hosts, hostfile, &sel);
+    if (PRTE_SUCCESS == rc) {
+        *nactivated = ras_base_activate_commit(&sel);
+    }
+    PMIX_DESTRUCT(&sel);
+
+    return rc;
+}
+
 int prte_ras_base_activate_hosts(prte_job_t *jdata)
 {
     int i, rc, nactivated;
     prte_app_context_t *app;
     char *spec;
-    prte_node_t *node;
     pmix_pointer_array_t sel;
     bool found = false, adding = false;
 
@@ -2350,7 +2555,7 @@ int prte_ras_base_activate_hosts(prte_job_t *jdata)
             continue;
         }
         found = true;
-        rc = ras_base_activate_spec(spec, &sel);
+        rc = ras_base_activate_resolve(spec, NULL, &sel);
         free(spec);
         if (PRTE_SUCCESS != rc) {
             PMIX_DESTRUCT(&sel);
@@ -2364,19 +2569,7 @@ int prte_ras_base_activate_hosts(prte_job_t *jdata)
     }
 
     /* every token resolved, so the selection can now be committed */
-    nactivated = 0;
-    for (i = 0; i < sel.size; i++) {
-        node = (prte_node_t *) pmix_pointer_array_get_item(&sel, i);
-        if (NULL == node) {
-            continue;
-        }
-        if (PRTE_NODE_STATE_ADDED == node->state) {
-            /* already claimed by a pending grow, which will launch it */
-            continue;
-        }
-        node->state = PRTE_NODE_STATE_ADDED;
-        ++nactivated;
-    }
+    nactivated = ras_base_activate_commit(&sel);
     PMIX_DESTRUCT(&sel);
 
     if (0 == nactivated) {

--- a/src/prted/pmix/pmix_server_session.c
+++ b/src/prted/pmix/pmix_server_session.c
@@ -1060,9 +1060,17 @@ static pmix_status_t session_instantiate(prte_pmix_server_req_t *req,
     }
 
     if (grew) {
-        /* extend the DVM across the new nodes. This clears prte_dvm_ready, so
-         * a job submitted below is held in the job cache and released once the
-         * daemons are up - which is exactly the ordering we need. */
+        /* Extend the DVM across the new nodes.  Mark it not-ready first: the
+         * job built below is submitted through the ordinary launch path,
+         * which parks a job in prte_cache while the DVM is not ready and
+         * releases it at the VM_READY re-entry that ends the grow.  That is
+         * exactly the ordering an instantiation needs - its apps are meant to
+         * run on the nodes this call is about to bring in - and without the
+         * mark the job goes straight to the mapper, which sees nodes that as
+         * yet have no daemon.  Every other producer of a grow that submits
+         * work behind it does the same (prte_ras_base_add_hosts,
+         * prte_ras_base_activate_hosts). */
+        prte_dvm_ready = false;
         prte_ras_base_activate_dvm_grow();
     }
 

--- a/test/unit/ras/test_ras.c
+++ b/test/unit/ras/test_ras.c
@@ -38,9 +38,13 @@
  *      --display-allocation.
  *
  *   5. prte_ras_base_activate_hosts, which resolves a --activate
- *      specification against the node pool. It is the one operation that
- *      may extend the DVM under an allocation PRRTE does not own, so what
- *      it will and will not accept is exactly the safety property.
+ *      specification against the node pool, and
+ *      prte_ras_base_activate_nodes beneath it, which is the same resolver
+ *      as a PMIX_ALLOC_ACTIVATE request reaches - with the hostfile as its
+ *      own argument rather than folded into the host list. It is the one
+ *      operation that may extend the DVM under an allocation PRRTE does not
+ *      own, so what it will and will not accept is exactly the safety
+ *      property.
  *
  *   6. ras/slurm's "detect and report an allocation" capability, driven
  *      through the framework rather than by calling into the component.
@@ -1363,6 +1367,162 @@ static int test_activate_hosts(void)
 }
 
 
+/*
+ * prte_ras_base_activate_nodes: the entry point both requesters share.
+ *
+ * The command line reaches it through prte_ras_base_activate_hosts() above,
+ * folding its hostfile into the host list as "file=<path>"; a
+ * PMIX_ALLOC_ACTIVATE request reaches it directly, carrying the hostfile as a
+ * separate attribute.  What is tested here is the part only the second caller
+ * can reach - the hostfile as its own argument - plus the activation count,
+ * which is what tells that caller whether anything will be launched and so
+ * whether a completion event is coming.
+ *
+ * No grow is activated by this function at all, which is why every case can
+ * be run without a state machine behind it.
+ */
+static int mkactfile(const char *path, const char *content)
+{
+    FILE *fp = fopen(path, "w");
+
+    if (NULL == fp) {
+        fprintf(stderr, "could not write test hostfile %s\n", path);
+        return PRTE_ERROR;
+    }
+    fputs(content, fp);
+    fclose(fp);
+    return PRTE_SUCCESS;
+}
+
+static int test_activate_nodes(void)
+{
+    int failures = 0;
+    prte_node_t *idle1, *idle2, *nptr;
+    prte_node_state_t *parked;
+    const char *hf1 = "prte_test_activate_nodes1.txt";
+    const char *hf2 = "prte_test_activate_nodes2.txt";
+    char *both;
+    int i, npool, n = -1;
+
+    /* own the pool, as the +e forms above require - the same reason applies
+     * to "+all" here */
+    npool = prte_node_pool->size;
+    parked = (prte_node_state_t *) malloc(npool * sizeof(prte_node_state_t));
+    for (i = 0; i < npool; i++) {
+        nptr = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, i);
+        if (NULL == nptr) {
+            continue;
+        }
+        parked[i] = nptr->state;
+        nptr->state = PRTE_NODE_STATE_NOT_INCLUDED;
+    }
+
+    idle1 = PMIX_NEW(prte_node_t);
+    idle1->name = strdup("actn-idle1");
+    idle1->state = PRTE_NODE_STATE_UP;
+    idle1->slots = 4;
+    idle1->index = pmix_pointer_array_add(prte_node_pool, idle1);
+
+    idle2 = PMIX_NEW(prte_node_t);
+    idle2->name = strdup("actn-idle2");
+    idle2->state = PRTE_NODE_STATE_UP;
+    idle2->slots = 4;
+    idle2->index = pmix_pointer_array_add(prte_node_pool, idle2);
+
+    /* naming nothing at all is a bad request, not an empty success: a
+     * requester that meant "everything" says so with "+all" */
+    CHECK("activate_nodes: nothing named is refused",
+          PRTE_ERR_BAD_PARAM == prte_ras_base_activate_nodes(NULL, NULL, &n));
+    CHECK("activate_nodes: refusal reports no activation", 0 == n);
+    CHECK("activate_nodes: an empty spec is the same as none",
+          PRTE_ERR_BAD_PARAM == prte_ras_base_activate_nodes("", "", &n));
+
+    /* the host specification alone */
+    CHECK("activate_nodes: host spec accepted",
+          PRTE_SUCCESS == prte_ras_base_activate_nodes("actn-idle1", NULL, &n));
+    CHECK("activate_nodes: it marked the node", PRTE_NODE_STATE_ADDED == idle1->state);
+    CHECK("activate_nodes: and counted it", 1 == n);
+
+    /* a node already marked is met, and counts for nothing: there is no
+     * second daemon to launch, so no completion to wait for */
+    CHECK("activate_nodes: re-naming a marked node succeeds",
+          PRTE_SUCCESS == prte_ras_base_activate_nodes("actn-idle1", NULL, &n));
+    CHECK("activate_nodes: with nothing left to activate", 0 == n);
+
+    /* the hostfile as its own argument - the form only the PMIx directive
+     * produces, since the command line spells it "file=<path>" */
+    idle1->state = PRTE_NODE_STATE_UP;
+    if (PRTE_SUCCESS != mkactfile(hf1, "actn-idle1\n")) {
+        return failures + 1;
+    }
+    CHECK("activate_nodes: hostfile argument accepted",
+          PRTE_SUCCESS == prte_ras_base_activate_nodes(NULL, hf1, &n));
+    CHECK("activate_nodes: the file's node was marked",
+          PRTE_NODE_STATE_ADDED == idle1->state);
+    CHECK("activate_nodes: and counted", 1 == n);
+
+    /* both arguments together, each naming a different node */
+    idle1->state = PRTE_NODE_STATE_UP;
+    CHECK("activate_nodes: host spec and hostfile together",
+          PRTE_SUCCESS == prte_ras_base_activate_nodes("actn-idle2", hf1, &n));
+    CHECK("activate_nodes: both nodes marked",
+          PRTE_NODE_STATE_ADDED == idle1->state &&
+          PRTE_NODE_STATE_ADDED == idle2->state);
+    CHECK("activate_nodes: both counted", 2 == n);
+
+    /* several hostfiles, comma-delimited, as every other hostfile attribute
+     * accepts */
+    idle1->state = PRTE_NODE_STATE_UP;
+    idle2->state = PRTE_NODE_STATE_UP;
+    if (PRTE_SUCCESS != mkactfile(hf2, "actn-idle2\n")) {
+        return failures + 1;
+    }
+    pmix_asprintf(&both, "%s,%s", hf1, hf2);
+    CHECK("activate_nodes: a comma-delimited hostfile list",
+          PRTE_SUCCESS == prte_ras_base_activate_nodes(NULL, both, &n));
+    CHECK("activate_nodes: every file's node marked",
+          PRTE_NODE_STATE_ADDED == idle1->state &&
+          PRTE_NODE_STATE_ADDED == idle2->state);
+    CHECK("activate_nodes: all of them counted", 2 == n);
+    free(both);
+
+    /* a refusal anywhere marks nothing and says so */
+    idle1->state = PRTE_NODE_STATE_UP;
+    idle2->state = PRTE_NODE_STATE_UP;
+    CHECK("activate_nodes: an unknown host is refused",
+          PRTE_ERR_SILENT == prte_ras_base_activate_nodes("actn-idle1,actn-nosuch",
+                                                          NULL, &n));
+    CHECK("activate_nodes: nothing was marked by the refused spec",
+          PRTE_NODE_STATE_UP == idle1->state);
+    CHECK("activate_nodes: and nothing counted", 0 == n);
+
+    /* the refusal covers the hostfile argument too */
+    if (PRTE_SUCCESS != mkactfile(hf2, "actn-nosuch\n")) {
+        return failures + 1;
+    }
+    CHECK("activate_nodes: an unknown host in the hostfile is refused",
+          PRTE_ERR_SILENT == prte_ras_base_activate_nodes("actn-idle1", hf2, &n));
+    CHECK("activate_nodes: the host spec's node was not marked either",
+          PRTE_NODE_STATE_UP == idle1->state);
+
+    unlink(hf1);
+    unlink(hf2);
+    for (i = 0; i < npool; i++) {
+        nptr = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, i);
+        if (NULL == nptr) {
+            continue;
+        }
+        nptr->state = parked[i];
+    }
+    free(parked);
+    pmix_pointer_array_set_item(prte_node_pool, idle1->index, NULL);
+    pmix_pointer_array_set_item(prte_node_pool, idle2->index, NULL);
+    PMIX_RELEASE(idle1);
+    PMIX_RELEASE(idle2);
+
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0;
@@ -1399,6 +1559,7 @@ int main(void)
     failures += test_flag_string();
     failures += test_dvm_growing();
     failures += test_activate_hosts();
+    failures += test_activate_nodes();
     /* after test_select(), which opens the framework and latches a
      * selection made with no SLURM allocation in the environment -- so
      * nothing has called slurm's init() before this does */


### PR DESCRIPTION
Closes the `docs/todo.rst` item "Only a command line can ask for a daemon on an allocated node".

**Depends on openpmix/openpmix#4190**, which adds the directive. Built against a PMIx that predates it, the new arm compiles out and the request is answered `PMIX_ERR_NOT_SUPPORTED`, exactly as it is today.

### The problem

The node pool holds every node the allocation contains, but only those the DVM was started across carry a daemon: a `--host`/`--hostfile` given to `prte` narrows which pool entries get one, a `prte_max_vm_size` cap leaves the rest behind, and a released reservation hands its nodes back without one. Such a node is allocated, up, and unusable.

`--activate` brings it into the DVM, and is permitted even under a scheduler-owned allocation because it can name nothing the allocation does not already contain. A *programmatic* requester had no equivalent — the directive travelled as a PRRTE-private spawn key precisely because PMIx had no standard way to say "start a daemon on a node I already hold".

### The change

Serve `PMIX_ALLOC_ACTIVATE`, naming its nodes with `PMIX_HOST` and/or `PMIX_HOSTFILE`, and resolve them through **the same code** that resolves an `--activate` specification. `prte_ras_base_activate_nodes()` is factored out of `prte_ras_base_activate_hosts()` and takes the host specification and the hostfile as two arguments, since the command line folds its hostfile into the list as `file=<path>` while the PMIx form carries it separately. Everything else — the syntax, the refusal of a slot count, of `+e`, and of any host the DVM does not hold, and the rule that a node already in the DVM is a no-op rather than an error — is one implementation and cannot drift apart from the command line.

`prte_ras_base_modify()` answers it **before the module loop** rather than offering it to the selected component. This is a deliberate deviation from the todo item's sketch (which put it in `ras/hosts`' `modify()`): there is nothing for a module to do, and routing it by allocation owner would make the answer depend on which resource manager is in play — refusing under a scheduler the one size change that is always safe under one.

It answers in **two phases**, as an extend does, because no job stands behind the request to make its completion observable: the grant returns at once, and the daemons are reported by the directed `PMIX_DVM_IS_READY` when the campaign drains. Where no campaign will exist — outside elastic mode, or when every named node is already in the DVM — the grant is the whole answer and `PMIX_SUCCESS` is returned at phase one, so nothing waits on an event no one will send.

That completion needed one piece of plumbing. A campaign resolves its requesters through the *session* owning each target; an activation creates no session, so `prte_plm_base_add_grow_requester()` carries the requester from the grant to the campaign that adopts it. Anything no campaign adopts is answered rather than stranded — success where the launch simply had nothing to record, failure where it was never computed — and framework close flushes whatever is left. The completion event also stops carrying an empty `PMIX_ALLOC_ID`: an activation names no allocation, and a key present with a NULL value says less than no key at all.

### Drive-by fix

Instantiating a session can bring nodes in and then launch the apps the request describes on them, and the comment at its grow says the job is parked until the daemons are up. It was not: activating a grow posts a state, and nothing along that path clears `prte_dvm_ready`, so the job went straight on to be mapped against a DVM whose newest nodes had no daemon yet. Marked not-ready before the grow, as every other producer of a grow that submits work behind it already does.

### Testing

* Warning-free `--enable-debug` build; `make check`; offline mapper harness (2449 pass / 0 fail).
* New `test/unit/ras` coverage for `prte_ras_base_activate_nodes` — the hostfile as its own argument (alone, beside a host spec, comma-delimited), the activation count that tells a caller whether a completion event is coming, and the rule that a refusal anywhere marks nothing.
* New `contrib/dockerswarm` case (`elastic activate`): a DVM capped to two of its four allocated nodes; one node activated by name and one from a `PMIX_HOSTFILE`, each proving its daemon appeared and its phase-two `PMIX_DVM_IS_READY` arrived; a job then run there; an unallocated host refused with the refusal reaching the caller; `+all` answered outright once nothing is left to activate. Verified green.
* New `contrib/slurmswarm` sub-case asking the same thing where SLURM owns the allocation — the only place "served under a scheduler" can be shown, since everywhere else add-host would have served the same request.
* Local end-to-end through `palloc --activate` on a single-host DVM: grant, refusal, slot-count refusal, `+e` refusal, `+all`, hostfile form.

The full dockerswarm suite is re-running at the time of writing (an external stop killed the containers partway through the first pass); everything it had reached was green apart from two stale assertion strings of mine, which are fixed here.