### PR TITLE
Exercise prterun with a terminal on its own stdin

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -401,6 +401,30 @@ archive whose name contains a space, a collision with a *different* file being
 refused rather than overwriting the user's copy, a `..` in the delivered name
 being refused, and a file reaching a node grown into the DVM afterwards.
 
+**Terminal stdin (`iof`)**: `prterun -n 1 head -1` run under `script(1)`, so
+its own stdin is a real **pty**, with a fifo writer that outlives the run so
+the terminal never sees EOF. The application consumes its line and exits
+immediately, and the case asserts that `prterun` comes back. It used not to
+([#2709](https://github.com/openpmix/prrte/issues/2709)): libevent keeps one
+process-wide record of which event base owns signals, re-claimed both by
+adding a signal event and by entering `event_base_loop`, so a second base
+carrying signals does not just warn — it swallows the first base's signals.
+PRRTE traps `SIGCHLD` on `prte_event_base`, and PMIx's stdin setup armed a
+`SIGCONT` on its *own* progress-thread base — but only when stdin is a tty.
+The reap notice for the application was then dropped perhaps three runs in
+five, so PRRTE never learned it had died and the job never ended. openpmix
+answered it by not trapping signals at all: a library has no business owning
+a process-wide disposition, and `tcgetpgrp()` answers "do I have the
+terminal" directly, so PMIx now polls for that while suspended instead.
+
+Hence the shape of the case: five runs, because the hang is a race, plus a
+deterministic canary on libevent's own "Only one can have signals at a time"
+warning, which fired on every affected run and now fires on none. Keep that
+canary — it is the half that does not have to be raced for, and it will catch
+any future signal event registered on a second base, whichever library puts
+it there. A pipe on stdin exercises none of this, which is why the case has
+to go to the trouble of a pty.
+
 **Remote stdin (`iof`)**: a large base64 payload is piped into `prterun` on
 node1 for a job whose rank 0 is mapped onto **node2**, running `cat`. Because
 the reading proc is not on the head node, every byte must cross

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -6264,6 +6264,66 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     for n in 1 2 3 4; do docker exec "$NODE$n" sh -c 'rm -f /root/pfbig.dat /root/pfsmall.dat' >/dev/null 2>&1; done
     cleanup_swarm
 
+    banner "iof: prterun returns when its own stdin is a TERMINAL"
+    # prterun forwarding its own stdin from a *tty* is a different code path
+    # from forwarding it from a pipe, and it used to hang: the job ran, the
+    # application read its line and exited, and prterun sat forever on an
+    # unreaped zombie (issue #2709).
+    #
+    # The mechanism is why this case is worth its runtime. Libevent keeps ONE
+    # process-wide record of which event base owns signals (evsig_base in its
+    # signal.c), re-claimed both by adding a signal event and by entering
+    # event_base_loop, and the OS handler writes the signal number to whichever
+    # base holds it at that instant. PRRTE traps SIGCHLD on prte_event_base and
+    # hands that same base to PMIx as PMIX_EXTERNAL_AUX_EVENT_BASE precisely so
+    # everything signal-related lands on one base; PMIx's stdin setup used to
+    # put its SIGCONT event on its OWN progress-thread base instead, and only
+    # when stdin is a tty. The two loops then traded ownership on every
+    # iteration and a SIGCHLD delivered while PMIx held it was dropped on the
+    # floor -- so PRRTE never learned the child had died.
+    #
+    # It follows that the case has to (a) give prterun a real pty -- script(1)
+    # supplies one -- and (b) hold that pty's stdin open for the whole run, so
+    # that exiting cannot be mistaken for "saw EOF on stdin". A fifo with a
+    # writer that outlives the run does the second part. And it has to run more
+    # than once: which base owns signals at the moment the child dies is a race,
+    # and the broken build still exited cleanly perhaps one time in five.
+    if ! RUN 'command -v script >/dev/null 2>&1'; then
+        skp "no script(1) in the image -- cannot hand prterun a pty"
+    else
+        out=$(RUN 'h=0; for i in 1 2 3 4 5; do
+                       rm -f /tmp/ttyin$i; mkfifo /tmp/ttyin$i;
+                       ( sleep 1; printf "hello\n"; sleep 30 ) \
+                           > /tmp/ttyin$i 2>/dev/null </dev/null &
+                       timeout -k 5 15 script -qec "prterun -n 1 head -1" /dev/null \
+                           < /tmp/ttyin$i > /tmp/ttyout$i.txt 2>&1 || h=$((h+1));
+                   done;
+                   echo "hangs=$h";
+                   echo "warned=$(grep -l "Only one can have signals" /tmp/ttyout*.txt 2>/dev/null | wc -l)";
+                   echo "echoed=$(grep -l "hello" /tmp/ttyout*.txt 2>/dev/null | wc -l)"')
+        h=$(echo "$out" | sed -n 's/^hangs=//p' | tr -d ' \r')
+        w=$(echo "$out" | sed -n 's/^warned=//p' | tr -d ' \r')
+        e=$(echo "$out" | sed -n 's/^echoed=//p' | tr -d ' \r')
+        # The delivery assertion first: a prterun that exits without ever
+        # forwarding the line would sail through the hang check.
+        [ "$e" = 5 ] \
+            && ok "stdin from a pty reached the application in all 5 runs" \
+            || bad "stdin from a pty reached the application in only $e/5 runs"
+        [ "$h" = 0 ] \
+            && ok "prterun exited as soon as the app did, all 5 tty runs" \
+            || bad "prterun hung on $h/5 runs with a tty stdin (#2709 -- SIGCHLD lost to a second event base)"
+        # The direct canary for the cause, not just the symptom: libevent says
+        # so out loud when a second base claims signals. It is the thing to
+        # check first if the hang ever comes back, and it fires even on the
+        # runs the race happens to let through.
+        [ "$w" = 0 ] \
+            && ok "no event base contended for signal ownership" \
+            || bad "$w/5 runs registered a signal on a second event base (libevent: 'Only one can have signals at a time')"
+        RUN 'rm -f /tmp/ttyin* /tmp/ttyout*' >/dev/null 2>&1
+    fi
+    cleanup_swarm
+
+
     banner "iof: stdin forwarded to a REMOTE proc (HNP -> prted -> proc)"
     # Rank 0 is mapped onto node2, not the head node, so every stdin byte must
     # travel HNP -> RML(PRTE_RML_TAG_IOF_PROXY) -> prted -> the proc's stdin


### PR DESCRIPTION
Regression coverage for #2709. The fix itself is openpmix/openpmix#4192.

## The gap

The swarm drives `prterun`'s stdin from a pipe everywhere, and a pipe is the one shape of stdin that never reaches the code this is about. When stdin is a **terminal**, PMIx armed a `SIGCONT` event so it could stop reading while backgrounded — and libevent keeps a single process-wide record of which event base owns signals, so that event took the signals away from `prte_event_base`, where PRRTE traps `SIGCHLD` (`src/runtime/prte_wait.c:119`).

A reap notice that arrived while PMIx held ownership was dropped on the floor. `prterun -n 1 head -1` typed at a terminal never returned: the application read its line, exited, and stayed an unreaped zombie because the HNP never learned it had died.

## The case

`prterun -n 1 head -1` under `script(1)`, so its own stdin is a real pty, with a fifo writer that outlives the run — so exiting cannot be confused with having seen EOF. It asserts three things:

1. stdin from the pty actually reached the application (a `prterun` that exits without forwarding anything would sail through the hang check);
2. `prterun` came back as soon as the application did;
3. libevent never printed its `Only one can have signals at a time` warning.

It runs **five times**, because which base owns signals at the instant the child dies is a race — the broken build still exited cleanly about one run in five. Assertion 3 is the deterministic half: it fired on *every* affected run and now fires on none, and it will catch any future signal event registered on a second base, by any library in the process, before the resulting hang has to be raced for.

## Verification

- Against an unfixed PMIx: `hung on 3/5 runs`, `5/5 warned` — red both standalone and in the suite.
- Against the fix: green, and the full suite is **684 passed, 0 failed, 3 skipped** (the skips are the pre-existing no-network-device topology cases).

`contrib/dockerswarm/AGENTS.md` gains a paragraph on why the case needs a pty and why the canary is worth keeping.

## Note

This does not fix anything on its own — it will fail against a PMIx older than openpmix/openpmix#4192.