### PR TITLE
Deep review of src/grpcomm

### DIFF
--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -89,6 +89,39 @@ with that blast radius has to be asked for by the run that wants it.  An
 older ``prte.conf`` carrying the keys still parses: they are unknown keys
 now, and unknown keys are ignored.
 
+**A fence cannot tell a post-release straggler from the next round.**  A
+fence signature is only its participant list, so nothing on the
+``PRTE_RML_TAG_FENCE`` wire says which *round* a contribution belongs to.
+That is invisible in the normal flow — a daemon converges only once every
+contribution it expects has arrived, so nothing can arrive afterwards — but
+the controller also ends a fence early, on a ``PMIX_TIMEOUT`` and on a
+participant lost to a failed daemon (``abort_fence_op()``,
+``src/grpcomm/grpcomm_fence.c``).  A contribution still climbing the tree
+then lands on a daemon that has already retired its tracker, and
+``fence_recv()`` builds a fresh one for it.  The next fence over the same
+participants finds that tracker, inherits its ``nreported`` and its bucket,
+and can converge early carrying the previous round's data.
+
+The group collective solves the same problem with ``completed_group_ops``, a
+bounded memo of released operations that ``grp_recv`` consults, and that fix
+**cannot** be copied here.  A group is keyed by ``groupID`` plus operation
+and ``group()`` forgets the memo entry when a local client starts one; a
+daemon relaying a fence for its subtree has no local client, so the memo
+would never be forgotten there and the *next* fence's legitimate
+contribution would be dropped — a hang in place of a wrong answer.  On a
+pure relay the two are genuinely indistinguishable without a round
+discriminator on the wire, and a fence has no originator to assign one: this
+is the same "every participant must reach the same answer independently"
+problem that the withdrawn lateral fence ran into
+(``src/grpcomm/AGENTS.md``).
+
+What would work is a per-signature release count: each daemon counts the
+releases it has seen for a signature, stamps its contributions with that
+count, and drops a contribution stamped below its own — the recovery epoch's
+mechanism, scoped to a signature and driven by releases rather than by
+failures.  That is a wire change plus a memo that holds a counter, and it
+needs the dockerswarm harness to validate, so it has not been attempted.
+
 **A job cannot ask for a transport.**  The network allocation request the
 odls builds for each job names ``<nspace>.net`` and a security key and
 otherwise takes whatever transport the resource manager offers by default

--- a/src/grpcomm/AGENTS.md
+++ b/src/grpcomm/AGENTS.md
@@ -458,6 +458,39 @@ The in-file comments are the real spec — read them. The load-bearing ideas:
   assuming its *newly-acquired* subtree finished ops it completed before
   promotion.
 
+### The forward is shared, and that changes what a send completion means
+
+`tree_whole_forward()` packs the forward **once** and hands the same
+`prte_rml_payload_t` to every child, because the bytes do not depend on the
+destination. Two consequences are easy to get wrong:
+
+- **A send takes its own reference, and only once it has accepted the
+  message.** `prte_rml_send_payload_cb_nb()` retains after every early
+  return, so a *refused* send leaves the caller's count exactly as it found
+  it — which is why `forward_payload_to()` has nothing to unwind on failure
+  and `tree_whole_forward()` drops exactly one reference of its own after
+  the loop.
+- **The completion callback is handed a NULL buffer.** For an ordinary
+  buffer send the callback owns the buffer; for a shared payload the buffer
+  belongs to the payload and the other destinations may still be
+  transmitting it, so `PRTE_RML_SEND_COMPLETE` passes NULL instead. That is
+  what lets `forward_lost()` pass its arguments straight through to
+  `prte_rml_send_callback()` without freeing a buffer `k-1` other sends are
+  still using.
+
+**A forward that fails synchronously ends the DVM; one that fails
+asynchronously only costs the op that subtree.** `forward_payload_to()`
+force-exits on a non-success return, while `forward_lost()` deliberately
+just drops `nexpected` — the same event, opposite reactions. What makes
+that safe is an invariant that lives in `src/rml`: `update_descendants()`
+replaces any child found in `failed_dmns` with its next living descendant,
+and it runs *after* `prte_rml_repair_routing_tree()` has marked the new
+failures — so a rank in `prte_rml_base.children` is never one
+`prte_rml_is_node_up()` calls down, and `PRTE_ERR_NODE_DOWN` is not a
+return this loop can actually see. A change on either side of that (a
+child set that can hold a failed rank, or a marking that moves after the
+repair) turns an ordinary daemon loss into a DVM teardown.
+
 ### Completion callbacks (the `pending_completions` FIFO)
 
 The op the master ends up *tracking* is a fresh one built on receipt, not
@@ -874,6 +907,22 @@ previous one of that name is over.
   through `convert_info_list()` in `grpcomm_group.c`, which initialises the
   array itself and answers an empty one on any failure, so what comes back
   is always safe to pack from and to destruct.
+- **Three numbering schemes meet in `grpcomm_xcast.c`, and the mixture is
+  deliberate.** The `DIRECT_XCAST_PACK`/`_UNPACK` packers hand back
+  `PMIx_Data_pack`'s status, so `pack_sig`, `pack_msg`, `pack_relay_msg` and
+  `pack_forward_msg` answer in **PMIx** statuses; every `PRTE_RML_SEND*`
+  answers in **PRTE** codes. A function that does both — `send_ack_msg()`
+  is the clearest — needs two checks logged through two decoders, and
+  collapsing them into one "tidier" test logs half its failures against the
+  wrong table. `process_wireup()` looks worst of all, testing
+  `prte_util_decode_nidmap()` against `PMIX_SUCCESS` and
+  `prte_util_decode_job_catchup()` against `PRTE_SUCCESS` two lines apart:
+  both are right, because those two functions genuinely answer in different
+  numbering. Check the callee before making them agree.
+  The entry points themselves answer in **PRTE** codes, as the API table
+  above says — callers log them with `PRTE_ERROR_LOG` and at least one
+  (`pmix_server_monitor.c`) runs the result back through
+  `prte_pmix_convert_rc()`, which mistranslates a PMIx status.
 - Standard PRRTE rules: `prte_config.h` first, constant-on-left, braces
   everywhere, `PMIX_ERROR_LOG`/`PRTE_ERROR_LOG`, no new warnings.
 

--- a/src/grpcomm/AGENTS.md
+++ b/src/grpcomm/AGENTS.md
@@ -527,6 +527,34 @@ gathers the *local* contributions, then deletes it the instant the request
 is handed to the host — deliberately, so a late host answer cannot reach a
 tracker it already released.
 
+**A contribution can outlive the release that ended its fence, and nothing
+here can tell that from the next round.**  A fence signature is only its
+participant list — no round, no sequence number, nothing on the wire that
+distinguishes one fence over a set of procs from the next.  In the normal
+flow that costs nothing, because a daemon converges only when everything it
+expects has arrived, so nothing *can* arrive afterwards.  But
+`abort_fence_op()` ends a fence early — on a `PMIX_TIMEOUT`, and on a
+participant lost to a failed daemon — and a contribution still climbing the
+tree then reaches a daemon whose tracker the release already retired.
+`fence_recv()` builds a new tracker for it, and the next fence over those
+same participants *finds* that tracker, inherits its `nreported` and its
+bucket, and can converge early carrying the previous round's data.
+
+**Do not fix this by copying `completed_group_ops`.**  The group memo works
+because a group is keyed by `groupID` + operation and `group()` drops the
+memo entry when a local client starts one.  A daemon relaying a fence for
+its subtree has no local client and would never drop the entry, so the next
+fence's legitimate contribution would be discarded — a hang, which is worse
+than the wrong answer it was meant to prevent.  On a pure relay a straggler
+and a new round are genuinely the same message, and a fence has no
+originator to stamp a round id: this is the same "every participant must
+reach the same answer independently" problem the withdrawn lateral fence
+ran into.  What would work is a per-signature *release count* — each daemon
+counts releases seen for a signature, stamps contributions with it, drops
+anything stamped lower — which is the recovery epoch's mechanism scoped to a
+signature.  That is a wire change and needs the dockerswarm harness; see
+[`docs/todo.rst`](../../docs/todo.rst).
+
 **A release with no local callback still has data to free.** A daemon
 holding a tracker only because it relayed for its subtree has no `cbfunc`
 — the common case on any interior daemon — so that branch frees the

--- a/src/grpcomm/AGENTS.md
+++ b/src/grpcomm/AGENTS.md
@@ -659,6 +659,31 @@ Three things about the shape are load-bearing:
 status; the normal non-success path then completes each daemon's local
 participants and deletes the tracker — so a cancel/abort tears down the
 collective **without tearing down the DVM**, which is the whole point.
+Only the controller may call it — it is the sole xcast source — and every
+caller sits behind a `PRTE_PROC_IS_MASTER` test for that reason.
+
+**The entry point owes the participant an answer on every path.**
+`prte_grpcomm_group()` has already returned `PMIX_SUCCESS` to the PMIx
+server by the time `group()` runs, so nothing upstream will fail the
+client if the handler bails out: a silent `return` leaves it blocked in
+`PMIx_Group_construct` with no collective in flight to release it. Every
+failure therefore leaves by the `error:` label. That label does two things
+and both are load-bearing — it invokes `cd->cbfunc` with the reason, and it
+first clears `coll->cbfunc`/`coll->cbdata`, because the tracker itself
+*stays* (a release from the controller, which can still abort the
+operation, has to find it) and a release arriving later would otherwise
+complete the same client a second time with the same `cbdata`. This is the
+same rule the fence entry point follows — see *Retire before you deliver*.
+
+**A controller that cannot build the release must abort, not return.** By
+the time `check_complete()` starts packing, `converged` is latched, so
+nothing will drive that tracker again — and on the controller the recovery
+restart deliberately skips a converged tracker, because its release is
+supposed to be on the wire already. A bare `return` out of the packing
+therefore hangs *every* participant in the DVM, permanently. The `failed:`
+label instead falls back to `abort_group_op()`, whose message is only a
+signature plus a status and so is by far the smallest thing still worth
+trying to build.
 
 **`ft_collective` means "some *surviving* participant asked for it."** It
 is accumulated by sticky-OR as contributions merge, so a participant that
@@ -835,6 +860,20 @@ previous one of that name is over.
   with `PMIX_PROC_CREATE` and freed with `PMIX_PROC_FREE` everywhere —
   those allocate and free *inside the PMIx library*, so a plain `free()`
   crosses the library boundary.
+- **Never call `PMIx_Info_list_convert()` and reach for the array without
+  reading the status.** An empty list — the ordinary case for a construct
+  carrying no `PMIX_GROUP_INFO` and no endpoints — answers
+  `PMIX_ERR_EMPTY`, and on that early return PMIx is under no obligation to
+  have touched the `pmix_data_array_t` you handed it. Callers here pass an
+  *uninitialised stack* variable, so an unchecked call reads whatever was on
+  the stack for `.array`/`.size`, packs that many `pmix_info_t` from that
+  pointer, and then hands the same pointer to `PMIX_DATA_ARRAY_DESTRUCT`.
+  Current PMIx master initialises the argument before its first failure
+  return, but no *released* PMIx in the supported range does, and depending
+  on that is depending on the callee to clean up after the caller. Go
+  through `convert_info_list()` in `grpcomm_group.c`, which initialises the
+  array itself and answers an empty one on any failure, so what comes back
+  is always safe to pack from and to destruct.
 - Standard PRRTE rules: `prte_config.h` first, constant-on-left, braces
   everywhere, `PMIX_ERROR_LOG`/`PRTE_ERROR_LOG`, no new warnings.
 

--- a/src/grpcomm/AGENTS.md
+++ b/src/grpcomm/AGENTS.md
@@ -797,6 +797,12 @@ previous one of that name is over.
   field is packed and unpacked unguarded, so every daemon in a DVM agrees
   on the message layout no matter what its PMIx advertised. Guard the
   *behaviour*, never the bytes.
+- **The trackers' `pmix_bitmap_init(&reported_slots, 1)` is deliberately
+  unchecked.** `pmix_bitmap_set_bit()` grows the bitmap on demand, and an
+  `init` that fails leaves `array_size` at zero behind a NULL pointer, so the
+  first slot recorded allocates and every accessor before that reads zero -
+  which is the right answer for a tracker nothing has reported to. A
+  constructor cannot fail anyway; do not add an abort here.
 - **One allocator per array.** The proc arrays on a signature are built
   with `PMIX_PROC_CREATE` and freed with `PMIX_PROC_FREE` everywhere —
   those allocate and free *inside the PMIx library*, so a plain `free()`

--- a/src/grpcomm/grpcomm.c
+++ b/src/grpcomm/grpcomm.c
@@ -101,8 +101,6 @@ int prte_grpcomm_init(void)
                   PRTE_RML_PERSISTENT, prte_grpcomm_xcast_recv, NULL);
     PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_XCAST_ACK,
                   PRTE_RML_PERSISTENT, prte_grpcomm_xcast_ack, NULL);
-    /* A bulk broadcast's exchange partners are not routing-tree neighbours, so
-     * the RML hands their losses here instead of repairing the tree. */
 
     /* fence receives */
     PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_FENCE,
@@ -110,8 +108,6 @@ int prte_grpcomm_init(void)
     /* setup recv for barrier release */
     PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_FENCE_RELEASE,
                   PRTE_RML_PERSISTENT, prte_grpcomm_fence_release, NULL);
-    /* ...and for a fence's lateral allgather, which arrives from exchange
-     * partners rather than from a routing-tree child */
 
     /* group receives */
     PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_GROUP,
@@ -134,7 +130,6 @@ void prte_grpcomm_finalize(void)
 
     PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_XCAST);
     PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_XCAST_ACK);
-    prte_rml_lateral_set_lost_callback(NULL);
     PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_FENCE);
     PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_FENCE_RELEASE);
     PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_GROUP);

--- a/src/grpcomm/grpcomm_classes.c
+++ b/src/grpcomm/grpcomm_classes.c
@@ -223,8 +223,6 @@ PMIX_CLASS_INSTANCE(prte_grpcomm_group_memo_t,
 
 static void mdcon(prte_pmix_fence_caddy_t *p)
 {
-    p->sig = NULL;
-    p->buf = NULL;
     p->procs = NULL;
     p->nprocs = 0;
     p->info = NULL;
@@ -236,12 +234,6 @@ static void mdcon(prte_pmix_fence_caddy_t *p)
 }
 static void mddes(prte_pmix_fence_caddy_t *p)
 {
-    if (NULL != p->sig) {
-        PMIX_RELEASE(p->sig);
-    }
-    if (NULL != p->buf) {
-        PMIX_DATA_BUFFER_RELEASE(p->buf);
-    }
     /* The modex bucket PMIx handed up with the fence.  Ownership transfers on
      * that call and cannot not: PMIx unloads the buffer into a bare pointer
      * and returns, while we park it here and read it later from another

--- a/src/grpcomm/grpcomm_fence.c
+++ b/src/grpcomm/grpcomm_fence.c
@@ -313,7 +313,7 @@ void prte_grpcomm_fence_fault_handler(const prte_rml_recovery_status_t* status)
         return;
     }
 
-        if (!PRTE_PROC_IS_MASTER) {
+    if (!PRTE_PROC_IS_MASTER) {
         return;
     }
     PMIX_LIST_FOREACH_SAFE(coll, nxt, &prte_grpcomm_globals.fence_ops,
@@ -388,13 +388,6 @@ static void fence(int sd, short args, void *cbdata)
         st = prte_pmix_convert_rc(rc);
         goto done;
     }
-
-    /* Say how we intend to move this fence's contributions. Nobody downstream
-     * obeys it - every participant decides for itself, because there is no
-     * originator to decide for them - so this is not an instruction but an
-     * assertion, and the receiver's job is to notice if it disagrees. Packed
-     * unguarded: every daemon in a DVM runs the same build, so the bytes are
-     * never conditional even when the behaviour is. */
 
     // pack the info structs
     rc = PMIx_Data_pack(NULL, relay, &cd->ninfo, 1, PMIX_SIZE);
@@ -594,7 +587,10 @@ void prte_grpcomm_fence_recv(int status, pmix_proc_t *sender,
         }
     }
 
-    /* cycle thru the info to look for keys we support */
+    /* Merge the directives this contribution carried into the tracker. The
+     * array itself is freed unread below - what gets forwarded upward is
+     * rebuilt from the tracker in tree_gather_answer(), so writing the merged
+     * values back into these entries would say nothing to anybody. */
     for (n=0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
             PMIX_VALUE_GET_NUMBER(rc, &info[n].value, timeout, int);
@@ -606,9 +602,6 @@ void prte_grpcomm_fence_recv(int status, pmix_proc_t *sender,
             if (coll->timeout < timeout) {
                 coll->timeout = timeout;
             }
-            /* update the info with the collected value */
-            info[n].value.type = PMIX_INT;
-            info[n].value.data.integer = coll->timeout;
 
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_LOCAL_COLLECTIVE_STATUS)) {
             PMIX_VALUE_GET_NUMBER(rc, &info[n].value, st, pmix_status_t);
@@ -621,9 +614,6 @@ void prte_grpcomm_fence_recv(int status, pmix_proc_t *sender,
                 PMIX_SUCCESS == coll->status) {
                 coll->status = st;
             }
-            /* update the info with the collected value */
-            info[n].value.type = PMIX_STATUS;
-            info[n].value.data.status = coll->status;
         }
     }
 

--- a/src/grpcomm/grpcomm_fence.c
+++ b/src/grpcomm/grpcomm_fence.c
@@ -159,18 +159,19 @@ static int pack_epoch_frame(pmix_data_buffer_t *framed, pmix_data_buffer_t *body
 static void abort_fence_op(prte_grpcomm_fence_t *coll, pmix_status_t st)
 {
     pmix_data_buffer_t *reply;
-    pmix_status_t rc;
+    pmix_status_t prc;
+    int rc;
 
     PMIX_DATA_BUFFER_CREATE(reply);
     rc = fence_sig_pack(reply, coll->sig);
-    if (PMIX_SUCCESS != rc) {
+    if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(reply);
         return;
     }
-    rc = PMIx_Data_pack(NULL, reply, &st, 1, PMIX_INT32);
-    if (PMIX_SUCCESS != rc) {
-        PRTE_ERROR_LOG(rc);
+    prc = PMIx_Data_pack(NULL, reply, &st, 1, PMIX_INT32);
+    if (PMIX_SUCCESS != prc) {
+        PMIX_ERROR_LOG(prc);
         PMIX_DATA_BUFFER_RELEASE(reply);
         return;
     }
@@ -741,8 +742,8 @@ static void tree_gather_answer(prte_grpcomm_fence_t *coll)
                              PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
         PMIX_DATA_BUFFER_CREATE(reply);
         rc = fence_sig_pack(reply, coll->sig);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
+        if (PRTE_SUCCESS != rc) {
+            PRTE_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_RELEASE(reply);
             return;
         }
@@ -771,8 +772,8 @@ static void tree_gather_answer(prte_grpcomm_fence_t *coll)
 
     PMIX_DATA_BUFFER_CREATE(reply);
     rc = fence_sig_pack(reply, coll->sig);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(reply);
         return;
     }
@@ -862,8 +863,8 @@ void prte_grpcomm_fence_release(int status, pmix_proc_t *sender,
 
     /* unpack the signature */
     rc = fence_sig_unpack(buffer, &sig);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
         return;
     }
 

--- a/src/grpcomm/grpcomm_group.c
+++ b/src/grpcomm/grpcomm_group.c
@@ -595,7 +595,6 @@ void prte_grpcomm_group_fault_handler(const prte_rml_recovery_status_t* status)
             }
         }
     }
-
 }
 
 
@@ -858,7 +857,7 @@ void prte_grpcomm_grp_recv(int status, pmix_proc_t *sender,
     struct timeval tv;
     size_t n, nendpts, ngrpinfo;
     pmix_status_t st;
-    pmix_info_t *endpts, *grpinfo = NULL;
+    pmix_info_t *endpts = NULL, *grpinfo = NULL;
     prte_grpcomm_group_signature_t *sig = NULL;
     prte_grpcomm_group_t *coll;
     PRTE_HIDE_UNUSED_PARAMS(status, tag, cbdata);
@@ -1347,7 +1346,6 @@ answer:
         if (PRTE_SUCCESS != rc) {
             PRTE_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_RELEASE(reply);
-            PMIX_PROC_FREE(finalmembership, nfinal);
             /* the abort below puts this on the wire as a PMIx status */
             rc = prte_pmix_convert_rc(rc);
             goto failed;
@@ -1357,7 +1355,6 @@ answer:
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_RELEASE(reply);
-            PMIX_PROC_FREE(finalmembership, nfinal);
             goto failed;
         }
 
@@ -1367,7 +1364,6 @@ answer:
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(reply);
-                PMIX_PROC_FREE(finalmembership, nfinal);
                 goto failed;
             }
             if (0 < nfinal) {
@@ -1375,7 +1371,6 @@ answer:
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DATA_BUFFER_RELEASE(reply);
-                    PMIX_PROC_FREE(finalmembership, nfinal);
                     goto failed;
                 }
                 PMIX_PROC_FREE(finalmembership, nfinal);
@@ -1409,7 +1404,7 @@ answer:
                 goto failed;
             }
             if (0 < ninfo) {
-               rc =  PMIx_Data_pack(NULL, reply, info, ninfo, PMIX_INFO);
+               rc = PMIx_Data_pack(NULL, reply, info, ninfo, PMIX_INFO);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DATA_BUFFER_RELEASE(reply);
@@ -1525,7 +1520,7 @@ failed:
                 return;
             }
             if (0 < ninfo) {
-                rc =PMIx_Data_pack(NULL, reply, info, ninfo, PMIX_INFO);
+                rc = PMIx_Data_pack(NULL, reply, info, ninfo, PMIX_INFO);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DATA_BUFFER_RELEASE(reply);
@@ -2254,6 +2249,8 @@ static prte_grpcomm_group_t *get_tracker(prte_grpcomm_group_signature_t *sig,
                     }
                     coll->sig->members = p;
                     coll->sig->nmembers = n;
+                } else {
+                    PMIX_LIST_DESTRUCT(&plist);
                 }
 
             } else if (sig->follower) {
@@ -2306,6 +2303,8 @@ static prte_grpcomm_group_t *get_tracker(prte_grpcomm_group_signature_t *sig,
                     coll->sig->addmembers = p;
                     coll->sig->naddmembers = n;
                     coll->nfollowers = n;
+                } else {
+                    PMIX_LIST_DESTRUCT(&plist);
                 }
             }
             // if they specified a final order, see if one was already given

--- a/src/grpcomm/grpcomm_group.c
+++ b/src/grpcomm/grpcomm_group.c
@@ -75,6 +75,40 @@ static int pack_epoch_frame(pmix_data_buffer_t *framed, pmix_data_buffer_t *body
     return PRTE_SUCCESS;
 }
 
+/* Turn an info list into the array we pack, screening the conversion.
+ *
+ * PMIx_Info_list_convert() answers PMIX_ERR_EMPTY for a list nothing was ever
+ * added to - the ordinary case for a construct that carries no group info and
+ * no endpoints - and on that early return it is under no obligation to have
+ * touched the caller's pmix_data_array_t. Callers here hand it an
+ * uninitialized stack variable, so reading darray.array/darray.size after an
+ * unchecked call reads whatever was on the stack, packs that many pmix_info_t
+ * from that pointer, and then hands the same pointer to
+ * PMIX_DATA_ARRAY_DESTRUCT. Initialize it ourselves and answer an empty array
+ * on any failure, so the array is always one the caller can pack from and
+ * destruct. */
+static void convert_info_list(void *ilist, pmix_data_array_t *darray,
+                              pmix_info_t **info, size_t *ninfo)
+{
+    pmix_status_t rc;
+
+    PMIX_DATA_ARRAY_INIT(darray, PMIX_INFO);
+    rc = PMIx_Info_list_convert(ilist, darray);
+    if (PMIX_SUCCESS != rc) {
+        /* an empty list is not an error - it just means there is nothing of
+         * this kind to carry */
+        if (PMIX_ERR_EMPTY != rc) {
+            PMIX_ERROR_LOG(rc);
+        }
+        PMIX_DATA_ARRAY_INIT(darray, PMIX_INFO);
+        *info = NULL;
+        *ninfo = 0;
+        return;
+    }
+    *info = (pmix_info_t *) darray->array;
+    *ninfo = darray->size;
+}
+
 /* Take a copy of a proc array a directive carried into the signature.
  *
  * The array belongs to the caller: the directives come straight from the
@@ -252,7 +286,7 @@ static void abort_group_op(prte_grpcomm_group_t *coll, pmix_status_t st)
     PMIX_DATA_BUFFER_CREATE(reply);
     /* pack the signature */
     rc = pack_signature(reply, coll->sig);
-    if (PMIX_SUCCESS != rc) {
+    if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(reply);
         return;
@@ -569,7 +603,7 @@ static void group(int sd, short args, void *cbdata)
 {
     prte_pmix_grp_caddy_t *cd = (prte_pmix_grp_caddy_t*)cbdata;
     prte_grpcomm_group_signature_t sig;
-    prte_grpcomm_group_t *coll;
+    prte_grpcomm_group_t *coll = NULL;
     pmix_data_buffer_t *relay, *framed;
     pmix_status_t rc, st = PMIX_SUCCESS;
     int timeout = 0;
@@ -619,12 +653,17 @@ static void group(int sd, short args, void *cbdata)
      * from the completed memo so this one is not mistaken for a straggler */
     group_op_forget(&sig);
 
-    /* create a tracker for this operation */
+    /* create a tracker for this operation. A failure here has to leave by the
+     * error label like any other: the two info lists are open, and - more to
+     * the point - nothing else is going to answer the participant. This entry
+     * point already returned PRTE_SUCCESS to the PMIx server, so a silent
+     * return leaves the client blocked in PMIx_Group_construct with no
+     * collective in flight to ever release it. */
     if (NULL == (coll = get_tracker(&sig, true))) {
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
-        PMIX_RELEASE(cd);
         PMIX_DESTRUCT(&sig);
-        return;
+        rc = PMIX_ERR_NOT_FOUND;
+        goto error;
     }
     coll->cbfunc = cd->cbfunc;
     coll->cbdata = cd->cbdata;
@@ -664,13 +703,12 @@ static void group(int sd, short args, void *cbdata)
 
     if (PMIX_GROUP_CONSTRUCT == sig.op) {
         // pack any group info
-        PMIx_Info_list_convert(grpinfo, &darray);
-        info = (pmix_info_t*)darray.array;
-        ninfo = darray.size;
+        convert_info_list(grpinfo, &darray, &info, &ninfo);
         rc = PMIx_Data_pack(NULL, relay, &ninfo, 1, PMIX_SIZE);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_RELEASE(relay);
+            PMIX_DATA_ARRAY_DESTRUCT(&darray);
             PMIX_DESTRUCT(&sig);
             goto error;
         }
@@ -679,6 +717,7 @@ static void group(int sd, short args, void *cbdata)
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(relay);
+                PMIX_DATA_ARRAY_DESTRUCT(&darray);
                 PMIX_DESTRUCT(&sig);
                 goto error;
             }
@@ -686,13 +725,12 @@ static void group(int sd, short args, void *cbdata)
         PMIX_DATA_ARRAY_DESTRUCT(&darray);
 
         // pack any endpts
-        PMIx_Info_list_convert(endpts, &darray);
-        info = (pmix_info_t*)darray.array;
-        ninfo = darray.size;
+        convert_info_list(endpts, &darray, &info, &ninfo);
         rc = PMIx_Data_pack(NULL, relay, &ninfo, 1, PMIX_SIZE);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_RELEASE(relay);
+            PMIX_DATA_ARRAY_DESTRUCT(&darray);
             PMIX_DESTRUCT(&sig);
             goto error;
         }
@@ -701,6 +739,7 @@ static void group(int sd, short args, void *cbdata)
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(relay);
+                PMIX_DATA_ARRAY_DESTRUCT(&darray);
                 PMIX_DESTRUCT(&sig);
                 goto error;
             }
@@ -792,6 +831,16 @@ error:
     }
     if (NULL != endpts) {
         PMIx_Info_list_release(endpts);
+    }
+    /* Our contribution never entered the rollup, so nothing upstream knows to
+     * fail this participant - we have to, right here. Take it off the tracker
+     * first: the tracker itself stays (a release from the controller, which
+     * can still abort the operation, has to find it), and a release arriving
+     * later would otherwise complete the same client a second time with the
+     * same cbdata. This is the same rule the fence entry point follows. */
+    if (NULL != coll) {
+        coll->cbfunc = NULL;
+        coll->cbdata = NULL;
     }
     if (NULL != cd->cbfunc) {
         cd->cbfunc(rc, NULL, 0, cd->cbdata, NULL, NULL);
@@ -1292,12 +1341,16 @@ answer:
         PMIX_DATA_BUFFER_CREATE(reply);
 
         /* pack the signature */
+        /* pack_signature answers in PRTE codes - log it through the
+         * decoder that knows them */
         rc = pack_signature(reply, coll->sig);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
+        if (PRTE_SUCCESS != rc) {
+            PRTE_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_RELEASE(reply);
             PMIX_PROC_FREE(finalmembership, nfinal);
-            return;
+            /* the abort below puts this on the wire as a PMIx status */
+            rc = prte_pmix_convert_rc(rc);
+            goto failed;
         }
         /* pack the status */
         rc = PMIx_Data_pack(NULL, reply, &coll->status, 1, PMIX_STATUS);
@@ -1305,7 +1358,7 @@ answer:
             PMIX_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_RELEASE(reply);
             PMIX_PROC_FREE(finalmembership, nfinal);
-            return;
+            goto failed;
         }
 
         if (PMIX_GROUP_CONSTRUCT == coll->sig->op) {
@@ -1315,7 +1368,7 @@ answer:
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(reply);
                 PMIX_PROC_FREE(finalmembership, nfinal);
-                return;
+                goto failed;
             }
             if (0 < nfinal) {
                 rc = PMIx_Data_pack(NULL, reply, finalmembership, nfinal, PMIX_PROC);
@@ -1323,7 +1376,7 @@ answer:
                     PMIX_ERROR_LOG(rc);
                     PMIX_DATA_BUFFER_RELEASE(reply);
                     PMIX_PROC_FREE(finalmembership, nfinal);
-                    return;
+                    goto failed;
                 }
                 PMIX_PROC_FREE(finalmembership, nfinal);
             }
@@ -1334,7 +1387,7 @@ answer:
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(reply);
-                return;
+                goto failed;
             }
             if (0 < coll->ndeparted) {
                 rc = PMIx_Data_pack(NULL, reply, coll->departed,
@@ -1342,20 +1395,18 @@ answer:
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DATA_BUFFER_RELEASE(reply);
-                    return;
+                    goto failed;
                 }
             }
 
             // pack any group info
-            PMIx_Info_list_convert(coll->grpinfo, &darray);
-            info = (pmix_info_t*)darray.array;
-            ninfo = darray.size;
+            convert_info_list(coll->grpinfo, &darray, &info, &ninfo);
             rc = PMIx_Data_pack(NULL, reply, &ninfo, 1, PMIX_SIZE);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(reply);
                 PMIX_DATA_ARRAY_DESTRUCT(&darray);
-                return;
+                goto failed;
             }
             if (0 < ninfo) {
                rc =  PMIx_Data_pack(NULL, reply, info, ninfo, PMIX_INFO);
@@ -1363,21 +1414,19 @@ answer:
                     PMIX_ERROR_LOG(rc);
                     PMIX_DATA_BUFFER_RELEASE(reply);
                     PMIX_DATA_ARRAY_DESTRUCT(&darray);
-                    return;
+                    goto failed;
                 }
             }
             PMIX_DATA_ARRAY_DESTRUCT(&darray);
 
             // pack any endpts
-            PMIx_Info_list_convert(coll->endpts, &darray);
-            info = (pmix_info_t*)darray.array;
-            ninfo = darray.size;
+            convert_info_list(coll->endpts, &darray, &info, &ninfo);
             rc = PMIx_Data_pack(NULL, reply, &ninfo, 1, PMIX_SIZE);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_DATA_BUFFER_RELEASE(reply);
                 PMIX_DATA_ARRAY_DESTRUCT(&darray);
-                return;
+                goto failed;
             }
             if (0 < ninfo) {
                 rc = PMIx_Data_pack(NULL, reply, info, ninfo, PMIX_INFO);
@@ -1385,7 +1434,7 @@ answer:
                     PMIX_ERROR_LOG(rc);
                     PMIX_DATA_BUFFER_RELEASE(reply);
                     PMIX_DATA_ARRAY_DESTRUCT(&darray);
-                    return;
+                    goto failed;
                 }
             }
             PMIX_DATA_ARRAY_DESTRUCT(&darray);
@@ -1395,6 +1444,21 @@ answer:
          * buffer is still ours to free */
         (void) prte_grpcomm_release_bcast(PRTE_RML_TAG_GROUP_RELEASE, reply);
         PMIX_DATA_BUFFER_RELEASE(reply);
+        return;
+
+failed:
+        /* We could not build the release. "converged" is already latched, so
+         * nothing will drive this tracker again, and on the controller there
+         * is no recovery either - the restart deliberately skips a converged
+         * tracker here because its release is supposed to be on the wire. So
+         * a bare return leaves every participant in the DVM blocked in
+         * PMIx_Group_construct forever. Fail them instead: the abort carries
+         * only the signature and a status, which is far the smallest message
+         * we could still manage to build, and it drives each daemon's release
+         * path to complete its own clients and retire the tracker. */
+        PMIX_PROC_FREE(finalmembership, nfinal);
+        abort_group_op(coll, (PMIX_SUCCESS == rc) ? PMIX_ERROR : rc);
+        return;
 
     } else {
         PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
@@ -1406,9 +1470,10 @@ answer:
         PMIX_DATA_BUFFER_CREATE(reply);
 
         /* pack the signature */
+        /* pack_signature answers in PRTE codes - see the note above */
         rc = pack_signature(reply, coll->sig);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
+        if (PRTE_SUCCESS != rc) {
+            PRTE_ERROR_LOG(rc);
             PMIX_DATA_BUFFER_RELEASE(reply);
             return;
         }
@@ -1431,9 +1496,7 @@ answer:
 
         if (PMIX_GROUP_CONSTRUCT == coll->sig->op) {
             // pack any group info
-            PMIx_Info_list_convert(coll->grpinfo, &darray);
-            info = (pmix_info_t*)darray.array;
-            ninfo = darray.size;
+            convert_info_list(coll->grpinfo, &darray, &info, &ninfo);
             rc = PMIx_Data_pack(NULL, reply, &ninfo, 1, PMIX_SIZE);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
@@ -1453,9 +1516,7 @@ answer:
             PMIX_DATA_ARRAY_DESTRUCT(&darray);
 
             // pack any endpts
-            PMIx_Info_list_convert(coll->endpts, &darray);
-            info = (pmix_info_t*)darray.array;
-            ninfo = darray.size;
+            convert_info_list(coll->endpts, &darray, &info, &ninfo);
             rc = PMIx_Data_pack(NULL, reply, &ninfo, 1, PMIX_SIZE);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);

--- a/src/grpcomm/grpcomm_internal.h
+++ b/src/grpcomm/grpcomm_internal.h
@@ -282,8 +282,6 @@ PMIX_CLASS_DECLARATION(prte_grpcomm_group_t);
 typedef struct {
     pmix_object_t super;
     prte_event_t ev;
-    prte_grpcomm_fence_signature_t *sig;
-    pmix_data_buffer_t *buf;
     pmix_proc_t *procs;
     size_t nprocs;
     pmix_info_t *info;

--- a/src/grpcomm/grpcomm_xcast.c
+++ b/src/grpcomm/grpcomm_xcast.c
@@ -274,7 +274,10 @@ int prte_grpcomm_xcast_nb(prte_rml_tag_t tag, pmix_data_buffer_t *msg,
             PMIX_ERROR_LOG(rc);
             PMIx_Data_buffer_destruct(&msg_copy);
             PMIX_RELEASE(op);
-            return rc;
+            /* this entry point answers in PRTE codes - callers log it with
+             * PRTE_ERROR_LOG and at least one runs it back through
+             * prte_pmix_convert_rc(), which would mistranslate a PMIx status */
+            return prte_pmix_convert_status(rc);
         }
 
         PMIx_Data_unload(&msg_copy, &op->msg);
@@ -288,7 +291,7 @@ int prte_grpcomm_xcast_nb(prte_rml_tag_t tag, pmix_data_buffer_t *msg,
     PMIX_POST_OBJECT(&op);
     prte_event_active(&op->ev, PRTE_EV_WRITE, 1);
 
-    return PMIX_SUCCESS;
+    return PRTE_SUCCESS;
 }
 
 void prte_grpcomm_xcast_recv(
@@ -587,9 +590,12 @@ static void begin_xcast(int sd, short args, void* cbdata){
 
     // setup the payload
     pmix_data_buffer_t *xcast_msg = PMIx_Data_buffer_create();
+    /* the packers answer in PMIx statuses - PRTE_RML_RELIABLE_SEND below
+     * answers in PRTE codes, so the two failures below are logged through
+     * different decoders on purpose */
     int rc = pack_relay_msg(xcast_msg, op);
     if (PMIX_SUCCESS != rc) {
-        PRTE_ERROR_LOG(rc);
+        PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(xcast_msg);
         PMIX_RELEASE(op);
         return;
@@ -659,8 +665,9 @@ static void send_ack_msg(
     } else {
         PRTE_RML_SEND(ret, dest, msg, PRTE_RML_TAG_XCAST_ACK);
     }
-    if(PMIX_SUCCESS != ret){
-        PMIX_ERROR_LOG(ret);
+    /* the RML answers in PRTE codes, unlike the packers above */
+    if(PRTE_SUCCESS != ret){
+        PRTE_ERROR_LOG(ret);
         PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         PMIx_Data_buffer_release(msg);
     }
@@ -975,9 +982,10 @@ static prte_rml_payload_t* build_forward_payload(op_t* op){
     pmix_data_buffer_t* xcast_msg = PMIx_Data_buffer_create();
     prte_rml_payload_t* payload;
 
+    /* pack_forward_msg answers in PMIx statuses */
     int rc = pack_forward_msg(xcast_msg, op);
     if (PMIX_SUCCESS != rc) {
-        PRTE_ERROR_LOG(rc);
+        PMIX_ERROR_LOG(rc);
         PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         PMIX_DATA_BUFFER_RELEASE(xcast_msg);
         return NULL;
@@ -1138,6 +1146,9 @@ static void process_msg(op_t* op){
         ret = PMIx_Data_embed(msg, &op->msg);
     }
     if(PMIX_SUCCESS != ret){
+        /* this ends the DVM, so it must say why - the decompress failure
+         * above has its own show_help, and this path had nothing at all */
+        PMIX_ERROR_LOG(ret);
         PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
         PMIx_Data_buffer_release(msg);
         return;

--- a/src/grpcomm/grpcomm_xcast.c
+++ b/src/grpcomm/grpcomm_xcast.c
@@ -133,12 +133,11 @@ static void send_ack(signature_t* sig, pmix_rank_t ack_id);
 static void request_ack(pmix_rank_t from, signature_t* sig, pmix_rank_t ack_id);
 // Remove local tracking and ack to parent
 static void finish_op(op_t *op);
-// Finish every op that is now both complete and next in op-id order
+// Finish every op whose subtree has reported. Ops are held in op-id order
+// and finish_op is what enforces that they retire in it
 static void drive_completions(void);
 // Give up on this op's exchange and get the payload the tree way
 static void tree_whole_forward(op_t *op);
-// How this broadcast will travel - decided by its originator, and only there
-// Is an op ahead of this one in op-id order still waiting on its payload?
 
 
 // Pack the xcast message forwarded to our children.  Takes no destination:
@@ -288,7 +287,7 @@ int prte_grpcomm_xcast_nb(prte_rml_tag_t tag, pmix_data_buffer_t *msg,
      * access framework-global data safely */
 
     prte_event_set(prte_event_base, &op->ev, -1, PRTE_EV_WRITE, begin_xcast, op);
-    PMIX_POST_OBJECT(&op);
+    PMIX_POST_OBJECT(op);
     prte_event_active(&op->ev, PRTE_EV_WRITE, 1);
 
     return PRTE_SUCCESS;
@@ -311,12 +310,11 @@ void prte_grpcomm_xcast_recv(
     signature_t sig;
     if(PMIX_SUCCESS != unpack_sig(buffer, &sig)) return;
 
-    /* An op-id of zero is an originator relaying to the controller, not a
-     * forward down the tree. The distinction decides how the payload that
-     * follows is laid out: the relay always carries it whole, because that hop
-     * is an ordinary point-to-point send even when the broadcast is going to
-     * Capture it before the controller stamps an id
-     * on the signature below. */
+    /* An op-id of zero is an originator relaying to the controller rather than
+     * a forward down the tree; the controller stamps the real id below. The
+     * two carry the same fields in the same order - pack_relay_msg and
+     * pack_forward_msg are deliberately identical - so nothing downstream has
+     * to tell them apart. */
 
     // A daemon that has never seen any xcast (op_id_inited == 0) yet is being
     // handed an op is a *late joiner*: a daemon grown into a running DVM, or one
@@ -422,7 +420,8 @@ void prte_grpcomm_xcast_recv(
     PMIX_OUTPUT_VERBOSE((
         1, prte_grpcomm_globals.output,
         "%s grpcomm:xcast:recv: new xcast of tag %u with op_id %lu",
-        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), op->msg_tag, sig.op_id
+        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (unsigned) op->msg_tag,
+        (unsigned long) sig.op_id
     ));
 
     // We need to process (invoke the user msg's callback, generally) and
@@ -585,7 +584,7 @@ static void begin_xcast(int sd, short args, void* cbdata){
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
     op_t* op = (op_t*) cbdata;
-    PMIX_ACQUIRE_OBJECT(&op);
+    PMIX_ACQUIRE_OBJECT(op);
 
 
     // setup the payload
@@ -1114,6 +1113,11 @@ static void process_wireup(pmix_data_buffer_t *msg){
         if(PMIX_SUCCESS != ret){ PMIX_ERROR_LOG(ret); break; }
     } while(PMIX_SUCCESS == ret);
 
+    /* Reaching here means the loop broke on a real unpack failure - a wireup
+     * we cannot read leaves this daemon with no route to anyone, so it ends
+     * the job. The clean end of the record stream is the
+     * READ_PAST_END_OF_BUFFER return inside the loop, which is why that one
+     * is a return and not a break. */
     if(val.type != PMIX_UNDEF) PMIx_Value_destruct(&val);
     if(sval.type != PMIX_UNDEF) PMIx_Value_destruct(&sval);
     PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
@@ -1180,7 +1184,10 @@ static void op_con(op_t* p)
     p->replay_pending_parent = false;
 
     p->nreported = 0;
-    p->nexpected = -1;
+    /* "not yet computed" - forward_op() sets the real count. Deliberately the
+     * largest value rather than zero, so an op that has not been forwarded can
+     * never satisfy op_ready() and retire without having been sent anywhere */
+    p->nexpected = SIZE_MAX;
     p->ack_id_up = 0;
     p->ack_id_down = 0;
 

--- a/test/unit/grpcomm/test_grpcomm.c
+++ b/test/unit/grpcomm/test_grpcomm.c
@@ -204,8 +204,6 @@ static int test_classes(void)
 
     /* fence caddy: all borrowed pointers NULL, sizes zero */
     prte_pmix_fence_caddy_t *fcd = PMIX_NEW(prte_pmix_fence_caddy_t);
-    CHECK("fence caddy sig NULL", NULL == fcd->sig);
-    CHECK("fence caddy buf NULL", NULL == fcd->buf);
     CHECK("fence caddy procs NULL", NULL == fcd->procs);
     CHECK("fence caddy nprocs 0", 0 == fcd->nprocs);
     CHECK("fence caddy data NULL", NULL == fcd->data);


### PR DESCRIPTION
A file-by-file review of `src/grpcomm` — all five `.c` files, each audited
through five independent lenses (memory/lifetime, threading and the PMIx
boundary, error paths, portability/representation, contracts) with every
finding above LOW adversarially verified before it was fixed.

## The problem being solved

Most of what this found is not a wrong algorithm — the collectives work.
It is the layer underneath: values crossing the PRRTE/PMIx boundary in the
wrong numbering, failure paths that answer nobody, and an array read before
anyone established that it had been written.

**A group construct packed an array PMIx never handed back.**
`PMIx_Info_list_convert()` answers `PMIX_ERR_EMPTY` for a list nothing was
added to — the ordinary case for a construct carrying no `PMIX_GROUP_INFO`
and no endpoints — and on that early return it is under no obligation to
have touched the caller's `pmix_data_array_t`. Six calls in
`grpcomm_group.c` discarded the status and read `darray.array`/`darray.size`
straight afterwards, off an uninitialized stack variable: the daemon would
pack whatever count the stack held, from whatever pointer sat beside it, and
then hand that same pointer to `PMIX_DATA_ARRAY_DESTRUCT`. Current PMIx
master initializes the argument before it can fail (openpmix `8315915a5`,
which is in no release tag), so this is latent against that one tree and
live against every released PMIx in the supported range. The file already
knew better in one place — `grp_release()` checks the status and says in a
comment that darray is left untouched.

**Two ways a group operation hung the client waiting on it.** A
`get_tracker()` failure in `group()` returned without releasing two open
info lists and, more importantly, without calling the participant's
callback — while the entry point had already answered `PRTE_SUCCESS` to the
PMIx server, so nothing upstream would fail that client either. And the
error label left the tracker's `cbfunc`/`cbdata` set, so a release the
controller can still send would complete the same client a second time with
the same `cbdata`. The fence entry point has cleared those for some time;
this is the group half of the same rule.

**A controller that could not build a release hung the whole DVM.** By the
time `check_complete()` starts packing, `converged` is latched — which stops
the tracker being driven again, and which the recovery restart takes on the
controller as proof that a release is on the wire. Every failure there
returned bare. It now falls back to `abort_group_op()`, whose message is
only a signature and a status.

**Return codes reported in the wrong project's numbering.** Nine places
across the fence, group and xcast paths tested or logged a value through the
wrong table. Control flow was right by luck — both projects spell success as
zero — but the diagnostics were not, and PRRTE's codes are based at
`PMIX_EXTERNAL_ERR_BASE` precisely so a stray one lands where PMIx will
never assign, i.e. prints a name belonging to nothing. One of these
mattered beyond diagnostics: `prte_grpcomm_xcast_nb()` is documented as
answering in PRTE codes and `pmix_server_monitor.c` runs its result through
`prte_pmix_convert_rc()` to answer a client, but its one failure return was
a PMIx status. `process_msg()` separately force-exited the entire DVM if it
could not load a payload, logging nothing at all.

Alongside these, the withdrawn lateral movements left fragments behind in
every file — comments describing wire fields that are not packed, a
prototype comment with no declaration under it, a `set_lost_callback(NULL)`
for a callback nothing registers, and two caddy fields no path assigns whose
destructor asserts an ownership this object does not have. Those are the
"leftovers" commits: they change nothing at run time and quite a lot for a
reader, which in a directory this intricate is the point.

## What the review established but did not change

The `AGENTS.md` gains the reasoning behind the refutations, which is the
part that otherwise gets re-derived at every review:

- why the shared xcast forward payload is safe — a send retains only after
  it has accepted the message, and its completion callback is handed a NULL
  buffer, which is what lets `forward_lost()` pass straight through to
  `prte_rml_send_callback()` without freeing a buffer the other children are
  still transmitting;
- why `forward_payload_to()` may force-exit on a synchronous send failure
  while `forward_lost()` handles the identical asynchronous one gracefully —
  it rests on `update_descendants()` in `src/rml` keeping `children` clear of
  `failed_dmns` *and running after* the marking. Move either side and an
  ordinary daemon loss becomes a DVM teardown;
- that the three numbering schemes meeting in `grpcomm_xcast.c` are
  deliberate, including two decoders `process_wireup()` calls two lines
  apart that genuinely answer differently — so the next reader does not
  "make them consistent";
- the fence defect this pass found and did *not* fix, recorded in
  `docs/todo.rst`: a contribution can outlive the release that ended its
  fence, and the tracker built for it is inherited by the next fence over
  the same participants. The group collective's memo does not transfer —
  a daemon relaying for its subtree has no local client to drop the entry,
  so it would discard the next fence's legitimate contribution and hang.
  Telling the two apart needs a per-signature release count on the wire,
  which is a design change rather than a correction.

## Testing

Clean warning-free `--enable-debug` build and 22/22 `make check` after every
round. Also built with `PRTE_PMIX_HAVE_GROUP_FT` forced to `0` to compile
the conditionally-compiled paths this machine's PMIx never selects.

The dockerswarm suite was **not** run: every confirmed fix lands on a
failure or diagnostic path no swarm case exercises. Recording that as
skipped rather than as a pass.

No new tests. The two client-hang findings live in `group()`'s error label,
reachable only through the entry point's thread-shift, and pinning them
would mean exporting more internals than the fixes touch. The
`Info_list_convert` finding cannot be distinguished by a test built against
current PMIx — old and new code both pass, because the callee now
initializes the array — so a test there would assert nothing.