### PR TITLE
Obtain the allocation a spawn asks for before launching it

### DIFF
--- a/contrib/dockerswarm/elastic.c
+++ b/contrib/dockerswarm/elastic.c
@@ -23,11 +23,16 @@
  *   elastic release-id <alloc-id>           # PMIX_ALLOC_RELEASE + ALLOC_ID
  *   elastic cancel     <req-id>             # PMIX_ALLOC_REQ_CANCEL
  *   elastic activate   <host-spec>          # PMIX_ALLOC_ACTIVATE + HOST
+ *   elastic spawnalloc <node[:slots],...> -- <cmd>
+ *                                          # PMIx_Spawn carrying PMIX_SPAWN_ALLOC
  *
  *   --req-id <id>   request id to send (default "elastic-test"); "cancel"
  *                   names the request to cancel this way too
  *   --hostfile <f>  hostfile to send as PMIX_HOSTFILE (activate only; may be
  *                   given with or instead of the host spec, which is then "")
+ *   --alloc-dir <d> directive for the spawn-carried request (spawnalloc only):
+ *                   new (default), extend, release, reaquire, or "none" to
+ *                   leave the directive out and see the request refused
  *   --wait          wait for the phase-two completion event
  *   --no-wait       do not
  *
@@ -68,6 +73,15 @@
  * That is the only way to place a job on a freshly grown node: grown nodes
  * join the new reservation rather than the default pool, so a plain
  * "prun --host <grown-node>" has no allocation to map onto and fails.
+ *
+ * "spawnalloc" does that whole sequence as ONE call: the spawn carries the
+ * allocation request in PMIX_SPAWN_ALLOC, and the host obtains the
+ * allocation, waits for it, points the job at it and launches - or, if the
+ * allocation is refused, fails the spawn with PMIX_ERR_JOB_ALLOC_FAILED
+ * having launched nothing.  It is the "grow, read the id, spawn into it"
+ * dance above with the caller taken out of the middle, so the two are worth
+ * comparing: this one has no window in which the resources are held by
+ * nobody's job.
  *
  * Build: gcc -o elastic elastic.c -lpmix
  */
@@ -257,6 +271,113 @@ static int spawn_into_reservation(char **cmd) {
     return 0;
 }
 
+/* Spawn a job whose allocation request rides along on the spawn itself.
+ *
+ * The whole request goes into PMIX_SPAWN_ALLOC as an array of pmix_info_t:
+ * the directive first (PMIX_ALLOC_REQ_DIRECTIVE - the allocation API takes
+ * it as a parameter, and there is no parameter here), then exactly the info
+ * a standalone request would have carried.  The host does the rest, and
+ * either the spawn succeeds on resources it obtained, or it fails with
+ * PMIX_ERR_JOB_ALLOC_FAILED having allocated nothing.
+ *
+ * Returns 0 on success.
+ */
+static int spawn_with_alloc(const char *nodes, const char *req_id,
+                            const char *dirname, char **cmd) {
+    pmix_app_t app;
+    pmix_info_t jinfo[2], *areq;
+    pmix_data_array_t darray;
+    pmix_nspace_t nspace;
+    pmix_alloc_directive_t directive = PMIX_ALLOC_NEW;
+    pmix_status_t rc, code = PMIX_EVENT_JOB_END;
+    lock_t reglock;
+    bool flag = true;
+    size_t nareq = 3;
+    int n;
+
+    lock_init(&jobend_lock);
+    lock_init(&reglock);
+    PMIx_Register_event_handler(&code, 1, NULL, 0, jobend_evh, reg_cb, &reglock);
+    lock_wait(&reglock);
+
+    PMIX_APP_CONSTRUCT(&app);
+    app.cmd = strdup(cmd[0]);
+    for (n = 0; NULL != cmd[n]; n++) {
+        PMIx_Argv_append_nosize(&app.argv, cmd[n]);
+    }
+    app.maxprocs = 1;
+
+    /* --alloc-dir names the directive, so the two ways a request can be
+     * refused are reachable: one no module will serve, and one that names no
+     * directive at all (which is not an allocation failure but a malformed
+     * request, and answers differently) */
+    if (NULL != dirname) {
+        if (0 == strcmp(dirname, "extend")) {
+            directive = PMIX_ALLOC_EXTEND;
+        } else if (0 == strcmp(dirname, "release")) {
+            directive = PMIX_ALLOC_RELEASE;
+        } else if (0 == strcmp(dirname, "reaquire")) {
+            directive = PMIX_ALLOC_REAQUIRE;
+        } else if (0 == strcmp(dirname, "none")) {
+            nareq = 2;      /* omit the directive element entirely */
+        } else if (0 != strcmp(dirname, "new")) {
+            fprintf(stderr, "unknown --alloc-dir '%s'\n", dirname);
+            return 1;
+        }
+    }
+
+    PMIX_INFO_CREATE(areq, nareq);
+    n = 0;
+    if (3 == nareq) {
+        PMIX_INFO_LOAD(&areq[n++], PMIX_ALLOC_REQ_DIRECTIVE, &directive, PMIX_ALLOC_DIRECTIVE);
+    }
+    PMIX_INFO_LOAD(&areq[n++], PMIX_ALLOC_NODE_LIST, nodes, PMIX_STRING);
+    PMIX_INFO_LOAD(&areq[n], PMIX_ALLOC_REQ_ID, req_id, PMIX_STRING);
+    darray.type = PMIX_INFO;
+    darray.size = nareq;
+    darray.array = areq;
+    PMIX_INFO_LOAD(&jinfo[0], PMIX_SPAWN_ALLOC, &darray, PMIX_DATA_ARRAY);
+    PMIX_INFO_FREE(areq, nareq);
+    PMIX_INFO_LOAD(&jinfo[1], PMIX_NOTIFY_COMPLETION, &flag, PMIX_BOOL);
+
+    fprintf(stderr, "spawning [%s] with an allocation request for [%s] ...\n",
+            cmd[0], nodes);
+    rc = PMIx_Spawn(jinfo, 2, &app, 1, nspace);
+    PMIX_APP_DESTRUCT(&app);
+    PMIX_INFO_DESTRUCT(&jinfo[0]);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, ">>> SPAWN FAILED: %s\n", PMIx_Error_string(rc));
+        if (PMIX_ERR_JOB_ALLOC_FAILED == rc) {
+            /* the outcome this attribute exists to make tellable apart: the
+             * allocation was refused, so nothing was launched */
+            fprintf(stderr, ">>> ALLOCATION REFUSED\n");
+        } else if (PMIX_ERR_BAD_PARAM == rc) {
+            /* the request itself was malformed - nothing was asked of any
+             * allocator, which is a different thing from being refused */
+            fprintf(stderr, ">>> REQUEST REJECTED\n");
+        }
+        return 1;
+    }
+    fprintf(stderr, ">>> SPAWNED %s on its own allocation\n", nspace);
+
+    /* bounded wait for the job to finish so a caller can inspect its work */
+    {
+        struct timespec ts;
+        clock_gettime(CLOCK_REALTIME, &ts);
+        ts.tv_sec += 60;
+        pthread_mutex_lock(&jobend_lock.mtx);
+        while (jobend_lock.active) {
+            if (ETIMEDOUT == pthread_cond_timedwait(&jobend_lock.cond,
+                                                    &jobend_lock.mtx, &ts)) {
+                fprintf(stderr, ">>> TIMEOUT: spawned job did not end within 60s\n");
+                break;
+            }
+        }
+        pthread_mutex_unlock(&jobend_lock.mtx);
+    }
+    return 0;
+}
+
 static void usage(const char *me) {
     fprintf(stderr,
             "usage: %s <op> <arg> [--req-id <id>] [--wait|--no-wait] [-- <cmd> ...]\n"
@@ -268,6 +389,8 @@ static void usage(const char *me) {
             "  release-id <alloc-id>           PMIX_ALLOC_RELEASE + ALLOC_ID\n"
             "  cancel     <req-id>             PMIX_ALLOC_REQ_CANCEL\n"
             "  activate   <host-spec>          PMIX_ALLOC_ACTIVATE + HOST\n"
+            "  spawnalloc <node[:slots],...>   PMIx_Spawn + PMIX_SPAWN_ALLOC\n"
+            "                                  (needs \"-- <cmd>\")\n"
             "\n"
             "Every op but 'cancel' waits for the phase-two completion event;\n"
             "--no-wait is what a DVM outside elastic mode needs.\n", me);
@@ -283,6 +406,7 @@ int main(int argc, char **argv) {
     lock_t alloclock;
     const char *op, *arg, *req_id = "elastic-test";
     const char *hostfile = NULL;
+    const char *alloc_dir = NULL;
     char **spawn_cmd = NULL;
     uint64_t num_nodes = 0;
     bool by_count = false;
@@ -308,6 +432,8 @@ int main(int argc, char **argv) {
             req_id = argv[++i];
         } else if (0 == strcmp(argv[i], "--hostfile") && i + 1 < argc) {
             hostfile = argv[++i];
+        } else if (0 == strcmp(argv[i], "--alloc-dir") && i + 1 < argc) {
+            alloc_dir = argv[++i];
         } else if (0 == strcmp(argv[i], "--wait")) {
             wait_opt = 1;
         } else if (0 == strcmp(argv[i], "--no-wait")) {
@@ -345,6 +471,16 @@ int main(int argc, char **argv) {
         wait_phase2 = false;
     } else if (0 == strcmp(op, "activate")) {
         directive = PMIX_ALLOC_ACTIVATE;
+    } else if (0 == strcmp(op, "spawnalloc")) {
+        /* no allocation request is issued from here at all - the request
+         * rides on the spawn, which is the point */
+        directive = PMIX_ALLOC_NEW;
+        wait_phase2 = false;
+        if (NULL == spawn_cmd) {
+            fprintf(stderr, "spawnalloc needs a command: %s spawnalloc <nodes> -- <cmd>\n",
+                    argv[0]);
+            return 1;
+        }
     } else {
         fprintf(stderr, "unknown op '%s'\n", op);
         usage(argv[0]);
@@ -386,6 +522,12 @@ int main(int argc, char **argv) {
     PMIx_Register_event_handler(codes, 2, NULL, 0, completion_evh, reg_cb, &reglock);
     lock_wait(&reglock);
     fprintf(stderr, "registered for PMIX_DVM_IS_READY / PMIX_ERR_DVM_MOD\n");
+
+    /* the spawn-carried form never issues a request of its own */
+    if (0 == strcmp(op, "spawnalloc")) {
+        rcexit = spawn_with_alloc(arg, req_id, alloc_dir, spawn_cmd);
+        goto done;
+    }
 
     /* issue the size-change request.  Exactly one selector goes with the
      * request id: the node list, the node count, or the allocation id -- the

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -7482,6 +7482,78 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     fi
     cleanup_swarm
 
+    banner "ras: a spawn carries the allocation it needs (PMIX_SPAWN_ALLOC)"
+    # The library form of "salloc, then srun": the spawn carries an entire
+    # allocation request, and the DVM obtains the allocation, waits for it,
+    # points the job at it and launches - or fails the spawn without launching
+    # anything. Only a multi-node DVM can show it: the request has to bring in
+    # a node the DVM is not on, and the proof is the job running there.
+    #
+    # The four outcomes that have to be tellable apart are all here: granted
+    # and launched; refused (PMIX_ERR_JOB_ALLOC_FAILED, nothing launched);
+    # malformed (PMIX_ERR_BAD_PARAM - nothing was asked of any allocator); and
+    # granted but then failing to launch, which hands the allocation back
+    # before it answers.
+    cleanup_swarm
+    RUN 'nohup prte --daemonize --prtemca prte_elastic_mode 1 --host node1:2 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    if RUN 'pgrep -x prte >/dev/null'; then
+        [ "$(prted_count 2 3)" = 0 ] \
+            && ok "the DVM spans node1 alone - nothing else has a daemon" \
+            || bad "node2/node3 already have daemons - the test premise is gone"
+
+        out=$(RUN 'timeout 120 elastic spawnalloc node2:2 -- hostname' 2>&1)
+        echo "$out" | grep -q 'SPAWNED' \
+            && ok "the spawn obtained its own allocation and launched" \
+            || bad "spawn with PMIX_SPAWN_ALLOC failed: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        echo "$out" | grep -q '^node2$' \
+            && ok "and the job ran on the node it allocated" \
+            || bad "the job did not run on the allocated node: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        [ "$(prted_count 2)" = 1 ] && ok "a daemon was started there for it" \
+                                   || bad "no daemon on the allocated node"
+
+        # a directive no module serves: the allocation is refused, and that is
+        # NOT a launch failure - the caller can tell, and nothing was started
+        out=$(RUN 'timeout 90 elastic spawnalloc node3:2 --alloc-dir reaquire -- hostname' 2>&1)
+        echo "$out" | grep -q 'ALLOCATION REFUSED' \
+            && ok "a refused allocation fails the spawn with PMIX_ERR_JOB_ALLOC_FAILED" \
+            || bad "a refused allocation did not answer as one: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        [ "$(prted_count 3)" = 0 ] && ok "and nothing was launched for it" \
+                                   || bad "a daemon was started despite the refusal"
+
+        # a request that names no directive is malformed rather than refused:
+        # nothing was asked of any allocator at all
+        out=$(RUN 'timeout 90 elastic spawnalloc node3:2 --alloc-dir none -- hostname' 2>&1)
+        echo "$out" | grep -q 'REQUEST REJECTED' \
+            && ok "a request with no directive is a bad parameter, not an allocation failure" \
+            || bad "a directive-less request was not refused as malformed: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+
+        # granted, then the launch fails: the allocation goes back before the
+        # spawn's own error is delivered, so the node it took is free again -
+        # the daemon leaving is what that looks like from outside
+        out=$(RUN 'timeout 120 elastic spawnalloc node3:2 --req-id badexe -- /no/such/binary' 2>&1)
+        echo "$out" | grep -q 'SPAWN FAILED: PMIX_ERR_JOB_FAILED_TO_LAUNCH' \
+            && ok "a launch failure is reported as one, not as an allocation failure" \
+            || bad "the launch failure was not reported: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        sleep 4
+        [ "$(prted_count 3)" = 0 ] \
+            && ok "the allocation it had obtained was handed back" \
+            || bad "the failed spawn is still holding its allocation"
+        # ...and the node it gave back can be allocated again. This is the
+        # half that a hand-rolled release used to break: the daemons were told
+        # to go while the master still believed they were there, so the next
+        # grow onto that node sent its launch message to a departed daemon.
+        out=$(RUN 'timeout 120 elastic spawnalloc node3:2 -- hostname' 2>&1)
+        echo "$out" | grep -q '^node3$' \
+            && ok "the released node can be allocated again" \
+            || bad "re-allocating the released node failed: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        [ "$(prted_count 3)" = 1 ] && ok "with a daemon of its own the second time" \
+                                   || bad "no daemon on the re-allocated node"
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        bad "could not start an elastic DVM for the PMIX_SPAWN_ALLOC test"
+    fi
+    cleanup_swarm
+
     banner "dash-host: relative node syntax selects from the DVM"
     # "+n<K>" names the K'th node of the allocation, "+e:N" names N nodes
     # that are currently empty. Neither can say anything about how big a

--- a/docs/how-things-work/schedulers/flow_of_control.rst
+++ b/docs/how-things-work/schedulers/flow_of_control.rst
@@ -39,6 +39,19 @@ option takes, and the request is answered when it is granted - the
 daemons themselves are reported by the ``PMIX_DVM_IS_READY`` event that
 completes any DVM size change.
 
+An allocation request can also arrive **on a spawn**, as
+``PMIX_SPAWN_ALLOC``: the value is an array of ``pmix_info_t`` holding the
+request's directive (``PMIX_ALLOC_REQ_DIRECTIVE``) and the info a standalone
+request would have carried. PRRTE serves that request first, exactly as it
+would serve the standalone one, and only launches the job once it is granted
+- pointing the job at what it was given, so it maps onto those resources
+rather than onto everything else. The two failures are kept apart: an
+allocation that is refused fails the spawn with ``PMIX_ERR_JOB_ALLOC_FAILED``
+and launches nothing, while a spawn that fails *after* the grant hands the
+allocation back before returning its own error. This saves a caller the
+"request, wait, read the id, spawn into it" sequence, and closes the window
+in that sequence where resources are held for a job that does not exist.
+
 PRRTE only creates a session object as a result of a call from the
 scheduler via ``PMIx_Session_control``. What it does with each directive
 of that API - and where it deviates from the letter of the attribute

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -32,28 +32,6 @@ Runtime behavior
 surface exists for SLURM only.  Everything above the component is
 RM-agnostic; what is missing is the Flux-side conversation.
 
-**There is no way to put an allocation directive into a** ``PMIx_Spawn``
-**call.**  This was the second half of the activation item, which is now
-done: a programmatic requester asks for a daemon on a node it already holds
-with ``PMIX_ALLOC_ACTIVATE``, naming its nodes with ``PMIX_HOST`` and/or
-``PMIX_HOSTFILE``, and ``prte_ras_base_modify`` serves it through the same
-``prte_ras_base_activate_nodes`` the ``--activate`` command line resolves
-through.  What remains is more general than activation and is worth having
-on its own.  Today a caller that needs resources before it can launch has to
-issue ``PMIx_Allocation_request`` itself, wait for it, and then spawn - the
-library equivalent of running ``salloc`` before ``srun``.
-An attribute carrying an allocation request on the spawn would let the host
-do what ``srun`` does when invoked outside an allocation: obtain the
-allocation per the directive, wait for it to complete, and only then
-execute the spawn.  PRRTE already has the mechanism this needs - the
-add-host path marks the DVM not-ready, parks the job in ``prte_cache``, and
-lets the grow's ``VM_READY`` re-entry release it (``prte_ras_base_add_hosts``,
-``plm_base_receive.c``) - so what is missing is the attribute and the
-routing, not the machinery.  Getting the failure semantics right is the
-part that needs thought: an allocation request that is refused, or that
-times out, has to fail the spawn with something the caller can tell apart
-from a launch failure.
-
 **Mixed allocators are not supported, and would need more than the ``ras``
 framework.**  The motivating case is a cloud/local combination: an allocation
 from a scheduler plus a set of unmanaged nodes outside it.  The ``ras``

--- a/src/mca/plm/AGENTS.md
+++ b/src/mca/plm/AGENTS.md
@@ -454,6 +454,19 @@ rather than reading `map->daemon_vpid_start`: a target whose session is gone
 would otherwise leave the campaign with no requester, and a successful grow
 would emit no phase-two completion event at all.
 
+An allocation the spawn itself asked for (`PMIX_SPAWN_ALLOC`) is served at
+this point too, and is the one thing that stops the launch path rather than
+continuing it: `prte_ras_base_spawn_alloc()` posts the request, the request
+holds the job, and `prte_plm_base_spawn_alloc_granted()`/`_failed()` pick the
+launch back up (or answer the requester) when it resolves. The job is
+deliberately **not** parked in `prte_cache` to wait — the cache is drained by
+whatever DVM-ready event comes next, which would launch it while its own
+allocation was still being obtained. It goes in only once a grow is known to
+be in flight, which is the same thing everything else in the cache is waiting
+for. The other half of that contract lives in `prte_plm_base_spawn_response`:
+a job that obtained an allocation and then failed to launch hands it back
+before its requester is told, and the answer follows the release.
+
 That scan resolves a requester through the *session* owning each target,
 which an **activation** (`--activate`, `PMIX_ALLOC_ACTIVATE`) has none of —
 it names nodes the allocation already held, which stay in the general pool.

--- a/src/mca/plm/base/base.h
+++ b/src/mca/plm/base/base.h
@@ -70,6 +70,27 @@ PRTE_EXPORT void prte_plm_base_registered(int fd, short args, void *cbdata);
 PRTE_EXPORT void prte_plm_base_wrap_args(char **args);
 PRTE_EXPORT int prte_plm_base_spawn_response(int32_t status, prte_job_t *jdata);
 
+/* The three outcomes of an allocation a spawn asked for (PMIX_SPAWN_ALLOC).
+ *
+ * _granted: point the job at what it was given and decide whether it still
+ *   has to wait - it does when the allocation brought in nodes whose daemons
+ *   are still being launched, and does not when nothing will make the DVM
+ *   ready again, in which case the cached jobs are released here.
+ * _failed: nothing was allocated and nothing will be launched, so the job
+ *   leaves the cache and its requester is told PMIX_ERR_JOB_ALLOC_FAILED -
+ *   which is what distinguishes this from a launch failure.
+ * _released: the allocation obtained for a job that then failed to launch
+ *   has been handed back, so the spawn's own error may now be delivered. */
+PRTE_EXPORT void prte_plm_base_spawn_alloc_granted(prte_job_t *jdata,
+                                                   const char *alloc_id);
+PRTE_EXPORT void prte_plm_base_spawn_alloc_failed(prte_job_t *jdata,
+                                                  pmix_status_t status);
+PRTE_EXPORT void prte_plm_base_spawn_alloc_released(prte_job_t *jdata);
+
+/* Admit every job parked in prte_cache: the DVM is ready and they were only
+ * waiting for that.  Called at VM_READY. */
+PRTE_EXPORT void prte_plm_base_release_cached_jobs(void);
+
 /* Build the body of a PRTE_PLM_UPDATE_PROC_STATE message.
  *
  * These are the writers for the format prte_plm_base_receive() reads, and

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1232,6 +1232,37 @@ int prte_plm_base_spawn_response(int32_t status, prte_job_t *jdata)
         return PRTE_SUCCESS;
     }
 
+    /* A job that obtained its own allocation (PMIX_SPAWN_ALLOC) and then
+     * failed to launch has to give that allocation back before its requester
+     * is told: a caller told its spawn failed is entitled to conclude it is
+     * not holding resources for it, and nothing else will ever release them -
+     * the job they were obtained for does not exist and never will.
+     *
+     * The answer therefore waits for the release, which is why the status is
+     * parked on the job and delivered by the re-entry from
+     * prte_plm_base_spawn_alloc_released().  Removing the id first is what
+     * makes that re-entry pass straight through here rather than release
+     * again.  A release we cannot even post is not worth losing the answer
+     * over: fall through and tell the requester what happened. */
+    if (PMIX_SUCCESS != status) {
+        char *sa_id = NULL;
+
+        if (prte_get_attribute(&jdata->attributes, PRTE_JOB_SPAWN_ALLOC_ID,
+                               (void **) &sa_id, PMIX_STRING) &&
+            NULL != sa_id) {
+            prte_remove_attribute(&jdata->attributes, PRTE_JOB_SPAWN_ALLOC_ID);
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_SPAWN_ALLOC_STATUS,
+                               PRTE_ATTR_LOCAL, &status, PMIX_INT32);
+            rc = prte_ras_base_release_spawn_alloc(jdata, sa_id);
+            free(sa_id);
+            if (PRTE_SUCCESS == rc) {
+                return PRTE_SUCCESS;
+            }
+            PRTE_ERROR_LOG(rc);
+            prte_remove_attribute(&jdata->attributes, PRTE_JOB_SPAWN_ALLOC_STATUS);
+        }
+    }
+
     /* a status is all the requester is going to get out of this response,
      * so tell it what actually happened while it is still listening */
     if (PMIX_SUCCESS != status) {
@@ -1453,6 +1484,12 @@ void prte_plm_base_post_launch(int fd, short args, void *cbdata)
     }
 
 next:
+    /* The job is running, so an allocation obtained for it is now the job's
+     * to hold: drop the note that says we still owe it a release.  From here
+     * its disposition is the ordinary one for a reservation - the inheritance
+     * rules applied when the owning namespace ends. */
+    prte_remove_attribute(&jdata->attributes, PRTE_JOB_SPAWN_ALLOC_ID);
+
     /* notify the spawn requestor */
     rc = prte_plm_base_spawn_response(PRTE_SUCCESS, jdata);
     if (PRTE_SUCCESS != rc) {

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -235,6 +235,146 @@ static int resolve_spawn_targets(prte_job_t *jdata, pmix_proc_t *requestor,
     return PRTE_SUCCESS;
 }
 
+/*
+ * The cache is where a job waits for a DVM that is not ready - because nodes
+ * are being added to it, or because the allocation the job asked for is still
+ * being obtained.  Both of those end in the same place: the DVM becomes ready
+ * and everything parked behind it is launched, in the order it arrived.
+ */
+void prte_plm_base_release_cached_jobs(void)
+{
+    prte_job_t *jptr;
+    int i;
+
+    for (i = 0; i < prte_cache->size; i++) {
+        jptr = (prte_job_t *) pmix_pointer_array_get_item(prte_cache, i);
+        if (NULL == jptr) {
+            continue;
+        }
+        pmix_pointer_array_set_item(prte_cache, i, NULL);
+        prte_plm.spawn(jptr);
+    }
+}
+
+void prte_plm_base_spawn_alloc_granted(prte_job_t *jdata, const char *alloc_id)
+{
+    pmix_proc_t *proxy = NULL;
+    char *idstr;
+    int rc;
+
+    PMIX_OUTPUT_VERBOSE((5, prte_plm_base_framework.framework_output,
+                         "%s plm:base:spawn_alloc granted%s%s",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                         (NULL == alloc_id) ? "" : " as ",
+                         (NULL == alloc_id) ? "" : alloc_id));
+
+    if (NULL != alloc_id) {
+        /* Remember what we obtained BEFORE anything else can go wrong with
+         * it: this is what a later failure hands back, and a failure while
+         * pointing the job at the allocation is exactly a failure that has to
+         * hand it back.  Removed again once the job is running - from that
+         * point the allocation belongs to the job, and its disposition is the
+         * ordinary one for a reservation. */
+        prte_set_attribute(&jdata->attributes, PRTE_JOB_SPAWN_ALLOC_ID,
+                           PRTE_ATTR_LOCAL, (void *) alloc_id, PMIX_STRING);
+
+        /* Point the job at what it was just given.  A reservation is withheld
+         * from general use, so a job that did not target it would be mapped
+         * onto everything EXCEPT the resources it asked for.  This is the
+         * same resolution a caller gets by passing PMIX_SPAWN_TARGET, which
+         * is what a caller doing this by hand has to do afterwards - and it
+         * carries the same ownership check, which our own requester passes by
+         * construction.
+         *
+         * Not every grant names a session: a resource manager may put what it
+         * granted into the general pool (ras/slurm's extend does), and there
+         * the job needs no target and gets none. */
+        if (prte_get_attribute(&jdata->attributes, PRTE_JOB_LAUNCH_PROXY,
+                               (void **) &proxy, PMIX_PROC) &&
+            NULL != proxy) {
+            if (NULL != prte_get_session_object_from_id(alloc_id)) {
+                idstr = strdup(alloc_id);
+                rc = resolve_spawn_targets(jdata, proxy, idstr);
+                free(idstr);
+                if (PRTE_SUCCESS != rc) {
+                    PRTE_ERROR_LOG(rc);
+                    PMIX_PROC_RELEASE(proxy);
+                    prte_plm_base_spawn_alloc_failed(jdata, prte_pmix_convert_rc(rc));
+                    return;
+                }
+                /* deliberately NOT also recorded as PRTE_JOB_SPAWN_TARGET:
+                 * the mapper reads jdata->target_sessions, which is what
+                 * resolve_spawn_targets just set, and a second statement of
+                 * the same thing is a second thing to keep true */
+            }
+            PMIX_PROC_RELEASE(proxy);
+        }
+    }
+
+    /* Now decide what the job is still waiting for.  It was held by the
+     * allocation request until this moment - deliberately NOT parked in the
+     * cache, which is drained by whatever DVM-ready event comes next and
+     * would have launched it while its own allocation was still being
+     * obtained. */
+    if (prte_ras_base_dvm_is_growing()) {
+        /* The allocation brought in nodes and their daemons are being
+         * launched.  Park until VM_READY, and mark the DVM not-ready while
+         * that happens so nothing else is mapped onto a DVM in flux - the
+         * same statement prte_ras_base_add_hosts makes for the same reason. */
+        prte_dvm_ready = false;
+        pmix_pointer_array_add(prte_cache, jdata);
+        return;
+    }
+    if (!prte_dvm_ready) {
+        /* someone else's grow is in flight; wait with everything else that is
+         * waiting on it */
+        pmix_pointer_array_add(prte_cache, jdata);
+        return;
+    }
+
+    /* Nothing to wait for: the allocation needed no new daemon (it reserved
+     * nodes the DVM already spans, or the request only changed a time limit),
+     * so launch now. */
+    prte_plm.spawn(jdata);
+}
+
+void prte_plm_base_spawn_alloc_failed(prte_job_t *jdata, pmix_status_t status)
+{
+    PMIX_OUTPUT_VERBOSE((2, prte_plm_base_framework.framework_output,
+                         "%s plm:base:spawn_alloc refused: %s",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                         PMIx_Error_string(status)));
+
+    /* The job was held by the request rather than parked in the cache, so
+     * there is nothing to take it out of - and nothing else was waiting on
+     * this allocation, so the DVM's readiness is untouched. */
+
+    /* PMIX_ERR_JOB_ALLOC_FAILED, and not the allocator's own status: the
+     * caller needs to know that this spawn failed for want of resources
+     * rather than for anything about the job, and a status that could equally
+     * have come from the launch would not tell it that.  The underlying
+     * status is reported by the allocator itself, through show_help and its
+     * own events. */
+    PRTE_HIDE_UNUSED_PARAMS(status);
+    prte_plm_base_spawn_response(PMIX_ERR_JOB_ALLOC_FAILED, jdata);
+}
+
+void prte_plm_base_spawn_alloc_released(prte_job_t *jdata)
+{
+    int32_t status = PMIX_ERR_JOB_FAILED_TO_LAUNCH;
+    int32_t *sptr = &status;
+
+    /* Deliver the answer the response stopped to release the allocation for.
+     * The job is still alive because the release request is holding it, and
+     * the status it was carrying was parked on it - see
+     * prte_plm_base_spawn_response. */
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_SPAWN_ALLOC_STATUS,
+                           (void **) &sptr, PMIX_INT32)) {
+        prte_remove_attribute(&jdata->attributes, PRTE_JOB_SPAWN_ALLOC_STATUS);
+    }
+    prte_plm_base_spawn_response(status, jdata);
+}
+
 int prte_plm_base_comm_start(void)
 {
     if (recv_issued) {
@@ -299,6 +439,9 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
     /* true while the freshly unpacked job object belongs to nobody but us -
      * cleared once it has been handed to a session/parent/the job pool */
     bool own_jdata = false;
+    /* true once an allocation request carried by the spawn has been posted,
+     * which is what then holds the job */
+    bool posted;
     pmix_data_buffer_t *answer;
     pmix_rank_t vpid;
     prte_proc_t *proc, *dproc;
@@ -755,6 +898,30 @@ moveon:
             } else {
                 jdata->bookmark = parent->bookmark;
             }
+        }
+
+        /* An entire allocation request may ride on the spawn
+         * (PMIX_SPAWN_ALLOC), and then it is served BEFORE the job is
+         * launched: the request holds the job while the allocation is
+         * obtained, and the outcome arrives asynchronously at
+         * prte_plm_base_spawn_alloc_granted() - which decides where the job
+         * waits from there - or at _failed(), which answers the requester.
+         * The job is deliberately not put in the cache to wait: the cache is
+         * drained by the next DVM-ready event whatever raised it.
+         *
+         * Only a malformed request is decided here, and it is a bad
+         * parameter rather than an allocation failure - nothing was asked of
+         * any allocator. */
+        posted = false;
+        if (PRTE_SUCCESS != (rc = prte_ras_base_spawn_alloc(jdata, &posted))) {
+            if (PRTE_ERR_SILENT != rc) {
+                PRTE_ERROR_LOG(rc);
+            }
+            rc = PRTE_ERR_BAD_PARAM;
+            goto ANSWER_LAUNCH;
+        }
+        if (posted) {
+            return;
         }
 
         if (!prte_dvm_ready) {

--- a/src/mca/ras/AGENTS.md
+++ b/src/mca/ras/AGENTS.md
@@ -294,6 +294,54 @@ against the *tool's* cwd, because the HNP is the process that opens it.
 
 ---
 
+## An allocation a spawn brings with it
+
+`PMIX_SPAWN_ALLOC` puts an entire allocation request **on** a spawn: the
+value is an array of `pmix_info_t` beginning with the request's directive
+(`PMIX_ALLOC_REQ_DIRECTIVE`) and continuing with exactly the info a
+standalone `PMIx_Allocation_request` would have carried. The host obtains the
+allocation, waits for it, and only then launches — what a launcher does for
+itself when invoked outside an allocation, and what a caller otherwise has to
+write by hand as "request, wait, read the id, spawn with
+`PMIX_SPAWN_TARGET`".
+
+The request itself is nothing new: `prte_ras_base_spawn_alloc()` splits the
+array into its directive and its info and hands it to `prte_ras_base_modify`
+like any other, so it reaches the same modules with the same semantics. Four
+things about the *surroundings* are worth knowing.
+
+- **Who asks.** The requester is the process that asked for the spawn
+  (`PRTE_JOB_LAUNCH_PROXY`), not the job being spawned — that job has no
+  namespace yet, and an allocation must be owned by somebody who exists. It
+  also puts the reservation under the ordinary ownership rules, so the same
+  process can target and release it.
+- **Where the job waits.** The job is held by the *request* — not parked in
+  `prte_cache`, which is drained by whatever DVM-ready event comes next and
+  would launch it while its own allocation was still being obtained. Only
+  once the answer is in does `prte_plm_base_spawn_alloc_granted()` decide:
+  cache it if a grow is now in flight (`prte_ras_base_dvm_is_growing()`), or
+  launch it at once if nothing is coming to make the DVM ready again.
+- **Where the job runs.** A grant that names a session is resolved through
+  the same `resolve_spawn_targets()` a `PMIX_SPAWN_TARGET` goes through, so
+  the job maps onto what it was just given. Without that it would map onto
+  everything *except* those nodes — a reservation is withheld from general
+  use. A grant that names no session (ras/slurm's extend puts its nodes in
+  the general pool) needs no target and gets none.
+- **The two failures, kept apart.** A refused allocation fails the spawn with
+  `PMIX_ERR_JOB_ALLOC_FAILED` and launches nothing; a *malformed* request —
+  no directive, a value that is not an info array — is `PMIX_ERR_BAD_PARAM`,
+  because nothing was asked of any allocator. And a spawn that fails *after*
+  the grant hands the allocation back before its own error is delivered
+  (`prte_ras_base_release_spawn_alloc()`, driven from
+  `prte_plm_base_spawn_response`): a caller told its spawn failed is entitled
+  to conclude it is not holding resources for it, and nothing else would ever
+  release them — the job they were obtained for does not exist and never
+  will. `PRTE_JOB_SPAWN_ALLOC_ID` is what records that debt; it is dropped
+  once the job is running, from which point the allocation is the job's and
+  its disposition is the ordinary one for a reservation.
+
+---
+
 ## `prte_ras_base_allocate()` — the driver
 
 This state callback in `ras_base_allocate.c` is the heart of the
@@ -422,6 +470,8 @@ elastic-DVM or PMIx_Allocation code:
 | `prte_ras_base_modify()` | The `modify` driver (also a state callback). Cycles modules (keyed by `req->key`) to serve a `prte_pmix_server_req_t`; on `PMIX_SUCCESS` calls `prte_ras_base_complete_request`, then invokes the requester's `infocbfunc`. |
 | `prte_ras_base_add_hosts()` | Collect `PRTE_APP_ADD_HOSTFILE`/`PRTE_APP_ADD_HOST` directives across apps into a `PMIX_ALLOC_EXTEND` request and hand it to `prte_ras_base_modify`. Sets `prte_dvm_ready = false` until processed. |
 | `prte_ras_base_activate_hosts()` | Collect `PRTE_APP_ACTIVATE_HOSTS` directives across apps, resolve them against the node pool, mark the resolved entries `PRTE_NODE_STATE_ADDED` and activate a grow. Adds nothing to the allocation, so it is permitted under a scheduler; must run after `prte_ras_base_add_hosts()`. Sets `prte_dvm_ready = false` when it activates a grow of its own. |
+| `prte_ras_base_spawn_alloc()` | Serve the allocation request carried by a spawn (`PMIX_SPAWN_ALLOC`), in the name of the spawn's requester. Sets `*posted` when one is in flight - the request then holds the job, and the outcome arrives at `prte_plm_base_spawn_alloc_granted()`/`_failed()`. |
+| `prte_ras_base_release_spawn_alloc()` | Give back an allocation obtained for a job that then failed to launch, calling `prte_plm_base_spawn_alloc_released()` when it resolves so the spawn's own error can follow. |
 | `prte_ras_base_activate_nodes()` | Resolve one activation — a host specification, a hostfile, or both — against the node pool and mark the resolved entries `PRTE_NODE_STATE_ADDED`, reporting how many entries that changed. Shared by `--activate` and `PMIX_ALLOC_ACTIVATE`. Resolves and marks only: activating the grow is the caller's. |
 | `prte_ras_base_complete_request()` | The heavy reservation router. For `PMIX_ALLOC_NEW`/`EXTEND` it resolves the destination `prte_session_t` (honoring `PMIX_ALLOC_TARGET`/`SHARE`/`INHERITANCE`/`ID`/`REQ_ID`), parses `PMIX_ALLOC_NODE_LIST`, inserts the nodes, and attaches them to the reservation (`add_nodes_to_session`). For `PMIX_ALLOC_RELEASE` it tears down a named reservation or xcasts a `PRTE_DAEMON_SHRINK_CMD`. Marks `PRTE_JOB_EXTEND_DVM` and re-launches daemons for grows. |
 | `prte_ras_base_release_allocation()` | Session-destruct hook: cycles modules whose `release_allocation` matches `session->alloc_module`. |

--- a/src/mca/ras/base/base.h
+++ b/src/mca/ras/base/base.h
@@ -153,6 +153,24 @@ PRTE_EXPORT int prte_ras_base_add_hosts(prte_job_t *jdata);
  * of its own. */
 PRTE_EXPORT int prte_ras_base_activate_hosts(prte_job_t *jdata);
 
+/* Serve the allocation request a spawn carries (PMIX_SPAWN_ALLOC), in the
+ * name of the process that asked for the spawn.  Sets *posted when there was
+ * one and it is now in flight - the request holds the job until it answers,
+ * so the caller must stop there and launch nothing; the outcome reaches plm
+ * through prte_plm_base_spawn_alloc_granted()/_failed().  Leaves *posted
+ * false, and succeeds, where the spawn carries no allocation request at all.
+ * A malformed request - no directive, a value that is not an info array - is
+ * refused here and now, so the caller can fail the spawn outright. */
+PRTE_EXPORT int prte_ras_base_spawn_alloc(prte_job_t *jdata, bool *posted);
+
+/* Hand back an allocation obtained by prte_ras_base_spawn_alloc() for a job
+ * that then failed to launch.  Issues an ordinary PMIX_ALLOC_RELEASE in the
+ * requester's name and calls prte_plm_base_spawn_alloc_released() when it
+ * resolves, whatever the outcome.  Returns an error only if the release
+ * could not be posted at all. */
+PRTE_EXPORT int prte_ras_base_release_spawn_alloc(prte_job_t *jdata,
+                                                  const char *alloc_id);
+
 /* Resolve an activation request - a host specification, a hostfile, or both -
  * against the node pool and mark the resolved entries PRTE_NODE_STATE_ADDED,
  * reporting in nactivated how many entries that changed (zero meaning every

--- a/src/mca/ras/base/help-ras-base.txt
+++ b/src/mca/ras/base/help-ras-base.txt
@@ -124,6 +124,19 @@ The form is "--activate file=<hostfile>", naming a file in the same format
 "--hostfile" reads. A PMIX_ALLOC_ACTIVATE request may instead give the file
 as its own PMIX_HOSTFILE attribute.
 
+[ras-base:spawn-alloc-nodirective]
+A spawn carried an allocation request (PMIX_SPAWN_ALLOC) that does not say
+what it is asking for.
+
+The value is an array of pmix_info_t describing an allocation request, and
+its first element must carry the request's directive as
+PMIX_ALLOC_REQ_DIRECTIVE - PMIX_ALLOC_NEW, PMIX_ALLOC_EXTEND, and so on.
+The allocation API takes that directive as a parameter; carried as data, it
+has to be stated. There is no default: a request whose directive had to be
+guessed would ask for something nobody asked for.
+
+The spawn was refused. Nothing was allocated and no processes were started.
+
 [ras-base:activate-nothing-named]
 A PMIX_ALLOC_ACTIVATE allocation request named nothing to activate.
 

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -46,6 +46,7 @@
 #include "src/mca/errmgr/errmgr.h"
 #include "src/mca/iof/base/base.h"
 #include "src/mca/odls/odls_types.h"
+#include "src/mca/plm/base/base.h"
 #include "src/mca/plm/base/plm_private.h"
 #include "src/mca/rmaps/base/base.h"
 #include "src/mca/state/state.h"
@@ -1166,6 +1167,11 @@ static void add_nodes_to_session(char **names, prte_session_t *dest)
     }
 }
 
+static int ras_base_start_dvm_shrink(prte_pmix_server_req_t *req,
+                                     pmix_rank_t *ranks, int32_t nranks,
+                                     prte_shrink_campaign_t **campaign,
+                                     bool report_xcast_failure);
+
 void prte_ras_base_teardown_reservation(prte_session_t *session,
                                         bool return_to_scheduler)
 {
@@ -1173,9 +1179,7 @@ void prte_ras_base_teardown_reservation(prte_session_t *session,
     int k;
     pmix_rank_t *ranks = NULL;
     int32_t m = 0;
-    pmix_data_buffer_t msg;
-    prte_daemon_cmd_flag_t cmd = PRTE_DAEMON_SHRINK_CMD;
-    pmix_status_t rc;
+    int ret;
 
     if (NULL == session || session == prte_default_session) {
         return;
@@ -1242,22 +1246,21 @@ void prte_ras_base_teardown_reservation(prte_session_t *session,
     }
 
     if (return_to_scheduler && NULL != ranks && 0 < m) {
-        PMIX_DATA_BUFFER_CONSTRUCT(&msg);
-        rc = PMIx_Data_pack(NULL, &msg, &cmd, 1, PMIX_UINT8);
-        if (PMIX_SUCCESS == rc) {
-            rc = PMIx_Data_pack(NULL, &msg, &m, 1, PMIX_INT32);
+        /* Shrink them out through the ordinary machinery rather than by hand.
+         * This used to pack and broadcast the shrink command itself, which
+         * told the daemons to go but left the master still believing they
+         * were there: node->daemon still pointing at a departed proc, the
+         * node still in the daemon job's map, the daemon count unreduced.
+         * A later grow onto that same node then "reused" the dead daemon and
+         * sent its launch message to nobody ("node has gone down"), so a node
+         * that had once been released could never be allocated again.  The
+         * campaign's completion is what does that bookkeeping - one routing
+         * repair and one node reset for the whole set - and it costs nothing
+         * to go through it. */
+        ret = ras_base_start_dvm_shrink(NULL, ranks, m, NULL, false);
+        if (PRTE_SUCCESS != ret) {
+            PRTE_ERROR_LOG(ret);
         }
-        if (PMIX_SUCCESS == rc) {
-            rc = PMIx_Data_pack(NULL, &msg, ranks, m, PMIX_PROC_RANK);
-        }
-        if (PMIX_SUCCESS == rc) {
-            if (PRTE_SUCCESS != (rc = prte_grpcomm_xcast(PRTE_RML_TAG_DAEMON, &msg))) {
-                PRTE_ERROR_LOG(rc);
-            }
-        } else {
-            PMIX_ERROR_LOG(rc);
-        }
-        PMIX_DATA_BUFFER_DESTRUCT(&msg);
     }
     if (NULL != ranks) {
         free(ranks);
@@ -1779,17 +1782,23 @@ static int ras_base_create_shrink_campaign(prte_pmix_server_req_t *req,
     memcpy(camp->targets, ranks, nranks * sizeof(pmix_rank_t));
     camp->ntargets = nranks;
     camp->pending = nranks;
-    /* record the requester so the phase-two completion event can be
-     * directed at the process that issued this PMIX_ALLOC_RELEASE */
-    PMIX_XFER_PROCID(&camp->requester, &req->tproc);
-    for (size_t n = 0; n < req->ninfo; n++) {
-        if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_ID)) {
-            camp->alloc_id = strdup(req->info[n].value.data.string);
-        } else if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_REQ_ID)) {
-            camp->req_id = strdup(req->info[n].value.data.string);
+    /* Record the requester so the phase-two completion event can be directed
+     * at the process that issued this PMIX_ALLOC_RELEASE.  There need not be
+     * one: a reservation torn down on its own account - by its timeout, by
+     * its owner departing, by the inheritance rules at job end - is nobody's
+     * request, and the campaign then exists purely for the bookkeeping its
+     * completion does. */
+    if (NULL != req) {
+        PMIX_XFER_PROCID(&camp->requester, &req->tproc);
+        for (size_t n = 0; n < req->ninfo; n++) {
+            if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_ID)) {
+                camp->alloc_id = strdup(req->info[n].value.data.string);
+            } else if (PMIx_Check_key(req->info[n].key, PMIX_ALLOC_REQ_ID)) {
+                camp->req_id = strdup(req->info[n].value.data.string);
+            }
         }
+        camp->have_requester = true;
     }
-    camp->have_requester = true;
     pmix_list_append(&prte_shrink_campaigns, &camp->super);
     prte_dvm_launch_fence += nranks;
 
@@ -2143,6 +2152,248 @@ int prte_ras_base_add_hosts(prte_job_t *jdata)
     // mark that the DVM is not ready so the launch does not continue
     // until we have processed the nodes
     prte_dvm_ready = false;
+
+    return PRTE_SUCCESS;
+}
+
+/*
+ * PMIX_SPAWN_ALLOC - a spawn that carries the allocation it needs.
+ *
+ * The request is served exactly as a standalone PMIx_Allocation_request
+ * would be: the same directive, the same info, the same modules, the same
+ * answer.  What differs is only what is done with that answer, and that is
+ * plm's business - so the two callbacks below decide nothing themselves,
+ * they hand the outcome to prte_plm_base_spawn_alloc_granted/_failed.
+ *
+ * The requester is the process that asked for the spawn, not the job being
+ * spawned: the job has no namespace yet (the HNP assigns it at launch), and
+ * an allocation has to be owned by somebody who exists.  That also puts the
+ * reservation under the ordinary ownership rules - the spawn requester can
+ * release it, target it, and is the one it outlives.
+ */
+static void spawn_alloc_complete(pmix_status_t status, pmix_info_t *info, size_t ninfo,
+                                 void *cbdata, pmix_release_cbfunc_t rel, void *relcbdata)
+{
+    prte_job_t *jdata = (prte_job_t *) cbdata;
+    char *alloc_id = NULL;
+    size_t n;
+
+    /* the id of what we were given, where the answer carries one - it is
+     * what points the job at those resources, and what has to be handed back
+     * if the job then fails to launch */
+    for (n = 0; n < ninfo; n++) {
+        if (PMIx_Check_key(info[n].key, PMIX_ALLOC_ID) &&
+            PMIX_STRING == info[n].value.type) {
+            alloc_id = info[n].value.data.string;
+            break;
+        }
+    }
+
+    /* PMIX_OPERATION_IN_PROGRESS is a grant, not a maybe: it is what a
+     * resource manager answers when the resources are promised and their
+     * daemons are still coming (ras/slurm's extend), and the DVM-ready event
+     * that ends it is the same one the job is already waiting on. */
+    if (PMIX_SUCCESS == status || PMIX_OPERATION_SUCCEEDED == status ||
+        PMIX_OPERATION_IN_PROGRESS == status) {
+        prte_plm_base_spawn_alloc_granted(jdata, alloc_id);
+    } else {
+        prte_plm_base_spawn_alloc_failed(jdata, status);
+    }
+
+    if (NULL != rel) {
+        rel(relcbdata);
+    }
+}
+
+int prte_ras_base_spawn_alloc(prte_job_t *jdata, bool *posted)
+{
+    pmix_data_array_t *darray = NULL;
+    pmix_info_t *src, *info = NULL;
+    size_t n, ninfo = 0, idx = 0, nalloc;
+    pmix_alloc_directive_t directive = 0;
+    bool have_directive = false;
+    prte_pmix_server_req_t *req;
+    pmix_proc_t *proxy = NULL;
+
+    *posted = false;
+    if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_SPAWN_ALLOC,
+                            (void **) &darray, PMIX_DATA_ARRAY) ||
+        NULL == darray) {
+        /* this spawn asks for no allocation - the ordinary case */
+        return PRTE_SUCCESS;
+    }
+    /* consumed: the launch is re-driven once the DVM is ready again, and a
+     * second pass must not ask for a second allocation */
+    prte_remove_attribute(&jdata->attributes, PRTE_JOB_SPAWN_ALLOC);
+
+    if (PMIX_INFO != darray->type || 0 == darray->size || NULL == darray->array) {
+        PMIX_DATA_ARRAY_FREE(darray);
+        return PRTE_ERR_BAD_PARAM;
+    }
+    src = (pmix_info_t *) darray->array;
+    nalloc = darray->size;
+
+    /* Split the request into its directive and its info array - the shape a
+     * request has everywhere else in the code, and the shape the modules
+     * expect.  Everything that is not the directive is the request.  The
+     * array is sized for the whole thing and filled short by exactly the
+     * directive; the tail stays as PMIX_INFO_CREATE left it, which destructs
+     * to nothing, so the request may carry the filled count. */
+    PMIX_INFO_CREATE(info, nalloc);
+    if (NULL == info) {
+        PMIX_DATA_ARRAY_FREE(darray);
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+    for (n = 0; n < nalloc; n++) {
+        if (PMIx_Check_key(src[n].key, PMIX_ALLOC_REQ_DIRECTIVE)) {
+            if (PMIX_ALLOC_DIRECTIVE != src[n].value.type) {
+                PMIX_INFO_FREE(info, nalloc);
+                PMIX_DATA_ARRAY_FREE(darray);
+                return PRTE_ERR_BAD_PARAM;
+            }
+            directive = src[n].value.data.uint8;
+            have_directive = true;
+            continue;
+        }
+        PMIX_INFO_XFER(&info[idx++], &src[n]);
+    }
+    ninfo = idx;
+    PMIX_DATA_ARRAY_FREE(darray);
+
+    if (!have_directive) {
+        /* the one element that cannot be defaulted: a request whose directive
+         * we had to guess would ask for something nobody asked for */
+        prte_show_help("help-ras-base.txt", "ras-base:spawn-alloc-nodirective", true);
+        PMIX_INFO_FREE(info, nalloc);
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    req = PMIX_NEW(prte_pmix_server_req_t);
+    if (NULL == req) {
+        PMIX_INFO_FREE(info, nalloc);
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+    pmix_asprintf(&req->operation, "SPAWN-ALLOC: %s",
+                  PMIx_Alloc_directive_string(directive));
+    req->allocdir = directive;
+    req->info = info;
+    req->ninfo = ninfo;
+    req->copy = true;
+    /* ask in the name of whoever asked for the spawn */
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_LAUNCH_PROXY,
+                           (void **) &proxy, PMIX_PROC) &&
+        NULL != proxy) {
+        PMIX_XFER_PROCID(&req->tproc, proxy);
+        PMIX_PROC_RELEASE(proxy);
+    } else {
+        PMIX_XFER_PROCID(&req->tproc, &jdata->originator);
+    }
+    /* The request OWNS the job object it carries - and this one is not ours
+     * to give away, so take a reference of our own for it to drop (the same
+     * borrowing prte_ras_base_add_hosts does).  That reference is what keeps
+     * the job alive across the request, so the callbacks may use it freely
+     * until they hand the request back. */
+    PMIX_RETAIN(jdata);
+    req->jdata = jdata;
+    req->cbdata = jdata;
+    req->infocbfunc = spawn_alloc_complete;
+    req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
+
+    /* Note what is NOT done here: the job is not parked in the cache and the
+     * DVM is not marked un-ready.  The request itself is what holds the job
+     * while the allocation is obtained - the cache is drained by the next
+     * DVM-ready event whatever it was raised for, which would launch this job
+     * before it had the resources it asked for.  Where to wait, and for what,
+     * is decided once the answer is in (prte_plm_base_spawn_alloc_granted). */
+    prte_event_set(prte_event_base, &req->ev, -1, PRTE_EV_WRITE, prte_ras_base_modify, req);
+    PMIX_POST_OBJECT(req);
+    prte_event_active(&req->ev, PRTE_EV_WRITE, 1);
+
+    *posted = true;
+    return PRTE_SUCCESS;
+}
+
+/*
+ * Hand back an allocation obtained for a spawn that then failed to launch.
+ *
+ * The requester is told the spawn's own error - but only once the resources
+ * are on their way back, since a caller that is told its spawn failed is
+ * entitled to assume it is no longer holding anything for it.  The release
+ * is an ordinary PMIX_ALLOC_RELEASE, so it goes wherever a release goes: to
+ * the module that owns the allocation, and through the same deferral if a
+ * grow is in flight.  cb is invoked when it resolves, either way - there is
+ * no outcome in which the spawn's own error is not delivered.
+ */
+static void spawn_alloc_release_complete(pmix_status_t status, pmix_info_t *info,
+                                         size_t ninfo, void *cbdata,
+                                         pmix_release_cbfunc_t rel, void *relcbdata)
+{
+    prte_job_t *jdata = (prte_job_t *) cbdata;
+    PRTE_HIDE_UNUSED_PARAMS(info, ninfo);
+
+    if (PMIX_SUCCESS != status && PMIX_OPERATION_SUCCEEDED != status) {
+        /* nothing more can be done about it here - the resources stay held,
+         * and the requester still has to be told what became of its spawn */
+        PMIX_OUTPUT_VERBOSE((2, prte_ras_base_framework.framework_output,
+                             "%s ras:base:spawn_alloc release refused: %s",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                             PMIx_Error_string(status)));
+    }
+
+    prte_plm_base_spawn_alloc_released(jdata);
+
+    if (NULL != rel) {
+        rel(relcbdata);
+    }
+}
+
+int prte_ras_base_release_spawn_alloc(prte_job_t *jdata, const char *alloc_id)
+{
+    prte_pmix_server_req_t *req;
+    pmix_proc_t *proxy = NULL;
+
+    if (NULL == alloc_id) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+
+    PMIX_OUTPUT_VERBOSE((2, prte_ras_base_framework.framework_output,
+                         "%s ras:base:spawn_alloc releasing %s - the job it was "
+                         "obtained for did not launch",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), alloc_id));
+
+    req = PMIX_NEW(prte_pmix_server_req_t);
+    if (NULL == req) {
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+    req->operation = strdup("SPAWN-ALLOC-RELEASE");
+    req->allocdir = PMIX_ALLOC_RELEASE;
+    req->ninfo = 1;
+    PMIX_INFO_CREATE(req->info, req->ninfo);
+    if (NULL == req->info) {
+        PMIX_RELEASE(req);
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+    req->copy = true;
+    PMIX_INFO_LOAD(&req->info[0], PMIX_ALLOC_ID, (void *) alloc_id, PMIX_STRING);
+    /* release in the same name it was obtained in, or the ownership check
+     * refuses us our own allocation */
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_LAUNCH_PROXY,
+                           (void **) &proxy, PMIX_PROC) &&
+        NULL != proxy) {
+        PMIX_XFER_PROCID(&req->tproc, proxy);
+        PMIX_PROC_RELEASE(proxy);
+    } else {
+        PMIX_XFER_PROCID(&req->tproc, &jdata->originator);
+    }
+    PMIX_RETAIN(jdata);
+    req->jdata = jdata;
+    req->cbdata = jdata;
+    req->infocbfunc = spawn_alloc_release_complete;
+    req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
+
+    prte_event_set(prte_event_base, &req->ev, -1, PRTE_EV_WRITE, prte_ras_base_modify, req);
+    PMIX_POST_OBJECT(req);
+    prte_event_active(&req->ev, PRTE_EV_WRITE, 1);
 
     return PRTE_SUCCESS;
 }

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -265,7 +265,7 @@ static void init_complete(int sd, short args, void *cbdata)
 static void vm_ready(int fd, short args, void *cbdata)
 {
     prte_state_caddy_t *caddy = (prte_state_caddy_t *) cbdata;
-    int rc, i;
+    int rc;
     pmix_data_buffer_t buf;
     prte_job_t *jptr;
     prte_proc_t *dmn;
@@ -462,13 +462,7 @@ static void vm_ready(int fd, short args, void *cbdata)
             close(prte_state_base.parent_fd);
             prte_state_base.parent_fd = -1;
         }
-        for (i = 0; i < prte_cache->size; i++) {
-            jptr = (prte_job_t *) pmix_pointer_array_get_item(prte_cache, i);
-            if (NULL != jptr) {
-                pmix_pointer_array_set_item(prte_cache, i, NULL);
-                prte_plm.spawn(jptr);
-            }
-        }
+        prte_plm_base_release_cached_jobs();
         /* progress the job */
         caddy->jdata->state = PRTE_JOB_STATE_VM_READY;
         PMIX_RELEASE(caddy);

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -317,6 +317,25 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
             }
 #endif
 
+#if defined(PMIX_SPAWN_ALLOC)
+            /***   ALLOCATION TO OBTAIN FIRST   ***/
+        } else if (PMIX_CHECK_KEY(info, PMIX_SPAWN_ALLOC)) {
+            /* An entire allocation request, to be served before this job is
+             * launched. It is carried through to the HNP unexamined - the HNP
+             * is where ras lives, and the only thing to be decided here is
+             * that the value is the shape the attribute calls for. Stored
+             * GLOBAL so the generic job-attribute pack loop forwards it. */
+            if (PMIX_DATA_ARRAY != info->value.type ||
+                NULL == info->value.data.darray ||
+                PMIX_INFO != info->value.data.darray->type ||
+                0 == info->value.data.darray->size) {
+                return PRTE_ERR_BAD_PARAM;
+            }
+            prte_set_attribute(&jdata->attributes, PRTE_JOB_SPAWN_ALLOC,
+                               PRTE_ATTR_GLOBAL, info->value.data.darray,
+                               PMIX_DATA_ARRAY);
+#endif
+
             /***   DISPLAY MAP   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_DISPLAY_MAP)) {
             flag = PMIX_INFO_TRUE(info);

--- a/src/util/attr.c
+++ b/src/util/attr.c
@@ -526,6 +526,12 @@ const char *prte_attr_key_to_str(prte_attribute_key_t key)
             return "STOP-IN-APP";
         case PRTE_JOB_BREAKPOINT:
             return "BREAKPOINT";
+        case PRTE_JOB_SPAWN_ALLOC:
+            return "SPAWN-ALLOCATION-REQUEST";
+        case PRTE_JOB_SPAWN_ALLOC_ID:
+            return "SPAWN-ALLOCATION-ID";
+        case PRTE_JOB_SPAWN_ALLOC_STATUS:
+            return "SPAWN-ALLOCATION-HELD-STATUS";
         case PRTE_JOB_ENVARS_HARVESTED:
             return "ENVARS-HARVESTED";
         case PRTE_JOB_OUTPUT_NOCOPY:

--- a/src/util/attr.h
+++ b/src/util/attr.h
@@ -241,6 +241,14 @@ typedef uint16_t prte_job_flags_t;
 #define PRTE_JOB_STOP_IN_INIT               (PRTE_JOB_START_KEY +  88) // bool - stop in PMIx_Init
 #define PRTE_JOB_STOP_IN_APP                (PRTE_JOB_START_KEY +  89) // bool - stop at app-determined location
 #define PRTE_JOB_BREAKPOINT                 (PRTE_JOB_START_KEY + 131) // char* - string ID of the app-determined location at which to stop
+#define PRTE_JOB_SPAWN_ALLOC                (PRTE_JOB_START_KEY + 132) // pmix_data_array_t* - an entire allocation request (PMIX_SPAWN_ALLOC)
+                                                                       // to be executed before this job is launched: the array's first
+                                                                       // element carries the directive, the rest are the request's info
+#define PRTE_JOB_SPAWN_ALLOC_ID             (PRTE_JOB_START_KEY + 133) // char* - PMIX_ALLOC_ID of the allocation obtained FOR this job by
+                                                                       // PRTE_JOB_SPAWN_ALLOC. Present only while the job owes that
+                                                                       // allocation a release should it fail to launch
+#define PRTE_JOB_SPAWN_ALLOC_STATUS         (PRTE_JOB_START_KEY + 134) // int32_t - the spawn status held while the allocation obtained for a
+                                                                       // failed job is handed back, and delivered once it has been
 #define PRTE_JOB_ENVARS_HARVESTED           (PRTE_JOB_START_KEY +  90) // envars have already been harvested
 #define PRTE_JOB_OUTPUT_NOCOPY              (PRTE_JOB_START_KEY +  91) // bool - do not copy output to stdout/err
 #define PRTE_JOB_RANK_OUTPUT                (PRTE_JOB_START_KEY +  92) // bool - tag stdout/stderr with rank

--- a/test/unit/ras/test_ras.c
+++ b/test/unit/ras/test_ras.c
@@ -1523,9 +1523,99 @@ static int test_activate_nodes(void)
     return failures;
 }
 
+/*
+ * prte_ras_base_spawn_alloc: the allocation request a spawn can carry.
+ *
+ * What is testable without a live DVM is the front half - whether the
+ * request is well enough formed to be posted at all - and that is exactly
+ * the half that decides between "this spawn is refused outright" and "the
+ * job is now held while an allocator answers". The posting itself needs the
+ * event base and an allocator to answer, so the cases here all stop before
+ * it: no request at all, and the two ways a request can be malformed.
+ */
+static prte_job_t *mkspawnalloc_job(pmix_info_t *req, size_t nreq)
+{
+    prte_job_t *jdata;
+    pmix_data_array_t darray;
+
+    jdata = PMIX_NEW(prte_job_t);
+    if (NULL != req) {
+        darray.type = PMIX_INFO;
+        darray.size = nreq;
+        darray.array = req;
+        prte_set_attribute(&jdata->attributes, PRTE_JOB_SPAWN_ALLOC,
+                           PRTE_ATTR_GLOBAL, &darray, PMIX_DATA_ARRAY);
+    }
+    return jdata;
+}
+
+static int test_spawn_alloc(void)
+{
+    int failures = 0;
+    prte_job_t *jdata;
+    pmix_info_t req[2];
+    pmix_alloc_directive_t directive = PMIX_ALLOC_NEW;
+    bool posted = true;
+    int rc;
+
+    /* a spawn that asks for no allocation is not this function's business,
+     * and must not be reported as having posted anything */
+    jdata = mkspawnalloc_job(NULL, 0);
+    rc = prte_ras_base_spawn_alloc(jdata, &posted);
+    CHECK("spawn_alloc: no request is a no-op", PRTE_SUCCESS == rc);
+    CHECK("spawn_alloc: and posts nothing", !posted);
+    PMIX_RELEASE(jdata);
+
+    /* a request that names no directive cannot be served: the allocation API
+     * takes the directive as a parameter, and carried as data it has to be
+     * stated rather than guessed */
+    PMIX_INFO_LOAD(&req[0], PMIX_ALLOC_NODE_LIST, "node01", PMIX_STRING);
+    jdata = mkspawnalloc_job(req, 1);
+    posted = true;
+    rc = prte_ras_base_spawn_alloc(jdata, &posted);
+    CHECK("spawn_alloc: a request with no directive is refused",
+          PRTE_ERR_BAD_PARAM == rc);
+    CHECK("spawn_alloc: nothing was posted for it", !posted);
+    CHECK("spawn_alloc: and the request is not left on the job to be retried",
+          !prte_get_attribute(&jdata->attributes, PRTE_JOB_SPAWN_ALLOC,
+                              NULL, PMIX_DATA_ARRAY));
+    PMIX_RELEASE(jdata);
+    PMIX_INFO_DESTRUCT(&req[0]);
+
+    /* a directive of the wrong type is refused rather than reinterpreted -
+     * the value arrived from a client, and every other reading of it would
+     * be an allocation nobody asked for */
+    PMIX_INFO_LOAD(&req[0], PMIX_ALLOC_REQ_DIRECTIVE, "new", PMIX_STRING);
+    PMIX_INFO_LOAD(&req[1], PMIX_ALLOC_NODE_LIST, "node01", PMIX_STRING);
+    jdata = mkspawnalloc_job(req, 2);
+    posted = true;
+    rc = prte_ras_base_spawn_alloc(jdata, &posted);
+    CHECK("spawn_alloc: a mistyped directive is refused",
+          PRTE_ERR_BAD_PARAM == rc);
+    CHECK("spawn_alloc: nothing posted for the mistyped directive", !posted);
+    PMIX_RELEASE(jdata);
+    PMIX_INFO_DESTRUCT(&req[0]);
+    PMIX_INFO_DESTRUCT(&req[1]);
+
+    /* the attribute is consumed by the attempt, whatever its outcome: the
+     * launch is re-driven once the DVM is ready, and a second pass must not
+     * ask for a second allocation. Shown here on the refusal path, which is
+     * the one that returns while the job still exists to inspect. */
+    PMIX_INFO_LOAD(&req[0], PMIX_ALLOC_REQ_DIRECTIVE, &directive, PMIX_ALLOC_DIRECTIVE);
+    jdata = mkspawnalloc_job(req, 1);
+    CHECK("spawn_alloc: the request is carried on the job",
+          prte_get_attribute(&jdata->attributes, PRTE_JOB_SPAWN_ALLOC,
+                             NULL, PMIX_DATA_ARRAY));
+    PMIX_RELEASE(jdata);
+    PMIX_INFO_DESTRUCT(&req[0]);
+
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0;
+    pmix_status_t prc;
 
     rc = prte_init_util(PRTE_PROC_MASTER);
     if (PRTE_SUCCESS != rc) {
@@ -1536,6 +1626,18 @@ int main(void)
     rc = setup_globals();
     if (PRTE_SUCCESS != rc) {
         fprintf(stderr, "test globals setup failed: %d\n", rc);
+        return 1;
+    }
+
+    /* An allocation request carried on a spawn is a pmix_data_array_t, and
+     * copying one is a PMIx operation - PMIx_Data_copy refuses to run until
+     * PMIx itself is up, which is how prte_set_attribute would fail to store
+     * such an attribute here while working perfectly in a daemon.  A daemon
+     * reaches that state through PMIx_server_init, so do the same. */
+    prc = PMIx_server_init(NULL, NULL, 0);
+    if (PMIX_SUCCESS != prc) {
+        fprintf(stderr, "PMIx_server_init failed: %s\n", PMIx_Error_string(prc));
+        prte_finalize();
         return 1;
     }
 
@@ -1560,12 +1662,16 @@ int main(void)
     failures += test_dvm_growing();
     failures += test_activate_hosts();
     failures += test_activate_nodes();
+    failures += test_spawn_alloc();
     /* after test_select(), which opens the framework and latches a
      * selection made with no SLURM allocation in the environment -- so
      * nothing has called slurm's init() before this does */
     failures += test_pmix_gate();
     failures += test_slurm_allocation();
 
+    /* PMIx last, and after the frameworks are closed: finalizing it unloads
+     * the components PRRTE has open in a DSO build */
+    PMIx_server_finalize();
     prte_finalize();
 
     if (0 == failures) {


### PR DESCRIPTION
Closes the remaining `docs/todo.rst` item "There is no way to put an allocation directive into a `PMIx_Spawn` call".

**Depends on openpmix/openpmix#4191**, which adds `PMIX_SPAWN_ALLOC` and `PMIX_ALLOC_REQ_DIRECTIVE`.

### The problem

A caller that needs resources before it can launch has had to issue `PMIx_Allocation_request` itself, wait for it, read the allocation id out of the answer, and then spawn with `PMIX_SPAWN_TARGET` naming it — with a window in the middle where resources are held for a job that does not exist yet, and if the spawn fails, for one that never will.

### The change

`PMIX_SPAWN_ALLOC` carries the request on the spawn. `prte_ras_base_spawn_alloc()` splits it back into the directive and info an allocation request has everywhere else and hands it to `prte_ras_base_modify`: same directive, same modules, same answer. Four things about its *surroundings* are new.

**Who asks.** The requester is the process that asked for the spawn, not the job being spawned — that job has no namespace yet, and an allocation must be owned by somebody who exists. It also puts the reservation under the ordinary ownership rules, so the same process can target and release it.

**Where the job waits.** The request holds it. It is deliberately *not* parked in `prte_cache`, which is drained by whatever DVM-ready event comes next and would launch the job while its own allocation was still being obtained; it goes there only once the grant is in and a grow is known to be in flight, which is the same thing everything else in the cache is waiting for.

**Where the job runs.** A grant that names a session is resolved through the same `resolve_spawn_targets()` a `PMIX_SPAWN_TARGET` goes through — a reservation is withheld from general use, so a job that did not target it would be mapped onto everything *except* the resources it just asked for. A grant that names no session (a resource manager may put what it granted into the general pool) needs no target and gets none.

**The failures, kept apart.** A refused allocation fails the spawn with `PMIX_ERR_JOB_ALLOC_FAILED` and launches nothing; a malformed request is `PMIX_ERR_BAD_PARAM`, since nothing was asked of any allocator. A spawn that fails after the grant hands the allocation back *before* its own error is delivered.

### A pre-existing bug this uncovered (first commit)

Tearing down a reservation whose nodes go back to the scheduler packed and broadcast the shrink command by hand. The daemons left — and the master went on believing they were there: `node->daemon` pointing at a departed proc, the node still in the daemon job's map, the daemon count unreduced, the routing tree unrepaired. A later grow onto that node found a daemon already recorded, launched nothing, and sent the job's launch message to a process that no longer existed ("node has gone down"). **A node released this way could never be allocated again for the life of the DVM.**

The node-list form of a release never had this: it goes through `ras_base_start_dvm_shrink`, whose campaign completion does the whole teardown in one batch and returns each node to a pristine, never-launched state precisely so a later grow can relaunch on it. The by-allocation-id form now goes the same way. (A campaign may consequently exist with no requester — a reservation torn down by its timeout, by its owner departing, or by the inheritance rules is nobody's request — and simply emits no phase-two event.)

### Testing

* Warning-free `--enable-debug` build; `make check`; offline mapper harness (2449 pass / 0 fail).
* New `test/unit/ras` coverage of the request's front half — no request, no directive, a mistyped directive, and the rule that the attribute is consumed by the attempt. It needs PMIx up (copying a `pmix_data_array_t` is a PMIx operation), so the test now does `PMIx_server_init` as the plm test does.
* New `contrib/dockerswarm` case (`elastic spawnalloc`) walking every outcome across nodes: granted and launched on the node it allocated, a daemon started there; refused with nothing launched; malformed answered as a bad parameter; granted-then-failed handing the allocation back; and the released node allocated again afterwards — the half the hand-rolled release used to break.
* **Full dockerswarm suite: 681 passed, 0 failed, 3 skipped**, including all 11 checks of the new case. The five outcomes were re-verified against the final build of this branch.