### PR TITLE
Serve a local-range request instead of relaying it away

### DIFF
--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -2146,6 +2146,45 @@ test_runtime() {
                 RUN "timeout -k 5 30 pterm --dvm-uri file:$PRTED_URI" >/dev/null 2>&1
             fi
 
+            banner "runtime/data_server: LOCAL-range data is NOT relayed away"
+            # A PMIX_RANGE_LOCAL item belongs to the store of the daemon that
+            # relayed it and must never leave the DVM, whatever
+            # prte_data_server_uri says.  The relay used to take everything:
+            # a local-range publish was forwarded to the external server, so
+            # it was stored where its own publisher could never look it up,
+            # and the matching lookup was answered out of a store that cannot
+            # hold local-range data at all.  Both legs now carry
+            # PRTE_RML_TAG_DATA_SERVER_LOCAL, which is what tells the receive
+            # to serve rather than relay - the range itself is buried in a
+            # payload whose shape depends on the command.
+            #
+            # This needs a DVM that IS pointed at an external server, so it
+            # lives here rather than beside the other local-range test.
+            #
+            # Both legs are on node4, and deliberately: LOCAL range means
+            # "behind the same daemon", so the lookup has to run where the
+            # publish did, and node3's other slot is held for 90s by the
+            # cross-DVM publisher above.  Asking node3 for a second slot
+            # fails the MAP, which reads as "the data was relayed away".
+            PRUN_URI_BG /tmp/ds-a.uri /tmp/ds-loc.out \
+                "--host node4:1 -n 1 $DS publish prte.test.xloc stayshome local 30"
+            sleep 8
+            if ! RUN 'grep -q "^PUBLISHED prte.test.xloc" /tmp/ds-loc.out'; then
+                bad "the local-range publish never happened: $(RUN 'cat /tmp/ds-loc.out' 2>&1 | tr '\n' ' ' | tail -c 250)"
+            else
+                ok "a LOCAL-range key was published in a DVM using an external server"
+                out=$(PRUN_URI /tmp/ds-a.uri "--host node4:1 -n 1 $DS lookup prte.test.xloc 20 local" 2>&1)
+                echo "$out" | grep -q '^FOUND prte.test.xloc stayshome' \
+                    && ok "...and a peer on that node found it - it stayed home" \
+                    || bad "local-range data was relayed away: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+                # the control: it must not have reached the external server,
+                # which is what a SESSION-range lookup would be answered from
+                out=$(PRUN_URI /tmp/ds-b.uri "--host node5:1 -n 1 $DS lookup prte.test.xloc 15" 2>&1)
+                echo "$out" | grep -q '^FOUND prte.test.xloc' \
+                    && bad "local-range data reached the external server: $(echo "$out" | tr '\n' ' ' | tail -c 250)" \
+                    || ok "...and the other DVM cannot see it, as LOCAL requires"
+            fi
+
             banner "runtime/data_server: a waiting lookup crosses DVMs too"
             # The parked-request path, but with the park in one DVM and the
             # publish in another.  Both legs are relays, and the wake-up has

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -397,7 +397,7 @@ void prte_state_base_report_progress(int fd, short argc, void *cbdata)
  * than when its individual publisher exits - later than the Standard's
  * "until the publishing process terminates", but a message per terminating
  * process is not a cost this path can carry at scale. */
-static void send_purge(pmix_rank_t dest, pmix_proc_t *target)
+static void send_purge(pmix_rank_t dest, prte_rml_tag_t tag, pmix_proc_t *target)
 {
     pmix_data_buffer_t *buf;
     pmix_info_t horizon;
@@ -449,7 +449,7 @@ static void send_purge(pmix_rank_t dest, pmix_proc_t *target)
         return;
     }
 
-    PRTE_RML_RELIABLE_SEND(rc, dest, buf, PRTE_RML_TAG_DATA_SERVER);
+    PRTE_RML_RELIABLE_SEND(rc, dest, buf, tag);
     if (PRTE_SUCCESS != rc) {
         PMIX_DATA_BUFFER_RELEASE(buf);
     }
@@ -469,7 +469,7 @@ void prte_state_base_notify_data_server(pmix_proc_t *target)
      * request goes to the master, which relays it. */
     global = (NULL == prte_data_server_uri) ? prte_pmix_server_globals.server.rank
                                             : PRTE_PROC_MY_HNP->rank;
-    send_purge(global, target);
+    send_purge(global, PRTE_RML_TAG_DATA_SERVER, target);
 
     /* ...and OUR OWN store, which is a different one on every daemon but
      * the master.  A PMIX_RANGE_LOCAL publish never leaves the daemon that
@@ -479,14 +479,12 @@ void prte_state_base_notify_data_server(pmix_proc_t *target)
      * the global store reclaimed everything EXCEPT local-range data, which
      * a single-node run cannot show: there the two stores are one object.
      *
-     * Gated on there being no external data server because in that case a
-     * daemon's prte_data_server() relays what it receives rather than
-     * serving it, so a request addressed to ourselves would not reach our
-     * store at all.  (Local-range publish has the same problem in that
-     * configuration, and is broken there for the same reason - a separate
-     * defect, not one to paper over from here.) */
-    if (NULL == prte_data_server_uri && global != PRTE_PROC_MY_NAME->rank) {
-        send_purge(PRTE_PROC_MY_NAME->rank, target);
+     * The tag is what keeps this one at home: a daemon pointed at an
+     * external data server relays what arrives on the ordinary tag, so a
+     * purge of our own store addressed to ourselves would be forwarded to
+     * a DVM that does not hold the data and cannot act on it. */
+    if (global != PRTE_PROC_MY_NAME->rank) {
+        send_purge(PRTE_PROC_MY_NAME->rank, PRTE_RML_TAG_DATA_SERVER_LOCAL, target);
     }
 }
 

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -195,6 +195,8 @@ static void execute(int sd, short args, void *cbdata)
     int rc;
     pmix_data_buffer_t *xfer;
     pmix_proc_t *target;
+    /* the DVM's store unless the range says otherwise */
+    prte_rml_tag_t dstag = PRTE_RML_TAG_DATA_SERVER;
     bool stored = false;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
@@ -239,10 +241,13 @@ static void execute(int sd, short args, void *cbdata)
         target = (NULL == prte_data_server_uri) ? &prte_pmix_server_globals.server
                                                 : PRTE_PROC_MY_HNP;
     } else if (PMIX_RANGE_LOCAL == req->range) {
-        /* if the range is local, send it to myself */
+        /* if the range is local, send it to myself - and say so with the
+         * tag, so that a DVM pointed at an external data server serves this
+         * out of its own store instead of relaying it away */
         pmix_output_verbose(1, prte_pmix_server_globals.output, "%s orted:pmix:server range LOCAL",
                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
         target = PRTE_PROC_MY_NAME;
+        dstag = PRTE_RML_TAG_DATA_SERVER_LOCAL;
     } else {
         pmix_output_verbose(1, prte_pmix_server_globals.output, "%s orted:pmix:server range GLOBAL",
                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
@@ -250,7 +255,7 @@ static void execute(int sd, short args, void *cbdata)
     }
 
     /* send the request to the target */
-    PRTE_RML_RELIABLE_SEND(rc, target->rank, xfer, PRTE_RML_TAG_DATA_SERVER);
+    PRTE_RML_RELIABLE_SEND(rc, target->rank, xfer, dstag);
     if (PRTE_SUCCESS == rc) {
         return;
     }

--- a/src/rml/rml_types.h
+++ b/src/rml/rml_types.h
@@ -148,6 +148,12 @@ typedef void (*prte_rml_buffer_callback_fn_t)(int status, pmix_proc_t *peer,
 /* support data store/lookup */
 #define PRTE_RML_TAG_DATA_SERVER 27
 #define PRTE_RML_TAG_DATA_CLIENT 28
+/* ...and the same request, but for THIS daemon's own store rather than the
+ * DVM's.  A PMIX_RANGE_LOCAL item never leaves the daemon that relayed it,
+ * so a request about one must not be handed to an external data server -
+ * which is what the tag tells the receive, since by then the range is
+ * buried in the payload.  See src/runtime/data_server/AGENTS.md. */
+#define PRTE_RML_TAG_DATA_SERVER_LOCAL 84
 
 /* collectives */
 #define PRTE_RML_TAG_FENCE_RELEASE     31

--- a/src/runtime/data_server/AGENTS.md
+++ b/src/runtime/data_server/AGENTS.md
@@ -343,6 +343,18 @@ exists.
 
 Two things about the relay path are easy to get wrong, and both were.
 
+**A local-range request must not be relayed.** `prte_data_server()` used to
+hand *everything* to `prte_ds_relay()` whenever `prte_data_server_uri` was set.
+But `PMIX_RANGE_LOCAL` data belongs to the store of the daemon that relayed
+it, so forwarding it stored a publish where its own publisher could never look
+it up, and answered a local-range lookup out of a store that cannot hold
+local-range data. By the time the dispatch runs, the range is buried in a
+payload whose shape depends on the command — so the *sender* says which store
+it means by choosing the tag, `PRTE_RML_TAG_DATA_SERVER_LOCAL` rather than
+`PRTE_RML_TAG_DATA_SERVER`. `execute()` picks it for a local range, the
+lifecycle purge picks it for our own store, and the receive is registered for
+both.
+
 **The master must attach even when nothing local asks it to.** The attach
 (`init_server()`, now behind `prte_pmix_server_init_pubsub()`) used to happen
 only inside `execute()` in `pmix_server_pub.c` — that is, only when a **local

--- a/src/runtime/data_server/ds_main.c
+++ b/src/runtime/data_server/ds_main.c
@@ -92,6 +92,9 @@ int prte_data_server_init(void)
 
     PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_DATA_SERVER,
                   PRTE_RML_PERSISTENT, prte_data_server, NULL);
+    /* requests that are about our own store, whatever else is configured */
+    PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_DATA_SERVER_LOCAL,
+                  PRTE_RML_PERSISTENT, prte_data_server, NULL);
 
     return PRTE_SUCCESS;
 }
@@ -125,7 +128,7 @@ void prte_data_server(int status, pmix_proc_t *sender,
     pmix_data_buffer_t *answer;
     pmix_status_t rc;
     int room_number;
-    PRTE_HIDE_UNUSED_PARAMS(status, tag, cbdata);
+    PRTE_HIDE_UNUSED_PARAMS(status, cbdata);
 
     pmix_output_verbose(1, prte_data_store.output,
                         "%s data server got message from %s",
@@ -164,18 +167,27 @@ void prte_data_server(int status, pmix_proc_t *sender,
         return;
     }
 
-    /* When an external data server is configured, this DVM stores nothing:
-     * the request is reissued to that server over our PMIx tool connection
-     * to it, and the relay answers this sender when it replies.  Only the
-     * master holds that connection, which is why every daemon addressed
-     * its request here (pmix_server_pub.c, execute).
+    /* When an external data server is configured, this DVM stores nothing
+     * that is not local to it: the request is reissued to that server over
+     * our PMIx tool connection, and the relay answers this sender when it
+     * replies.  Only the master holds that connection, which is why every
+     * daemon addressed its request here (pmix_server_pub.c, execute).
+     *
+     * "Not local to it" is the whole of the exception, and the tag is what
+     * carries it.  A PMIX_RANGE_LOCAL item never leaves the daemon that
+     * relayed it - execute() routes it to PRTE_PROC_MY_NAME - so sending it
+     * on to another DVM would store it where its own publisher could never
+     * look it up, and would answer a local-range lookup out of a store that
+     * cannot hold local-range data.  By the time we get here the range is
+     * buried in a payload whose shape depends on the command, so the sender
+     * says which store it means by choosing the tag.
      *
      * A relay that could NOT take the request on has to be reported like any
      * other failure.  This used to log the error and return, answering
      * nobody - so the daemon that asked stayed parked on its room number and
      * the process behind it hung for good.  An unreachable data server is
      * something a caller can be told about; a hang is not. */
-    if (NULL != prte_data_server_uri) {
+    if (NULL != prte_data_server_uri && PRTE_RML_TAG_DATA_SERVER_LOCAL != tag) {
         rc = prte_ds_relay(sender, room_number, command, buffer);
         if (PMIX_SUCCESS == rc) {
             /* the relay owns the request now and answers from a reply of


### PR DESCRIPTION
Follow-up to #2729 (merged), which exposed this. Also closes the last of the
gaps listed there.

## The bug

`prte_data_server()` handed a request to `prte_ds_relay()` whenever
`prte_data_server_uri` was set — **all** of them, unconditionally. But a
`PMIX_RANGE_LOCAL` item belongs to the store of the daemon that relayed it and
never leaves this DVM: `execute()` routes it to `PRTE_PROC_MY_NAME` precisely
so that it does not.

Forwarding it to an external server stored a publish where its own publisher
could never look it up, and answered a local-range lookup out of a store that
cannot hold local-range data at all. Local-range publish/lookup was therefore
broken outright in any DVM pointed at an external data server.

A single host cannot show this, because there "my store" and "the HNP's store"
are the same object.

## The fix

The range decides it, but by the time the dispatch runs the range is buried in
a payload whose shape depends on the command, and digging it back out would
mean three command-specific unpackings of a buffer the handler still needs.

The sender knows it already, so the sender says which store it means:
requests about our own go out on a new `PRTE_RML_TAG_DATA_SERVER_LOCAL`, the
receive is registered for both tags, and the relay branch takes only the other
one. **No message format changes** — the `tag` parameter the receive already
took was simply unused (`PRTE_HIDE_UNUSED_PARAMS`).

`execute()` picks the local tag for a local range; the lifecycle purge picks it
for our own store. That second part lets the purge stop being conditional: it
was gated on there being no external data server for exactly this reason —
addressed to ourselves it would have been forwarded to a DVM that does not hold
the data — and on the local tag it now reaches the store it names in every
configuration.

## Testing

- Clean `--enable-debug` build, zero warnings; 22/22 `make check` suites.
- `contrib/dockerswarm` `test_runtime`: **65 passed, 0 failed**, with a new
  block that only exists because it needs a DVM pointed at an external server:
  a `LOCAL`-range key published in that DVM is found by a peer on the same
  node (it stayed home) and is *not* visible from the DVM sharing the external
  server (as `LOCAL` requires).
- Existing local-range and cross-DVM coverage unchanged and passing.

Both legs of the new test run on node4 deliberately — `LOCAL` means "behind the
same daemon", so the lookup has to run where the publish did, and node3's other
slot is held for 90s by the cross-DVM publisher above it. Asking node3 for a
second slot fails the map, which reads misleadingly as "the data was relayed
away".

## Residual

`PMIx_Unpublish(NULL, ...)` under an external data server still reaches only
the global store, so a caller's local-range items survive it. One request
carries one room number and gets one reply, so splitting it across both stores
is more than a tag can express; left alone deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuA7xp9nnDcraSNQKx6cZp
