### PR TITLE
Refuse duplicate published keys, and honor the persistence a publisher asked for

### DIFF
--- a/contrib/dockerswarm/dataserver.c
+++ b/contrib/dockerswarm/dataserver.c
@@ -45,6 +45,14 @@
  * instance rather than to the HNP (see pmix_server_pub.c), so it is only
  * reachable by a lookup carrying the same range.
  *
+ *   dataserver persist <key> <value> <persistence> [seconds] [range]
+ *       Publish with an explicit PMIX_PERSISTENCE and exit, so the JOB
+ *       ends.  <persistence> is one of first-read, proc, app, session,
+ *       indef.  What a later job can still look up is what the data server
+ *       kept: "app" must be gone once this job terminates, "session" must
+ *       not be.  Persistence means nothing until something removes data on
+ *       a lifetime boundary, so this is the test that it does.
+ *
  *   dataserver unpublish <key> [seconds] [pubrange] [unpubrange]
  *       Publish, then unpublish, then look up - all from one process, since
  *       only the publisher may unpublish its own data.  Prints
@@ -311,6 +319,58 @@ static int do_unpublish(const char *key, int seconds, const char *pubrange,
     return 0;
 }
 
+static pmix_persistence_t parse_persist(const char *s)
+{
+    if (NULL == s) {
+        return PMIX_PERSIST_APP;
+    }
+    if (0 == strcmp(s, "first-read")) {
+        return PMIX_PERSIST_FIRST_READ;
+    }
+    if (0 == strcmp(s, "proc")) {
+        return PMIX_PERSIST_PROC;
+    }
+    if (0 == strcmp(s, "session")) {
+        return PMIX_PERSIST_SESSION;
+    }
+    if (0 == strcmp(s, "indef")) {
+        return PMIX_PERSIST_INDEF;
+    }
+    return PMIX_PERSIST_APP;
+}
+
+static int do_persist(const char *key, const char *value, const char *pstr,
+                      int seconds, const char *rangestr)
+{
+    pmix_status_t rc;
+    pmix_info_t info[3];
+    pmix_data_range_t range = parse_range(rangestr);
+    pmix_persistence_t persist = parse_persist(pstr);
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Init: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+    PMIX_INFO_LOAD(&info[0], key, value, PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_RANGE, &range, PMIX_DATA_RANGE);
+    PMIX_INFO_LOAD(&info[2], PMIX_PERSISTENCE, &persist, PMIX_PERSIST);
+    rc = PMIx_Publish(info, 3);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    PMIX_INFO_DESTRUCT(&info[2]);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Publish(%s): %s\n", key, PMIx_Error_string(rc));
+        PMIx_Finalize(NULL, 0);
+        return 1;
+    }
+    printf("PUBLISHED %s\n", key);
+    fflush(stdout);
+    sleep(seconds);
+    PMIx_Finalize(NULL, 0);
+    return 0;
+}
+
 int main(int argc, char **argv)
 {
     char *keys[2];
@@ -321,8 +381,9 @@ int main(int argc, char **argv)
                 "       %s lookup <key> [secs] [range]\n"
                 "       %s lookupwait <key> [secs] [range]\n"
                 "       %s lookup2 <key1> <key2> [secs]\n"
-                "       %s unpublish <key> [secs] [pubrange] [unpubrange]\n",
-                argv[0], argv[0], argv[0], argv[0], argv[0]);
+                "       %s unpublish <key> [secs] [pubrange] [unpubrange]\n"
+                "       %s persist <key> <value> <persistence> [secs] [range]\n",
+                argv[0], argv[0], argv[0], argv[0], argv[0], argv[0]);
         return 2;
     }
 
@@ -362,6 +423,16 @@ int main(int argc, char **argv)
         return do_unpublish(argv[2], (4 > argc) ? 20 : atoi(argv[3]),
                             (5 > argc) ? NULL : argv[4],
                             (6 > argc) ? NULL : argv[5]);
+    }
+
+    if (0 == strcmp(argv[1], "persist")) {
+        if (5 > argc) {
+            fprintf(stderr, "persist needs <key> <value> <persistence>\n");
+            return 2;
+        }
+        return do_persist(argv[2], argv[3], argv[4],
+                          (6 > argc) ? 0 : atoi(argv[5]),
+                          (7 > argc) ? NULL : argv[6]);
     }
 
     fprintf(stderr, "unknown mode: %s\n", argv[1]);

--- a/contrib/dockerswarm/dataserver.c
+++ b/contrib/dockerswarm/dataserver.c
@@ -45,6 +45,28 @@
  * instance rather than to the HNP (see pmix_server_pub.c), so it is only
  * reachable by a lookup carrying the same range.
  *
+ *   dataserver dup <key> <value> [seconds] [range]
+ *       Publish and print "STATUS <status>" whatever happens, without
+ *       failing the process.  For the duplicate-key case, where the
+ *       expected outcome IS an error: a key already published on the same
+ *       range by ANOTHER process must come back
+ *       PMIX_ERR_DUPLICATE_KEY.
+ *
+ *   dataserver republish <key> [seconds] [range]
+ *       One process, three publishes of the same key on the same range.
+ *       Prints "PUBLISH <status>" (and "PUBLISHED <key>" when that
+ *       succeeded), then "REPUBLISH <status>" for a bare second publish
+ *       (which must be refused), then "REPLACE <status>" for one carrying
+ *       "prte.pub.replace" (which must succeed), with a lookup after each.
+ *       This is the self-republish path: the first value must survive the
+ *       refusal, and the third must displace it.
+ *
+ *       Pointed at a key ANOTHER process already holds, the first publish
+ *       is the one that gets refused - which is the case that says the
+ *       replace directive grants no reach over somebody else's name.  That
+ *       is a result, not a failure, so it stops there and exits 0 rather
+ *       than having PRRTE tear the job down over it.
+ *
  *   dataserver persist <key> <value> <persistence> [seconds] [range]
  *       Publish with an explicit PMIX_PERSISTENCE and exit, so the JOB
  *       ends.  <persistence> is one of first-read, proc, app, session,
@@ -339,6 +361,97 @@ static pmix_persistence_t parse_persist(const char *s)
     return PMIX_PERSIST_APP;
 }
 
+/* Publish and report the status whatever it is.  Returns 0 even on failure:
+ * the duplicate-key case EXPECTS an error, and exiting non-zero would have
+ * PRRTE tear the job down and bury the STATUS line under an abort banner. */
+static int do_dup(const char *key, const char *value, int seconds,
+                  const char *rangestr)
+{
+    pmix_status_t rc;
+    pmix_info_t info[2];
+    pmix_data_range_t range = parse_range(rangestr);
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Init: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+    PMIX_INFO_LOAD(&info[0], key, value, PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_RANGE, &range, PMIX_DATA_RANGE);
+    rc = PMIx_Publish(info, 2);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    printf("STATUS %s\n", PMIx_Error_string(rc));
+    fflush(stdout);
+    sleep(seconds);
+    PMIx_Finalize(NULL, 0);
+    return 0;
+}
+
+/* Publish the same key three times from one process: bare, bare again, then
+ * with the replace directive.  A lookup after each says which value the
+ * store is actually serving, which is the whole point - the failure this
+ * covers was a republish that reported success and could not be read back. */
+static int do_republish(const char *key, int seconds, const char *rangestr)
+{
+    pmix_status_t rc;
+    pmix_info_t info[3];
+    pmix_data_range_t range = parse_range(rangestr);
+    char *keys[2] = {NULL, NULL};
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Init: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+    keys[0] = (char *) key;
+
+    PMIX_INFO_LOAD(&info[0], key, "first", PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_RANGE, &range, PMIX_DATA_RANGE);
+    rc = PMIx_Publish(info, 2);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    printf("PUBLISH %s\n", PMIx_Error_string(rc));
+    fflush(stdout);
+    if (PMIX_SUCCESS != rc) {
+        /* somebody else holds this key, which is one of the outcomes this
+         * mode exists to report.  There is no "own prior publication" to
+         * replace, so there is nothing further to do - and exiting non-zero
+         * would have PRRTE tear the job down and bury the line above under
+         * an abort banner. */
+        PMIx_Finalize(NULL, 0);
+        return 0;
+    }
+    printf("PUBLISHED %s\n", key);
+    fflush(stdout);
+
+    /* a bare republish must be refused, and must not disturb what is there */
+    PMIX_INFO_LOAD(&info[0], key, "second", PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_RANGE, &range, PMIX_DATA_RANGE);
+    rc = PMIx_Publish(info, 2);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    printf("REPUBLISH %s\n", PMIx_Error_string(rc));
+    fflush(stdout);
+    (void) lookup_keys(keys, 1, seconds, false, rangestr);
+
+    /* ...and one that asks to replace must take it over */
+    PMIX_INFO_LOAD(&info[0], key, "third", PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_RANGE, &range, PMIX_DATA_RANGE);
+    PMIX_INFO_LOAD(&info[2], "prte.pub.replace", NULL, PMIX_BOOL);
+    rc = PMIx_Publish(info, 3);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    PMIX_INFO_DESTRUCT(&info[2]);
+    printf("REPLACE %s\n", PMIx_Error_string(rc));
+    fflush(stdout);
+    keys[0] = (char *) key;
+    (void) lookup_keys(keys, 1, seconds, false, rangestr);
+
+    PMIx_Finalize(NULL, 0);
+    return 0;
+}
+
 static int do_persist(const char *key, const char *value, const char *pstr,
                       int seconds, const char *rangestr)
 {
@@ -382,8 +495,11 @@ int main(int argc, char **argv)
                 "       %s lookupwait <key> [secs] [range]\n"
                 "       %s lookup2 <key1> <key2> [secs]\n"
                 "       %s unpublish <key> [secs] [pubrange] [unpubrange]\n"
+                "       %s dup <key> <value> [secs] [range]\n"
+                "       %s republish <key> [secs] [range]\n"
                 "       %s persist <key> <value> <persistence> [secs] [range]\n",
-                argv[0], argv[0], argv[0], argv[0], argv[0], argv[0]);
+                argv[0], argv[0], argv[0], argv[0], argv[0], argv[0], argv[0],
+                argv[0]);
         return 2;
     }
 
@@ -425,6 +541,22 @@ int main(int argc, char **argv)
                             (6 > argc) ? NULL : argv[5]);
     }
 
+    if (0 == strcmp(argv[1], "dup")) {
+        if (4 > argc) {
+            fprintf(stderr, "dup needs <key> <value>\n");
+            return 2;
+        }
+        return do_dup(argv[2], argv[3], (5 > argc) ? 0 : atoi(argv[4]),
+                      (6 > argc) ? NULL : argv[5]);
+    }
+    if (0 == strcmp(argv[1], "republish")) {
+        if (3 > argc) {
+            fprintf(stderr, "republish needs a key\n");
+            return 2;
+        }
+        return do_republish(argv[2], (4 > argc) ? 20 : atoi(argv[3]),
+                            (5 > argc) ? NULL : argv[4]);
+    }
     if (0 == strcmp(argv[1], "persist")) {
         if (5 > argc) {
             fprintf(stderr, "persist needs <key> <value> <persistence>\n");

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -1855,6 +1855,53 @@ test_runtime() {
     fi
     cleanup_swarm
 
+    banner "runtime/data_server: PMIX_PERSISTENCE is honored when a job ends"
+    # PMIX_PERSISTENCE was recorded at publish and then never consulted
+    # again: nothing removed data on a lifetime boundary, so PERSIST_APP
+    # and PERSIST_PROC both behaved as PERSIST_INDEF and a persistent DVM's
+    # store only ever grew.  The state machine now tells the data server
+    # which lifetime ended, and ds_purge takes what does not outlive it.
+    #
+    # It takes a PERSISTENT DVM and two jobs: the publisher has to
+    # terminate while the store lives on.  The two keys are published by
+    # separate jobs so that neither outcome can be an artifact of the other.
+    if ! RUN "test -x $DS"; then
+        skp "dataserver client not installed -- re-run ./build.sh"
+    elif ! prted_dvm_start 'node1:2,node2:2,node3:2'; then
+        bad "could not start a DVM for the persistence test"
+    else
+        out=$(PRUN "--host node2:1 -n 1 $DS persist prte.test.pers.keep kept session 0" 2>&1)
+        echo "$out" | grep -q '^PUBLISHED prte.test.pers.keep' \
+            && ok "a PERSIST_SESSION key was published by a job that then ended" \
+            || bad "the session-persistence publish never happened: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        out=$(PRUN "--host node2:1 -n 1 $DS persist prte.test.pers.drop dropped app 0" 2>&1)
+        echo "$out" | grep -q '^PUBLISHED prte.test.pers.drop' \
+            && ok "a PERSIST_APP key was published by a job that then ended" \
+            || bad "the app-persistence publish never happened: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        sleep 5
+
+        out=$(PRUN "--host node3:1 -n 1 $DS lookup prte.test.pers.keep 15" 2>&1)
+        echo "$out" | grep -q '^FOUND prte.test.pers.keep kept' \
+            && ok "the PERSIST_SESSION key outlived its publishing job" \
+            || bad "session-persistence data was reclaimed too early: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+
+        out=$(PRUN "--host node3:1 -n 1 $DS lookup prte.test.pers.drop 15" 2>&1)
+        echo "$out" | grep -q '^FOUND prte.test.pers.drop' \
+            && bad "app-persistence data survived its application: $(echo "$out" | tr '\n' ' ' | tail -c 250)" \
+            || ok "the PERSIST_APP key went when its application ended"
+
+        # ...and the key it freed is available again, which is the whole
+        # point on a long-lived DVM: successive generations of a job get a
+        # fresh namespace, and without this the first one to publish a name
+        # owned it until the DVM went away.
+        out=$(PRUN "--host node3:1 -n 1 $DS persist prte.test.pers.drop reused app 0" 2>&1)
+        echo "$out" | grep -q '^PUBLISHED prte.test.pers.drop' \
+            && ok "...and a later job could publish that key again" \
+            || bad "a reclaimed key could not be republished: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    fi
+    cleanup_swarm
+
     banner "runtime/data_server: PMIX_RANGE_LOCAL data does not leave its node"
     # A LOCAL-range publish is not sent to the HNP at all: the daemon routes
     # it to its OWN data server instance (pmix_server_pub.c picks

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -1992,6 +1992,38 @@ test_runtime() {
         echo "$out" | grep -q 'STATUS PMIX_SUCCESS' \
             && ok "...and a later job could publish that key again" \
             || bad "a reclaimed key could not be republished: $(echo "$out" | grep '^STATUS' | tr -d '\r')"
+
+        banner "runtime/data_server: LOCAL-range data is reclaimed from the daemon holding it"
+        # THE case that only exists with more than one node.  A LOCAL-range
+        # publish never reaches the HNP: pmix_server_pub.c routes it to
+        # PRTE_PROC_MY_NAME, and every daemon runs prte_data_server_init(),
+        # so the item lives in node2's OWN store.  The termination purge
+        # went only to the global store, which left local-range data
+        # unreclaimed -- and a single host cannot show that, because there
+        # "my store" and "the HNP's store" are the same object.
+        #
+        # Both keys are published by jobs that then end, and both are read
+        # back from node2, since node2's store is the only place a
+        # LOCAL-range lookup from node2 is routed to.
+        out=$(PRUN "--host node2:1 -n 1 $DS persist prte.test.loc.drop dropped app 0 local" 2>&1)
+        echo "$out" | grep -q '^PUBLISHED prte.test.loc.drop' \
+            && ok "a PERSIST_APP key was published LOCAL on node2" \
+            || bad "the local-range publish never happened: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        out=$(PRUN "--host node2:1 -n 1 $DS persist prte.test.loc.keep kept session 0 local" 2>&1)
+        echo "$out" | grep -q '^PUBLISHED prte.test.loc.keep' \
+            && ok "a PERSIST_SESSION key was published LOCAL on node2" \
+            || bad "the local-range publish never happened: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        sleep 5
+
+        out=$(PRUN "--host node2:1 -n 1 $DS lookup prte.test.loc.drop 15 local" 2>&1)
+        echo "$out" | grep -q '^FOUND prte.test.loc.drop' \
+            && bad "local-range app data survived its application: $(echo "$out" | tr '\n' ' ' | tail -c 250)" \
+            || ok "the LOCAL PERSIST_APP key went from node2's own store"
+        # the control: the purge must take what expired and nothing else
+        out=$(PRUN "--host node2:1 -n 1 $DS lookup prte.test.loc.keep 15 local" 2>&1)
+        echo "$out" | grep -q '^FOUND prte.test.loc.keep kept' \
+            && ok "...and the LOCAL PERSIST_SESSION key beside it did not" \
+            || bad "the purge took local-range data it should have kept: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
         RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     fi
     cleanup_swarm

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -1855,6 +1855,100 @@ test_runtime() {
     fi
     cleanup_swarm
 
+    banner "runtime/data_server: a duplicate key is refused"
+    # "Duplicate keys being published on the same data range shall return
+    # the PMIX_ERR_DUPLICATE_KEY error."  Until that was enforced the
+    # duplicate was STORED, behind the original -- and since ds_lookup
+    # answers a key from the first match it finds, unreachable for the life
+    # of the DVM.  The publish reported success and did nothing.
+    #
+    # This is a cross-node case because the two publishers have to be
+    # genuinely different processes reaching one store through different
+    # daemons; the ownership test that decides "yours to replace" from
+    # "somebody else's name" is what a single process cannot exercise.
+    if ! RUN "test -x $DS"; then
+        skp "dataserver client not installed -- re-run ./build.sh"
+    elif ! prted_dvm_start 'node1:2,node2:2,node3:2,node4:2'; then
+        bad "could not start a DVM for the duplicate-key tests"
+    else
+        PRUN_BG /tmp/ds-dup-own.out "--host node2:1 -n 1 $DS publish prte.test.dup taken session 90"
+        sleep 8
+        if ! RUN 'grep -q "^PUBLISHED prte.test.dup" /tmp/ds-dup-own.out'; then
+            bad "the first publish never happened: $(RUN 'cat /tmp/ds-dup-own.out' 2>&1 | tr '\n' ' ' | tail -c 250)"
+        else
+            ok "node2 holds prte.test.dup on the SESSION range"
+
+            out=$(PRUN "--host node3:1 -n 1 $DS dup prte.test.dup mine 0" 2>&1)
+            echo "$out" | grep -q 'STATUS PMIX_ERR_DUPLICATE_KEY' \
+                && ok "another process publishing the same key was refused" \
+                || bad "a duplicate publish was not refused: $(echo "$out" | grep '^STATUS' | tr -d '\r')"
+
+            # ...and the refusal must leave the original alone.  The scan
+            # runs to completion before anything is removed for exactly
+            # this reason.
+            out=$(PRUN "--host node4:1 -n 1 $DS lookup prte.test.dup 15" 2>&1)
+            echo "$out" | grep -q '^FOUND prte.test.dup taken' \
+                && ok "...and the original publication survived the refusal" \
+                || bad "a refused publish disturbed the store: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+
+            # A range is a SET OF PROCESSES, not the pmix_data_range_t word.
+            # This job's NAMESPACE range is its own namespace, which is
+            # disjoint from the publisher's, so the same key on it is a
+            # different range and must be permitted.
+            out=$(PRUN "--host node3:1 -n 1 $DS dup prte.test.dup elsewhere 0 namespace" 2>&1)
+            echo "$out" | grep -q 'STATUS PMIX_SUCCESS' \
+                && ok "the same key on a range naming a different set was allowed" \
+                || bad "a publish on a genuinely different range was refused: $(echo "$out" | grep '^STATUS' | tr -d '\r')"
+
+            # ...and a key nobody has published is still fine, so what is
+            # being refused above is the collision and not publishing itself
+            out=$(PRUN "--host node3:1 -n 1 $DS dup prte.test.dup.free free 0" 2>&1)
+            echo "$out" | grep -q 'STATUS PMIX_SUCCESS' \
+                && ok "an uncontested key still publishes normally" \
+                || bad "an uncontested publish was refused: $(echo "$out" | grep '^STATUS' | tr -d '\r')"
+
+            banner "runtime/data_server: a publisher may replace its own key"
+            # prte.pub.replace is owner-scoped: it takes back what the
+            # CALLER published, so a self-republish works without an
+            # intervening PMIx_Unpublish, and somebody else's live name
+            # still cannot be taken.
+            out=$(PRUN "--host node3:1 -n 1 $DS republish prte.test.rp 15" 2>&1)
+            echo "$out" | grep -q 'PUBLISH PMIX_SUCCESS' \
+                && ok "an uncontested key published normally" \
+                || bad "the first publish was refused: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+            echo "$out" | grep -q 'REPUBLISH PMIX_ERR_DUPLICATE_KEY' \
+                && ok "a bare self-republish was refused" \
+                || bad "a bare self-republish was not refused: $(echo "$out" | grep '^REPUBLISH' | tr -d '\r')"
+            echo "$out" | grep -q '^FOUND prte.test.rp first' \
+                && ok "...and the value that was there survived it" \
+                || bad "a refused republish disturbed the value: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+            echo "$out" | grep -q 'REPLACE PMIX_SUCCESS' \
+                && ok "the same publish carrying prte.pub.replace was accepted" \
+                || bad "a replace directive was refused: $(echo "$out" | grep '^REPLACE' | tr -d '\r')"
+            echo "$out" | grep -q '^FOUND prte.test.rp third' \
+                && ok "...and the new value is what a lookup now returns" \
+                || bad "a replace did not take effect: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+
+            # The directive grants no reach over another publisher's key.
+            # node2 still holds prte.test.dup, so it is the FIRST publish
+            # here that is refused -- and the run must stop there, having
+            # neither replaced nor displaced anything.
+            out=$(PRUN "--host node4:1 -n 1 $DS republish prte.test.dup 15" 2>&1)
+            echo "$out" | grep -q 'PUBLISH PMIX_ERR_DUPLICATE_KEY' \
+                && ok "prte.pub.replace did not reach another process's key" \
+                || bad "a replace took a key belonging to somebody else: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+            echo "$out" | grep -q '^REPLACE' \
+                && bad "the replace was attempted against another process's key" \
+                || ok "...and it did not get as far as trying"
+            out=$(PRUN "--host node4:1 -n 1 $DS lookup prte.test.dup 15" 2>&1)
+            echo "$out" | grep -q '^FOUND prte.test.dup taken' \
+                && ok "...and node2's value is still what a lookup returns" \
+                || bad "another process's key was disturbed: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+        fi
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    fi
+    cleanup_swarm
+
     banner "runtime/data_server: PMIX_PERSISTENCE is honored when a job ends"
     # PMIX_PERSISTENCE was recorded at publish and then never consulted
     # again: nothing removed data on a lifetime boundary, so PERSIST_APP
@@ -1894,10 +1988,10 @@ test_runtime() {
         # point on a long-lived DVM: successive generations of a job get a
         # fresh namespace, and without this the first one to publish a name
         # owned it until the DVM went away.
-        out=$(PRUN "--host node3:1 -n 1 $DS persist prte.test.pers.drop reused app 0" 2>&1)
-        echo "$out" | grep -q '^PUBLISHED prte.test.pers.drop' \
+        out=$(PRUN "--host node3:1 -n 1 $DS dup prte.test.pers.drop reused 0" 2>&1)
+        echo "$out" | grep -q 'STATUS PMIX_SUCCESS' \
             && ok "...and a later job could publish that key again" \
-            || bad "a reclaimed key could not be republished: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+            || bad "a reclaimed key could not be republished: $(echo "$out" | grep '^STATUS' | tr -d '\r')"
         RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     fi
     cleanup_swarm

--- a/docs/how-things-work/index.rst
+++ b/docs/how-things-work/index.rst
@@ -12,6 +12,7 @@ find information on that subject here.
    session_dirs.rst
    per-app-mapping.rst
    preloading-files.rst
+   publish-lookup.rst
    schedulers/index.rst
    state_machine.rst
    rml/index.rst

--- a/docs/how-things-work/publish-lookup.rst
+++ b/docs/how-things-work/publish-lookup.rst
@@ -1,0 +1,139 @@
+Publishing and looking up data
+==============================
+
+PRRTE backs the PMIx publish/lookup service — what an MPI application
+reaches through ``MPI_Publish_name``, ``MPI_Lookup_name`` and
+``MPI_Unpublish_name``.  The store is a **single datastore on one process**,
+normally the DVM master, that every participant reaches over the RML.  (It
+can instead live in a *different* DVM; see :doc:`the cross-DVM data server
+plan </plans/cross_dvm_data_server/cross-dvm-data-server>`.)
+
+This page describes the rules the datastore applies, since several of them
+decide whether a call succeeds.
+
+
+Who can see what
+----------------
+
+Two independent constraints govern every lookup, and both must pass:
+
+* **The publisher's range** (``PMIX_RANGE``, default
+  ``PMIX_RANGE_SESSION``) says who may see the item.  A publisher can
+  restrict its data to its own namespace, to processes behind the same
+  daemon, to itself, or to a list of user and group ids it names with
+  ``PMIX_ACCESS_PERMISSIONS``.
+
+* **The requester's range**, also ``PMIX_RANGE`` and also defaulting to
+  ``PMIX_RANGE_SESSION``, says whose data it is willing to search.
+
+A publisher that names no accessors keeps its data to itself: the requester
+must present the publisher's own effective uid and gid.  A lookup that is
+refused data it would otherwise have found gets
+``PMIX_ERR_NO_PERMISSIONS`` rather than ``PMIX_ERR_NOT_FOUND``, so a
+permission problem does not look like a missing key.
+
+
+Duplicate keys
+--------------
+
+A key may be published more than once **provided the publications are on
+different ranges**.  Publishing a key that is already published on the same
+range fails with ``PMIX_ERR_DUPLICATE_KEY``, and nothing is stored — the
+publication that was already there is untouched.
+
+A "range" here is a *set of processes*, not merely the ``PMIX_RANGE`` word:
+``PMIX_RANGE_NAMESPACE`` used by two processes of different namespaces names
+two disjoint sets, and those do not collide.  Neither do two publications
+that are invisible to each other because of their access permissions.  What
+does collide is the common case — two processes publishing the same key on
+``PMIX_RANGE_SESSION``, which is exactly the name collision
+``MPI_Publish_name`` is required to report.
+
+Only the process that published an item may remove it.  An unpublish from
+anyone else reports success and removes nothing, because there was nothing
+of *theirs* to remove.
+
+This is felt most when two generations of a job **overlap**.  A replacement
+server starting while its predecessor is still running cannot claim the
+predecessor's name: its publish is refused, ``prte.pub.replace`` does not
+reach another process's key, and only the original publisher can let the
+name go.  The remedies are the ones MPI offers — have the outgoing server
+unpublish, publish on a range the newcomer's readers will search, or use a
+distinct key.  What is no longer possible is for the newcomer to believe it
+succeeded.
+
+Generations that do *not* overlap need none of that: an item published with
+the default persistence goes when its job ends, so the next generation
+publishes into a store that no longer holds the name.  See `How long data
+lasts`_.
+
+.. note:: Earlier releases accepted a duplicate publish, reported
+   ``PMIX_SUCCESS``, and stored the value where no lookup would reach it.
+   Applications that republished a key without unpublishing it first will
+   now see ``PMIX_ERR_DUPLICATE_KEY`` instead of a write that silently did
+   nothing.
+
+
+Replacing your own publication
+------------------------------
+
+Because a duplicate is refused, a process that wants to *update* a value it
+published itself would have to call ``PMIx_Unpublish`` first.  PRRTE accepts
+a directive that does both in one step:
+
+.. code-block:: c
+
+   pmix_info_t info[3];
+   PMIX_INFO_LOAD(&info[0], "my_key", value, PMIX_STRING);
+   PMIX_INFO_LOAD(&info[1], PMIX_RANGE, &range, PMIX_DATA_RANGE);
+   PMIX_INFO_LOAD(&info[2], "prte.pub.replace", NULL, PMIX_BOOL);
+   rc = PMIx_Publish(info, 3);
+
+``prte.pub.replace`` reaches **only the caller's own publications**.  A
+collision with another process's key is refused with
+``PMIX_ERR_DUPLICATE_KEY`` whether or not the directive was given, so this
+is a republish and not a way to take a live name away from somebody else.
+Only the keys being republished are dropped: a publication holding other
+keys keeps them.
+
+This attribute is PRRTE's own — the PMIx Standard defines none for the
+purpose.  ``PMIx_Query_info`` reports it among the attributes supported for
+``PMIx_Publish``.
+
+
+How long data lasts
+-------------------
+
+``PMIX_PERSISTENCE`` says how long the datastore is to keep an item.  The
+default is ``PMIX_PERSIST_APP``.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Persistence
+     - Retained until
+   * - ``PMIX_PERSIST_FIRST_READ``
+     - the first lookup that returns it
+   * - ``PMIX_PERSIST_PROC``
+     - the publishing process terminates
+   * - ``PMIX_PERSIST_APP``
+     - the publishing application terminates
+   * - ``PMIX_PERSIST_SESSION``
+     - the DVM terminates
+   * - ``PMIX_PERSIST_INDEF``
+     - it is explicitly unpublished
+
+PRRTE reclaims ``PMIX_PERSIST_PROC`` and ``PMIX_PERSIST_APP`` data when the
+publishing **job** ends.  ``PMIX_PERSIST_PROC`` therefore lives slightly
+longer than the Standard requires — until the job ends rather than until the
+individual publisher exits — because a message to the datastore for every
+terminating process is not a cost the termination path can carry at scale.
+
+This matters most on a persistent DVM, where the store outlives any one job.
+A value published with the default persistence is gone once its job ends, so
+a later job can publish the same key; one published with
+``PMIX_PERSIST_SESSION`` holds the key for the life of the DVM, and a later
+job that wants it must have its original publisher take it back first.
+
+``PMIx_Unpublish(NULL, ...)`` removes **everything** the calling process
+published, regardless of persistence.

--- a/docs/plans/cross_dvm_data_server/cross-dvm-data-server.rst
+++ b/docs/plans/cross_dvm_data_server/cross-dvm-data-server.rst
@@ -12,10 +12,23 @@ lives on this DVM's own master and every participant reaches it over the RML
 ``prte_pmix_server_uri`` asks for something else: that the store live in a
 **different DVM**, so that jobs launched by *different invocations* can find
 each other's data.  That is what an MPI application is doing when one
-``mpirun`` calls ``MPI_Publish_name`` and another calls ``MPI_Comm_accept``,
-and it is why ``pmix_server_register_fns.c`` publishes a job's info whenever
-an external server is configured: any subsequent connect has to be able to
-retrieve it.
+``mpirun`` calls ``MPI_Publish_name`` and another calls ``MPI_Comm_accept``.
+
+What crosses is the data an application publishes, and only that.
+``pmix_server_register_fns.c`` used to also publish each job's registration
+info whenever an external server was configured, on the stated grounds that
+"any subsequent connect has to be able to retrieve it" — but nothing ever
+retrieved it.  Every ``PMIx_Lookup`` caller in PRRTE, PMIx and Open MPI takes
+a key the user supplied, and no reader keyed by a namespace has existed at
+any point in the history.  It could not have served that purpose in any case:
+the key was ``prte_process_info.myproc.nspace``, the *daemon* job's namespace
+and so one constant string per DVM, while the value was the registration info
+for whichever job was being registered — so every daemon, and every job, wrote
+a different payload under the one key, and a reader would have got an
+arbitrary daemon's copy of an arbitrary job.  It is an ORTE-era carry-over,
+from when cross-``mpirun`` accept/connect really did fetch the remote job's
+info by name; under PMIx that travels through ``PMIx_Connect`` and the
+server's own machinery.  The write has been removed.
 
 
 Why it could not work over the RML

--- a/src/mca/state/AGENTS.md
+++ b/src/mca/state/AGENTS.md
@@ -259,7 +259,7 @@ These live in `state_base_fns.c` and are wired into components' tables
 | `prte_state_base_local_launch_complete` | Optionally kicks `REPORT_PROGRESS` every 100 daemons when `PRTE_JOB_SHOW_PROGRESS` is set. |
 | `prte_state_base_report_progress` | Prints the "App launch reported: N daemons / M procs" line. |
 | `prte_state_base_check_fds` | Debug leak check: enumerates open fds after a job completes (enabled by `state_base_check_fds`). |
-| `prte_state_base_notify_data_server` | Tells a co-resident data server to purge a terminated nspace's published data. |
+| `prte_state_base_notify_data_server` | Tells the data server a job has ended, naming the lifetime that ended (`PMIX_PERSIST_APP`) so it drops the nspace's published data that was not to outlive it. Not gated on an external data server: the built-in one needs telling too, and while it was gated nothing was ever reclaimed from it. |
 | `prte_state_base_recover_resources` | Idempotently returns one proc's slot/cpu resources to its node and drops the node from the map when empty — used on daemon-loss / partial-failure recovery paths. Written to tolerate being called twice for the same proc. |
 
 ### Every handler here is wired — keep it that way

--- a/src/mca/state/AGENTS.md
+++ b/src/mca/state/AGENTS.md
@@ -259,7 +259,7 @@ These live in `state_base_fns.c` and are wired into components' tables
 | `prte_state_base_local_launch_complete` | Optionally kicks `REPORT_PROGRESS` every 100 daemons when `PRTE_JOB_SHOW_PROGRESS` is set. |
 | `prte_state_base_report_progress` | Prints the "App launch reported: N daemons / M procs" line. |
 | `prte_state_base_check_fds` | Debug leak check: enumerates open fds after a job completes (enabled by `state_base_check_fds`). |
-| `prte_state_base_notify_data_server` | Tells the data server a job has ended, naming the lifetime that ended (`PMIX_PERSIST_APP`) so it drops the nspace's published data that was not to outlive it. Not gated on an external data server: the built-in one needs telling too, and while it was gated nothing was ever reclaimed from it. |
+| `prte_state_base_notify_data_server` | Tells the data server a job has ended, naming the lifetime that ended (`PMIX_PERSIST_APP`) so it drops the nspace's published data that was not to outlive it. Not gated on an external data server: the built-in one needs telling too, and while it was gated nothing was ever reclaimed from it. Sends to **two** stores where they differ — the global one, and this daemon's own, which is where a `PMIX_RANGE_LOCAL` publish lives. On the master those are one object, which is why a single-node run cannot tell the two apart. |
 | `prte_state_base_recover_resources` | Idempotently returns one proc's slot/cpu resources to its node and drops the node from the map when empty — used on daemon-loss / partial-failure recovery paths. Written to tolerate being called twice for the same proc. |
 
 ### Every handler here is wired — keep it that way

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -385,9 +385,23 @@ void prte_state_base_report_progress(int fd, short argc, void *cbdata)
     PMIX_RELEASE(caddy);
 }
 
+/* Tell the data server that a job has ended, so it can drop the published
+ * data that was not to outlive it.
+ *
+ * The lifetime that ended is named in the message: PMIX_PERSIST_APP, since
+ * the target is a whole namespace.  Without it the server cannot tell this
+ * from an explicit "remove everything I published" and would take data the
+ * publisher asked to keep for the session.
+ *
+ * PMIX_PERSIST_PROC data is therefore reclaimed at job granularity rather
+ * than when its individual publisher exits - later than the Standard's
+ * "until the publishing process terminates", but a message per terminating
+ * process is not a cost this path can carry at scale. */
 void prte_state_base_notify_data_server(pmix_proc_t *target)
 {
     pmix_data_buffer_t *buf;
+    pmix_info_t horizon;
+    pmix_persistence_t persist = PMIX_PERSIST_APP;
     int rc, room = -1;
     uint8_t cmd = PRTE_PMIX_PURGE_PROC_CMD;
     size_t ninfo;
@@ -423,10 +437,17 @@ void prte_state_base_notify_data_server(pmix_proc_t *target)
         return;
     }
 
-    /* no directives of our own - the count still has to be there, as the
-     * command carries one and the reader unpacks it unconditionally */
-    ninfo = 0;
+    /* one directive: the lifetime that just ended */
+    ninfo = 1;
     rc = PMIx_Data_pack(NULL, buf, &ninfo, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        return;
+    }
+    PMIX_INFO_LOAD(&horizon, PMIX_PERSISTENCE, &persist, PMIX_PERSIST);
+    rc = PMIx_Data_pack(NULL, buf, &horizon, 1, PMIX_INFO);
+    PMIX_INFO_DESTRUCT(&horizon);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(buf);
@@ -744,12 +765,14 @@ void prte_state_base_track_procs(int fd, short argc, void *cbdata)
             if (prte_state_base.run_fdcheck) {
                 prte_state_base_check_fds(jdata);
             }
-            /* if ompi-server is around, then notify it to purge
-             * any session-related info */
-            if (NULL != prte_data_server_uri) {
-                PMIX_LOAD_PROCID(&target, jdata->nspace, PMIX_RANK_WILDCARD);
-                prte_state_base_notify_data_server(&target);
-            }
+            /* tell the data server the job is over, so it can drop what
+             * this namespace published that was not to outlive it.  This
+             * used to be done only when an external data server was
+             * configured, which left the built-in one - the usual case -
+             * never told a job had ended, so nothing was ever reclaimed
+             * from it short of the DVM shutting down */
+            PMIX_LOAD_PROCID(&target, jdata->nspace, PMIX_RANK_WILDCARD);
+            prte_state_base_notify_data_server(&target);
             PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_TERMINATED);
         }
     }

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -397,7 +397,7 @@ void prte_state_base_report_progress(int fd, short argc, void *cbdata)
  * than when its individual publisher exits - later than the Standard's
  * "until the publishing process terminates", but a message per terminating
  * process is not a cost this path can carry at scale. */
-void prte_state_base_notify_data_server(pmix_proc_t *target)
+static void send_purge(pmix_rank_t dest, pmix_proc_t *target)
 {
     pmix_data_buffer_t *buf;
     pmix_info_t horizon;
@@ -405,11 +405,6 @@ void prte_state_base_notify_data_server(pmix_proc_t *target)
     int rc, room = -1;
     uint8_t cmd = PRTE_PMIX_PURGE_PROC_CMD;
     size_t ninfo;
-
-    /* if nobody local to us published anything, then we can ignore this */
-    if (PMIX_NSPACE_INVALID(prte_pmix_server_globals.server.nspace)) {
-        return;
-    }
 
     PMIX_DATA_BUFFER_CREATE(buf);
 
@@ -454,15 +449,44 @@ void prte_state_base_notify_data_server(pmix_proc_t *target)
         return;
     }
 
-    /* Send the request to the server.  An external data server is not
-     * addressable over the RML - only the master holds the PMIx connection
-     * to it - so the request goes to the master, which relays it. */
-    PRTE_RML_RELIABLE_SEND(rc, (NULL == prte_data_server_uri)
-                                   ? prte_pmix_server_globals.server.rank
-                                   : PRTE_PROC_MY_HNP->rank,
-                  buf, PRTE_RML_TAG_DATA_SERVER);
+    PRTE_RML_RELIABLE_SEND(rc, dest, buf, PRTE_RML_TAG_DATA_SERVER);
     if (PRTE_SUCCESS != rc) {
         PMIX_DATA_BUFFER_RELEASE(buf);
+    }
+}
+
+void prte_state_base_notify_data_server(pmix_proc_t *target)
+{
+    pmix_rank_t global;
+
+    /* if nobody local to us published anything, then we can ignore this */
+    if (PMIX_NSPACE_INVALID(prte_pmix_server_globals.server.nspace)) {
+        return;
+    }
+
+    /* The global store.  An external data server is not addressable over
+     * the RML - only the master holds the PMIx connection to it - so the
+     * request goes to the master, which relays it. */
+    global = (NULL == prte_data_server_uri) ? prte_pmix_server_globals.server.rank
+                                            : PRTE_PROC_MY_HNP->rank;
+    send_purge(global, target);
+
+    /* ...and OUR OWN store, which is a different one on every daemon but
+     * the master.  A PMIX_RANGE_LOCAL publish never leaves the daemon that
+     * relayed it - pmix_server_pub.c routes it to PRTE_PROC_MY_NAME - and
+     * every daemon runs prte_data_server_init(), so what a local-range
+     * publish leaves behind is reclaimable only from here.  Purging just
+     * the global store reclaimed everything EXCEPT local-range data, which
+     * a single-node run cannot show: there the two stores are one object.
+     *
+     * Gated on there being no external data server because in that case a
+     * daemon's prte_data_server() relays what it receives rather than
+     * serving it, so a request addressed to ourselves would not reach our
+     * store at all.  (Local-range publish has the same problem in that
+     * configuration, and is broken there for the same reason - a separate
+     * defect, not one to paper over from here.) */
+    if (NULL == prte_data_server_uri && global != PRTE_PROC_MY_NAME->rank) {
+        send_purge(PRTE_PROC_MY_NAME->rank, target);
     }
 }
 

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -779,9 +779,6 @@ static void check_complete_resume(int fd, short args, void *cbdata)
     prte_job_map_t *map;
     int32_t index;
     pmix_proc_t pname;
-    uint8_t command = PRTE_PMIX_PURGE_PROC_CMD;
-    size_t ninfo;
-    pmix_data_buffer_t *buf;
     pmix_pointer_array_t procs;
     prte_app_context_t *app;
     hwloc_obj_t obj;
@@ -876,48 +873,14 @@ static void check_complete_resume(int fd, short args, void *cbdata)
         return;
     }
 
-    if (NULL != prte_data_server_uri) {
-        /* tell the data server to purge any data from this nspace */
-        PMIX_DATA_BUFFER_CREATE(buf);
-        /* room number is ignored, but has to be included for pack sequencing */
-        i = 0;
-        rc = PMIx_Data_pack(NULL, buf, &i, 1, PMIX_INT);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(buf);
-            goto release;
-        }
-        rc = PMIx_Data_pack(NULL, buf, &command, 1, PMIX_UINT8);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(buf);
-            goto release;
-        }
-        /* pack the nspace to be purged */
-        pname.rank = PMIX_RANK_WILDCARD;
-        rc = PMIx_Data_pack(NULL, buf, &pname, 1, PMIX_PROC);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(buf);
-            goto release;
-        }
-        /* no directives of our own - the count still has to be there, as
-         * the command carries one and the reader unpacks it
-         * unconditionally */
-        ninfo = 0;
-        rc = PMIx_Data_pack(NULL, buf, &ninfo, 1, PMIX_SIZE);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(buf);
-            goto release;
-        }
-        /* send it to the data server */
-        PRTE_RML_RELIABLE_SEND(rc, PRTE_PROC_MY_NAME->rank, buf, PRTE_RML_TAG_DATA_SERVER);
-        if (PRTE_SUCCESS != rc) {
-            PRTE_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(buf);
-        }
-    }
+    /* Tell the data server the job is over, so it can drop what this
+     * namespace published that was not to outlive it.  This used to be an
+     * open-coded copy of prte_state_base_notify_data_server(), sent only
+     * when an external data server was configured; the built-in one - the
+     * usual case - was therefore never told a job had ended, and nothing
+     * was ever reclaimed from it short of the DVM shutting down. */
+    pname.rank = PMIX_RANK_WILDCARD;
+    prte_state_base_notify_data_server(&pname);
 
 release:
     /* Release the resources used by this job. Since some errmgrs may want

--- a/src/mca/state/prted/state_prted.c
+++ b/src/mca/state/prted/state_prted.c
@@ -681,12 +681,11 @@ static void job_teardown(int fd, short argc, void *cbdata)
         prte_state_base_check_fds(jdata);
     }
 
-    /* if ompi-server is around, then notify it to purge
-     * any session-related info */
-    if (NULL != prte_data_server_uri) {
-        PMIX_LOAD_PROCID(&target, jdata->nspace, PMIX_RANK_WILDCARD);
-        prte_state_base_notify_data_server(&target);
-    }
+    /* tell the data server the job is over, so it can drop what this
+     * namespace published that was not to outlive it - see the same call
+     * in state_base_fns.c for why this is not gated on an external server */
+    PMIX_LOAD_PROCID(&target, jdata->nspace, PMIX_RANK_WILDCARD);
+    prte_state_base_notify_data_server(&target);
 
     /* The resources are back, but the JOB OBJECT STAYS until the DVM says
      * the job is over everywhere - prted_comm.c's DVM_CLEANUP_JOB.

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -194,6 +194,9 @@ static char *prte_attrs_publish[] = {"PMIX_RANGE",
                                      "PMIX_ACCESS_PERMISSIONS",
                                      "PMIX_ACCESS_USERIDS",
                                      "PMIX_ACCESS_GRPIDS",
+                                     /* PRRTE's own - the Standard has no
+                                      * attribute for republishing a key */
+                                     PRTE_PUBLISH_REPLACE,
                                      NULL};
 
 static char *prte_attrs_lookup[] = {"PMIX_RANGE",

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -269,6 +269,12 @@ PRTE_EXPORT extern pmix_status_t pmix_server_dmodex_req_fn(const pmix_proc_t *pr
                                                            const pmix_info_t info[], size_t ninfo,
                                                            pmix_modex_cbfunc_t cbfunc,
                                                            void *cbdata);
+/* Attach to the data server named by prte_data_server_uri, if that has not
+ * already happened.  Idempotent.  The master needs this even when it has no
+ * publishing client of its own: it is the only daemon holding the tool
+ * connection every other daemon's request is relayed over. */
+PRTE_EXPORT int prte_pmix_server_init_pubsub(void);
+
 PRTE_EXPORT extern pmix_status_t pmix_server_publish_fn(const pmix_proc_t *proc,
                                                         const pmix_info_t info[], size_t ninfo,
                                                         pmix_op_cbfunc_t cbfunc, void *cbdata);

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -62,6 +62,34 @@
  * RML exactly as it does for a data server hosted here, so a DVM holds one
  * connection to the external server however many daemons it has.
  */
+static int init_server(void);
+
+/* Attach to the external data server if we have not already.
+ *
+ * This used to happen only inside execute() below - that is, only when a
+ * LOCAL client of this daemon published or looked something up.  The master
+ * needs the connection for a different reason: every other daemon relays its
+ * requests to the master, and the master is the only one that holds the tool
+ * connection to the far end.  A master with no publishing client of its own
+ * therefore never attached, and the relay failed PMIX_ERR_UNREACH for every
+ * request the DVM made.  Nothing noticed, because a job's nspace
+ * registration used to publish through execute() and attach as a side
+ * effect. */
+int prte_pmix_server_init_pubsub(void)
+{
+    int ret;
+
+    if (prte_pmix_server_globals.pubsub_init) {
+        return PRTE_SUCCESS;
+    }
+    ret = init_server();
+    if (PRTE_SUCCESS != ret) {
+        prte_show_help("help-prted.txt", "noserver", true,
+                       (NULL == prte_data_server_uri) ? "NULL" : prte_data_server_uri);
+    }
+    return ret;
+}
+
 static int init_server(void)
 {
     char *server;
@@ -172,13 +200,9 @@ static void execute(int sd, short args, void *cbdata)
 
     PMIX_ACQUIRE_OBJECT(req);
 
-    if (!prte_pmix_server_globals.pubsub_init) {
-        /* we need to initialize our connection to the server */
-        if (PRTE_SUCCESS != (rc = init_server())) {
-            prte_show_help("help-prted.txt", "noserver", true,
-                           (NULL == prte_data_server_uri) ? "NULL" : prte_data_server_uri);
-            goto callback;
-        }
+    /* we need our connection to the server */
+    if (PRTE_SUCCESS != (rc = prte_pmix_server_init_pubsub())) {
+        goto callback;
     }
 
     /* add this request to our tracker array */

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -65,7 +65,6 @@ typedef struct {
     pmix_event_t ev;
     pmix_info_t *pinfo;
     size_t ninfo;
-    bool publish;
     pmix_op_cbfunc_t cbfunc;
     void *cbdata;
     pmix_status_t status;
@@ -74,7 +73,6 @@ static void regcon(prte_pmix_reg_caddy_t *p)
 {
     p->pinfo = NULL;
     p->ninfo = 0;
-    p->publish = false;
     p->cbfunc = NULL;
     p->cbdata = NULL;
     p->status = PMIX_SUCCESS;
@@ -87,130 +85,20 @@ static void regdes(prte_pmix_reg_caddy_t *p)
 }
 static PMIX_CLASS_INSTANCE(prte_pmix_reg_caddy_t, pmix_object_t, regcon, regdes);
 
-/* invoke the caller's callback (on the PRRTE progress thread)
- * and cleanup */
-static void complete_reg(prte_pmix_reg_caddy_t *cd)
+/* the registration has completed and PMIx has handed it back on ITS
+ * progress thread; regcbfunc shifted us here.  Invoke the caller's callback
+ * on the PRRTE progress thread and clean up. */
+static void _nspace_reg_done(int sd, short args, void *cbdata)
 {
+    prte_pmix_reg_caddy_t *cd = (prte_pmix_reg_caddy_t *) cbdata;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(cd);
+
     if (NULL != cd->cbfunc) {
         cd->cbfunc(cd->status, cd->cbdata);
     }
     PMIX_RELEASE(cd);
-}
-
-static void _pub_done(int sd, short args, void *cbdata)
-{
-    prte_pmix_reg_caddy_t *cd = (prte_pmix_reg_caddy_t *) cbdata;
-    PRTE_HIDE_UNUSED_PARAMS(sd, args);
-
-    PMIX_ACQUIRE_OBJECT(cd);
-    complete_reg(cd);
-}
-
-static void pubcbfunc(pmix_status_t status, void *cbdata)
-{
-    prte_pmix_reg_caddy_t *cd = (prte_pmix_reg_caddy_t *) cbdata;
-
-    /* shift to be safe against whatever context completed
-     * the publish operation */
-    cd->status = status;
-    prte_event_set(prte_event_base, &cd->ev, -1, PRTE_EV_WRITE, _pub_done, cd);
-    PMIX_POST_OBJECT(cd);
-    prte_event_active(&cd->ev, PRTE_EV_WRITE, 1);
-}
-
-static void _nspace_reg_done(int sd, short args, void *cbdata)
-{
-    prte_pmix_reg_caddy_t *cd = (prte_pmix_reg_caddy_t *) cbdata;
-    pmix_status_t ret;
-    PRTE_HIDE_UNUSED_PARAMS(sd, args);
-
-    PMIX_ACQUIRE_OBJECT(cd);
-
-    if (PMIX_SUCCESS != cd->status) {
-        complete_reg(cd);
-        return;
-    }
-
-    /* when the user has connected us to an external data server, we
-     * must assume there is going to be some cross-mpirun exchange,
-     * and so we protect against that situation by publishing the
-     * job info for this job - this allows any subsequent "connect"
-     * to retrieve the job info */
-    if (cd->publish && NULL != prte_data_server_uri) {
-        pmix_data_buffer_t pbkt;
-        pmix_byte_object_t pbo;
-        uid_t euid;
-        pmix_data_range_t range = PMIX_RANGE_SESSION;
-        pmix_persistence_t persist = PMIX_PERSIST_APP;
-        pmix_info_t *pinfo;
-        size_t n;
-
-        PMIX_DATA_BUFFER_CONSTRUCT(&pbkt);
-        ret = PMIx_Data_pack(NULL, &pbkt, &cd->ninfo, 1, PMIX_SIZE);
-        if (PMIX_SUCCESS != ret) {
-            PMIX_ERROR_LOG(ret);
-            PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
-            cd->status = ret;
-            complete_reg(cd);
-            return;
-        }
-        ret = PMIx_Data_pack(NULL, &pbkt, cd->pinfo, cd->ninfo, PMIX_INFO);
-        if (PMIX_SUCCESS != ret) {
-            PMIX_ERROR_LOG(ret);
-            PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
-            cd->status = ret;
-            complete_reg(cd);
-            return;
-        }
-        PMIX_INFO_FREE(cd->pinfo, cd->ninfo);
-        cd->pinfo = NULL;
-        cd->ninfo = 0;
-        ret = PMIx_Data_unload(&pbkt, &pbo);
-        if (PMIX_SUCCESS != ret) {
-            PMIX_ERROR_LOG(ret);
-            PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
-            cd->status = ret;
-            complete_reg(cd);
-            return;
-        }
-
-        cd->ninfo = 4;
-        PMIX_INFO_CREATE(pinfo, cd->ninfo);
-
-        /* first pass the packed values with a key of the nspace */
-        n = 0;
-        PMIX_INFO_LOAD(&pinfo[n], prte_process_info.myproc.nspace, &pbo, PMIX_BYTE_OBJECT);
-        PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
-        ++n;
-
-        /* set the range to be session */
-        PMIX_INFO_LOAD(&pinfo[n], PMIX_RANGE, &range, PMIX_DATA_RANGE);
-        ++n;
-
-        /* set the persistence to be app */
-        PMIX_INFO_LOAD(&pinfo[n], PMIX_PERSISTENCE, &persist, PMIX_PERSIST);
-        ++n;
-
-        /* add our effective userid to the directives */
-        euid = geteuid();
-        PMIX_INFO_LOAD(&pinfo[n], PMIX_USERID, &euid, PMIX_UINT32);
-        ++n;
-
-        /* now publish it */
-        cd->pinfo = pinfo;
-        ret = pmix_server_publish_fn(&prte_process_info.myproc, cd->pinfo, cd->ninfo,
-                                     pubcbfunc, cd);
-        if (PMIX_SUCCESS != ret) {
-            PMIX_ERROR_LOG(ret);
-            cd->status = ret;
-            complete_reg(cd);
-            return;
-        }
-        /* the publish callback completes the chain */
-        return;
-    }
-
-    complete_reg(cd);
 }
 
 static void regcbfunc(pmix_status_t status, void *cbdata)
@@ -894,13 +782,11 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
     PMIX_INFO_LIST_RELEASE(info);
 
     /* do not block waiting for the registration - the callback
-     * chain will thread-shift, perform any required data-server
-     * publication, and then invoke the caller's callback on our
-     * progress thread */
+     * chain will thread-shift and then invoke the caller's callback
+     * on our progress thread */
     cd = PMIX_NEW(prte_pmix_reg_caddy_t);
     cd->pinfo = (pmix_info_t *) darray.array;
     cd->ninfo = darray.size;
-    cd->publish = true;
     cd->cbfunc = cbfunc;
     cd->cbdata = cbdata;
     ret = PMIx_server_register_nspace(pproc.nspace, jdata->num_local_procs,

--- a/src/runtime/data_server/AGENTS.md
+++ b/src/runtime/data_server/AGENTS.md
@@ -205,6 +205,58 @@ uninitialized memory.
 
 ---
 
+## Duplicate keys: same key, same *set of processes*
+
+`ds_publish` refuses a key that is already published on the range being
+published to, with `PMIX_ERR_DUPLICATE_KEY` and nothing stored. The Standard
+requires that, and the alternative is worse than it sounds: `ds_lookup`
+answers a key from the **first match it finds**, so a stored duplicate is
+unreachable — a write that reported success and did nothing.
+
+Nor is the loser reliably the newcomer. The store is a
+`pmix_pointer_array_t` and `pmix_pointer_array_add()` fills the **lowest
+free slot**, so a duplicate landing in a slot that some earlier unpublish
+freed sits *ahead* of the original and displaces it instead. Which value a
+lookup resolves to was a function of unrelated publish/unpublish history.
+
+**"Same range" is a set of processes, not the `pmix_data_range_t` word.**
+`PMIX_RANGE_NAMESPACE` published by two processes of different namespaces
+names two disjoint sets; refusing the second would refuse a publish the
+Standard permits. So `same_data_range()` tests the range word **and** asks
+whether the new publisher could itself have looked the stored item up
+(`prte_data_server_check_access` then `prte_data_server_check_range`) —
+which for `NAMESPACE`, `LOCAL` and `PROC_LOCAL` is exactly set equality, is
+trivially true for `SESSION`, `GLOBAL` and `RM`, and separates two users'
+identically-keyed items because neither can see the other's.
+
+The scan runs in two passes and the order is the point: `count_duplicates()`
+decides, `drop_prior()` acts. A publish that is going to be refused must
+leave the store exactly as it found it.
+
+The consequence worth knowing before you field a bug report: two *concurrent*
+publishers of one name no longer both appear to succeed. The second is
+refused, and since removal is a question of ownership, only the first can let
+the name go. Sequential generations of a job are unaffected — the previous
+one's `PERSIST_APP` data goes when it ends (see below) — but overlapping ones
+must now handle `PMIX_ERR_DUPLICATE_KEY` where they used to get a write that
+quietly went nowhere.
+
+`PRTE_PUBLISH_REPLACE` (`"prte.pub.replace"`, in `prte_data_server.h`) lets
+a publisher take back its **own** prior publication of those keys instead of
+failing — otherwise updating a value you published yourself needs an
+intervening `PMIx_Unpublish`. It is deliberately owner-scoped: if any
+colliding item belongs to somebody else the publish is refused whether or
+not the directive was given, so it is a republish and never a way to take a
+live name away. Only the republished keys go; an object holding others keeps
+them.
+
+Everything those checks read — the owner (which `PMIX_REQUESTOR` may have
+replaced), the range, the uid and gid — is final only *after* the directive
+scan, so the gate has to sit between that scan and
+`pmix_pointer_array_add()`.
+
+---
+
 ## Persistence and parked requests
 
 `PMIX_PERSIST_FIRST_READ` removes an item from `data->info` as soon as it is
@@ -283,6 +335,12 @@ exists.
 - **An access rule is not an ownership rule.** See the section above: what
   may be read and what may be removed are different questions, and the
   answer to the first one refused owners their own data.
+- **Decide before you remove.** The duplicate scan is two passes for a
+  reason: a refused publish must leave the store untouched, so nothing may
+  be dropped until every collision has been found and attributed.
+- **A range word is not a range.** Two publications can carry the same
+  `pmix_data_range_t` and still name disjoint sets of processes. Never
+  compare `data->range` alone and call it "the same range".
 - **A parked request can own an armed timer.** Remove it from `pending` and
   `PMIX_RELEASE` it; never `free` around it, and never leave the list
   holding one you have released.
@@ -324,11 +382,11 @@ by a publish in the other, that an ended job's data is purged from the server
 and that the purge takes *only* that job's data — plus the control, that a
 DVM which was not given the URI sees none of it.
 
-**Not covered:** `PMIX_PERSIST_FIRST_READ` end-to-end, and the lifecycle side
-of `ds_purge` (which is driven by job termination rather than by a client
-call) — in particular that a `PERSIST_APP` item is gone once its job ends
-while a `PERSIST_SESSION` one is not, which needs two jobs under one
-persistent DVM. Access
+**Not covered:** `PMIX_PERSIST_FIRST_READ` end-to-end, the duplicate-key and
+`PRTE_PUBLISH_REPLACE` paths, and the lifecycle side of `ds_purge` (which is
+driven by job termination rather than by a client call) — in particular that
+a `PERSIST_APP` item is gone once its job ends while a `PERSIST_SESSION` one
+is not, which needs two jobs under one persistent DVM. Access
 permissions are covered only with the harness running as a single user, so
 what the swarm proves is that a list naming *somebody else* keeps us out —
 not that a genuinely different uid gets in.

--- a/src/runtime/data_server/AGENTS.md
+++ b/src/runtime/data_server/AGENTS.md
@@ -339,6 +339,33 @@ exists.
 
 ---
 
+## The external server: attach, and answer
+
+Two things about the relay path are easy to get wrong, and both were.
+
+**The master must attach even when nothing local asks it to.** The attach
+(`init_server()`, now behind `prte_pmix_server_init_pubsub()`) used to happen
+only inside `execute()` in `pmix_server_pub.c` — that is, only when a **local
+client of that daemon** published or looked something up. But relaying is the
+*master's* job: every other daemon sends its request to the master, which is
+the only one holding the tool connection to the far end. A master with no
+publishing client of its own therefore never attached, and every relayed
+request failed `PMIX_ERR_UNREACH`. Nothing noticed for as long as each job's
+nspace registration also published — that went through `execute()` and
+attached as a side effect. Remove the accidental attach and the feature stops
+working, which is exactly what happened. `prte_ds_relay()` now forces it.
+
+**A relay that cannot take the request must still answer.** The dispatch in
+`prte_data_server()` used to log a relay failure and `return`, sending
+nothing. The daemon that asked stayed parked on its room number, and the
+process behind it hung for good. An unreachable data server is something a
+caller can be told about; a hang is not. The relay branch now falls into the
+same error reply every other failure uses, and the contract is unchanged:
+`prte_ds_relay()` returning `PMIX_SUCCESS` means it owns the request and will
+answer — including when it has already sent a failure.
+
+---
+
 ## Gotchas before you edit
 
 - **The answer-buffer contract above.** Every new exit path has to say which
@@ -364,6 +391,12 @@ exists.
 - **A parked request can own an armed timer.** Remove it from `pending` and
   `PMIX_RELEASE` it; never `free` around it, and never leave the list
   holding one you have released.
+- **Every exit from the dispatch must answer somebody.** A caller is parked
+  on a room number; a path that returns silently is a hang, not an error.
+  See the section above.
+- **`rc` in `prte_data_server()` is a `pmix_status_t`.** Format it with
+  `PMIx_Error_string()`; `PRTE_ERROR_NAME()` knows only PRRTE's codes and
+  renders every PMIx status as "Unknown error".
 - **No locking, and none is wanted.** Everything here runs inside the RML
   receive on the progress thread.
 - **`prte_data_store.output` is `-1` until a verbosity is registered**, so

--- a/src/runtime/data_server/AGENTS.md
+++ b/src/runtime/data_server/AGENTS.md
@@ -293,6 +293,26 @@ published, regardless of persistence. That case must *not* drop the
 requestor's parked lookups — cancelling the lookups a process is waiting on
 is no part of taking its published data back.
 
+**There is a store on every daemon, not just the master.**
+`pmix_server_start()` calls `prte_data_server_init()` unconditionally, and it
+runs in `ess/hnp` and `ess/base/ess_base_std_prted` alike. What decides which
+store a request reaches is the RANGE, in `execute()`
+(`src/prted/pmix/pmix_server_pub.c`) — one routing decision, no local-first
+search and no fallback:
+
+| Range | Target |
+|-------|--------|
+| `PMIX_RANGE_SESSION` | the global server (`prte_pmix_server_globals.server`; the HNP relays when it is external) |
+| `PMIX_RANGE_LOCAL` | `PRTE_PROC_MY_NAME` — **this daemon's own store** |
+| everything else | `PRTE_PROC_MY_HNP` |
+
+So a prted's store holds *only* local-range items published by its own local
+procs, and a lookup that misses gets `PMIX_ERR_NOT_FOUND` rather than trying
+somewhere else. On the master the two stores are the same object, which is
+why a single-node run cannot tell them apart — and why the purge going only
+to the global store left local-range data unreclaimed until it also went to
+`PRTE_PROC_MY_NAME`.
+
 `prte_state_base_notify_data_server()` is what sends the lifecycle purge,
 with `PMIX_PERSIST_APP`, when a job's procs have all terminated. All three
 call sites used to be gated on `NULL != prte_data_server_uri`, so the

--- a/src/runtime/data_server/AGENTS.md
+++ b/src/runtime/data_server/AGENTS.md
@@ -227,9 +227,43 @@ timer, so every path is covered by `PMIX_RELEASE`. Without the timer a wait
 for a key nobody publishes never returned: the timeout reached the daemon's
 caddy (`req->timeout` in `pmix_server_pub.c`) and went no further.
 
-`ds_purge` drops both the departing process's published items *and* any
-lookup it left parked; a request that outlives its requestor would otherwise
-have a later publish trying to reply to a process that no longer exists.
+**`PMIX_PERSISTENCE` is enforced by `ds_purge`, and only because the state
+machine tells it a lifetime ended.** The purge command carries the horizon
+that was reached as a `PMIX_PERSISTENCE` directive, and `expires_by()`
+decides what that takes: `FIRST_READ` and `PROC` at any horizon, `APP` at
+`APP` or `SESSION`, `INDEF` never. The values are *not* a numeric ladder —
+`PMIX_PERSIST_INDEF` is 0 and outlives all of them — so the ordering is
+spelled out rather than compared.
+
+A purge with **no** horizon (`PMIX_PERSIST_INVALID`) means an explicit
+`PMIx_Unpublish(NULL, ...)`: a live publisher taking back everything it
+published, regardless of persistence. That case must *not* drop the
+requestor's parked lookups — cancelling the lookups a process is waiting on
+is no part of taking its published data back.
+
+`prte_state_base_notify_data_server()` is what sends the lifecycle purge,
+with `PMIX_PERSIST_APP`, when a job's procs have all terminated. All three
+call sites used to be gated on `NULL != prte_data_server_uri`, so the
+**built-in** data server — the usual case — was never told a job had ended;
+nothing was ever reclaimed from it short of the DVM shutting down, and
+`PERSIST_APP` and `PERSIST_PROC` both behaved as `PERSIST_INDEF`. The
+function itself had always routed correctly for the built-in case; its own
+callers were what gated it out.
+
+`PMIX_PERSIST_PROC` is therefore reclaimed at **job** granularity rather
+than when its individual publisher exits. That is later than the Standard's
+"until the publishing process terminates", and it is deliberate: a message
+to the store for every terminating process is not a cost the termination
+path can carry at scale.
+
+The object's default is `PMIX_PERSIST_APP`, which is the Standard's default.
+PMIx adds none of its own before handing a publish to the host, so the value
+in `ds_main.c`'s constructor is the one that governs.
+
+A lifecycle purge drops both the departing process's published items *and*
+any lookup it left parked; a request that outlives its requestor would
+otherwise have a later publish trying to reply to a process that no longer
+exists.
 
 ---
 
@@ -290,8 +324,11 @@ by a publish in the other, that an ended job's data is purged from the server
 and that the purge takes *only* that job's data — plus the control, that a
 DVM which was not given the URI sees none of it.
 
-**Not covered:** `PMIX_PERSIST_FIRST_READ` end-to-end, and `ds_purge` (which
-is driven by process termination rather than by a client call). Access
+**Not covered:** `PMIX_PERSIST_FIRST_READ` end-to-end, and the lifecycle side
+of `ds_purge` (which is driven by job termination rather than by a client
+call) — in particular that a `PERSIST_APP` item is gone once its job ends
+while a `PERSIST_SESSION` one is not, which needs two jobs under one
+persistent DVM. Access
 permissions are covered only with the harness running as a single user, so
 what the swarm proves is that a list naming *somebody else* keeps us out —
 not that a genuinely different uid gets in.

--- a/src/runtime/data_server/ds.h
+++ b/src/runtime/data_server/ds.h
@@ -148,6 +148,17 @@ PRTE_EXPORT pmix_status_t prte_data_server_check_range(prte_data_req_t *req,
 PRTE_EXPORT pmix_status_t prte_data_server_check_access(prte_data_req_t *req,
                                                         prte_data_object_t *data);
 
+/* Has data with this persistence outlived the lifetime that just ended?
+ *
+ * The persistence values are not a numeric ladder that can be compared -
+ * PMIX_PERSIST_INDEF is 0 and outlives all of them - so the ordering is
+ * spelled out rather than derived.  A horizon of PMIX_PERSIST_INVALID means
+ * no lifetime ended and the caller asked for everything, which is what an
+ * explicit PMIx_Unpublish(NULL, ...) means: a publisher taking back all of
+ * its own data regardless of how long it had asked for it to be kept. */
+PRTE_EXPORT bool prte_data_server_expires_by(pmix_persistence_t persist,
+                                             pmix_persistence_t horizon);
+
 /* Apply the REQUESTER's range: is this publisher one the lookup asked to
  * search?  The PMIx retrieval rules constrain a lookup to data whose
  * publisher falls within the range the requester gave (the default being

--- a/src/runtime/data_server/ds_main.c
+++ b/src/runtime/data_server/ds_main.c
@@ -444,7 +444,10 @@ static void construct(prte_data_object_t *ptr)
     ptr->agids = NULL;
     ptr->nagids = 0;
     ptr->range = PMIX_RANGE_SESSION;
-    ptr->persistence = PMIX_PERSIST_SESSION;
+    /* the Standard's default is PMIX_PERSIST_APP - "retain until the
+     * application terminates".  PMIx adds no default of its own before
+     * handing a publish to the host, so this is the one that governs */
+    ptr->persistence = PMIX_PERSIST_APP;
     PMIX_CONSTRUCT(&ptr->info, pmix_list_t);
 }
 

--- a/src/runtime/data_server/ds_main.c
+++ b/src/runtime/data_server/ds_main.c
@@ -148,19 +148,6 @@ void prte_data_server(int status, pmix_proc_t *sender,
         return;
     }
 
-    /* When an external data server is configured, this DVM stores nothing:
-     * the request is reissued to that server over our PMIx tool connection
-     * to it, and the relay answers this sender when it replies.  Only the
-     * master holds that connection, which is why every daemon addressed
-     * its request here (pmix_server_pub.c, execute). */
-    if (NULL != prte_data_server_uri) {
-        rc = prte_ds_relay(sender, room_number, command, buffer);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-        }
-        return;
-    }
-
     PMIX_DATA_BUFFER_CREATE(answer);
     /* pack the room number as this must lead any response */
     rc = PMIx_Data_pack(NULL, answer, &room_number, 1, PMIX_INT);
@@ -175,6 +162,28 @@ void prte_data_server(int status, pmix_proc_t *sender,
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(answer);
         return;
+    }
+
+    /* When an external data server is configured, this DVM stores nothing:
+     * the request is reissued to that server over our PMIx tool connection
+     * to it, and the relay answers this sender when it replies.  Only the
+     * master holds that connection, which is why every daemon addressed
+     * its request here (pmix_server_pub.c, execute).
+     *
+     * A relay that could NOT take the request on has to be reported like any
+     * other failure.  This used to log the error and return, answering
+     * nobody - so the daemon that asked stayed parked on its room number and
+     * the process behind it hung for good.  An unreachable data server is
+     * something a caller can be told about; a hang is not. */
+    if (NULL != prte_data_server_uri) {
+        rc = prte_ds_relay(sender, room_number, command, buffer);
+        if (PMIX_SUCCESS == rc) {
+            /* the relay owns the request now and answers from a reply of
+             * its own, so ours is surplus */
+            PMIX_DATA_BUFFER_RELEASE(answer);
+            return;
+        }
+        goto report;
     }
 
     /* From here on the handlers own "answer": each of them either sends it
@@ -208,13 +217,17 @@ void prte_data_server(int status, pmix_proc_t *sender,
             break;
     }
 
+report:
     if (PMIX_SUCCESS != rc) {
         pmix_status_t ret;
 
+        /* rc is a pmix_status_t here, so it takes the PMIx formatter -
+         * PRTE_ERROR_NAME knows only PRRTE's codes and rendered every
+         * status this reports as "Unknown error" */
         pmix_output_verbose(1, prte_data_store.output,
                             "%s data server: sending error %s",
                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                            PRTE_ERROR_NAME(rc));
+                            PMIx_Error_string(rc));
         /* pack the error code. Keep the pack status in its own variable:
          * overwriting rc with it lost the very code we were reporting, and
          * a failed pack then went out as a "successful" empty answer. */

--- a/src/runtime/data_server/ds_publish.c
+++ b/src/runtime/data_server/ds_publish.c
@@ -131,6 +131,120 @@ static pmix_status_t load_permissions(const pmix_value_t *val,
     return PMIX_SUCCESS;
 }
 
+/* Is a stored item on the SAME DATA RANGE as this publication?
+ *
+ * The Standard permits duplicate keys on different ranges and requires
+ * PMIX_ERR_DUPLICATE_KEY for a duplicate on the same one.  A range is a
+ * SET OF PROCESSES, and the pmix_data_range_t is only that set's name as
+ * seen from the publisher: PMIX_RANGE_NAMESPACE published by two processes
+ * of different namespaces names two disjoint sets, not one, and refusing
+ * the second of those would refuse a publish the Standard permits.
+ *
+ * So "same data range" is the range word matching AND the stored item being
+ * one this publisher could itself have looked up.  For NAMESPACE, LOCAL and
+ * PROC_LOCAL that second test is exactly set equality; for SESSION, GLOBAL
+ * and RM it is trivially true, which is what makes those the cases that do
+ * collide.  Bringing the access check in with it separates two users'
+ * identically-keyed items for the same reason: neither can see the other's,
+ * so neither can shadow it.
+ *
+ * The req is the PUBLISHER cast as a requestor - the publisher's range is
+ * carried in it too, but only so a CUSTOM publication is asked the right
+ * question; the range word is compared before either check runs. */
+static bool same_data_range(prte_data_req_t *rq, prte_data_object_t *data,
+                            pmix_data_range_t range)
+{
+    if (range != data->range) {
+        return false;
+    }
+    if (PMIX_SUCCESS != prte_data_server_check_access(rq, data)) {
+        return false;
+    }
+    return (PMIX_SUCCESS == prte_data_server_check_range(rq, data));
+}
+
+/* Does this publication collide with what is already stored?
+ *
+ * Counts the colliding keys and reports whether any of them belongs to a
+ * DIFFERENT publisher, which is what decides between "you may replace your
+ * own" and "that name is taken".  Nothing is modified here: the decision
+ * has to be complete before anything is removed, so that a publish which
+ * ends up refused leaves the store exactly as it found it. */
+static size_t count_duplicates(prte_data_req_t *rq, prte_data_object_t *data,
+                               bool *foreign)
+{
+    prte_data_object_t *dptr;
+    prte_info_item_t *mine, *theirs;
+    size_t ndups = 0;
+    int k;
+
+    *foreign = false;
+    for (k = 0; k < prte_data_store.store.size; k++) {
+        dptr = (prte_data_object_t *) pmix_pointer_array_get_item(&prte_data_store.store, k);
+        if (NULL == dptr) {
+            continue;
+        }
+        if (!same_data_range(rq, dptr, data->range)) {
+            continue;
+        }
+        PMIX_LIST_FOREACH(mine, &data->info, prte_info_item_t) {
+            PMIX_LIST_FOREACH(theirs, &dptr->info, prte_info_item_t) {
+                if (!PMIx_Check_key(mine->info.key, theirs->info.key)) {
+                    continue;
+                }
+                pmix_output_verbose(1, prte_data_store.output,
+                                    "%s data server: %s is already published on %s by %s",
+                                    PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                    mine->info.key,
+                                    PMIx_Data_range_string(data->range),
+                                    PMIX_NAME_PRINT(&dptr->owner));
+                ndups++;
+                if (!PMIX_CHECK_PROCID(&data->owner, &dptr->owner)) {
+                    *foreign = true;
+                }
+            }
+        }
+    }
+    return ndups;
+}
+
+/* Take back the publisher's own prior publication of these keys.  Only the
+ * republished keys go: an object holding others keeps them, and one left
+ * empty leaves the store, exactly as an unpublish of those keys would have
+ * done.  Called only once count_duplicates() has established that every
+ * collision is this publisher's own. */
+static void drop_prior(prte_data_req_t *rq, prte_data_object_t *data)
+{
+    prte_data_object_t *dptr;
+    prte_info_item_t *mine, *theirs, *tnext;
+    int k;
+
+    for (k = 0; k < prte_data_store.store.size; k++) {
+        dptr = (prte_data_object_t *) pmix_pointer_array_get_item(&prte_data_store.store, k);
+        if (NULL == dptr) {
+            continue;
+        }
+        if (!PMIX_CHECK_PROCID(&data->owner, &dptr->owner)) {
+            continue;
+        }
+        if (!same_data_range(rq, dptr, data->range)) {
+            continue;
+        }
+        PMIX_LIST_FOREACH(mine, &data->info, prte_info_item_t) {
+            PMIX_LIST_FOREACH_SAFE(theirs, tnext, &dptr->info, prte_info_item_t) {
+                if (PMIx_Check_key(mine->info.key, theirs->info.key)) {
+                    pmix_list_remove_item(&dptr->info, &theirs->super);
+                    PMIX_RELEASE(theirs);
+                }
+            }
+        }
+        if (0 == pmix_list_get_size(&dptr->info)) {
+            pmix_pointer_array_set_item(&prte_data_store.store, dptr->index, NULL);
+            PMIX_RELEASE(dptr);
+        }
+    }
+}
+
 pmix_status_t prte_ds_publish(pmix_proc_t *sender,
                               pmix_data_buffer_t *buffer,
                               pmix_data_buffer_t *answer)
@@ -148,10 +262,12 @@ pmix_status_t prte_ds_publish(pmix_proc_t *sender,
     pmix_byte_object_t pbo;
     pmix_status_t ret;
     prte_info_item_t *ds1, *ds2, *ds3;
-    size_t n;
+    size_t n, ndups;
     pmix_info_t *info;
     char **cache;
     pmix_list_t answers;
+    prte_data_req_t rq;
+    bool replace = false, foreign;
 
     data = PMIX_NEW(prte_data_object_t);
     memcpy(&data->proxy, sender, sizeof(pmix_proc_t));
@@ -223,6 +339,9 @@ pmix_status_t prte_ds_publish(pmix_proc_t *sender,
         } else if (PMIx_Check_key(info[n].key, PMIX_REQUESTOR)) {
             /* a relay publishing on behalf of a process in its own DVM */
             prte_ds_check_requestor(&data->owner, &info[n]);
+        } else if (PMIx_Check_key(info[n].key, PRTE_PUBLISH_REPLACE)) {
+            /* the publisher is updating something it published itself */
+            replace = PMIX_INFO_TRUE(&info[n]);
         } else {
             /* add it to the list of data */
             ds1 = PMIX_NEW(prte_info_item_t);
@@ -242,6 +361,52 @@ pmix_status_t prte_ds_publish(pmix_proc_t *sender,
      * unpacked array has done its job - it used to be freed only on the
      * unpack-failure path, which leaked it on every successful publish */
     PMIX_INFO_FREE(info, ninfo);
+
+    /* Refuse a duplicate BEFORE anything is stored.
+     *
+     * "Duplicate keys being published on the same data range shall return
+     * the PMIX_ERR_DUPLICATE_KEY error" - and until this was here the
+     * duplicate was stored behind the original instead.  prte_ds_lookup()
+     * answers a key from the first match it finds, so the second value was
+     * unreachable for the life of the DVM: a write that reported success
+     * and did nothing.  Nor was the loser reliably the newcomer, which is
+     * what made it silent in both directions - the store is a
+     * pmix_pointer_array_t and pmix_pointer_array_add() fills the LOWEST
+     * FREE slot, so a duplicate landing in a slot some earlier unpublish
+     * freed sits ahead of the original and displaces it instead.
+     *
+     * Which publisher owns the collision is the whole of the difference
+     * between the two outcomes, so it is settled before the store is
+     * touched: a publisher may take back its own prior publication if it
+     * asked to, and nobody may take somebody else's name.
+     *
+     * Everything the checks read - the owner (which PMIX_REQUESTOR may have
+     * replaced), the range, the uid and gid - is final only now that the
+     * directive scan above has run. */
+    PMIX_CONSTRUCT(&rq, prte_data_req_t);
+    PMIX_XFER_PROCID(&rq.requestor, &data->owner);
+    PMIX_XFER_PROCID(&rq.proxy, &data->proxy);
+    rq.uid = data->uid;
+    rq.gid = data->gid;
+    rq.range = data->range;
+
+    ndups = count_duplicates(&rq, data, &foreign);
+    if (0 < ndups) {
+        if (!replace || foreign) {
+            pmix_output_verbose(1, prte_data_store.output,
+                                "%s data server: refusing publish from %s - "
+                                "%lu key(s) already published on %s",
+                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                PMIX_NAME_PRINT(&data->owner),
+                                (unsigned long) ndups,
+                                PMIx_Data_range_string(data->range));
+            PMIX_DESTRUCT(&rq);
+            PMIX_RELEASE(data);
+            return PMIX_ERR_DUPLICATE_KEY;
+        }
+        drop_prior(&rq, data);
+    }
+    PMIX_DESTRUCT(&rq);
 
     // add this data to our store
     data->index = pmix_pointer_array_add(&prte_data_store.store, data);

--- a/src/runtime/data_server/ds_purge.c
+++ b/src/runtime/data_server/ds_purge.c
@@ -49,6 +49,31 @@
 #include "src/runtime/data_server/prte_data_server.h"
 #include "src/runtime/data_server/ds.h"
 
+/* see the header for the rule this encodes */
+bool prte_data_server_expires_by(pmix_persistence_t persist,
+                                 pmix_persistence_t horizon)
+{
+    if (PMIX_PERSIST_INVALID == horizon) {
+        return true;
+    }
+    switch (persist) {
+    case PMIX_PERSIST_FIRST_READ:
+    case PMIX_PERSIST_PROC:
+        /* the shortest lifetimes: over by the time any lifetime we are
+         * told about has ended.  FIRST_READ is normally consumed by the
+         * read that answers it - this is what becomes of one nobody read */
+        return true;
+    case PMIX_PERSIST_APP:
+        return (PMIX_PERSIST_APP == horizon || PMIX_PERSIST_SESSION == horizon);
+    case PMIX_PERSIST_SESSION:
+        return (PMIX_PERSIST_SESSION == horizon);
+    case PMIX_PERSIST_INDEF:
+    default:
+        /* retained until specifically deleted */
+        return false;
+    }
+}
+
 void prte_ds_purge(pmix_proc_t *sender,
                    pmix_data_buffer_t *buffer,
                    pmix_data_buffer_t *answer)
@@ -61,6 +86,9 @@ void prte_ds_purge(pmix_proc_t *sender,
     prte_data_req_t *req, *rqnext;
     pmix_info_t *info;
     size_t n, ninfo;
+    /* absent a PMIX_PERSISTENCE directive this is an explicit
+     * "remove everything I published", not the end of a lifetime */
+    pmix_persistence_t horizon = PMIX_PERSIST_INVALID;
 
     /* unpack the proc whose data is to be purged - session
      * data is purged by providing a requestor whose rank
@@ -94,6 +122,9 @@ void prte_ds_purge(pmix_proc_t *sender,
                  * Without this the purge would take everything the relay
                  * itself owns - which is everything it ever published. */
                 prte_ds_check_requestor(&requestor, &info[n]);
+            } else if (PMIx_Check_key(info[n].key, PMIX_PERSISTENCE)) {
+                /* a lifetime ended, and this is which one */
+                horizon = info[n].value.data.persist;
             }
         }
         PMIX_INFO_FREE(info, ninfo);
@@ -114,6 +145,15 @@ void prte_ds_purge(pmix_proc_t *sender,
         if (!PMIX_CHECK_PROCID(&requestor, &data->owner)) {
             continue;
         }
+        /* ...and whether it was to outlive what just ended.  This is what
+         * makes PMIX_PERSISTENCE mean anything: the value was recorded at
+         * publish and then never consulted again, so data published to last
+         * only as long as its application sat in the store until the DVM
+         * itself went away, and PMIX_PERSIST_APP and PMIX_PERSIST_PROC both
+         * behaved as PMIX_PERSIST_INDEF. */
+        if (!prte_data_server_expires_by(data->persistence, horizon)) {
+            continue;
+        }
         /* remove the object */
         pmix_pointer_array_set_item(&prte_data_store.store, data->index, NULL);
         PMIX_RELEASE(data);
@@ -122,7 +162,15 @@ void prte_ds_purge(pmix_proc_t *sender,
     /* Drop any lookup this process left parked on the pending list. Those
      * requests outlived their requestor: a later publish would match one and
      * try to reply to a process that no longer exists, and until then the
-     * request kept the (already purged) proc's keys alive. */
+     * request kept the (already purged) proc's keys alive.
+     *
+     * Only when a lifetime actually ended, though.  An explicit
+     * PMIx_Unpublish(NULL, ...) arrives as this same command from a process
+     * that is very much alive, and cancelling the lookups it is waiting on
+     * is no part of taking its published data back. */
+    if (PMIX_PERSIST_INVALID == horizon) {
+        goto done;
+    }
     PMIX_LIST_FOREACH_SAFE(req, rqnext, &prte_data_store.pending, prte_data_req_t) {
         if (!PMIX_CHECK_PROCID(&requestor, &req->requestor)) {
             continue;

--- a/src/runtime/data_server/ds_relay.c
+++ b/src/runtime/data_server/ds_relay.c
@@ -389,6 +389,18 @@ pmix_status_t prte_ds_relay(pmix_proc_t *sender, int room_number,
         return rc;
     }
 
+    /* Make sure we are attached.  Relaying is the master's job, and the
+     * master may have no publishing client of its own - in which case
+     * nothing else would ever have opened this connection, because the
+     * attach used to happen only in execute(), on behalf of a LOCAL
+     * client.  Every relayed request then failed PMIX_ERR_UNREACH. */
+    rc = prte_pmix_server_init_pubsub();
+    if (PRTE_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(cd);
+        return prte_pmix_convert_rc(rc);
+    }
+
     /* Point our client-side calls at the data server.  We may hold more
      * than one server connection - a scheduler is the other - and PMIx
      * sends a client operation to whichever one is currently primary, so

--- a/src/runtime/data_server/prte_data_server.h
+++ b/src/runtime/data_server/prte_data_server.h
@@ -41,6 +41,22 @@ BEGIN_C_DECLS
 #define PRTE_PMIX_UNPUBLISH_CMD  0x03
 #define PRTE_PMIX_PURGE_PROC_CMD 0x04
 
+/* Directive for PMIx_Publish: replace this publisher's OWN prior
+ * publication of the keys being published rather than failing with
+ * PMIX_ERR_DUPLICATE_KEY.
+ *
+ * The Standard defines no such attribute, and refusing duplicates creates
+ * the need for one: a process that wants to update a value it published
+ * itself would otherwise have to PMIx_Unpublish first, and a publisher
+ * that skipped that step used to get a silent no-op.  The directive reaches
+ * only the caller's own publications - a published item belongs to the
+ * process that published it, the same rule PMIx_Unpublish applies - so it
+ * is a republish and not a way to take a live name away from somebody
+ * else.  A publish whose keys collide with ANOTHER publisher's is refused
+ * with or without it.
+ */
+#define PRTE_PUBLISH_REPLACE     "prte.pub.replace"     // (bool) replace the caller's own prior publication of these keys
+
 /* provide hooks to startup and finalize the data server */
 PRTE_EXPORT int prte_data_server_init(void);
 PRTE_EXPORT void prte_data_server_finalize(void);

--- a/test/unit/runtime/test_runtime.c
+++ b/test/unit/runtime/test_runtime.c
@@ -1157,6 +1157,10 @@ static int test_data_server_objects(void)
           PMIX_RANK_UNDEF == obj->owner.rank && 0 == strlen(obj->owner.nspace));
     CHECK("ds: a new data object defaults to session range",
           PMIX_RANGE_SESSION == obj->range);
+    /* the Standard's default, and the one that governs: PMIx adds no
+     * persistence of its own before handing a publish to the host */
+    CHECK("ds: a new data object defaults to app persistence",
+          PMIX_PERSIST_APP == obj->persistence);
     CHECK("ds: a new data object has no uid", UINT32_MAX == obj->uid);
     PMIX_RELEASE(obj);
 
@@ -1168,6 +1172,53 @@ static int test_data_server_objects(void)
     CHECK("ds: a new request has no keys", NULL == req->keys);
     /* the destructor free()s keys - it must not free garbage */
     PMIX_RELEASE(req);
+
+    return failures;
+}
+
+/* The persistence ordering ds_purge applies when a lifetime ends.  Worth
+ * pinning down because the values are NOT a usable numeric ladder:
+ * PMIX_PERSIST_INDEF is 0 and outlives every other value, so any attempt to
+ * decide this with a comparison gets it exactly backwards. */
+static int test_data_server_persistence(void)
+{
+    int failures = 0;
+
+    /* no horizon: an explicit PMIx_Unpublish(NULL, ...) takes everything
+     * the caller published, however long it asked for it to be kept */
+    CHECK("persist: no horizon takes INDEF",
+          prte_data_server_expires_by(PMIX_PERSIST_INDEF, PMIX_PERSIST_INVALID));
+    CHECK("persist: no horizon takes SESSION",
+          prte_data_server_expires_by(PMIX_PERSIST_SESSION, PMIX_PERSIST_INVALID));
+
+    /* a process ended */
+    CHECK("persist: PROC goes at the PROC horizon",
+          prte_data_server_expires_by(PMIX_PERSIST_PROC, PMIX_PERSIST_PROC));
+    CHECK("persist: an unread FIRST_READ goes at the PROC horizon",
+          prte_data_server_expires_by(PMIX_PERSIST_FIRST_READ, PMIX_PERSIST_PROC));
+    CHECK("persist: APP stays at the PROC horizon",
+          !prte_data_server_expires_by(PMIX_PERSIST_APP, PMIX_PERSIST_PROC));
+    CHECK("persist: SESSION stays at the PROC horizon",
+          !prte_data_server_expires_by(PMIX_PERSIST_SESSION, PMIX_PERSIST_PROC));
+
+    /* an application ended - what a terminating job reports */
+    CHECK("persist: PROC goes at the APP horizon",
+          prte_data_server_expires_by(PMIX_PERSIST_PROC, PMIX_PERSIST_APP));
+    CHECK("persist: APP goes at the APP horizon",
+          prte_data_server_expires_by(PMIX_PERSIST_APP, PMIX_PERSIST_APP));
+    CHECK("persist: SESSION stays at the APP horizon",
+          !prte_data_server_expires_by(PMIX_PERSIST_SESSION, PMIX_PERSIST_APP));
+    CHECK("persist: INDEF stays at the APP horizon",
+          !prte_data_server_expires_by(PMIX_PERSIST_INDEF, PMIX_PERSIST_APP));
+
+    /* the session ended */
+    CHECK("persist: SESSION goes at the SESSION horizon",
+          prte_data_server_expires_by(PMIX_PERSIST_SESSION, PMIX_PERSIST_SESSION));
+    CHECK("persist: APP goes at the SESSION horizon",
+          prte_data_server_expires_by(PMIX_PERSIST_APP, PMIX_PERSIST_SESSION));
+    /* the one value no lifetime reclaims */
+    CHECK("persist: INDEF stays at the SESSION horizon",
+          !prte_data_server_expires_by(PMIX_PERSIST_INDEF, PMIX_PERSIST_SESSION));
 
     return failures;
 }
@@ -1759,6 +1810,7 @@ int main(void)
     failures += test_session_teardown();
     failures += test_exit_status();
     failures += test_data_server_objects();
+    failures += test_data_server_persistence();
     failures += test_data_server_range();
     failures += test_data_server_search_range();
     failures += test_data_server_access();


### PR DESCRIPTION
Fixes #2727.

## The reported bug

Publishing a key the store already held returned `PMIX_SUCCESS` and stored the
value behind the existing one. `prte_ds_lookup()` answers a key from the first
match it finds, so one of the two was unreachable for the life of the DVM — a
write that reported success and did nothing.

Investigating it turned up that the loser was not reliably the newcomer. The
store is a `pmix_pointer_array_t` and `pmix_pointer_array_add()` fills the
**lowest free slot**, so a duplicate landing in a slot an earlier unpublish
freed sits *ahead* of the original and displaces it instead. Which value a
lookup resolved to was a function of unrelated publish/unpublish history, and
neither publisher was told anything. Demonstrated:

```
[@1:0] publish pad=x, publish k=FIRST, lookup k=FIRST, unpublish pad   <- frees index 0
[@2:0] publish k=SECOND  ->  lookup k: PMIX_SUCCESS k=SECOND (owner @2:0)
```

That matters for the design question the issue raised: it removes the argument
against replace-by-default, since a second publisher silently displacing a live
name was *already* possible.

The PMIx Standard settles the rest. `Chap_API_Publish.tex:76-78`: *"Publishing
duplicate keys is permitted provided they are published to different ranges.
Duplicate keys being published on the same data range shall return the
`PMIX_ERR_DUPLICATE_KEY` error."*

## What the issue was really chasing

The motivating use case — "a long-lived DVM cannot carry a mutable named value
across generations of a job" — was not caused by the duplicate handling at all.
`PMIX_PERSISTENCE` was recorded at publish and then never consulted again.
Nothing removed data on a lifetime boundary, so `PMIX_PERSIST_PROC` and
`PMIX_PERSIST_APP` both behaved as `PMIX_PERSIST_INDEF`, and a key published by
a job that ended an hour ago still held that name against every job after it.
The default was wrong too: `PMIX_PERSIST_SESSION` where the Standard says
`PMIX_PERSIST_APP`, and since PMIx adds no default before handing a publish to
the host, PRRTE's was the one that governed.

The state machine already had `prte_state_base_notify_data_server()` for this,
and it already routed correctly for the built-in store — but all three of its
callers were gated on an external data server being configured, so the built-in
one (the usual case) was never told a job had ended.

With persistence enforced, the issue's own reproducer works with no application
change and no new directive:

```
[...@1:0] publish gen1: PMIX_SUCCESS   lookup: gkey=gen1 (owner @1:0)
[...@2:0] publish gen2: PMIX_SUCCESS   lookup: gkey=gen2 (owner @2:0)
```

## The commits

| | |
|---|---|
| `Honor the persistence a publisher asked for` | Ungate the lifecycle purge, name the lifetime that ended in the message, correct the default to `PMIX_PERSIST_APP`. |
| `Refuse a key already published on the same range` | `PMIX_ERR_DUPLICATE_KEY`, storing nothing, plus a `prte.pub.replace` directive. |
| `Purge a daemon's own data store when a job ends` | Every daemon has a store; `PMIX_RANGE_LOCAL` data lives in the publishing daemon's, which the purge never reached. |
| `Stop publishing every job's registration info` | An unread write that collided with itself. |
| `Attach to the external data server before relaying to it` | The master only ever attached as a side effect of that write. |
| `Answer a relay that could not take the request` | A relay failure logged and returned, answering nobody — an unbounded hang. |
| `Serve a local-range request instead of relaying it away` | Everything was relayed under an external server, including `PMIX_RANGE_LOCAL` data that must never leave the DVM. |

Each after the second was exposed by the one before it, which is why they are
here together.

### On "same data range"

A range is a **set of processes**, not the `pmix_data_range_t` word.
`PMIX_RANGE_NAMESPACE` used by two processes of different namespaces names two
disjoint sets, and refusing the second would refuse a publish the Standard
permits. So the collision test is the range word matching **and** the stored
item being one this publisher could itself have looked up — exactly set
equality for `NAMESPACE`/`LOCAL`/`PROC_LOCAL`, trivially true for the ranges
that do collide, and it keeps two users' identically-keyed items apart because
neither can see the other's. The scan completes before anything is removed, so
a refused publish leaves the store untouched.

`prte.pub.replace` is owner-scoped on purpose: a collision with another
process's key is refused with or without it, so it is a republish and never a
way to take a live name away.

### The cascade

Refusing duplicates exposed that PRRTE's own nspace registration published each
job's info from **every** daemon under one constant key
(`prte_process_info.myproc.nspace`, the daemon job's namespace) — N jobs × M
daemons colliding on one string. Nothing has ever read it: every `PMIx_Lookup`
caller in PRRTE, PMIx and Open MPI takes a user-supplied key, and no reader
keyed by a namespace appears anywhere in the history. It is an ORTE-era
carry-over; under PMIx that information travels through `PMIx_Connect`.

Deleting it exposed that the master only ever attached to an external data
server as a *side effect* of that publish, so cross-DVM relaying had been
failing `PMIX_ERR_UNREACH` whenever the master had no publishing client of its
own. And that failure presented as an unbounded hang, because the dispatch
logged relay errors and answered nobody.

## Behavior changes

- **Overlapping publishers of one name now get an error.** Sequential
  generations of a job are unaffected (the previous one's `PERSIST_APP` data
  goes when it ends), but two live publishers of one name means the second is
  refused and only the first can release it. Documented in
  `docs/how-things-work/publish-lookup.rst`.
- **Self-republish requires `prte.pub.replace`** or an intervening
  `PMIx_Unpublish`.
- **`PERSIST_APP` data is now actually reclaimed** when its job ends, where
  before it lived for the DVM.

## Testing

- Warning-free `--enable-debug` build; 22/22 `make check` suites. New unit
  tests pin the persistence ordering (`PMIX_PERSIST_INDEF` is `0` and outlives
  everything, so it cannot be decided by comparison); confirmed to fail when
  the ordering is deliberately broken.
- `contrib/dockerswarm` `test_runtime`: **65 passed, 0 failed**. New coverage
  for duplicate refusal across owners, `prte.pub.replace` on your own key and
  refused on another's, same key on a genuinely different range, persistence
  across two jobs under one persistent DVM, and — the case a single host
  structurally cannot show, since there "my store" and "the HNP's store" are
  one object — a `PERSIST_APP` key published `LOCAL` on node2 being reclaimed
  from node2's own store while a `PERSIST_SESSION` key beside it is not.
  Plus, in a DVM pointed at an external server, a `LOCAL`-range key that stays
  home rather than being relayed to it.
- Docs build warning-free; new `publish-lookup.rst` page.

## Known gaps, not addressed here

- Overlapping-range duplicates (`SESSION` vs `NAMESPACE`) still resolve to
  whichever the search finds first. The Standard explicitly permits this and
  names "return the first value found" as an acceptable resolution, but
  "the most limited range of the found values" would be better.
- The `prte-swarm:latest` image's baked PMIx predates
  `PMIX_ALLOC_REQ_DIRECTIVE`, so PRRTE master will not build in it at all —
  the swarm needs `PMIX_SRC=<openpmix checkout> ./build.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuA7xp9nnDcraSNQKx6cZp
