### PR TITLE
Use the PMIx release statuses unconditionally

### DIFF
--- a/docs/plans/elastic_dvm/shrink_campaign.rst
+++ b/docs/plans/elastic_dvm/shrink_campaign.rst
@@ -468,9 +468,6 @@ The state's consequences:
   ``WAITPID_FIRED`` and ``IOF_COMPLETE`` for a remote proc, which drives the
   same ``TERMINATED`` activation this path raised directly before.
 
-Every PMIx constant above falls back to its cancellation or killed-by-cmd
-equivalent when PRRTE is built against a PMIx that predates them.
-
 Only procs not yet flagged ``PRTE_PROC_FLAG_RECORDED`` are reported.  A node
 lists procs that exited earlier until their whole job terminates, so without
 that test the release of an idle node would abort a healthy job.

--- a/src/mca/errmgr/dvm/AGENTS.md
+++ b/src/mca/errmgr/dvm/AGENTS.md
@@ -186,7 +186,7 @@ between "notify and keep going" and "abort the job":
 | `KILLED_BY_CMD` | notify `PMIX_ERR_PROC_KILLED_BY_CMD` + recover resources | if all procs terminated → `TERMINATED` |
 | `ABORTED_BY_SIG` | notify `PMIX_ERR_PROC_ABORTED_BY_SIG` + recover | set `JOB_STATE_ABORTED_BY_SIG`, record aborted proc, `_terminate_job` |
 | `TERM_WO_SYNC` | notify `PMIX_ERR_PROC_TERM_WO_SYNC` + recover | set `ABORTED_WO_SYNC`; if `exit_code == 0` force `PRTE_ERROR_DEFAULT_EXIT_CODE` so the user sees an error; `_terminate_job`. (No notification: this arm has just flagged the job ABORTED, and `check_send_notification` declines to speak about a proc in an aborting job, so the call that used to sit here could never send.) |
-| `KILLED_BY_RELEASE` | notify `PMIX_ERR_PROC_KILLED_BY_RELEASE` (`_BY_CMD` on an older PMIx) + recover | set `KILLED_BY_RELEASE`; force `PRTE_ERROR_DEFAULT_EXIT_CODE` when the killed proc reported none; `_terminate_job` |
+| `KILLED_BY_RELEASE` | notify `PMIX_ERR_PROC_KILLED_BY_RELEASE` + recover | set `KILLED_BY_RELEASE`; force `PRTE_ERROR_DEFAULT_EXIT_CODE` when the killed proc reported none; `_terminate_job` |
 | `FAILED_TO_START` / `FAILED_TO_LAUNCH` | *(unconditional)* set `FAILED_TO_START`/`_LAUNCH`, `_terminate_job`, activate `FAILED_TO_START` | same |
 | `CALLED_ABORT` | notify `PMIX_ERR_PROC_REQUESTED_ABORT` + recover | set `CALLED_ABORT`, `_terminate_job` |
 | `TERM_NON_ZERO` | if `PRTE_JOB_ERROR_NONZERO_EXIT` also set: notify `PMIX_ERR_EXIT_NONZERO_TERM` + recover | set `NON_ZERO_TERM`, `_terminate_job`; always bump `PRTE_JOB_NUM_NONZERO_EXIT` |

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -667,11 +667,7 @@ keep_going:
                              (NULL == pptr->node) ? "unknown" : pptr->node->name);
         if (flag) {
             /* a job that can absorb the loss is told and keeps running */
-#ifdef PMIX_ERR_PROC_KILLED_BY_RELEASE
             check_send_notification(jdata, pptr, PMIX_ERR_PROC_KILLED_BY_RELEASE);
-#else
-            check_send_notification(jdata, pptr, PMIX_ERR_PROC_KILLED_BY_CMD);
-#endif
             // recover the resources used by this proc
             prte_state_base_recover_resources(jdata, pptr);
         } else {

--- a/src/pmix/pmix.c
+++ b/src/pmix/pmix.c
@@ -385,12 +385,7 @@ pmix_proc_state_t prte_pmix_convert_state(int state)
     case PRTE_PROC_STATE_KILLED_BY_CMD:
         return PMIX_PROC_STATE_KILLED_BY_CMD;
     case PRTE_PROC_STATE_KILLED_BY_RELEASE:
-#ifdef PMIX_PROC_STATE_KILLED_BY_RELEASE
         return PMIX_PROC_STATE_KILLED_BY_RELEASE;
-#else
-        /* older PMIx: the runtime killed it on command either way */
-        return PMIX_PROC_STATE_KILLED_BY_CMD;
-#endif
     case PRTE_PROC_STATE_ABORTED:
         return PMIX_PROC_STATE_ABORTED;
     case PRTE_PROC_STATE_FAILED_TO_START:
@@ -452,10 +447,8 @@ int prte_pmix_convert_pstate(pmix_proc_state_t state)
         return PRTE_PROC_STATE_TERMINATED;
     case PMIX_PROC_STATE_KILLED_BY_CMD:
         return PRTE_PROC_STATE_KILLED_BY_CMD;
-#ifdef PMIX_PROC_STATE_KILLED_BY_RELEASE
     case PMIX_PROC_STATE_KILLED_BY_RELEASE:
         return PRTE_PROC_STATE_KILLED_BY_RELEASE;
-#endif
     case PMIX_PROC_STATE_ABORTED:
         return PRTE_PROC_STATE_ABORTED;
     case PMIX_PROC_STATE_FAILED_TO_START:
@@ -508,12 +501,7 @@ pmix_status_t prte_pmix_convert_job_state_to_error(int state)
             return PMIX_ERR_JOB_CANCELED;
 
         case PRTE_JOB_STATE_KILLED_BY_RELEASE:
-#ifdef PMIX_ERR_JOB_KILLED_BY_RELEASE
             return PMIX_ERR_JOB_KILLED_BY_RELEASE;
-#else
-            /* older PMIx: a tool cannot tell this from a cancellation */
-            return PMIX_ERR_JOB_CANCELED;
-#endif
 
         case PRTE_JOB_STATE_ABORTED:
         case PRTE_JOB_STATE_CALLED_ABORT:
@@ -544,11 +532,7 @@ pmix_status_t prte_pmix_convert_proc_state_to_error(int state)
             return PMIX_ERR_JOB_CANCELED;
 
         case PRTE_PROC_STATE_KILLED_BY_RELEASE:
-#ifdef PMIX_ERR_JOB_KILLED_BY_RELEASE
             return PMIX_ERR_JOB_KILLED_BY_RELEASE;
-#else
-            return PMIX_ERR_JOB_CANCELED;
-#endif
 
         case PRTE_PROC_STATE_ABORTED:
         case PRTE_PROC_STATE_CALLED_ABORT:

--- a/test/unit/pmix/test_pmix.c
+++ b/test/unit/pmix/test_pmix.c
@@ -73,19 +73,6 @@
         }                                                     \
     } while (0)
 
-/* A release kill has its own status and state only on a PMIx that
- * defines them */
-#ifdef PMIX_ERR_JOB_KILLED_BY_RELEASE
-#    define RELEASE_STATUS PMIX_ERR_JOB_KILLED_BY_RELEASE
-#else
-#    define RELEASE_STATUS PMIX_ERR_JOB_CANCELED
-#endif
-#ifdef PMIX_PROC_STATE_KILLED_BY_RELEASE
-#    define RELEASE_PSTATE PMIX_PROC_STATE_KILLED_BY_RELEASE
-#else
-#    define RELEASE_PSTATE PMIX_PROC_STATE_KILLED_BY_CMD
-#endif
-
 /* ------------------------------------------------------------------ */
 /* proc state translation                                             */
 /* ------------------------------------------------------------------ */
@@ -130,6 +117,7 @@ static struct {
     {"CANNOT_RESTART", PRTE_PROC_STATE_CANNOT_RESTART, PMIX_PROC_STATE_CANNOT_RESTART},
     {"TERM_NON_ZERO", PRTE_PROC_STATE_TERM_NON_ZERO, PMIX_PROC_STATE_TERM_NON_ZERO},
     {"FAILED_TO_LAUNCH", PRTE_PROC_STATE_FAILED_TO_LAUNCH, PMIX_PROC_STATE_FAILED_TO_LAUNCH},
+    {"KILLED_BY_RELEASE", PRTE_PROC_STATE_KILLED_BY_RELEASE, PMIX_PROC_STATE_KILLED_BY_RELEASE},
 
     /* every way PRRTE describes losing touch with a peer collapses onto
      * PMIx's single bucket */
@@ -138,8 +126,6 @@ static struct {
     {"NO_PATH_TO_TARGET", PRTE_PROC_STATE_NO_PATH_TO_TARGET, PMIX_PROC_STATE_COMM_FAILED},
     {"FAILED_TO_CONNECT", PRTE_PROC_STATE_FAILED_TO_CONNECT, PMIX_PROC_STATE_COMM_FAILED},
     {"PEER_UNKNOWN", PRTE_PROC_STATE_PEER_UNKNOWN, PMIX_PROC_STATE_COMM_FAILED},
-
-    {"KILLED_BY_RELEASE", PRTE_PROC_STATE_KILLED_BY_RELEASE, RELEASE_PSTATE},
 };
 
 static int test_convert_state(void)
@@ -238,11 +224,6 @@ static int test_state_roundtrip(void)
         }
         if (PMIX_PROC_STATE_COMM_FAILED == state_map[n].pmix
             && PRTE_PROC_STATE_COMM_FAILED != state_map[n].prte) {
-            continue;
-        }
-        /* only lossy where PMIx has no state of its own for it */
-        if (PMIX_PROC_STATE_KILLED_BY_CMD == state_map[n].pmix
-            && PRTE_PROC_STATE_KILLED_BY_CMD != state_map[n].prte) {
             continue;
         }
 
@@ -477,7 +458,7 @@ static int test_job_state_to_error(void)
         {"FAILED_TO_START", PRTE_JOB_STATE_FAILED_TO_START, PMIX_ERR_JOB_FAILED_TO_LAUNCH},
         {"CANNOT_LAUNCH", PRTE_JOB_STATE_CANNOT_LAUNCH, PMIX_ERR_JOB_FAILED_TO_LAUNCH},
         {"KILLED_BY_CMD", PRTE_JOB_STATE_KILLED_BY_CMD, PMIX_ERR_JOB_CANCELED},
-        {"KILLED_BY_RELEASE", PRTE_JOB_STATE_KILLED_BY_RELEASE, RELEASE_STATUS},
+        {"KILLED_BY_RELEASE", PRTE_JOB_STATE_KILLED_BY_RELEASE, PMIX_ERR_JOB_KILLED_BY_RELEASE},
         {"ABORTED", PRTE_JOB_STATE_ABORTED, PMIX_ERR_JOB_ABORTED},
         {"CALLED_ABORT", PRTE_JOB_STATE_CALLED_ABORT, PMIX_ERR_JOB_ABORTED},
         {"SILENT_ABORT", PRTE_JOB_STATE_SILENT_ABORT, PMIX_ERR_JOB_ABORTED},
@@ -511,7 +492,7 @@ static int test_proc_state_to_error(void)
         pmix_status_t expect;
     } tbl[] = {
         {"KILLED_BY_CMD", PRTE_PROC_STATE_KILLED_BY_CMD, PMIX_ERR_JOB_CANCELED},
-        {"KILLED_BY_RELEASE", PRTE_PROC_STATE_KILLED_BY_RELEASE, RELEASE_STATUS},
+        {"KILLED_BY_RELEASE", PRTE_PROC_STATE_KILLED_BY_RELEASE, PMIX_ERR_JOB_KILLED_BY_RELEASE},
         {"ABORTED", PRTE_PROC_STATE_ABORTED, PMIX_ERR_JOB_ABORTED},
         {"CALLED_ABORT", PRTE_PROC_STATE_CALLED_ABORT, PMIX_ERR_JOB_ABORTED},
         {"ABORTED_BY_SIG", PRTE_PROC_STATE_ABORTED_BY_SIG, PMIX_ERR_JOB_ABORTED_BY_SIG},


### PR DESCRIPTION
PRRTE requires a PMIx that carries PMIX_ERR_JOB_KILLED_BY_RELEASE, PMIX_ERR_PROC_KILLED_BY_RELEASE and PMIX_PROC_STATE_KILLED_BY_RELEASE, so drop the #ifdef guards and the fallbacks to the cancellation and killed-by-cmd codes. The proc-state round trip is no longer lossy, so test_state_roundtrip covers it like any other state.

Follows from discussion in https://github.com/openpmix/prrte/pull/2725

Credits: AccelCom @ Barcelona Supercomputing Center