### PR TITLE
ras/base: report the procs a node release kills

### DIFF
--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -6821,8 +6821,12 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
             # faulty rather than sleep: its ranks register with PMIx and name
             # their host on startup, which is how the case knows it spanned
             # node3.
+            # recoverable: the release kills the rank on node3, and a job
+            # that has not said it can absorb that is terminated whole (the
+            # case below covers that).  This one is about ACCOUNTING, so it
+            # uses the mode that leaves the survivors running to be counted.
             RUN 'rm -f /tmp/shrink-live.out' >/dev/null 2>&1
-            RUN_BG /tmp/shrink-live.out "timeout 180 prun --dvm-uri file:/tmp/dvm.uri -n 3 --map-by ppr:1:node $FLT clean 25"
+            RUN_BG /tmp/shrink-live.out "timeout 180 prun --dvm-uri file:/tmp/dvm.uri -n 3 --map-by ppr:1:node --runtime-options recoverable $FLT clean 25"
             sleep 8
             if ! RUN 'grep -q " HOST node3" /tmp/shrink-live.out'; then
                 bad "no rank landed on node3: $(RUN 'tr "\n" " " < /tmp/shrink-live.out' | tail -c 200)"
@@ -6846,6 +6850,60 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
                 [ "${n:-0}" -ge 2 ] \
                     && ok "...and the survivors finished normally" \
                     || bad "$n/2 survivors finished: $(RUN 'tr "\n" " " < /tmp/shrink-live.out' | tail -c 200)"
+                RUN 'pgrep -x prte >/dev/null' && ok "...and the HNP survived" \
+                                               || bad "the HNP died on the shrink"
+                out=$(RUN 'timeout 60 prun --dvm-uri file:/tmp/dvm.uri -n 2 --map-by ppr:1:node hostname' 2>&1)
+                [ "$(echo "$out" | grep -cE '^node[12]$')" = 2 ] \
+                    && ok "...and the reduced DVM still runs a job" \
+                    || bad "the reduced DVM could not run a job: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+            fi
+        fi
+        RUN 'timeout -k 5 30 pterm --dvm-uri file:/tmp/dvm.uri' >/dev/null 2>&1
+    fi
+    cleanup_swarm
+
+    banner "elastic DVM: a release reports the procs it killed"
+    # The counterpart to the case above: the same shrink under a job that has
+    # NOT declared itself recoverable.  Releasing the node kills its rank, and
+    # that must reach the outcome rather than passing for a clean run.
+    cleanup_swarm
+    RUN 'rm -f /tmp/dvm.uri; nohup prte --daemonize --report-uri /tmp/dvm.uri --prtemca prte_elastic_mode 1 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    duri=$(RUN 'head -1 /tmp/dvm.uri' 2>/dev/null | tr -d '\r')
+    if [ -z "$duri" ]; then
+        bad "could not start an elastic DVM for the release-reporting test"
+    else
+        out=$(RUN "PRTE_DVM_URI='$duri' timeout 90 elastic grow node2:2,node3:2" 2>&1)
+        if ! echo "$out" | grep -q PMIX_DVM_IS_READY; then
+            bad "grow did not complete -- cannot test the release reporting: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        else
+            RUN 'rm -f /tmp/shrink-kill.out' >/dev/null 2>&1
+            RUN_BG /tmp/shrink-kill.out "{ timeout 180 prun --dvm-uri file:/tmp/dvm.uri -n 3 --map-by ppr:1:node $FLT clean 25; echo RC=\$?; }"
+            sleep 8
+            if ! RUN 'grep -q " HOST node3" /tmp/shrink-kill.out'; then
+                bad "no rank landed on node3: $(RUN 'tr "\n" " " < /tmp/shrink-kill.out' | tail -c 200)"
+            else
+                out=$(RUN "PRTE_DVM_URI='$duri' timeout 90 elastic shrink node3" 2>&1)
+                echo "$out" | grep -q PMIX_DVM_IS_READY \
+                    && ok "shrink node3 completed under a live job" \
+                    || bad "shrink did not complete under a live job: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+                n=0
+                while [ "$n" -lt 60 ]; do
+                    RUN 'grep -q "^RC=" /tmp/shrink-kill.out' && break
+                    sleep 1; n=$((n+1))
+                done
+                if [ "$n" -ge 60 ]; then
+                    bad "prun never returned after the release"
+                else
+                    rc=$(RUN 'sed -n "s/^RC=//p" /tmp/shrink-kill.out' | tr -d ' \r')
+                    [ "${rc:-0}" != 0 ] \
+                        && ok "prun reported the loss (exit $rc), not a clean run" \
+                        || bad "prun exited 0 for a job that lost a rank to the release"
+                    # the help text wraps after "when that", so match within
+                    # one line -- and on the rank and node it names
+                    RUN 'grep -qE "process rank [0-9]+ on node node3 was killed" /tmp/shrink-kill.out' \
+                        && ok "...and named the rank and the node it was released with" \
+                        || bad "no diagnostic naming the killed rank: $(RUN 'tr "\n" " " < /tmp/shrink-kill.out' | tail -c 250)"
+                fi
                 RUN 'pgrep -x prte >/dev/null' && ok "...and the HNP survived" \
                                                || bad "the HNP died on the shrink"
                 out=$(RUN 'timeout 60 prun --dvm-uri file:/tmp/dvm.uri -n 2 --map-by ppr:1:node hostname' 2>&1)

--- a/docs/plans/elastic_dvm/shrink_campaign.rst
+++ b/docs/plans/elastic_dvm/shrink_campaign.rst
@@ -441,6 +441,44 @@ once the shrink command is on the wire, every targeted daemon's departure is a
 *success* for the campaign, since clean exit and crash are indistinguishable
 and both remove the node as requested.
 
+Reporting a release that killed running processes
+-------------------------------------------------
+
+Releasing a node removes its daemon, which kills the application processes
+still running under it.  Nothing drains a node first, so this is a legitimate
+outcome of a successful shrink, but it must not be silent.
+
+``release_node_procs()`` (``ras_base_allocate.c``) reports each such process as
+``PRTE_PROC_STATE_KILLED_BY_RELEASE``.  Reported as ``PRTE_PROC_STATE_TERMINATED``
+- correct for the DVM's own bookkeeping, since the release is planned - a job
+that lost most of its processes mid-collective ended "successfully": ``prun``
+exited 0, the survivors were told nothing, and the requester was told the
+shrink succeeded.
+
+The state's consequences:
+
+* errmgr/dvm handles it as a proc failure.  A **recoverable** or **continuous**
+  job is notified (``PMIX_ERR_PROC_KILLED_BY_RELEASE``) and keeps running with the
+  proc's resources recovered; any other job is flagged
+  ``PRTE_JOB_STATE_KILLED_BY_RELEASE``, given a non-zero exit code, and
+  terminated.
+* ``PMIX_JOB_TERM_STATUS`` becomes ``PMIX_ERR_JOB_KILLED_BY_RELEASE`` and the
+  ``prun:proc-killed-by-release`` help text names the first rank and its node.
+* Proc accounting is unchanged.  ``proc_errors()`` force-marks
+  ``WAITPID_FIRED`` and ``IOF_COMPLETE`` for a remote proc, which drives the
+  same ``TERMINATED`` activation this path raised directly before.
+
+Every PMIx constant above falls back to its cancellation or killed-by-cmd
+equivalent when PRRTE is built against a PMIx that predates them.
+
+Only procs not yet flagged ``PRTE_PROC_FLAG_RECORDED`` are reported.  A node
+lists procs that exited earlier until their whole job terminates, so without
+that test the release of an idle node would abort a healthy job.
+
+The campaign is unaffected: the release still succeeds and
+``PMIX_DVM_IS_READY`` still fires.  The DVM shrank as asked; the job lost
+processes, and that is now reported rather than dropped.
+
 Summary of Files Changed (Shrink Fence)
 -----------------------------------------
 

--- a/src/mca/errmgr/dvm/AGENTS.md
+++ b/src/mca/errmgr/dvm/AGENTS.md
@@ -186,6 +186,7 @@ between "notify and keep going" and "abort the job":
 | `KILLED_BY_CMD` | notify `PMIX_ERR_PROC_KILLED_BY_CMD` + recover resources | if all procs terminated → `TERMINATED` |
 | `ABORTED_BY_SIG` | notify `PMIX_ERR_PROC_ABORTED_BY_SIG` + recover | set `JOB_STATE_ABORTED_BY_SIG`, record aborted proc, `_terminate_job` |
 | `TERM_WO_SYNC` | notify `PMIX_ERR_PROC_TERM_WO_SYNC` + recover | set `ABORTED_WO_SYNC`; if `exit_code == 0` force `PRTE_ERROR_DEFAULT_EXIT_CODE` so the user sees an error; `_terminate_job`. (No notification: this arm has just flagged the job ABORTED, and `check_send_notification` declines to speak about a proc in an aborting job, so the call that used to sit here could never send.) |
+| `KILLED_BY_RELEASE` | notify `PMIX_ERR_PROC_KILLED_BY_RELEASE` (`_BY_CMD` on an older PMIx) + recover | set `KILLED_BY_RELEASE`; force `PRTE_ERROR_DEFAULT_EXIT_CODE` when the killed proc reported none; `_terminate_job` |
 | `FAILED_TO_START` / `FAILED_TO_LAUNCH` | *(unconditional)* set `FAILED_TO_START`/`_LAUNCH`, `_terminate_job`, activate `FAILED_TO_START` | same |
 | `CALLED_ABORT` | notify `PMIX_ERR_PROC_REQUESTED_ABORT` + recover | set `CALLED_ABORT`, `_terminate_job` |
 | `TERM_NON_ZERO` | if `PRTE_JOB_ERROR_NONZERO_EXIT` also set: notify `PMIX_ERR_EXIT_NONZERO_TERM` + recover | set `NON_ZERO_TERM`, `_terminate_job`; always bump `PRTE_JOB_NUM_NONZERO_EXIT` |

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -657,6 +657,44 @@ keep_going:
         }
         break;
 
+    /* This proc's node was released from the DVM and the departing daemon
+     * killed it.  Planned for the DVM, not for the job, so it is handled like
+     * the loss of a daemon - except that the cause is known and can be named. */
+    case PRTE_PROC_STATE_KILLED_BY_RELEASE:
+        pmix_output_verbose(5, prte_errmgr_base_framework.framework_output,
+                             "%s errmgr:dvm: proc %s killed by the release of node %s",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(proc),
+                             (NULL == pptr->node) ? "unknown" : pptr->node->name);
+        if (flag) {
+            /* a job that can absorb the loss is told and keeps running */
+#ifdef PMIX_ERR_PROC_KILLED_BY_RELEASE
+            check_send_notification(jdata, pptr, PMIX_ERR_PROC_KILLED_BY_RELEASE);
+#else
+            check_send_notification(jdata, pptr, PMIX_ERR_PROC_KILLED_BY_CMD);
+#endif
+            // recover the resources used by this proc
+            prte_state_base_recover_resources(jdata, pptr);
+        } else {
+            if (!PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_ABORTED)) {
+                jdata->state = PRTE_JOB_STATE_KILLED_BY_RELEASE;
+                /* point to the first rank to cause the problem */
+                prte_set_attribute(&jdata->attributes, PRTE_JOB_ABORTED_PROC, PRTE_ATTR_LOCAL, pptr,
+                                   PMIX_POINTER);
+                /* retain the object so it doesn't get free'd */
+                PMIX_RETAIN(pptr);
+                PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_ABORTED);
+                /* the proc was killed, so it reported no exit code of its
+                 * own - without one the termination reads as success */
+                jdata->exit_code = pptr->exit_code;
+                if (0 == jdata->exit_code) {
+                    jdata->exit_code = PRTE_ERROR_DEFAULT_EXIT_CODE;
+                }
+                /* kill what is left of the job */
+                _terminate_job(jdata->nspace);
+            }
+        }
+        break;
+
     case PRTE_PROC_STATE_FAILED_TO_START:
     case PRTE_PROC_STATE_FAILED_TO_LAUNCH:
         pmix_output_verbose(5, prte_errmgr_base_framework.framework_output,

--- a/src/mca/plm/plm_types.h
+++ b/src/mca/plm/plm_types.h
@@ -88,6 +88,7 @@ typedef int32_t prte_exit_code_t;
 #define PRTE_PROC_STATE_NO_PATH_TO_TARGET       (PRTE_PROC_STATE_ERROR + 16) /* no path for communicating to target peer */
 #define PRTE_PROC_STATE_FAILED_TO_CONNECT       (PRTE_PROC_STATE_ERROR + 17) /* unable to connect to target peer */
 #define PRTE_PROC_STATE_PEER_UNKNOWN            (PRTE_PROC_STATE_ERROR + 18) /* unknown peer */
+#define PRTE_PROC_STATE_KILLED_BY_RELEASE       (PRTE_PROC_STATE_ERROR + 19) /* the node the process ran on was released from the DVM */
 
 /* Define a boundary so that external developers
  * have a starting point for defining their own
@@ -181,6 +182,7 @@ typedef int32_t prte_job_state_t;
 #define PRTE_JOB_STATE_MAP_FAILED               (PRTE_JOB_STATE_ERROR + 19) /* job failed to map */
 #define PRTE_JOB_STATE_CANNOT_LAUNCH            (PRTE_JOB_STATE_ERROR + 20) /* resources were busy and so the job cannot be launched */
 #define PRTE_JOB_STATE_FILES_POSN_FAILED        (PRTE_JOB_STATE_ERROR + 21)
+#define PRTE_JOB_STATE_KILLED_BY_RELEASE        (PRTE_JOB_STATE_ERROR + 22) /* a node release killed at least one of this job's procs */
 
 #define PRTE_JOB_STATE_FT (PRTE_JOB_STATE_ERROR + 200)
 /* define an FT event */

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -815,16 +815,21 @@ void prte_ras_base_shrink_complete(prte_shrink_campaign_t *campaign)
     }
 }
 
-/* Mark the application procs on a released node as terminated.  Nothing else
- * does: the target daemon's proc-state updates race the routing teardown its
- * departure starts, and its later comm failure is ignored (errmgr_dvm.c), so
- * the errmgr's lost-daemon sweep never runs either.  An unaccounted proc holds
- * its job below PRTE_JOB_STATE_TERMINATED and prterun never shuts the DVM down.
+/* Report the application procs killed by the release of this node.  Nothing
+ * else does: the target daemon's proc-state updates race the routing teardown
+ * its departure starts, and its later comm failure is ignored (errmgr_dvm.c).
+ * An unaccounted proc holds its job below PRTE_JOB_STATE_TERMINATED forever.
  *
- * TERMINATED, not TERM_WO_SYNC: the release is planned.  track_procs() skips a
- * proc already flagged RECORDED, so a real report is not counted twice.  Runs
- * before prte_plm_base_reset_dvm_node(), which can drop the map's last
- * reference to the node. */
+ * KILLED_BY_RELEASE, not TERMINATED: the release is planned, the kill is not.
+ * Reported as a normal termination it left prun exiting 0 for a job that lost
+ * ranks mid-fence.  errmgr/dvm decides what it costs.  Accounting is
+ * unchanged - proc_errors force-marks WAITPID_FIRED and IOF_COMPLETE for a
+ * remote proc, driving the same TERMINATED activation raised here before.
+ *
+ * A node lists procs that exited earlier until their whole job terminates, so
+ * without the RECORDED test the release of an idle node would abort a healthy
+ * job.  Runs before prte_plm_base_reset_dvm_node(), which can drop the map's
+ * last reference to the node. */
 static void release_node_procs(prte_node_t *node)
 {
     prte_proc_t *proc;
@@ -845,11 +850,16 @@ static void release_node_procs(prte_node_t *node)
         if (PMIX_CHECK_NSPACE(proc->name.nspace, PRTE_PROC_MY_NAME->nspace)) {
             continue;
         }
+        /* already accounted for: it reported its own termination before the
+         * release reached it, so the release did not kill it */
+        if (PRTE_FLAG_TEST(proc, PRTE_PROC_FLAG_RECORDED)) {
+            continue;
+        }
         PMIX_OUTPUT_VERBOSE((2, prte_ras_base_framework.framework_output,
-                             "%s ras:base:shrink releasing proc %s with node %s",
+                             "%s ras:base:shrink killing live proc %s with node %s",
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                              PRTE_NAME_PRINT(&proc->name), node->name));
-        PRTE_ACTIVATE_PROC_STATE(&proc->name, PRTE_PROC_STATE_TERMINATED);
+        PRTE_ACTIVATE_PROC_STATE(&proc->name, PRTE_PROC_STATE_KILLED_BY_RELEASE);
     }
 }
 

--- a/src/mca/schizo/prte/help-prun.txt
+++ b/src/mca/schizo/prte/help-prun.txt
@@ -646,6 +646,19 @@ that was returned: %d.
 "abort". This may have caused other processes in the application to be
 terminated by signals sent by %s (as reported here).
 #
+[prun:proc-killed-by-release]
+
+%s has exited because process rank %lu on node %s was killed when that
+node was released from the DVM. Releasing a node removes its daemon,
+which kills the application processes still running under it.
+
+The node was released on request - by a process, a tool, or the
+scheduler. Nothing drains a node before releasing it.
+
+Any remaining processes in this job were terminated by %s. A job that
+can carry on without the lost processes can say so with
+"--runtime-options recoverable" and will not be terminated.
+#
 [prun:proc-exit-no-sync]
 
 %s has exited due to process rank %lu with PID %lu on node %s exiting

--- a/src/pmix/pmix.c
+++ b/src/pmix/pmix.c
@@ -384,6 +384,13 @@ pmix_proc_state_t prte_pmix_convert_state(int state)
 
     case PRTE_PROC_STATE_KILLED_BY_CMD:
         return PMIX_PROC_STATE_KILLED_BY_CMD;
+    case PRTE_PROC_STATE_KILLED_BY_RELEASE:
+#ifdef PMIX_PROC_STATE_KILLED_BY_RELEASE
+        return PMIX_PROC_STATE_KILLED_BY_RELEASE;
+#else
+        /* older PMIx: the runtime killed it on command either way */
+        return PMIX_PROC_STATE_KILLED_BY_CMD;
+#endif
     case PRTE_PROC_STATE_ABORTED:
         return PMIX_PROC_STATE_ABORTED;
     case PRTE_PROC_STATE_FAILED_TO_START:
@@ -445,6 +452,10 @@ int prte_pmix_convert_pstate(pmix_proc_state_t state)
         return PRTE_PROC_STATE_TERMINATED;
     case PMIX_PROC_STATE_KILLED_BY_CMD:
         return PRTE_PROC_STATE_KILLED_BY_CMD;
+#ifdef PMIX_PROC_STATE_KILLED_BY_RELEASE
+    case PMIX_PROC_STATE_KILLED_BY_RELEASE:
+        return PRTE_PROC_STATE_KILLED_BY_RELEASE;
+#endif
     case PMIX_PROC_STATE_ABORTED:
         return PRTE_PROC_STATE_ABORTED;
     case PMIX_PROC_STATE_FAILED_TO_START:
@@ -496,6 +507,14 @@ pmix_status_t prte_pmix_convert_job_state_to_error(int state)
         case PRTE_JOB_STATE_KILLED_BY_CMD:
             return PMIX_ERR_JOB_CANCELED;
 
+        case PRTE_JOB_STATE_KILLED_BY_RELEASE:
+#ifdef PMIX_ERR_JOB_KILLED_BY_RELEASE
+            return PMIX_ERR_JOB_KILLED_BY_RELEASE;
+#else
+            /* older PMIx: a tool cannot tell this from a cancellation */
+            return PMIX_ERR_JOB_CANCELED;
+#endif
+
         case PRTE_JOB_STATE_ABORTED:
         case PRTE_JOB_STATE_CALLED_ABORT:
         case PRTE_JOB_STATE_SILENT_ABORT:
@@ -523,6 +542,13 @@ pmix_status_t prte_pmix_convert_proc_state_to_error(int state)
     switch (state) {
         case PRTE_PROC_STATE_KILLED_BY_CMD:
             return PMIX_ERR_JOB_CANCELED;
+
+        case PRTE_PROC_STATE_KILLED_BY_RELEASE:
+#ifdef PMIX_ERR_JOB_KILLED_BY_RELEASE
+            return PMIX_ERR_JOB_KILLED_BY_RELEASE;
+#else
+            return PMIX_ERR_JOB_CANCELED;
+#endif
 
         case PRTE_PROC_STATE_ABORTED:
         case PRTE_PROC_STATE_CALLED_ABORT:

--- a/src/runtime/prte_quit.c
+++ b/src/runtime/prte_quit.c
@@ -302,6 +302,11 @@ static char *print_aborted_job(prte_job_t *job,
                                        (unsigned long) proc->pid, nodename, prte_tool_basename,
                                        prte_tool_basename);
         return output;
+    } else if (PRTE_PROC_STATE_KILLED_BY_RELEASE == proc->state) {
+        output = pmix_show_help_string("help-prun.txt", "prun:proc-killed-by-release", true,
+                                       prte_tool_basename, (unsigned long) proc->name.rank,
+                                       nodename, prte_tool_basename);
+        return output;
     } else if (PRTE_PROC_STATE_COMM_FAILED == proc->state) {
         output = pmix_show_help_string("help-prun.txt", "prun:proc-comm-failed", true,
                                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
@@ -366,6 +371,8 @@ static char *dump_job(prte_job_t *job)
         } else if (PRTE_PROC_STATE_ABORTED_BY_SIG == pptr->state) {
             ++num_killed;
         } else if (PRTE_PROC_STATE_SENSOR_BOUND_EXCEEDED == pptr->state) {
+            ++num_killed;
+        } else if (PRTE_PROC_STATE_KILLED_BY_RELEASE == pptr->state) {
             ++num_killed;
         }
     }

--- a/src/util/error_strings.c
+++ b/src/util/error_strings.c
@@ -136,6 +136,8 @@ const char *prte_job_state_to_str(prte_job_state_t state)
         return "CANNOT LAUNCH";
     case PRTE_JOB_STATE_FILES_POSN_FAILED:
         return "FILE PREPOSITION FAILED";
+    case PRTE_JOB_STATE_KILLED_BY_RELEASE:
+        return "KILLED BY RELEASE";
     case PRTE_JOB_STATE_FT_CHECKPOINT:
         return "FAULT TOLERANCE CHECKPOINT";
     case PRTE_JOB_STATE_FT_CONTINUE:
@@ -232,6 +234,8 @@ const char *prte_proc_state_to_str(prte_proc_state_t state)
         return "FAILED TO CONNECT";
     case PRTE_PROC_STATE_PEER_UNKNOWN:
         return "PEER UNKNOWN";
+    case PRTE_PROC_STATE_KILLED_BY_RELEASE:
+        return "KILLED BY RELEASE";
     case PRTE_PROC_STATE_ANY:
         return "ANY";
     default:

--- a/test/unit/pmix/test_pmix.c
+++ b/test/unit/pmix/test_pmix.c
@@ -73,6 +73,19 @@
         }                                                     \
     } while (0)
 
+/* A release kill has its own status and state only on a PMIx that
+ * defines them */
+#ifdef PMIX_ERR_JOB_KILLED_BY_RELEASE
+#    define RELEASE_STATUS PMIX_ERR_JOB_KILLED_BY_RELEASE
+#else
+#    define RELEASE_STATUS PMIX_ERR_JOB_CANCELED
+#endif
+#ifdef PMIX_PROC_STATE_KILLED_BY_RELEASE
+#    define RELEASE_PSTATE PMIX_PROC_STATE_KILLED_BY_RELEASE
+#else
+#    define RELEASE_PSTATE PMIX_PROC_STATE_KILLED_BY_CMD
+#endif
+
 /* ------------------------------------------------------------------ */
 /* proc state translation                                             */
 /* ------------------------------------------------------------------ */
@@ -125,6 +138,8 @@ static struct {
     {"NO_PATH_TO_TARGET", PRTE_PROC_STATE_NO_PATH_TO_TARGET, PMIX_PROC_STATE_COMM_FAILED},
     {"FAILED_TO_CONNECT", PRTE_PROC_STATE_FAILED_TO_CONNECT, PMIX_PROC_STATE_COMM_FAILED},
     {"PEER_UNKNOWN", PRTE_PROC_STATE_PEER_UNKNOWN, PMIX_PROC_STATE_COMM_FAILED},
+
+    {"KILLED_BY_RELEASE", PRTE_PROC_STATE_KILLED_BY_RELEASE, RELEASE_PSTATE},
 };
 
 static int test_convert_state(void)
@@ -223,6 +238,11 @@ static int test_state_roundtrip(void)
         }
         if (PMIX_PROC_STATE_COMM_FAILED == state_map[n].pmix
             && PRTE_PROC_STATE_COMM_FAILED != state_map[n].prte) {
+            continue;
+        }
+        /* only lossy where PMIx has no state of its own for it */
+        if (PMIX_PROC_STATE_KILLED_BY_CMD == state_map[n].pmix
+            && PRTE_PROC_STATE_KILLED_BY_CMD != state_map[n].prte) {
             continue;
         }
 
@@ -457,6 +477,7 @@ static int test_job_state_to_error(void)
         {"FAILED_TO_START", PRTE_JOB_STATE_FAILED_TO_START, PMIX_ERR_JOB_FAILED_TO_LAUNCH},
         {"CANNOT_LAUNCH", PRTE_JOB_STATE_CANNOT_LAUNCH, PMIX_ERR_JOB_FAILED_TO_LAUNCH},
         {"KILLED_BY_CMD", PRTE_JOB_STATE_KILLED_BY_CMD, PMIX_ERR_JOB_CANCELED},
+        {"KILLED_BY_RELEASE", PRTE_JOB_STATE_KILLED_BY_RELEASE, RELEASE_STATUS},
         {"ABORTED", PRTE_JOB_STATE_ABORTED, PMIX_ERR_JOB_ABORTED},
         {"CALLED_ABORT", PRTE_JOB_STATE_CALLED_ABORT, PMIX_ERR_JOB_ABORTED},
         {"SILENT_ABORT", PRTE_JOB_STATE_SILENT_ABORT, PMIX_ERR_JOB_ABORTED},
@@ -490,6 +511,7 @@ static int test_proc_state_to_error(void)
         pmix_status_t expect;
     } tbl[] = {
         {"KILLED_BY_CMD", PRTE_PROC_STATE_KILLED_BY_CMD, PMIX_ERR_JOB_CANCELED},
+        {"KILLED_BY_RELEASE", PRTE_PROC_STATE_KILLED_BY_RELEASE, RELEASE_STATUS},
         {"ABORTED", PRTE_PROC_STATE_ABORTED, PMIX_ERR_JOB_ABORTED},
         {"CALLED_ABORT", PRTE_PROC_STATE_CALLED_ABORT, PMIX_ERR_JOB_ABORTED},
         {"ABORTED_BY_SIG", PRTE_PROC_STATE_ABORTED_BY_SIG, PMIX_ERR_JOB_ABORTED_BY_SIG},


### PR DESCRIPTION
Releasing a node from the DVM kills the application processes still running on
it. They were recorded as `PRTE_PROC_STATE_TERMINATED`, so the job ended
normally: `prun` exited 0, the surviving ranks got no event, and the requester
was told the shrink succeeded. A caller could not distinguish "released three
idle nodes" from "released three nodes and killed most of a running job".

### Change

`release_node_procs()` raises `PRTE_PROC_STATE_KILLED_BY_RELEASE` instead of
`TERMINATED`:

- errmgr/dvm handles it as a proc failure. A **recoverable** or **continuous**
  job is notified (`PMIX_ERR_PROC_KILLED_BY_RELEASE`) and keeps running with the
  proc's resources recovered; any other job is flagged
  `PRTE_JOB_STATE_KILLED_BY_RELEASE`, given a non-zero exit code, and
  terminated — the same treatment as the loss of a daemon.
- `prun:proc-killed-by-release` names the first rank lost, its node, and
  `--runtime-options recoverable` as the way to keep such a job running.
- The job status, the proc notification and the proc state use the PMIx release
  constants, falling back to the cancellation and killed-by-cmd ones when built
  against a PMIx that predates them.
- Procs already flagged `PRTE_PROC_FLAG_RECORDED` are skipped. A node lists
  procs that exited earlier until their whole job terminates, so without that
  test the release of an idle node would abort a healthy job.

Proc accounting is unchanged: `proc_errors()` force-marks `WAITPID_FIRED` and
`IOF_COMPLETE` for a remote proc, driving the same `TERMINATED` activation this
path raised directly before. Only an elastic-mode shrink reaches this code —
`release_node_procs()` has one caller, and campaigns are created only when
`prte_elastic_mode` is set.

### Testing

3-node DVM, 12 ranks, two nodes released while their ranks sit in the closing
fence:

- 8 procs reported, job terminated, one message, `prun` exits non-zero. Was:
  exit 0 and silence.
- `--runtime-options recoverable`: survivors complete, `prun` exits 0, no
  message.
- Release of nodes whose procs had already exited: nothing reported, job exits
  0, later jobs and `pterm` unaffected.
- Both the ras/hosts and the ras/slurm release paths.
- `test/unit/pmix` passes against the current PMIx and against one carrying the
  new constants.
- dockerswarm: new case "a release reports the procs it killed"; the existing
  accounting case now marks its job recoverable, since the default is to
  terminate it. The elastic suite is green.

Depends on [openpmix#4196](https://github.com/openpmix/openpmix/pull/4196) for the new constants; builds and falls back without it.

Credits: AccelCom @ Barcelona Supercomputing Center