### PR TITLE
Review src/prted/pmix, file by file

### DIFF
--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -156,6 +156,27 @@ otherwise takes whatever transport the resource manager offers by default
 surface for saying which one, and the note there is the record that one was
 always intended.
 
+**Event registration is accepted and discarded.**  PMIx offers the host a
+pair of hooks — ``register_events``/``deregister_events`` — through which it
+reports which status codes its local clients have asked to hear about, so
+that a host can stop distributing the ones nobody wants.  PRRTE takes both
+(``_register_events``/``_deregister_events``,
+``src/prted/pmix/pmix_server_notify.c``), thread-shifts them, and answers
+success without recording anything: every notification a daemon originates is
+xcast to the whole DVM and every daemon hands it to its own PMIx server,
+which filters it against its clients' registrations there.
+
+That is correct — no event is lost, and none is delivered to a process that
+did not ask — and it is why the arms have been empty for as long as they have
+existed.  What it costs is a broadcast per event whether or not any process
+in the DVM wants the code.  Using the registrations would mean each daemon
+keeping the union of its clients' codes, propagating that set on change, and
+consulting it before the xcast in ``_notify_event()`` — a DVM-wide replicated
+set that has to be right under grow, shrink and daemon loss, which is
+considerably more machinery than the broadcast it saves.  It has not been
+judged worth it, and the empty arms are the record of the decision rather
+than of an oversight.
+
 Test coverage
 -------------
 
@@ -258,6 +279,9 @@ the marker is stale.
      - one bootstrap option is parsed and not plumbed
    * - ``mca/ras/flux/ras_flux_module.c``, ``modify``
      - ``ras/flux`` has no ``modify()``
+   * - ``prted/pmix/pmix_server_notify.c``, ``_register_events``,
+       ``_deregister_events``
+     - event registration is accepted and discarded
 
 Two families of marker are **not** ours, and are deliberately absent from
 that table: the ``TODO`` comments in ``hostfile_lex.c`` and

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -131,7 +131,7 @@ daemon in the DVM with a ``PMIX_EVENT_CUSTOM_RANGE`` naming the membership,
 so that PMIx delivers it to exactly the members that registered for it.
 
 Running to completion is not a disconnect, and a spawned child is connected
-to its parent by default, so an ``MPI_Comm_spawn``ed job of N ranks ends by
+to its parent by default, so an ``MPI_Comm_spawn``\ ed job of N ranks ends by
 issuing N broadcasts across the whole DVM.  Nothing pays for this unless an
 assemblage exists — the registry is empty in the ordinary case and the check
 is the first thing every one of those entry points makes — but where one

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -177,6 +177,24 @@ considerably more machinery than the broadcast it saves.  It has not been
 judged worth it, and the empty arms are the record of the decision rather
 than of an oversight.
 
+**Two resource-usage queries are recognized and answer nothing.**
+``PMIX_QUERY_PROC_RESOURCE_USAGE`` and ``PMIX_QUERY_NODE_RESOURCE_USAGE``
+have arms of their own in ``_query()``
+(``src/prted/pmix/pmix_server_queries.c``) and both arms are empty.  PRRTE
+collects no resource usage: the odls knows a child's pid and its exit code
+and nothing about what it consumed while it ran, and a daemon samples
+nothing about its node beyond the topology it discovered at startup.
+
+Having the arms rather than not having them changes what the caller is
+told, and for the worse.  The default arm answers
+``PMIX_ERR_NOT_SUPPORTED``, which is the truth; falling into an empty arm
+that adds no result makes the query come back ``PMIX_ERR_NOT_FOUND``,
+which says the DVM looked and found nothing.  Whoever implements these
+should either fill them in or delete them, and until then the honest
+reading of them is that they are placeholders for a sampling path that was
+never built - one that would need a per-proc collector in the odls and a
+node-level one in each daemon, plus a decision about how often either runs.
+
 Test coverage
 -------------
 
@@ -282,6 +300,9 @@ the marker is stale.
    * - ``prted/pmix/pmix_server_notify.c``, ``_register_events``,
        ``_deregister_events``
      - event registration is accepted and discarded
+   * - ``prted/pmix/pmix_server_queries.c``, ``_query``,
+       ``PMIX_QUERY_*_RESOURCE_USAGE``
+     - two resource-usage queries are recognized and answer nothing
 
 Two families of marker are **not** ours, and are deliberately absent from
 that table: the ``TODO`` comments in ``hostfile_lex.c`` and

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -45,6 +45,47 @@ which nodes, and the daemon-launch path would have to fan out through more
 than one.  At minimum it needs a launcher affinity recorded per node and
 honored by ``prte_plm_base_setup_virtual_machine``.
 
+**``register_nspace()`` checks the list it is building, not the entries it
+puts in it.**  ``prte_pmix_server_register_nspace``
+(``src/prted/pmix/pmix_server_register_fns.c``) makes roughly forty
+``PMIX_INFO_LIST_ADD`` calls and reads the status of three of them.  The
+review checked the two that decide whether the registration is coherent at
+all — that the list handle exists, and that the final conversion into the
+array handed to ``PMIx_server_register_nspace`` succeeded — and left the
+rest, on the argument that ``PMIx_Info_list_add`` fails only on a NULL list
+or out of memory, and that forty checks would treble the length of an
+already very long function to report a condition under which the daemon is
+failing everywhere at once.  The consequence if that argument is wrong is a
+job registered with a key silently missing.  What would settle it properly
+is not forty checks but an accumulator — one status the adds fold into,
+tested once — which is a change to the macro, not to this file.
+
+**A client registration that fails is logged and the launch continues.**
+``register_nspace()`` calls ``PMIx_server_register_client`` for each proc it
+is about to host and, on an error, logs it and carries on.  The proc's
+``PMIx_Init`` will then be refused by our own PMIx server, which the
+application sees as an obscure failure some way downstream rather than as
+the launch failure it is.  Failing the whole job on it would be the honest
+alternative and is not obviously right either — the observed failure modes
+are out-of-memory — so it is recorded rather than changed.
+
+**``PRTE_JOB_NSPACE_REGISTERED`` is written and never read.**  Both
+registration paths in ``pmix_server_register_fns.c`` set it, and nothing in
+the tree consults it.  Either something should — the obvious candidate is
+the wildcard direct-modex arm of ``dmodex_req``, which re-registers a
+namespace it may already have registered — or the attribute should go, along
+with its entry in ``src/util/attr.h``.  Leaving it is the third option and
+is what the code does today.
+
+**A session control addressed to every session answers with no session id.**
+``apply_to_all`` (``src/prted/pmix/pmix_server_session.c``) applies the
+operation to each session the requestor controls and then builds one answer
+carrying the request's control id and nothing else.  It used to report
+whichever session happened to be served last, which was worse; but the PMIx
+description of a ``UINT32_MAX`` session id does not say what the answer
+should carry, and an array of per-session results is the other plausible
+reading.  Naming none of them is a choice, not a settled question.
+
 **The bootstrap configuration parses one option it deliberately does not
 publish.**  ``SessionTmpDir`` is read into the bootstrap configuration and
 then left there (``prte_ess_base_bootstrap_params``,
@@ -268,6 +309,30 @@ topology file instead.  Nor is ``prte_hwloc_print()`` exercised against a
 machine of a few thousand PUs, which is the width its cpuset buffer is sized
 for (``src/hwloc/AGENTS.md``).
 
+**Session control over every session, relayed from a non-master daemon.**
+That combination is the one path through ``pmix_server_session.c`` that runs
+``apply_to_session`` more than once per request, and it is what made a
+use-after-free possible there: the answer for the second session was built
+out of strings pointing into the info array the first answer had already
+freed.  ``contrib/dockerswarm``'s ``test_session`` covers a relayed request
+and covers operations on one named session, but never the two together, so
+the fix is argued rather than demonstrated.  The case is cheap —
+``examples/sessionctrl.c`` already takes a session id, so it needs a
+``UINT32_MAX`` spelling, two sessions instantiated by the same requestor,
+and the request issued from a node that is not the master.
+
+**``prte_pmix_server_register_tool()`` past its early returns.**  The unit
+test (``test_tool_registration``) pins the three decisions the function
+makes before it needs a live PMIx server: the rank screen, the refusal of a
+namespace PRRTE will not file, and the already-registered short circuit.
+Everything after that — including the missing-command-line case, where PMIx
+sent no ``PMIX_CMD_LINE`` because it could not read its own argv — ends in
+``PMIx_server_register_nspace`` and so cannot be reached from
+``test/unit/prted``, which initializes no server.  Nor does the harness
+produce it: PMIx on Linux always finds ``/proc/self/cmdline``, so the tool
+always sends one.  What would cover it is a client that attaches with
+``PMIx_tool_init`` and composes its own connection info array.
+
 **The XML arm, and the copy constructors.**  In
 ``src/runtime/data_type_support/``, the print functions' XML output has no
 test, and ``prte_job_copy`` / ``prte_proc_copy`` have no callers to be tested
@@ -344,6 +409,9 @@ does.
    * - ``src/grpcomm``
      - 2026-08-25 (round 4)
      - nothing
+   * - ``src/prted/pmix``
+     - 2026-08-25
+     - nothing
    * - ``src/event``
      - 2026-07-31
      - nothing
@@ -381,11 +449,14 @@ is not a marginal case.
    * - subsystem
      - last reviewed
      - since
-   * - ``src/prted``
+   * - ``src/prted`` (excluding ``pmix/``)
      - 2026-07-30
-     - 43 commits, +3,187/-482.  The PMIx server host module
-       (``src/prted/pmix``) absorbed most of the launch-message work, the
-       lazy proc-data derivation, and the tool-connection data server.
+     - 23 commits, +677/-154.  ``prte.c``, ``prted_comm.c``,
+       ``prte_app_parse.c`` and ``prun_common.c``.  The PMIx server host
+       module underneath it has since had a review of its own and is listed
+       above; this row is what is left, and the churn in it is the
+       spawn-tree wait, the shrink departure timer and the ``--prefix``
+       normalizers.
    * - ``src/mca/ras``
      - 2026-07-26
      - 44 commits, +2,093/-494.  Elastic extend/release, the SLURM

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -122,6 +122,32 @@ mechanism, scoped to a signature and driven by releases rather than by
 failures.  That is a wire change plus a memo that holds a counter, and it
 needs the dockerswarm harness to validate, so it has not been attempted.
 
+**A connected job's teardown costs one DVM-wide broadcast per process.**
+`PMIx_Connect` obliges the host to tell an assemblage about every member
+that leaves without disconnecting first, and PRRTE keeps that promise in
+``notify_assemblage()`` (``src/prted/pmix/pmix_server_connect.c``): one
+``PMIX_ERR_PROC_TERM_WO_SYNC`` per departing proc, each broadcast to every
+daemon in the DVM with a ``PMIX_EVENT_CUSTOM_RANGE`` naming the membership,
+so that PMIx delivers it to exactly the members that registered for it.
+
+Running to completion is not a disconnect, and a spawned child is connected
+to its parent by default, so an ``MPI_Comm_spawn``ed job of N ranks ends by
+issuing N broadcasts across the whole DVM.  Nothing pays for this unless an
+assemblage exists — the registry is empty in the ordinary case and the check
+is the first thing every one of those entry points makes — but where one
+does exist the cost grows with the product of the job size and the DVM.
+
+Coalescing them is not simply an optimization to write.  The event is per
+proc by definition: a member is entitled to know *which* peer went, and the
+exit code travels with it.  A batched event would have to carry a list and
+every consumer would have to learn to read one, which is a PMIx interface
+question rather than a PRRTE one.  What could be done here without touching
+the definition is to stop broadcasting: the membership is held on the master
+and the daemons hosting those members are derivable from it, so the
+notification could be sent to those daemons rather than xcast to all of
+them.  That trades a broadcast for a proc-to-daemon walk on the master, and
+it needs the dockerswarm harness to show it delivers the same events.
+
 **A job cannot ask for a transport.**  The network allocation request the
 odls builds for each job names ``<nspace>.net`` and a security key and
 otherwise takes whatever transport the resource manager offers by default

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -270,6 +270,9 @@ does.
    * - subsystem
      - last reviewed
      - since
+   * - ``src/grpcomm``
+     - 2026-08-25 (round 4)
+     - nothing
    * - ``src/event``
      - 2026-07-31
      - nothing
@@ -307,13 +310,6 @@ is not a marginal case.
    * - subsystem
      - last reviewed
      - since
-   * - ``src/grpcomm``
-     - 2026-08-02 (round 3)
-     - The subsystem was then taken out of MCA and rebuilt at a new path
-       (``src/mca/grpcomm`` became ``src/grpcomm``), collective movements
-       were added and most of them removed again, and the xcast was
-       reworked twice.  Every line is now at an address the review never
-       saw.  **Re-review this one first.**
    * - ``src/prted``
      - 2026-07-30
      - 43 commits, +3,187/-482.  The PMIx server host module

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -956,6 +956,12 @@ told which one.
 The helper is not static only so that `test_group_left` can pin all of that
 without a DVM.
 
+**The xcast's failure is a PRRTE code and the caller reads PMIx ones.**
+`_notify_event()` used to flatten every `prte_grpcomm_xcast()` failure to a
+bare `PMIX_ERROR` before handing it to the client's completion callback,
+which is the convert-direction mistake described under "Conventions" wearing
+its other face — not converting at all.
+
 ---
 
 ## Conventions specific to this directory

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -329,6 +329,26 @@ bearing:
 - **A refresh must not be answered from here.** `PMIX_GET_REFRESH_CACHE` is
   the caller saying our copy may be stale, which is exactly when we must
   go and ask.
+- **`dmodex_req()` calls `PMIx_Get` on the PRRTE progress thread, and that
+  is safe for one reason only.** It is the blocking form, and it blocks the
+  caller until the *PMIx* progress thread answers — so the question is
+  whether that answer can require anything of the thread now waiting.  It
+  cannot, because `get_data()` refuses outright for a peer that is a server
+  and not a tool (`PMIx_ERR_NOT_FOUND` rather than a request parked pending
+  a commit), and a daemon's `pmix_globals.mypeer` stays server-only:
+  `PMIx_tool_attach_to_server()` builds a peer for the server it attached to
+  and never restamps ours, so even the master with a scheduler attached does
+  not take the tool branch.  What is left is a local datastore lookup on the
+  other thread.  Two things would break that: making our own peer a tool,
+  and letting a `PMIX_GET_REFRESH_CACHE` through — the refresh runs *ahead*
+  of the server check inside `PMIx_Get`, which is why the call here is
+  guarded by `!refresh_cache` and not merely skipped as an optimization.
+- **`PMIX_REQUIRED_KEY` never arrives with a NULL string**, so the `strdup`
+  of it is not the crash it looks like: PMIx loads that key under
+  `if (NULL != key)`, and the only other producer
+  (`pmix_pending_nspace_requests`) hands up the array the first one built.
+  A NULL key reaches us as no `PMIX_REQUIRED_KEY` at all, which is why
+  `prte_pmix_server_derivable_key()` takes NULL and answers false.
 - **A `PMIx_Get`'s `PMIX_TIMEOUT` reaches us, and we are the only one who
   honors it.** PMIx arms no timer on a host request — deliberately, so as
   not to race a host that also supports one — but it does hand the caller's

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -562,7 +562,16 @@ by a wildcard.
 
 A proc in more than one assemblage — a spawned child that also connects
 explicitly — produces **one** event, addressed to the union of the
-memberships, not one per assemblage.
+memberships, not one per assemblage. It does, though, produce that event
+**per proc**, and each one is a DVM-wide xcast: `notify_assemblage()`
+broadcasts to every daemon and lets PMIx's custom range decide who hears
+it. That is the PMIx definition — the promise is made to each member about
+each departure — but it means an `MPI_Comm_spawn`ed job of N ranks pays N
+broadcasts as it ends, since a child is connected to its parent by default
+and running to completion is *not* a disconnect. The registry check comes
+first, so a DVM with no assemblages pays nothing at all; see
+[`docs/todo.rst`](../../../docs/todo.rst) for what a cheaper shape would
+have to preserve.
 
 Note what this depends on: PMIx used to execute a connect or disconnect whose
 participants were **all local** without calling the host at all, which left

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -103,6 +103,18 @@ Three things about that:
   shift. Copy that pattern; do not write the request from the PMIx
   thread "just this once".
 
+**One upcall in here does not post an event, and it is not an oversight.**
+`pmix_server_group_fn()` validates its group id and calls
+`prte_grpcomm_group()` straight through, because *that* function is the one
+that builds a caddy and posts to `prte_event_base` — the shift happens one
+call deeper, so doing it here as well would shift twice. What makes the
+pass-through legal is that nothing above the hand-off reads PRRTE state: the
+only globals it touches are `prte_pmix_server_globals.output` (an `int`
+written once during init) and `PRTE_NAME_PRINT`, whose scratch buffers are
+thread-specific storage. Add anything to that function that reads a
+`prte_job_t`, a node, or a request array and it stops being legal — move the
+work into `prte_grpcomm_group()`'s handler rather than shifting here.
+
 The daemon-command side follows the same discipline: `prted_comm.c`'s
 `HALT_VM`/`SHRINK`/`DVM_CLEANUP_JOB` cases issue their PMIx call and
 return, and pick up in `_daemon_continue()` once PMIx is done. Nothing on

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -1006,6 +1006,22 @@ upcall for a tool only from `PMIX_CAP_TOOL_FINALIZED` onwards; before that
 the tool's job object, and anything it held, simply accumulated for the
 life of the DVM.
 
+**A tool's rank is its own to choose, and the job object has to be built at
+it.** `prte_pmix_server_register_tool()` files the tool's `prte_proc_t` in
+`jdata->procs` at that rank, because that is how everything downstream finds
+it — `prte_state_base_track_procs()` above all, which is what drives the
+namespace through the state machine. Filed at zero instead, a tool that
+self-assigned any other rank was simply never found there and its job never
+retired, taking with it the allocation disposition this section is about.
+The rank arrives from the connecting process, so screen it first: the
+sentinel ranks are not subscripts, and `PMIX_RANK_UNDEF` handed to
+`pmix_pointer_array_set_item()` asks the array to grow to four billion
+entries. The same applies to everything else `_toolconn()` recorded off the
+wire — an empty `PMIX_NSPACE` is one `prte_set_job_data_object()` refuses,
+and a `PMIX_CMD_LINE` that never arrived leaves a NULL that
+`PMIx_Argv_split()` turns into a NULL `argv`. `test_tool_registration` pins
+the checks that can be reached without a live PMIx server.
+
 `lost_connection_hdlr()` in `pmix_server.c` is the other half — the
 *abnormal* departure — and it is registered at the end of
 `pmix_server_init()`. Watch what precedes that registration: an early

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -962,6 +962,13 @@ bare `PMIX_ERROR` before handing it to the client's completion callback,
 which is the convert-direction mistake described under "Conventions" wearing
 its other face — not converting at all.
 
+**The two event-registration hooks are deliberately empty**, and
+[`docs/todo.rst`](../../../docs/todo.rst) carries the reasoning: a
+notification is broadcast to every daemon and filtered against each local
+PMIx server's own registrations there, so the host has nothing to record.
+Acting on them would trade that broadcast for a DVM-wide replicated set of
+codes that has to survive grow, shrink and daemon loss.
+
 ---
 
 ## Conventions specific to this directory

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -185,6 +185,31 @@ the end of `pmix_server_dmdx_resp()`, and `prte_pmix_server_clear()`.
 Without the guard the first parks a request that is never answered, and the
 other two *release* a request somebody is still waiting on.
 
+**...and the sentinel screen is still not enough, because some requests that
+are not modexes name a real proc.** The three scheduler relays — allocate,
+session control, and the group context id — deliberately record the
+*requesting* process in `tproc`, at both ends of the relay
+(`assign_group_ctxid()` in `pmix_server_job_ctrl.c`, and the branches of
+`pmix_server_sched()`). That is a genuine identity, so it sails past a
+`PMIX_NSPACE_INVALID` check, and it sits in `local_reqs` alongside the
+modex requests. A job-level fetch names `nspace/WILDCARD`, and
+`PMIX_CHECK_PROCID` covers every rank of that namespace — so the "anyone
+else waiting for this target" sweep in `pmix_server_dmdx_resp()` matched a
+relayed request from any proc of the job being fetched, cleared its slot and
+released it. Nobody was answered: the daemon that relayed it, and the client
+behind it, waited for the life of the DVM, and for allocate and session
+control that was also a *third* release on an object built to take two.
+
+The discriminator is `mdxcbfunc`, not `tproc`: `PRTE_DMX_REQ` is the only
+thing that builds a direct-modex request and it always sets one, and no other
+operation sets it at all. Both halves of `pmix_server_dmdx_resp()` test it —
+the sweep, and the indexed lookup above it, where the index arrived on the
+wire and names a slot that is reused the moment its occupant retires. **So
+if you add an operation to `local_reqs`, do not set `mdxcbfunc`**, and if you
+ever need to clear it, remember that `rqcon()` NULLing it is the only reason
+a recycled block does not carry the previous occupant's — which this code
+now *calls* rather than merely compares. `test_request_tracker` pins both.
+
 **The sentinel exists only because the constructor writes it.** `PMIX_NEW`
 mallocs and does not zero, so `rqcon()` leaving `tproc` alone did not mean
 "empty" — it meant whatever the previous occupant of that block left there,
@@ -307,6 +332,23 @@ too: `PMIX_HOSTNAME` and `PMIX_CMD_LINE` were `strdup`ed unchecked, and a
 `PMIX_STRING` carrying no string survives the wire as a NULL (the packer
 writes a zero length, the unpacker hands back NULL), so any tool could
 segfault the daemon it attached to by connecting.
+
+**A directive's value is untrusted until its type has been checked, and
+`job_control` is the second place that bit.** The directives reach
+`process_job_ctrl()` exactly as the client sent them - PMIx's job-control
+path forwards the array to the host without inspecting what any entry holds
+- so reading a fixed member of the value union is reading whatever eight
+bytes the caller chose to put there. `PMIX_JOB_CTRL_DEFINE_PSET` took the
+pset name straight from `value.data.string` and handed it to the packer,
+which calls `strlen` on it: any process attached to a daemon could fault it
+with one `PMIx_Job_control` carrying that key with, say, a `PMIX_SIZE`
+value. Check the type, and check the string is there - and while you are
+about it check the parts of the request the *receiving* daemon will need,
+because a directive that is merely useless rather than fatal still gets
+broadcast to the whole DVM and answered with success. A pset with no members
+is the case: `PMIx_Proc_create(0)` returns NULL and PMIx refuses a set with
+no name or no members, so every daemon logged an error and the requestor was
+told it had worked.
 
 **A collecting relay must complete on *every* path.** `monitor`
 fans out to all daemons and counts responses (`ndaemons` vs `nreported`).

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -475,21 +475,29 @@ treatment.
 
 ## What a daemon publishes, and what it derives
 
-`prte_pmix_server_register_nspace()` used to hand its local PMIx server a
+`prte_pmix_server_register_nspace()` hands its local PMIx server a
 `PMIX_PROC_INFO_ARRAY` for **every** proc of a job — rank, global rank,
-app rank, appnum, local and node rank, node id, hostname, cpuset and the
-locality string generated from it. Every daemon, for the whole job. That
-is a table proportional to the job on a node that will only ever run its
-own slice of it, and `prte_hostname_cutoff` — which drops one field of it
-above a thousand nodes — is the record of that wall having been met once
-already.
+app rank, appnum, local and node rank, node id, hostname and, for the procs
+it hosts, cpuset and the locality string generated from it. Every daemon,
+for the whole job. That is a table proportional to the job on a node that
+will only ever run its own slice of it, and `prte_hostname_cutoff` — which
+drops one field of it above a thousand nodes — is the record of that wall
+having been met once already.
 
-With `prte_pmix_lazy_procdata` (the default where PMIx allows it) a daemon
-publishes only the procs it hosts. Everything it withheld is still in its
-own job object, so when PMIx asks for one of those procs through the
-`direct_modex` upcall, `dmodex_req()` answers out of `jdata->procs[rank]`
-instead of going to the hosting daemon. Four things about that are load
-bearing:
+**Only the two location keys are withheld today, and for a different
+reason** (the cpuset scatter, below). `prte_pmix_lazy_procdata` — on by
+default — switches on the *deriving* half of the narrowing: when PMIx asks
+for one of the placement keys through the `direct_modex` upcall,
+`dmodex_req()` answers out of `jdata->procs[rank]` rather than going to the
+hosting daemon. The *withholding* half is **not** in: the per-proc loop
+here still emits an array for every proc of the job on every daemon, so the
+derivation almost never fires — everything the eager registration published
+is found locally first. Do not read the paragraphs below as a description
+of a daemon that publishes only its own procs; they describe the rules any
+such narrowing must keep to, and
+[`docs/todo.rst`](../../../docs/todo.rst) carries the measurement of what
+the derivation is worth as it stands and what the other half would cost.
+Four things about the derivation are load bearing:
 
 - **The key set is what PRRTE is the authority for, not what an app wants.**
   `derivable_key()` lists the placement and binding this DVM computed —
@@ -541,6 +549,18 @@ bearing:
   directives up to `direct_modex`, they are packed on to the servicing
   daemon, and `pmix_server_dmdx_recv()` arms the timer. That is why the
   attribute table registers `PMIX_TIMEOUT` under `PMIx_Get`.
+
+**`register_nspace()` is not called once per job.** The wildcard arm of
+`dmodex_req()` calls it again whenever a client asks a daemon that hosts none
+of the job's procs for job-level data the local server does not hold — once
+per such get. Rebuilding the info arrays is what that caller wants; anything
+in there with a *side effect* has to be idempotent, or it repeats at that
+rate. The process sets are the case: appending the registry entry again
+duplicated the pset in every query answer and took a reference on the job
+object that nothing would give back, so that append is now guarded by a
+lookup. Client registration is not, and does not need to be — the daemon
+that takes this second path hosts no procs of the job, so the loop that
+registers them does not run.
 
 ### A binding we were not sent is not a binding of "none"
 

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -277,6 +277,25 @@ request of theirs is completed with data it never asked for. The
 direction, when the answer we were waiting on arrives after we gave up:
 `_mdxresp()` drops a late payload rather than putting it on the wire.
 
+**...and a relay that cannot *build* its request must fail it, not ship
+what it managed.** The tool-connection relay in `_toolconn()`
+(`pmix_server_gen.c`) logged each pack failure and packed on, so the master
+received a buffer it could not read - and with no index unpacked from it,
+nobody to answer. The tool then waited for the life of the DVM. A pack
+failure there now releases the buffer, gives the array slot back, and
+answers the tool.
+
+**The info array on a tool connection is the tool's own, straight off the
+wire.** `ptl_base_connection_hdlr.c` unpacks whatever the connecting
+process sent and hands it to the `tool_connected` upcall with only the
+uid/gid/version appended, so `_toolconn()` is parsing untrusted input in
+exactly the way `prte_pmix_xfer_job_info()` is - see the NULL-value rule
+under "Directive translation" below, which is the same rule. It bit here
+too: `PMIX_HOSTNAME` and `PMIX_CMD_LINE` were `strdup`ed unchecked, and a
+`PMIX_STRING` carrying no string survives the wire as a NULL (the packer
+writes a zero length, the unpacker hands back NULL), so any tool could
+segfault the daemon it attached to by connecting.
+
 **A collecting relay must complete on *every* path.** `monitor`
 fans out to all daemons and counts responses (`ndaemons` vs `nreported`).
 It increments `nreported` as soon as a response arrives, so a response

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -738,7 +738,17 @@ it is enforced here:
     status — through `prte_pmix_convert_rc()`, the PRRTE→PMIx direction,
     so every failure of the `PMIX_SERVER_URI` query reached the tool as a
     bare `PMIX_ERROR`. Before converting, ask which space the value is
-    already in.
+    already in. An unpack status is the commonest case of a value
+    that is *already* a PMIx status — `pmix_server_alloc_request_resp()`
+    converted three of them — and `send_error()` in `pmix_server.c` is the
+    commonest case of the opposite, a function whose parameter is a PRRTE
+    code and which converts on the way out.
+  - **A function that returns `pmix_status_t` must return one on every
+    path.** `prte_server_send_request()` answers with the packers' PMIx
+    statuses and, on a send failure, answered with the RML's PRRTE code —
+    and each of its three callers hands what it returns straight to a
+    client's completion callback. Keep the two in separate variables, as
+    that function now does, so the compiler shows which is which.
 - **A helper must not answer for its caller.** `process_directive()` in
   `pmix_server_session.c` used to invoke `req->infocbfunc` itself on an
   error and then return to a caller that also invokes it — a double

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -350,6 +350,19 @@ is the case: `PMIx_Proc_create(0)` returns NULL and PMIx refuses a set with
 no name or no members, so every daemon logged an error and the requestor was
 told it had worked.
 
+**A query's qualifiers are the same array under another name.** `_query()`
+(`pmix_server_queries.c`) reads six of them - `PMIX_NSPACE`, `PMIX_GROUP_ID`,
+`PMIX_HOSTNAME`, `PMIX_PSET_NAME`, `PMIX_ALLOC_ID`, `PMIX_ALLOC_PROPERTY` -
+and every one is a string it goes on to hand to `strlen`, `strcmp`,
+`PMIx_Check_nspace` or a session lookup, so this is the fault version of the
+rule rather than the quiet one. Refuse a mistyped qualifier with
+`PMIX_ERR_BAD_PARAM`; do **not** fall back to treating it as absent, because
+"absent" has a meaning for all six of them and it is a different answer, not
+an error — a mistyped `PMIX_HOSTNAME` treated as unset makes the server-URI
+query answer about *this* node. The two numeric qualifiers were already read
+through `PMIX_VALUE_GET_NUMBER`, which refuses a non-number; check what it
+says, or a bad value silently leaves the sentinel in place and is ignored.
+
 **The same rule in publish/lookup/unpublish costs a mis-route rather than a
 fault, which is why it survived longer.** `scan_directives()`
 (`pmix_server_pub.c`) reads `PMIX_RANGE` and `PMIX_TIMEOUT` out of the
@@ -607,6 +620,39 @@ does: each rank asks every other rank in its job where it is, and the
 harness asserts that what a rank was told about a peer is what that peer
 says about itself. That comparison *is* the A/B, because a proc's own
 daemon publishes its data either way.
+
+---
+
+## Answering a query
+
+`_query()` is one very long `if`/`else if` chain over the keys of each
+`pmix_query_t`, in the shape of `prte_pmix_xfer_job_info()` and with the same
+hazards. Four things about it that are not local to any one arm:
+
+- **It walks every job object in the array, and meets them at every stage of
+  their lives.** So a pointer that is populated at some point in a job's
+  lifecycle is not populated for every job it will see: `jdata->session` is
+  optional (the launch path falls back to `prte_default_session` where it
+  finds none) and `proct->node` is NULL until the mapper places the proc.
+  Both faulted here, and the proc table two arms further down had already had
+  the check the namespace-info arm was missing.
+- **An arm that builds an info list owns it on every way out.** The nesting
+  goes three deep in places — a per-proc list inside a per-job list inside the
+  arm's own — and an early exit has to release all of the ones it is inside,
+  not just the innermost. Nine exits released the inner list and left the
+  outer one holding every job gathered so far.
+- **`dry` is shared by every arm** and is reused, converted and destructed
+  over and over. It is initialized at its declaration because the `done:`
+  label is reachable from qualifier failures that run before any arm has
+  touched it.
+- **The status the caller gets is decided at `done:` from what came back**,
+  not from what any arm returned: nothing at all is `PMIX_ERR_NOT_FOUND`,
+  fewer results than keys asked for is `PMIX_QUERY_PARTIAL_SUCCESS`, and an
+  arm that could not answer at all sets `ret` and jumps. An arm that adds no
+  result and does *not* set `ret` — the two resource-usage ones — therefore
+  makes the query answer "looked and found nothing" where the default arm
+  would have said `PMIX_ERR_NOT_SUPPORTED`; see
+  [`docs/todo.rst`](../../../docs/todo.rst).
 
 ---
 

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -358,6 +358,43 @@ daemons reported?" check. Returning early there means that if the *last*
 daemon's response is malformed, the request never completes and the
 client hangs forever.
 
+The same obligation runs the other way, on the daemon *serving* the
+request: `mycbfn()` used to abandon a reply it could not pack, and a
+daemon that goes quiet is one the requestor counts forever.
+`send_monitor_error()` is the minimum owed there — our vpid, the room
+number in the requestor's tracker, and why.
+
+**And a count of zero completes too.** `ndaemons` is `num_daemons - 1`,
+because the requesting daemon skips its own copy of the broadcast — so on
+a DVM of one it is zero, the xcast reaches nobody who will answer, and the
+completion test lives *only* in the response handler that nothing will
+ever run. PMIx has already taken this node's own contribution before
+up-calling (it asks the host only about participation it judges remote,
+and merges the local half itself), so an empty success is the whole of the
+honest answer. `mfn()` gives it before it builds anything.
+
+**The monitor tracker carries two indices and they name different
+arrays.** `local_index` is our own room — in `local_reqs` on the daemon
+that originated the request, in `remote_reqs` on the daemon serving it.
+`remote_index` is the *requestor's* room in *its* `local_reqs`, and it
+means nothing as a subscript on any array of ours. `mycbfn()` cleared
+`remote_reqs[remote_index]` when it finished: that left the served
+request's real slot holding a pointer to the object it then freed — which
+`prte_pmix_server_clear()` walks — and unlinked whatever unrelated peer
+request happened to occupy the slot it did name. The two coincide while
+one request is in flight, which is why it survived: both are zero.
+
+**A response's index does not prove what kind of request it found.**
+`pmix_server_monitor_resp()` bounds-checks the index it unpacks and
+NULL-checks the slot, but a slot is handed out again the instant its
+occupant retires, so a response that crossed with a retirement lands on a
+live request of some other kind — where it counts a report, overwrites the
+status, and merges monitor results into an `info` array that request never
+allocated. `req->monitor` is the discriminator (this file sets it and
+nothing else does), exactly as `req->mdxcbfunc` is for the direct-modex
+response. Any new operation sharing these arrays needs the same
+treatment.
+
 ---
 
 ## What a daemon publishes, and what it derives

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -469,6 +469,37 @@ onto PRRTE job and app attributes. Notes for extending them:
   handled early makes a later `else if` on the same key dead code —
   `PMIX_TIMEOUT` was matched by the `SPAWN_TIMEOUT` branch and its own
   branch was unreachable.
+- **A value the branch *parses* has to be checked; one it merely passes on
+  does not.** `PMIX_INFO_LOAD(&i, KEY, NULL, PMIX_STRING)` is ordinary,
+  legal PMIx — `pmix_bfrops_base_value_load()` zeroes the union for a NULL
+  `data`, so the info arrives as a `PMIX_STRING` whose `data.string` is
+  NULL, and PMIx's own `PMIX_INFO_TRUE` handles that case deliberately.
+  The many branches that hand the pointer straight to `prte_set_attribute`
+  or to a policy setter are safe, because those all test for NULL. The
+  branches that read it are not, and four of them faulted: `PMIX_STDIN_TGT`
+  (`strcmp`), `PMIX_PARENT_ID` (`PMIX_XFER_PROCID` on a NULL proc),
+  `PMIX_WDIR` (`pmix_path_is_absolute` dereferences its argument
+  immediately), and both timeout keys — `PMIX_CONVERT_TIME` indexes
+  `tmp[sz-1]` without checking that the split produced anything, so a NULL
+  string faults *inside PMIx*. Any of these let a client segfault the
+  daemon it was attached to with one `PMIx_Spawn`, which is why
+  `test_xfer_job_info` now pins each of them.
+- **Read a number with `PMIX_VALUE_GET_NUMBER`, never off a fixed union
+  member.** `u16 = info->value.data.uint32` reads four bytes of a union the
+  caller may have filled with two, which the truncation back to `uint16_t`
+  rescues on a little-endian machine and does not on a big-endian one. The
+  macro converts from whatever integer type the caller actually used and
+  says so in its status, which is also the only way a non-numeric value
+  gets refused rather than silently becoming a count.
+- **`pmix_getcwd()` answers in PMIx statuses.** It looks like one more
+  PRRTE-shaped `int` helper and it is not — it returns `PMIX_ERR_BAD_PARAM`
+  and `PMIX_ERR_IN_ERRNO`. `prte_pmix_xfer_app()` returned one of those to
+  a caller reading PRRTE codes, which then ran it through
+  `prte_pmix_convert_rc()` — the PRRTE→PMIx direction — and the client got
+  a bare `PMIX_ERROR`. The same trap is in `spawn()`, where `rc` carried a
+  `PMIx_Data_pack` status on one path and a `prte_job_pack`/RML code on the
+  others while one `goto callback` converted them all the same way; the two
+  spaces live in separate variables there now.
 
 ---
 

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -364,6 +364,49 @@ daemon that goes quiet is one the requestor counts forever.
 `send_monitor_error()` is the minimum owed there — our vpid, the room
 number in the requestor's tracker, and why.
 
+**A daemon that dies mid-collective is accounted, not waited on.** Nothing
+in this rollup is keyed on the routing tree — it xcasts the request and then
+counts direct replies — so the tree can be repaired around a dead daemon
+while the request goes on counting a DVM that no longer exists. It is wired
+into the same dispatch every other in-flight collective uses:
+`prte_pmix_server_fault_handler()`, called from `src/rml/routed_radix.c`
+beside `prte_grpcomm_fault_handler()`.
+
+What it does there is *not* what fence and group do. Their recovery is a
+restart — discard, recompute what the repaired tree owes, re-offer the
+contribution kept for the purpose — which works because a fence contribution
+is idempotent and re-derivable. A monitor reply is a sample of live state on
+a node that has just ceased to exist; there is nothing to re-offer. So
+recovery here is to stop waiting and say the sample is short. It needs no
+epoch, and deliberately does not have one.
+
+That is why the request records **which** daemons it is waiting on
+(`expected_dmns`) and which have been accounted for (`reported_dmns`), rather
+than the bare count it used to keep. A count cannot answer the only question
+a death poses — had that daemon already reported? — and both readings of it
+are wrong: decrement when it had reported and `nreported` sails past the
+target, decrement when it had not and you are correct only by luck. The
+identities also make the accounting idempotent, which it must be, because the
+routing tree reports every death **twice**, once at LOCAL scope and again at
+GLOBAL, and a rank can be named again later by an adoption notice to a new
+parent. Screening against `expected_dmns` is the other half: a death this
+request was never waiting on must not be counted at all, or it completes
+early — before the daemons it *is* waiting on have answered.
+
+The same two sets are what make a duplicate response harmless, which the
+bare count did not: counting one daemon twice completed the request before
+the daemon whose slot it took was heard from.
+
+**The status says how much of the DVM answered.** All expected daemons
+reported success — `PMIX_SUCCESS`. Some answered and some could not —
+`PMIX_ERR_PARTIAL_SUCCESS`, because the caller is holding a sample of part of
+the DVM and cannot otherwise tell. None answered — the reason, not a claim of
+partiality. Note that `pstatus` carries the *caller's* monitor code until
+`mfn()` packs it into the fan-out, and is cleared there before it starts
+accumulating the collective's own result; and that it keeps the **first**
+non-success rather than the last, which used to mean one daemon's failure was
+erased by the next daemon's success.
+
 **And a count of zero completes too.** `ndaemons` is `num_daemons - 1`,
 because the requesting daemon skips its own copy of the broadcast — so on
 a DVM of one it is zero, the xcast reaches nobody who will answer, and the

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -350,6 +350,26 @@ is the case: `PMIx_Proc_create(0)` returns NULL and PMIx refuses a set with
 no name or no members, so every daemon logged an error and the requestor was
 told it had worked.
 
+**The same rule in publish/lookup/unpublish costs a mis-route rather than a
+fault, which is why it survived longer.** `scan_directives()`
+(`pmix_server_pub.c`) reads `PMIX_RANGE` and `PMIX_TIMEOUT` out of the
+client's own info array, and neither is a pointer — so reading the wrong
+member of the union produces a plausible value instead of a crash. The range
+is what decides where the request goes: SESSION and GLOBAL are relayed to the
+master and on to the data server, LOCAL is answered here. Read it out of the
+wrong member and a publish the application meant to be visible across the
+session is quietly kept on this daemon, and the lookup that was supposed to
+find it does not. The timeout is the width half of the same rule — read with
+`PMIX_VALUE_GET_NUMBER`, never off `value.data.integer`, because a caller may
+legally have sent a `PMIX_SIZE`.
+
+**And the RML gives a refused buffer back.** `PRTE_RML_RELIABLE_SEND` takes
+ownership of what it is handed *only by succeeding*; on an error return the
+buffer is still the caller's, emptied of its payload or not. See
+[`../../rml/relm/AGENTS.md`](../../rml/relm/AGENTS.md). Every relay in this
+directory that reaches its callback tail through a failed send has to release
+its buffer on the way.
+
 **A collecting relay must complete on *every* path.** `monitor`
 fans out to all daemons and counts responses (`ndaemons` vs `nreported`).
 It increments `nreported` as soon as a response arrives, so a response
@@ -883,6 +903,19 @@ which is fine from the PRRTE progress thread and fatal from the PMIx one.
 The flag this replaced (`scheduler_set_as_server`) recorded "the scheduler has
 been made primary" once and never reconsidered — correct only for as long as
 the scheduler was the sole connection.
+
+**A failed attach to the external data server is not a state the DVM can
+carry on from, and it looks exactly like one.** `init_server()` sets
+`pubsub_init` before it does any work, so it runs once whatever happens, and
+only the request that provoked it learns that it failed. What the *next*
+request then does is the trap: the target for anything the master cannot
+relay outward is the master itself, which is this daemon's own data server.
+So after a failed attach the DVM went on publishing successfully into a store
+no other DVM will ever look in, and answering lookups out of it — one error
+message at the first request, and then a peer DVM blocked in
+`MPI_Lookup_name` with nothing to connect the two. `server_init_rc` remembers
+the outcome and every later request is refused with it. Anything else added
+here that can fail once and be skipped forever needs the same treatment.
 
 ---
 

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -114,6 +114,16 @@ The two `PRTE_PMIX_WAIT_THREAD` calls left in this directory are both in
 loop exists. There is no loop to park there, so blocking is correct. Any
 *new* one outside that function is almost certainly a bug.
 
+The *wakeup* side of those two calls is the mirror image of the golden
+rule, and deliberately so: `regcbfunc()` fires on the PMIx progress thread
+and calls `PRTE_PMIX_WAKEUP_THREAD` directly rather than thread-shifting.
+It has to. The waiter is `pmix_server_init()` itself, blocked in
+`PRTE_PMIX_WAIT_THREAD` on the lock's condition variable with nothing
+driving `prte_event_base` yet, so a shifted wakeup would never be
+dispatched and the daemon would never finish starting. The shifted form
+(`prte_pmix_shifted_wakeup()`) is for waiters that are driving the event
+loop — which is everybody else.
+
 The narrow exception is a callback that PMIx guarantees to invoke
 synchronously on our own thread — `prte_pmix_server_register_nspace`'s
 completion when we called it from a shifted handler. Those are marked
@@ -149,6 +159,30 @@ monitor/tool-connect. The dmodex de-duplication loop in
 job-level fetch matched the first unrelated entry in the array, got
 parked as "already requested", and was never answered. Compare `tproc`
 against `tproc`.
+
+**...and then screen the entries that name no target at all.** Comparing
+`tproc` against `tproc` is only half of it, because a great many requests
+never name a target proc — monitor, publish/lookup, spawn, tool connection
+— and they sit in the same two arrays as the ones that do. Their `tproc` is
+the `{"", PMIX_RANK_INVALID}` sentinel, whose empty nspace matches *every*
+namespace, so a job-level fetch (`rank=WILDCARD`) pairs with the first one
+of them in the array. **Three** loops match on `tproc` and each must skip
+`PMIX_NSPACE_INVALID(r->tproc.nspace)` first: the de-duplication loop in
+`pmix_server_fence.c`, the "anyone else waiting for this target" sweep at
+the end of `pmix_server_dmdx_resp()`, and `prte_pmix_server_clear()`.
+Without the guard the first parks a request that is never answered, and the
+other two *release* a request somebody is still waiting on.
+
+**The sentinel exists only because the constructor writes it.** `PMIX_NEW`
+mallocs and does not zero, so `rqcon()` leaving `tproc` alone did not mean
+"empty" — it meant whatever the previous occupant of that block left there,
+which for a recycled request is a real proc identity. That is the same
+field the three loops above key on, so the matching was not merely
+unguarded, it was nondeterministic. `test_request_tracker` in
+[`test/unit/prted/test_prted.c`](../../../test/unit/prted/test_prted.c)
+pins it down, and does it by recycling a released request rather than by
+inspecting a fresh one, because a fresh one usually comes off a zeroed
+page and looks fine.
 
 **A job object outlives its map, and finding one proves nothing.** The map
 is built when the job is mapped and released the moment the job completes
@@ -189,6 +223,14 @@ Two things about that sweep, both of which it got wrong:
   ended was quietly taking the outstanding monitor requests with it. Guard
   with `PMIX_NSPACE_INVALID()` first; this is the same trap described above
   for `tproc` versus `target`, in a second place.
+- **A request it leaves alive must forget its index.** The slot is free the
+  instant it is cleared and the array hands out the lowest free one, so an
+  `inprogress` request that keeps its old `local_index` will, when its
+  holder finally answers, clear the slot that by then belongs to an
+  unrelated request — and leave *that* peer waiting. Setting `local_index`
+  back to `-1` is the whole fix; `pmix_pointer_array_set_item()` refuses a
+  negative index, so every later use is inert rather than wrong. The same
+  rule appears again in the session-control path, for the same reason.
 
 ---
 
@@ -212,6 +254,28 @@ When adding to a relay, remember that the index arriving on the wire is
 untrusted input. `pmix_pointer_array_get_item()` bounds-checks and
 returns NULL, so check for NULL — but do not then `return` without
 completing the request, because the requester is still waiting.
+
+**A relay must answer even a request it cannot parse.** Every `goto reply`
+in `pmix_server_sched()` happens after the requestor's index has been
+unpacked, so there is always somebody addressable on the other end holding
+a tracker for it — and until recently the "we could not build a request"
+arm printed a line and returned, which left that daemon's client blocked
+for the life of the DVM. `send_sched_error()` packs the two fields
+`pmix_server_alloc_request_resp()` reads when the status is not success
+(the status and the index) and sends them; that is the minimum a relay
+owes a peer it cannot serve.
+
+**A timed-out request is finished, and its index belongs to the peer
+again.** `timeout_cbfunc()` answers the peer with `PRTE_ERR_TIMEOUT` and
+must then retire the request outright: delete the retry cycle, clear the
+array slot, and release it unless somebody else holds it. Leaving it armed
+does two bad things — the daemon retries a request nobody is waiting for
+until the DVM ends, and a retry that eventually succeeds sends a *second*
+reply under an index the peer has long since reused, so an unrelated
+request of theirs is completed with data it never asked for. The
+`timed_out` flag is what stops the same thing happening from the other
+direction, when the answer we were waiting on arrives after we gave up:
+`_mdxresp()` drops a late payload rather than putting it on the wire.
 
 **A collecting relay must complete on *every* path.** `monitor`
 fans out to all daemons and counts responses (`ndaemons` vs `nreported`).
@@ -265,6 +329,12 @@ bearing:
 - **A refresh must not be answered from here.** `PMIX_GET_REFRESH_CACHE` is
   the caller saying our copy may be stale, which is exactly when we must
   go and ask.
+- **A `PMIx_Get`'s `PMIX_TIMEOUT` reaches us, and we are the only one who
+  honors it.** PMIx arms no timer on a host request — deliberately, so as
+  not to race a host that also supports one — but it does hand the caller's
+  directives up to `direct_modex`, they are packed on to the servicing
+  daemon, and `pmix_server_dmdx_recv()` arms the timer. That is why the
+  attribute table registers `PMIX_TIMEOUT` under `PMIx_Get`.
 
 ### A binding we were not sent is not a binding of "none"
 

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -905,6 +905,30 @@ The parts that matter when editing this file:
 - **An unrecognized directive is not an error.** A request may be addressed at
   more than one kind of RTE. Refuse only what PRRTE is being asked to do and
   cannot (`PROVISION_*`, anything asking it to *choose* machines).
+- **Every value in the request is the caller's own, and this upcall is
+  reachable by any application process or tool attached to any daemon.** It is
+  the same untrusted-input rule as `_toolconn()` and `process_job_ctrl()` under
+  "The relay pattern", in another place, and the strings are the fault version
+  of it: `PMIX_SESSION_CTRL_ID`, `PMIX_ALLOC_ID`, `PMIX_ALLOC_REQ_ID`,
+  `PMIX_ALLOC_TIME`, `PMIX_PERSONALITY` and `PMIX_NSPACE` all go on to a
+  `strdup`, a `strlen` or a parser, so a mistyped one faulted the daemon on a
+  path that needs no authorization at all (the time is read during the parse,
+  before anyone has asked who is calling). `get_string_directive()` is the one
+  place they are read; keep it that way. `PMIX_ALLOC_INHERITANCE` is the quiet
+  half of the same rule — it decides whether the session's nodes are handed
+  *away* to the scheduler, so it is read with `PMIX_VALUE_GET_NUMBER` rather
+  than off a fixed union member. And a `PMIX_NSPACE` must name something: an
+  empty one is PMIx's wildcard, so it selects every job in the session instead
+  of none.
+- **`set_response()` may run only ONCE per parsed request.** It frees the info
+  array the request arrived with, and every string the parsed `prte_sessctrl_t`
+  holds points into that array — so a second call reads the copy the first
+  released. `apply_to_all()` used to call it once per session and did exactly
+  that; it now builds the answer once, after the loop, naming no session
+  (a request addressed to all of them has no one session to report). For the
+  same reason `set_response()` replaces the request's array even when it has
+  nothing to say: leaving the old one there answers the caller with its own
+  directives echoed back as results.
 - **`answer_request()` owns the completion for both callers**, because they
   answer through different callbacks: a local client's answer goes to PMIx's
   own callback (synchronous), a relayed one to `send_alloc_resp` (which

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -929,6 +929,33 @@ it is enforced here:
   broadcasts to every daemon including the originator, and the originator
   must update its group registry but must not re-notify its own clients.
 
+**An event's info array is the generating client's own, and it reaches every
+daemon in the DVM.** PMIx hands what a process passed to `PMIx_Notify_event`
+straight to the host without inspecting what any entry holds — the same
+untrusted-input rule as `_toolconn()` and `process_job_ctrl()` under "The
+relay pattern", in a third place, and the worst-placed of the three because
+the host's answer to the event is to broadcast it. So anything in here that
+*reads* an entry must check `value.type` first:
+`prte_pmix_server_group_member_left()` took the `PMIX_GROUP_ID` off
+`value.data.string` and the departing proc off `value.data.proc`, so one
+`PMIx_Notify_event(PMIX_GROUP_LEFT, ...)` carrying either key with, say, a
+`PMIX_SIZE` value faulted every daemon at once, on the `strcmp` or on the
+`PMIX_CHECK_PROCID`. Any process attached to any daemon could send it, and
+the registry is non-empty on every daemon from the first successful
+`PMIx_Group_construct` onwards, because `grpcomm_group.c` appends the group
+everywhere.
+
+The identity has to be concrete as well as well-typed. `PMIX_CHECK_PROCID`
+counts an empty nspace and a wildcard rank as matching anything, so a
+departure naming neither removed whichever member happened to sit first in
+the array — the wildcard trap that runs through this whole directory, here
+in a place where the wildcard arrived from outside rather than from an
+uninitialized field. A proc leaves a group one at a time; insist on being
+told which one.
+
+The helper is not static only so that `test_group_left` can pin all of that
+without a DVM.
+
 ---
 
 ## Conventions specific to this directory
@@ -984,7 +1011,8 @@ it is enforced here:
 **Unit — `test/unit/prted/`.** The directive translators
 (`prte_pmix_xfer_job_info`, `prte_pmix_xfer_app`), the job-info cache, the
 session time-limit parser (`prte_pmix_server_parse_session_time`), the
-departed-jobs list, and the connected-assemblage registry
+group-departure validator (`test_group_left`), the departed-jobs list, and
+the connected-assemblage registry
 (`test_connections` — set matching, wildcard coverage, and when a record is
 purged) are pure data transforms and are covered there. Most of the rest of
 this directory needs a live PMIx server and at least one peer daemon.

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -645,13 +645,18 @@ hazards. Four things about it that are not local to any one arm:
   over and over. It is initialized at its declaration because the `done:`
   label is reachable from qualifier failures that run before any arm has
   touched it.
-- **The status the caller gets is decided at `done:` from what came back**,
-  not from what any arm returned: nothing at all is `PMIX_ERR_NOT_FOUND`,
-  fewer results than keys asked for is `PMIX_QUERY_PARTIAL_SUCCESS`, and an
-  arm that could not answer at all sets `ret` and jumps. An arm that adds no
-  result and does *not* set `ret` — the two resource-usage ones — therefore
-  makes the query answer "looked and found nothing" where the default arm
-  would have said `PMIX_ERR_NOT_SUPPORTED`; see
+- **The status the caller gets is decided at `done:` — but only if no arm
+  decided it first.** Nothing at all is `PMIX_ERR_NOT_FOUND`, fewer results
+  than keys asked for is `PMIX_QUERY_PARTIAL_SUCCESS`, and an arm that could
+  not answer sets `ret` and jumps. That last case is why the decision has to
+  be gated on `ret` still being success: an arm that gives up leaves the
+  result list empty, which is indistinguishable at `done:` from having looked
+  and found nothing — so an ungated substitution replaces every real error
+  with `PMIX_ERR_NOT_FOUND` and the caller cannot tell "there is no such
+  thing" from "you asked wrongly". An arm that adds no result and does *not*
+  set `ret` — the two resource-usage ones — makes the query answer "looked
+  and found nothing" where the default arm would have said
+  `PMIX_ERR_NOT_SUPPORTED`; see
   [`docs/todo.rst`](../../../docs/todo.rst).
 
 ---
@@ -1103,8 +1108,10 @@ codes that has to survive grow, shrink and daemon loss.
 **Unit — `test/unit/prted/`.** The directive translators
 (`prte_pmix_xfer_job_info`, `prte_pmix_xfer_app`), the job-info cache, the
 session time-limit parser (`prte_pmix_server_parse_session_time`), the
-group-departure validator (`test_group_left`), the departed-jobs list, and
-the connected-assemblage registry
+group-departure validator (`test_group_left`), the query qualifier
+validation and status decision (`test_query_qualifiers`, driven through the
+real `pmix_server_query_fn` upcall with the test thread turning the event
+base), the departed-jobs list, and the connected-assemblage registry
 (`test_connections` — set matching, wildcard coverage, and when a record is
 purged) are pure data transforms and are covered there. Most of the rest of
 this directory needs a live PMIx server and at least one peer daemon.

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -171,10 +171,14 @@ typedef struct {
 static char *prte_attrs_none[] = {"NONE", NULL};
 static char *prte_attrs_na[] = {"N/A", NULL};
 
-/* PMIx_Get: the direct-modex upcall.  No PMIX_TIMEOUT - PMIx deliberately
- * sets no timeout on a host request, and we honor none of our own. */
+/* PMIx_Get: the direct-modex upcall.  PMIx arms no timer of its own on a
+ * host request - deliberately, so as not to race the host that may also
+ * honor one - but it does hand the caller's directives up, and the daemon
+ * that services the request arms the caller's PMIX_TIMEOUT itself
+ * (pmix_server_dmdx_recv). */
 static char *prte_attrs_get[] = {"PMIX_GET_REFRESH_CACHE",
                                  "PMIX_REQUIRED_KEY",
+                                 "PMIX_TIMEOUT",
                                  NULL};
 
 /* PMIx_Fence, and the connect/disconnect operations built on it */
@@ -614,16 +618,34 @@ static void timeout_cbfunc(int sd, short args, void *cbdata)
 
     /* mark that we timed out */
     req->timed_out = true;
+    /* the timer that brought us here has fired and is no longer armed */
+    req->event_active = false;
 
     /* don't let the caller hang */
     if (0 <= req->remote_index) {
-        /* this was a remote request */
-        send_error(PMIX_ERR_TIMEOUT, &req->tproc, &req->proxy, req->remote_index);
-        /* note: we cannot release the req object because whomever
-         * we gave it to (host or PMIx server library) is still
-         * using it. We'll take care of it once the current holder
-         * returns.
-         */
+        /* This was a remote request, and it is now finished: we have told
+         * the peer it timed out, and the index we answered under is one it
+         * is free to reuse.  So stop retrying - leaving the two-second
+         * cycle armed makes the daemon retry a dead request for the life of
+         * the DVM, and a retry that finally succeeds sends a SECOND reply
+         * under an index that by then belongs to some other request of
+         * theirs, which is answered with data it never asked for. */
+        send_error(PRTE_ERR_TIMEOUT, &req->tproc, &req->proxy, req->remote_index);
+        if (req->cycle_active) {
+            prte_event_del(&req->cycle);
+            req->cycle_active = false;
+        }
+        if (0 <= req->local_index) {
+            pmix_pointer_array_set_item(&prte_pmix_server_globals.remote_reqs,
+                                        req->local_index, NULL);
+            req->local_index = -1;
+        }
+        /* ...but we can only free it if nobody else holds it. A request
+         * handed to the PMIx server library is released by the callback
+         * that library still owes us */
+        if (!req->inprogress) {
+            PMIX_RELEASE(req);
+        }
         return;
     }
 
@@ -674,6 +696,13 @@ void prte_pmix_server_clear(pmix_proc_t *pname)
                 prte_event_del(&req->cycle);
             }
             pmix_pointer_array_set_item(&prte_pmix_server_globals.remote_reqs, n, NULL);
+            /* The slot is free again the moment we clear it, and the array
+             * hands out the lowest free one - so a request we leave alive
+             * here (because somebody else is holding it) must forget its
+             * index, or the reply it eventually sends will clear the slot
+             * that now belongs to an unrelated request and leave THAT
+             * peer waiting. */
+            req->local_index = -1;
             if (!req->inprogress) {
                 /* Somebody is still waiting on the other end of this, and
                  * dropping it in silence leaves them waiting forever.  The
@@ -1374,19 +1403,39 @@ void pmix_server_finalize(void)
     /* finalize our local data server */
     prte_data_server_finalize();
 
-    /* cleanup collectives */
+    /* cleanup collectives.  A request may still have a timer armed - the
+     * two-second dmodex retry cycle, or a caller's timeout - and libevent
+     * keeps a pointer to the event structure inside the request until it
+     * is deleted.  Freeing the request first leaves that pointer dangling
+     * in the base, which prte_event_base_close() then walks. */
     prte_pmix_server_req_t *cd;
     for (int i = 0; i < prte_pmix_server_globals.local_reqs.size; i++) {
-      cd = (prte_pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, i);
-      if (NULL != cd) {
-          PMIX_RELEASE(cd);
-      }
+        cd = (prte_pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, i);
+        if (NULL != cd) {
+            if (cd->event_active) {
+                prte_event_del(&cd->ev);
+                cd->event_active = false;
+            }
+            if (cd->cycle_active) {
+                prte_event_del(&cd->cycle);
+                cd->cycle_active = false;
+            }
+            PMIX_RELEASE(cd);
+        }
     }
     for (int i = 0; i < prte_pmix_server_globals.remote_reqs.size; i++) {
-      cd = (prte_pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.remote_reqs, i);
-      if (NULL != cd) {
-          PMIX_RELEASE(cd);
-      }
+        cd = (prte_pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.remote_reqs, i);
+        if (NULL != cd) {
+            if (cd->event_active) {
+                prte_event_del(&cd->ev);
+                cd->event_active = false;
+            }
+            if (cd->cycle_active) {
+                prte_event_del(&cd->cycle);
+                cd->cycle_active = false;
+            }
+            PMIX_RELEASE(cd);
+        }
     }
 
     PMIX_DESTRUCT(&prte_pmix_server_globals.remote_reqs);
@@ -1495,8 +1544,25 @@ static void _mdxresp(int sd, short args, void *cbdata)
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                         req->tproc.nspace, req->tproc.rank);
 
-    /* remove us from the pending array */
-    pmix_pointer_array_set_item(&prte_pmix_server_globals.remote_reqs, req->local_index, NULL);
+    /* remove us from the pending array - unless a job teardown already
+     * took us out of it, in which case the index names somebody else now */
+    if (0 <= req->local_index) {
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.remote_reqs, req->local_index, NULL);
+        req->local_index = -1;
+    }
+
+    /* If this request already timed out then the peer has had its answer
+     * and has retired the index we would reply under - it may well have
+     * given that index to a different request by now, which would receive
+     * this payload as its own. The data is late; drop it. */
+    if (req->timed_out) {
+        pmix_output_verbose(2, prte_pmix_server_globals.output,
+                            "%s DATA FOR PROC %s:%u ARRIVED AFTER TIMEOUT - DISCARDING",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                            req->tproc.nspace, req->tproc.rank);
+        PMIX_RELEASE(req);
+        return;
+    }
 
     /* pack the status */
     PMIX_DATA_BUFFER_CREATE(reply);
@@ -1533,6 +1599,8 @@ static void _mdxresp(int sd, short args, void *cbdata)
                 goto error;
             }
             free(req->data);
+            req->data = NULL;
+            req->sz = 0;
         }
     }
 
@@ -1790,7 +1858,10 @@ static void dmdx_check(int sd, short args, void *cbdata)
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         req->inprogress = false;
-        send_error(rc, &req->tproc, &req->proxy, req->remote_index);
+        /* send_error answers in PRRTE codes and converts on the way out;
+         * this one is already a PMIx status, so hand it over in the space
+         * that function expects rather than converting it backwards */
+        send_error(prte_pmix_convert_status(rc), &req->tproc, &req->proxy, req->remote_index);
         if (req->event_active) {
             /* delete the timeout event */
             prte_event_del(&req->ev);
@@ -1847,6 +1918,7 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
         cnt = ninfo;
         if (PMIX_SUCCESS != (prc = PMIx_Data_unpack(NULL, buffer, info, &cnt, PMIX_INFO))) {
             PMIX_ERROR_LOG(prc);
+            PMIX_INFO_FREE(info, ninfo);
             return;
         }
     }
@@ -1938,6 +2010,10 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
         pmix_asprintf(&req->operation, "DMDX: %s:%d", __FILE__, __LINE__);
         req->proxy = *sender;
         memcpy(&req->tproc, &pproc, sizeof(pmix_proc_t));
+        /* this array was unpacked off the wire, so it is ours to free -
+         * unlike the one a local client's dmodex borrows from PMIx, which
+         * is why the destructor frees only what "copy" claims */
+        req->copy = true;
         req->info = info;
         req->ninfo = ninfo;
         if (NULL != key) {
@@ -1977,16 +2053,22 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
     if (NULL == proc) {
         /* this is truly an error, so notify the sender */
         send_error(PRTE_ERR_NOT_FOUND, &pproc, sender, index);
+        if (NULL != info) {
+            PMIX_INFO_FREE(info, ninfo);
+        }
         if (NULL != key) {
-          free(key);
+            free(key);
         }
         return;
     }
     if (!PRTE_FLAG_TEST(proc, PRTE_PROC_FLAG_LOCAL)) {
         /* send back an error - they obviously have made a mistake */
         send_error(PRTE_ERR_NOT_FOUND, &pproc, sender, index);
+        if (NULL != info) {
+            PMIX_INFO_FREE(info, ninfo);
+        }
         if (NULL != key) {
-          free(key);
+            free(key);
         }
         return;
     }
@@ -2018,6 +2100,7 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
             pmix_asprintf(&req->operation, "DMDX: %s:%d", __FILE__, __LINE__);
             req->proxy = *sender;
             memcpy(&req->tproc, &pproc, sizeof(pmix_proc_t));
+            req->copy = true;  // unpacked here, so ours to free
             req->info = info;
             req->ninfo = ninfo;
             req->key = key;
@@ -2062,6 +2145,7 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
     pmix_asprintf(&req->operation, "DMDX: %s:%d", __FILE__, __LINE__);
     req->proxy = *sender;
     memcpy(&req->tproc, &pproc, sizeof(pmix_proc_t));
+    req->copy = true;  // unpacked here, so ours to free
     req->info = info;
     req->ninfo = ninfo;
     req->remote_index = index;
@@ -2094,6 +2178,8 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
         pmix_pointer_array_set_item(&prte_pmix_server_globals.remote_reqs, req->local_index, NULL);
         rc = prte_pmix_convert_status(prc);
         send_error(rc, &pproc, sender, index);
+        /* nobody holds it now - the server never took it */
+        PMIX_RELEASE(req);
         return;
     }
     return;
@@ -2102,7 +2188,9 @@ static void pmix_server_dmdx_recv(int status, pmix_proc_t *sender,
 typedef struct {
     pmix_object_t super;
     char *data;
-    int32_t ndata;
+    /* the payload size as it came off the wire and as the modex callback
+     * takes it - a size_t at both ends, so do not narrow it here */
+    size_t ndata;
 } datacaddy_t;
 static void dccon(datacaddy_t *p)
 {
@@ -2170,25 +2258,32 @@ static void pmix_server_dmdx_resp(int status, pmix_proc_t *sender,
         return;
     }
 
-    /* unload the remainder of the buffer */
+    /* Unload the remainder of the buffer.  We know which request this
+     * answers by now, so a failure here is reported to it rather than
+     * dropped: returning in silence leaves the client that asked blocked
+     * in PMIx_Get with nothing left to wake it. */
     if (PMIX_SUCCESS == pret) {
         cnt = 1;
         if (PMIX_SUCCESS != (prc = PMIx_Data_unpack(NULL, buffer, &psz, &cnt, PMIX_SIZE))) {
             PMIX_ERROR_LOG(prc);
-            PMIX_RELEASE(d);
-            return;
+            pret = prc;
+            psz = 0;
         }
-        if (0 < psz) {
-            d->ndata = psz;
+        if (PMIX_SUCCESS == pret && 0 < psz) {
             d->data = (char *) malloc(psz);
             if (NULL == d->data) {
                 PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
-            }
-            cnt = psz;
-            if (PMIX_SUCCESS != (prc = PMIx_Data_unpack(NULL, buffer, d->data, &cnt, PMIX_BYTE))) {
-                PMIX_ERROR_LOG(prc);
-                PMIX_RELEASE(d);
-                return;
+                pret = PMIX_ERR_NOMEM;
+            } else {
+                d->ndata = psz;
+                cnt = psz;
+                if (PMIX_SUCCESS != (prc = PMIx_Data_unpack(NULL, buffer, d->data, &cnt, PMIX_BYTE))) {
+                    PMIX_ERROR_LOG(prc);
+                    free(d->data);
+                    d->data = NULL;
+                    d->ndata = 0;
+                    pret = prc;
+                }
             }
         }
     }
@@ -2213,6 +2308,17 @@ static void pmix_server_dmdx_resp(int status, pmix_proc_t *sender,
     for (n = 0; n < prte_pmix_server_globals.local_reqs.size; n++) {
         req = (prte_pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, n);
         if (NULL == req) {
+            continue;
+        }
+        /* Only requests that name a target proc can be waiting on this
+         * answer.  local_reqs also holds the operations that name none -
+         * monitor, publish/lookup, spawn, tool connection - and their
+         * tproc is the {"", PMIX_RANK_INVALID} sentinel, whose empty
+         * nspace is PMIx's wildcard and matches every namespace.  Without
+         * this guard such a request is completed and released by somebody
+         * else's modex reply, and whoever was actually waiting on it waits
+         * for the life of the DVM. */
+        if (PMIX_NSPACE_INVALID(req->tproc.nspace)) {
             continue;
         }
         if (PMIX_CHECK_PROCID(&req->tproc, &pproc)) {
@@ -2575,6 +2681,40 @@ static void send_alloc_resp(pmix_status_t status,
     PRTE_PMIX_THREADSHIFT(cd, prte_event_base, _send_alloc_resp);
 }
 
+/* Answer a relayed scheduler request that we could not even parse.
+ *
+ * The requesting daemon is holding a tracker under the index it sent us and
+ * nothing else will ever complete it, so an error reply is the only thing
+ * that releases its client - dropping the request in silence leaves that
+ * client blocked for the life of the DVM.  The reply carries just the status
+ * and the index, which is all pmix_server_alloc_request_resp() reads when
+ * the status is not success. */
+static void send_sched_error(pmix_proc_t *dest, int refid, pmix_status_t st)
+{
+    pmix_data_buffer_t *reply;
+    pmix_status_t prc;
+    int rc;
+
+    PMIX_DATA_BUFFER_CREATE(reply);
+    prc = PMIx_Data_pack(NULL, reply, &st, 1, PMIX_STATUS);
+    if (PMIX_SUCCESS != prc) {
+        PMIX_ERROR_LOG(prc);
+        PMIX_DATA_BUFFER_RELEASE(reply);
+        return;
+    }
+    prc = PMIx_Data_pack(NULL, reply, &refid, 1, PMIX_INT);
+    if (PMIX_SUCCESS != prc) {
+        PMIX_ERROR_LOG(prc);
+        PMIX_DATA_BUFFER_RELEASE(reply);
+        return;
+    }
+    PRTE_RML_RELIABLE_SEND(rc, dest->rank, reply, PRTE_RML_TAG_SCHED_RESP);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(reply);
+    }
+}
+
 /* release the one-element context-id result once it has been packed */
 static void ctxid_relfn(void *cbdata)
 {
@@ -2799,8 +2939,15 @@ static void pmix_server_sched(int status, pmix_proc_t *sender,
 
 reply:
     if (NULL == req) {
-        // cannot send a response
-        pmix_output(0, "Unable to process/relay the scheduler controller command");
+        /* We never got far enough to build a tracker, but every path that
+         * arrives here has already unpacked the requestor's index - so we
+         * can still answer, and must: the daemon that relayed this to us is
+         * holding a request under that index on behalf of a blocked client. */
+        pmix_output_verbose(2, prte_pmix_server_globals.output,
+                            "%s unable to parse relayed scheduler command from %s: %s",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(sender),
+                            PMIx_Error_string(rc));
+        send_sched_error(sender, refid, rc);
         if (0 < ninfo) {
             PMIX_INFO_FREE(info, ninfo);
         }
@@ -2920,6 +3067,13 @@ static void rqcon(prte_pmix_server_req_t *p)
     p->range = PMIX_RANGE_SESSION;
     p->proxy = *PRTE_NAME_INVALID;
     p->target = *PRTE_NAME_INVALID;
+    /* PMIX_NEW mallocs - it does not zero - so a field the constructor
+     * forgets is heap garbage, and this is the field almost every request
+     * lookup in this directory matches on.  An operation that names no
+     * target proc (monitor, publish/lookup, spawn, tool connection) leaves
+     * it as we set it here, and the sentinel's empty nspace is what the
+     * "does this request name a target at all" guards test for. */
+    p->tproc = *PRTE_NAME_INVALID;
     p->procs = NULL;
     p->nprocs = 0;
     p->jdata = NULL;
@@ -2954,6 +3108,12 @@ static void rqdes(prte_pmix_server_req_t *p)
     }
     if (NULL != p->cmdline) {
         free(p->cmdline);
+    }
+    /* the modex payload, if we still hold one: _mdxresp frees it as it
+     * packs and clears the pointer, so what survives to here is a reply
+     * that was never sent */
+    if (NULL != p->data) {
+        free(p->data);
     }
     if (NULL != p->key) {
         free(p->key);

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -3085,6 +3085,12 @@ static void rqcon(prte_pmix_server_req_t *p)
     p->sz = 0;
     p->ndaemons = 0;
     p->nreported = 0;
+    p->nsuccess = 0;
+    /* constructed, deliberately not initialized: an empty bitmap is usable
+     * and set_bit grows it from nothing, so a request that never fans out
+     * pays nothing for carrying these */
+    PMIX_CONSTRUCT(&p->expected_dmns, pmix_bitmap_t);
+    PMIX_CONSTRUCT(&p->reported_dmns, pmix_bitmap_t);
     p->range = PMIX_RANGE_SESSION;
     p->proxy = *PRTE_NAME_INVALID;
     p->target = *PRTE_NAME_INVALID;
@@ -3143,6 +3149,8 @@ static void rqdes(prte_pmix_server_req_t *p)
         PMIX_RELEASE(p->jdata);
     }
     PMIX_DATA_BUFFER_DESTRUCT(&p->msg);
+    PMIX_DESTRUCT(&p->expected_dmns);
+    PMIX_DESTRUCT(&p->reported_dmns);
 }
 PMIX_CLASS_INSTANCE(prte_pmix_server_req_t,
                     pmix_object_t,

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -726,27 +726,27 @@ void prte_pmix_server_clear(pmix_proc_t *pname)
  * to cleanup after any tools once they depart */
 static void _lost_conn(int sd, short args, void *cbdata)
 {
-     prte_pmix_server_op_caddy_t *cd = (prte_pmix_server_op_caddy_t*)cbdata;
-     prte_job_t *jdata;
-     PRTE_HIDE_UNUSED_PARAMS(sd, args);
+    prte_pmix_server_op_caddy_t *cd = (prte_pmix_server_op_caddy_t*)cbdata;
+    prte_job_t *jdata;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
-     // check the source to see if it is a client or tool
-     jdata = prte_get_job_data_object(cd->proc.nspace);
-     if (NULL != jdata && !PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL)) {
+    // check the source to see if it is a client or tool
+    jdata = prte_get_job_data_object(cd->proc.nspace);
+    if (NULL != jdata && !PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL)) {
         // client - do nothing, the ODLS will see it go away
         goto complete;
-     }
+    }
 
-     // Either a tool, or a peer we hold no job object for - which on a
-     // daemon other than the master is what a tool looks like, since only
-     // the master keeps one. Not knowing the job is therefore not a reason
-     // to do nothing here; prte_pmix_server_tool_departed() decides, and on
-     // the master it re-checks the TOOL flag before acting.
-     //
-     // A tool isn't a child of ours, so we cannot see a waitpid fire: this
-     // is the only notice we get that a tool has dropped without finalizing
-     // (a clean finalize arrives as the client_finalized upcall instead).
-     prte_pmix_server_tool_departed(&cd->proc);
+    // Either a tool, or a peer we hold no job object for - which on a
+    // daemon other than the master is what a tool looks like, since only
+    // the master keeps one. Not knowing the job is therefore not a reason
+    // to do nothing here; prte_pmix_server_tool_departed() decides, and on
+    // the master it re-checks the TOOL flag before acting.
+    //
+    // A tool isn't a child of ours, so we cannot see a waitpid fire: this
+    // is the only notice we get that a tool has dropped without finalizing
+    // (a clean finalize arrives as the client_finalized upcall instead).
+    prte_pmix_server_tool_departed(&cd->proc);
 
 complete:
     // progress the PMIx event notification chain
@@ -758,25 +758,25 @@ complete:
 
 static void lost_connection_hdlr(size_t evhdlr_registration_id, pmix_status_t status,
                                  const pmix_proc_t *source, pmix_info_t info[], size_t ninfo,
-                                 pmix_info_t *results, size_t nresults,
-                                 pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
+                                pmix_info_t *results, size_t nresults,
+                                pmix_event_notification_cbfunc_fn_t cbfunc, void *cbdata)
 {
-     prte_pmix_server_op_caddy_t *cd;
-     PRTE_HIDE_UNUSED_PARAMS(evhdlr_registration_id);
+    prte_pmix_server_op_caddy_t *cd;
+    PRTE_HIDE_UNUSED_PARAMS(evhdlr_registration_id);
 
-     // need to threadshift this into our own progress thread
-     cd = PMIX_NEW(prte_pmix_server_op_caddy_t);
-     cd->status = status;
-     memcpy(&cd->proc, source, sizeof(pmix_proc_t));
-     cd->info = info;
-     cd->ninfo = ninfo;
-     cd->directives = results;
-     cd->ndirs = nresults;
-     cd->evcbfunc = cbfunc;
-     cd->cbdata = cbdata;
-     prte_event_set(prte_event_base, &(cd->ev), -1, PRTE_EV_WRITE, _lost_conn, cd);
-     PMIX_POST_OBJECT(cd);
-     prte_event_active(&(cd->ev), PRTE_EV_WRITE, 1);
+    // need to threadshift this into our own progress thread
+    cd = PMIX_NEW(prte_pmix_server_op_caddy_t);
+    cd->status = status;
+    memcpy(&cd->proc, source, sizeof(pmix_proc_t));
+    cd->info = info;
+    cd->ninfo = ninfo;
+    cd->directives = results;
+    cd->ndirs = nresults;
+    cd->evcbfunc = cbfunc;
+    cd->cbdata = cbdata;
+    prte_event_set(prte_event_base, &(cd->ev), -1, PRTE_EV_WRITE, _lost_conn, cd);
+    PMIX_POST_OBJECT(cd);
+    prte_event_active(&(cd->ev), PRTE_EV_WRITE, 1);
 }
 
 static void regcbfunc(pmix_status_t status, size_t ref, void *cbdata)
@@ -1002,13 +1002,13 @@ int pmix_server_init(void)
     }
 
     /* tell the server whether or not to drop a session-level PMIx connection point */
-   PMIX_INFO_LIST_ADD(prc, ilist, PMIX_SERVER_SESSION_SUPPORT,
-                      &prte_pmix_server_globals.session_server, PMIX_BOOL);
-   if (PMIX_SUCCESS != prc) {
-       PMIX_INFO_LIST_RELEASE(ilist);
-       rc = prte_pmix_convert_status(prc);
-       return rc;
-   }
+    PMIX_INFO_LIST_ADD(prc, ilist, PMIX_SERVER_SESSION_SUPPORT,
+                       &prte_pmix_server_globals.session_server, PMIX_BOOL);
+    if (PMIX_SUCCESS != prc) {
+        PMIX_INFO_LIST_RELEASE(ilist);
+        rc = prte_pmix_convert_status(prc);
+        return rc;
+    }
 
     if (PRTE_PROC_IS_MASTER) {
         // mark ourselves as a gateway server
@@ -1045,23 +1045,23 @@ int pmix_server_init(void)
          * PMIx connection point - only do this for the HNP as, in
          * at least one case, a daemon can be colocated with the
          * HNP and would overwrite the server rendezvous file */
-       PMIX_INFO_LIST_ADD(prc, ilist, PMIX_SERVER_SYSTEM_SUPPORT,
-                          (void*)&prte_pmix_server_globals.system_server, PMIX_BOOL);
-       if (PMIX_SUCCESS != prc) {
-           PMIX_INFO_LIST_RELEASE(ilist);
-           rc = prte_pmix_convert_status(prc);
-           return rc;
-       }
+        PMIX_INFO_LIST_ADD(prc, ilist, PMIX_SERVER_SYSTEM_SUPPORT,
+                           (void*)&prte_pmix_server_globals.system_server, PMIX_BOOL);
+        if (PMIX_SUCCESS != prc) {
+            PMIX_INFO_LIST_RELEASE(ilist);
+            rc = prte_pmix_convert_status(prc);
+            return rc;
+        }
 
         // tell if they want to allow tools from other users
-       flag = !prte_pmix_server_globals.no_foreign_tools;
-       PMIX_INFO_LIST_ADD(prc, ilist, PMIX_SERVER_ALLOW_FOREIGN_TOOLS,
-                          (void*)&flag, PMIX_BOOL);
-       if (PMIX_SUCCESS != prc) {
-           PMIX_INFO_LIST_RELEASE(ilist);
-           rc = prte_pmix_convert_status(prc);
-           return rc;
-       }
+        flag = !prte_pmix_server_globals.no_foreign_tools;
+        PMIX_INFO_LIST_ADD(prc, ilist, PMIX_SERVER_ALLOW_FOREIGN_TOOLS,
+                           (void*)&flag, PMIX_BOOL);
+        if (PMIX_SUCCESS != prc) {
+            PMIX_INFO_LIST_RELEASE(ilist);
+            rc = prte_pmix_convert_status(prc);
+            return rc;
+        }
 
         /* if requested and persistent, tell the server that we are the system
          * controller - don't do this for the non-persistent mode */
@@ -1131,13 +1131,13 @@ int pmix_server_init(void)
     }
 
     /* tell if we allow remote tool connections */
-     PMIX_INFO_LIST_ADD(prc, ilist, PMIX_SERVER_REMOTE_CONNECTIONS,
+    PMIX_INFO_LIST_ADD(prc, ilist, PMIX_SERVER_REMOTE_CONNECTIONS,
                        (void*)&prte_pmix_server_globals.remote_connections, PMIX_BOOL);
-     if (PMIX_SUCCESS != prc) {
-         PMIX_INFO_LIST_RELEASE(ilist);
-         rc = prte_pmix_convert_status(prc);
-         return rc;
-     }
+    if (PMIX_SUCCESS != prc) {
+        PMIX_INFO_LIST_RELEASE(ilist);
+        rc = prte_pmix_convert_status(prc);
+        return rc;
+    }
 
     PMIX_INFO_LIST_ADD(prc, ilist, PMIX_ALLOW_CLIENT_CLONES,
                       (void*)&prte_pmix_server_globals.allow_client_clones, PMIX_BOOL);
@@ -1159,7 +1159,7 @@ int pmix_server_init(void)
             rc = prte_pmix_convert_status(prc);
             return rc;
         }
-     }
+    }
 
     /* tell the server what we are doing with FQDN */
     PMIX_INFO_LIST_ADD(prc, ilist, PMIX_HOSTNAME_KEEP_FQDN, &prte_keep_fqdn_hostnames, PMIX_BOOL);
@@ -2786,12 +2786,12 @@ static void pmix_server_sched(int status, pmix_proc_t *sender,
     /* a group context-id request carries no field of its own - see the
      * matching pack in prte_server_send_request() */
 
-   /* unpack the number of info */
-   cnt = 1;
-   rc = PMIx_Data_unpack(NULL, buffer, &ninfo, &cnt, PMIX_SIZE);
+    /* unpack the number of info */
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &ninfo, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-            goto reply;
+        goto reply;
     }
 
     /* Need to add the requestor's ID to the info array, so allocate one
@@ -3140,7 +3140,7 @@ static void psdes(prte_pmix_server_pset_t *p)
         free(p->name);
     }
     if (NULL != p->jdata) {
-     PMIX_RELEASE(p->jdata);
+        PMIX_RELEASE(p->jdata);
     }
     if (NULL != p->members) {
         free(p->members);

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -2290,12 +2290,25 @@ static void pmix_server_dmdx_resp(int status, pmix_proc_t *sender,
 
     /* get the request out of the tracking array */
     req = (prte_pmix_server_req_t*)pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, index);
+    /* The index arrived on the wire, and the slot it names is reused the
+     * moment its previous occupant is retired - so a response that crossed
+     * with a retirement can name a live request of an entirely different
+     * kind.  local_reqs holds the scheduler relays too, and completing one
+     * of those here would retire it without answering the daemon waiting on
+     * it.  mdxcbfunc is the discriminator: PRTE_DMX_REQ is the only thing
+     * that builds a direct-modex request and it always sets one, and no
+     * other operation sets it at all. */
+    if (NULL != req && NULL == req->mdxcbfunc) {
+        pmix_output_verbose(2, prte_pmix_server_globals.output,
+                            "%s dmdx response for index %d found a %s request - dropping it",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), index,
+                            (NULL == req->operation) ? "non-modex" : req->operation);
+        req = NULL;
+    }
     /* return the returned data to the requestor */
     if (NULL != req) {
-        if (NULL != req->mdxcbfunc) {
-            PMIX_RETAIN(d);
-            req->mdxcbfunc(pret, d->data, d->ndata, req->cbdata, relcbfunc, d);
-        }
+        PMIX_RETAIN(d);
+        req->mdxcbfunc(pret, d->data, d->ndata, req->cbdata, relcbfunc, d);
         pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, index, NULL);
         PMIX_RELEASE(req);
     } else {
@@ -2310,22 +2323,30 @@ static void pmix_server_dmdx_resp(int status, pmix_proc_t *sender,
         if (NULL == req) {
             continue;
         }
-        /* Only requests that name a target proc can be waiting on this
-         * answer.  local_reqs also holds the operations that name none -
-         * monitor, publish/lookup, spawn, tool connection - and their
-         * tproc is the {"", PMIX_RANK_INVALID} sentinel, whose empty
-         * nspace is PMIx's wildcard and matches every namespace.  Without
-         * this guard such a request is completed and released by somebody
-         * else's modex reply, and whoever was actually waiting on it waits
-         * for the life of the DVM. */
-        if (PMIX_NSPACE_INVALID(req->tproc.nspace)) {
+        /* Only a direct-modex request can be waiting on this answer, and
+         * mdxcbfunc is what says one is: PRTE_DMX_REQ is the sole builder
+         * of them and always sets it, while nothing else does.  Everything
+         * else in local_reqs is matched here purely by accident of tproc
+         * and would be retired without ever being answered.
+         *
+         * Two different kinds of entry get caught without this test.  The
+         * operations that name no target at all - monitor, publish/lookup,
+         * spawn, tool connection - carry the {"", PMIX_RANK_INVALID}
+         * sentinel, and an empty nspace is PMIx's wildcard, so they match
+         * every namespace.  Worse, the scheduler relays - allocate,
+         * session control, group context id - deliberately record the
+         * REQUESTING proc in tproc, which is a real identity that sails
+         * past a sentinel check: a job-level fetch (rank WILDCARD) for the
+         * requestor's own namespace covers it, and the relayed request is
+         * released while the daemon that sent it, and its client, wait for
+         * the life of the DVM.  For allocate and session control that
+         * release is also one of three on an object built to take two. */
+        if (NULL == req->mdxcbfunc || PMIX_NSPACE_INVALID(req->tproc.nspace)) {
             continue;
         }
         if (PMIX_CHECK_PROCID(&req->tproc, &pproc)) {
-            if (NULL != req->mdxcbfunc) {
-                PMIX_RETAIN(d);
-                req->mdxcbfunc(pret, d->data, d->ndata, req->cbdata, relcbfunc, d);
-            }
+            PMIX_RETAIN(d);
+            req->mdxcbfunc(pret, d->data, d->ndata, req->cbdata, relcbfunc, d);
             pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, n, NULL);
             PMIX_RELEASE(req);
         }

--- a/src/prted/pmix/pmix_server_allocate.c
+++ b/src/prted/pmix/pmix_server_allocate.c
@@ -22,7 +22,8 @@ void pmix_server_alloc_request_resp(int status, pmix_proc_t *sender,
                                     void *cbdata)
 {
 
-    int req_index, cnt;
+    int req_index;
+    int32_t cnt;
     pmix_status_t ret, rc;
     prte_pmix_server_req_t *req;
 
@@ -33,7 +34,12 @@ void pmix_server_alloc_request_resp(int status, pmix_proc_t *sender,
     rc = PMIx_Data_unpack(NULL, buffer, &ret, &cnt, PMIX_STATUS);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        ret = prte_pmix_convert_rc(rc);
+        /* an unpack status is ALREADY a PMIx status, and this is the one we
+         * report to the client.  Running it through prte_pmix_convert_rc -
+         * the PRRTE-to-PMIx direction - matches no PRRTE constant and lands
+         * on the default, so every failure here reached the requestor as a
+         * bare PMIX_ERROR instead of saying what went wrong */
+        ret = rc;
     }
 
     /* we let the above errors fall thru in the vain hope that the req number can
@@ -74,7 +80,8 @@ void pmix_server_alloc_request_resp(int status, pmix_proc_t *sender,
     rc = PMIx_Data_unpack(NULL, buffer, &req->ninfo, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        ret = prte_pmix_convert_rc(rc);
+        ret = rc;
+        req->ninfo = 0;
         goto ANSWER;
     }
 
@@ -89,8 +96,13 @@ void pmix_server_alloc_request_resp(int status, pmix_proc_t *sender,
 
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            ret = prte_pmix_convert_rc(rc);
+            ret = rc;
+            /* free the array rather than just forgetting its size: the
+             * destructor frees req->ninfo entries, so zeroing the count
+             * while leaving the pointer in place loses the whole thing */
+            PMIX_INFO_FREE(req->info, req->ninfo);
             req->ninfo = 0;
+            req->copy = false;
             goto ANSWER;
         }
     }
@@ -193,6 +205,7 @@ pmix_status_t prte_server_send_request(uint8_t cmd, prte_pmix_server_req_t *req)
 {
     pmix_data_buffer_t *buf;
     pmix_status_t rc;
+    int ret;   // the RML answers in PRRTE codes, the packers in PMIx ones
 
     PMIX_DATA_BUFFER_CREATE(buf);
 
@@ -258,12 +271,15 @@ pmix_status_t prte_server_send_request(uint8_t cmd, prte_pmix_server_req_t *req)
         }
     }
 
-    /* send this request to the DVM controller */
-    PRTE_RML_RELIABLE_SEND(rc, PRTE_PROC_MY_HNP->rank, buf, PRTE_RML_TAG_SCHED);
-    if (PRTE_SUCCESS != rc) {
-        PRTE_ERROR_LOG(rc);
+    /* send this request to the DVM controller.  The send answers in PRRTE
+     * codes while everything else here - and this function's own return
+     * type - is a PMIx status, and each caller hands what we return straight
+     * to a client's completion callback, so convert it before it leaves */
+    PRTE_RML_RELIABLE_SEND(ret, PRTE_PROC_MY_HNP->rank, buf, PRTE_RML_TAG_SCHED);
+    if (PRTE_SUCCESS != ret) {
+        PRTE_ERROR_LOG(ret);
         PMIX_DATA_BUFFER_RELEASE(buf);
-        return rc;
+        return prte_pmix_convert_rc(ret);
     }
     return PMIX_SUCCESS;
 }

--- a/src/prted/pmix/pmix_server_connect.c
+++ b/src/prted/pmix/pmix_server_connect.c
@@ -346,8 +346,16 @@ void prte_pmix_server_connection_terminated(prte_proc_t *proc)
             continue;
         }
         if (ntargets + cptr->nmembers > cap) {
+            pmix_proc_t *tmp;
             cap = ntargets + cptr->nmembers;
-            targets = (pmix_proc_t *) realloc(targets, cap * sizeof(pmix_proc_t));
+            tmp = (pmix_proc_t *) realloc(targets, cap * sizeof(pmix_proc_t));
+            if (NULL == tmp) {
+                /* assigning through the same pointer would lose the block we
+                 * already have, and the loop below would then index a NULL */
+                PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+                break;
+            }
+            targets = tmp;
         }
         for (i = 0; i < cptr->nmembers; i++) {
             have = false;
@@ -652,6 +660,12 @@ void prte_pmix_server_connection_recv(int status, pmix_proc_t *sender,
         return;
     }
     PMIX_PROC_CREATE(members, nmembers);
+    if (NULL == members) {
+        /* nmembers came off the wire, so this is reachable by a peer asking
+         * for more than we can hold rather than only by genuine exhaustion */
+        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+        return;
+    }
     cnt = nmembers;
     rc = PMIx_Data_unpack(NULL, buffer, members, &cnt, PMIX_PROC);
     if (PMIX_SUCCESS != rc) {

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -106,6 +106,14 @@ void pmix_server_launch_resp(int status, pmix_proc_t *sender,
     pmix_nspace_t jobid;
     PRTE_HIDE_UNUSED_PARAMS(status, sender, tg, cbdata);
 
+    /* we deliberately continue past a failed unpack below so that the room
+     * number still has a chance of being read - which means the nspace may
+     * never be written.  Give it a defined value first: pmix_server_notify_spawn
+     * hands it straight to prte_get_job_data_object(), which reads it as a
+     * NUL-terminated string, and an unwritten pmix_nspace_t is 256 bytes of
+     * whatever the stack last held */
+    PMIX_LOAD_NSPACE(jobid, NULL);
+
     /* unpack the status - this is already a PMIx value */
     cnt = 1;
     rc = PMIx_Data_unpack(NULL, buffer, &ret, &cnt, PMIX_INT32);
@@ -143,6 +151,10 @@ static void spawn(int sd, short args, void *cbdata)
     pmix_data_buffer_t *buf;
     prte_plm_cmd_flag_t command;
     char nspace[PMIX_MAX_NSLEN + 1];
+    /* the packers answer in PMIx statuses and prte_job_pack and the RML in
+     * PRRTE ones.  They are separate spaces that agree only on success, so
+     * keep them in separate variables: the callback below converts, and it
+     * can only convert what is already known to be a PRRTE code */
     pmix_status_t prc;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
@@ -159,18 +171,19 @@ static void spawn(int sd, short args, void *cbdata)
     PMIX_DATA_BUFFER_CREATE(buf);
 
     command = PRTE_PLM_LAUNCH_JOB_CMD;
-    rc = PMIx_Data_pack(NULL, buf, &command, 1, PMIX_UINT8);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
+    prc = PMIx_Data_pack(NULL, buf, &command, 1, PMIX_UINT8);
+    if (PMIX_SUCCESS != prc) {
+        PMIX_ERROR_LOG(prc);
+        rc = prte_pmix_convert_status(prc);
         PMIX_DATA_BUFFER_RELEASE(buf);
         pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
         goto callback;
     }
 
-    /* pack the jdata object */
+    /* pack the jdata object - answers in PRRTE codes */
     rc = prte_job_pack(buf, req->jdata, PRTE_JOB_PACK_ALL);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
         pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
         PMIX_DATA_BUFFER_RELEASE(buf);
         goto callback;
@@ -220,6 +233,7 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
     int i, m, rc;
     bool flag;
     uint32_t u32;
+    int32_t i32;
     uint16_t u16;
     prte_job_t *djob;
     prte_app_context_t *app;
@@ -411,13 +425,21 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
 
             /***   NUMBER OF PROCS TO SPAWN AT EACH COLOCATION  ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_COLOCATE_NPERPROC)) {
+            PMIX_VALUE_GET_NUMBER(rc, &info->value, u16, uint16_t);
+            if (PMIX_SUCCESS != rc) {
+                return PRTE_ERR_BAD_PARAM;
+            }
             prte_set_attribute(&jdata->attributes, PRTE_JOB_COLOCATE_NPERPROC,
-                               PRTE_ATTR_GLOBAL, &info->value.data.uint16, PMIX_UINT16);
+                               PRTE_ATTR_GLOBAL, &u16, PMIX_UINT16);
 
             /***   NUMBER OF PROCS TO SPAWN AT EACH COLOCATION  ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_COLOCATE_NPERNODE)) {
+            PMIX_VALUE_GET_NUMBER(rc, &info->value, u16, uint16_t);
+            if (PMIX_SUCCESS != rc) {
+                return PRTE_ERR_BAD_PARAM;
+            }
             prte_set_attribute(&jdata->attributes, PRTE_JOB_COLOCATE_NPERNODE,
-                               PRTE_ATTR_GLOBAL, &info->value.data.uint16, PMIX_UINT16);
+                               PRTE_ATTR_GLOBAL, &u16, PMIX_UINT16);
 
             /***   RANK-BY   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_RANKBY)) {
@@ -499,13 +521,17 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
 
             /***   MAX RESTARTS  ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_MAX_RESTARTS)) {
+            PMIX_VALUE_GET_NUMBER(rc, &info->value, i32, int32_t);
+            if (PMIX_SUCCESS != rc) {
+                return PRTE_ERR_BAD_PARAM;
+            }
             for (i = 0; i < jdata->apps->size; i++) {
                 app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, i);
                 if (NULL == app) {
                     continue;
                 }
                 prte_set_attribute(&app->attributes, PRTE_APP_MAX_RESTARTS, PRTE_ATTR_GLOBAL,
-                                   &info->value.data.uint32, PMIX_INT32);
+                                   &i32, PMIX_INT32);
             }
 
            /*** EXEC AGENT ***/
@@ -532,7 +558,10 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
 
             /***   CPUS/RANK   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_CPUS_PER_PROC)) {
-            u16 = info->value.data.uint32;
+            PMIX_VALUE_GET_NUMBER(rc, &info->value, u16, uint16_t);
+            if (PMIX_SUCCESS != rc) {
+                return PRTE_ERR_BAD_PARAM;
+            }
             prte_set_attribute(&jdata->attributes, PRTE_JOB_PES_PER_PROC,
                                PRTE_ATTR_GLOBAL, &u16, PMIX_UINT16);
 
@@ -570,6 +599,9 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
                                PMIX_BOOL);
 
         } else if (PMIX_CHECK_KEY(info, PMIX_PARENT_ID)) {
+            if (NULL == info->value.data.proc) {
+                return PRTE_ERR_BAD_PARAM;
+            }
             PMIX_XFER_PROCID(&jdata->originator, info->value.data.proc);
 
             /***   SPAWN REQUESTOR IS TOOL   ***/
@@ -665,6 +697,9 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
 
             /***   STDIN TARGET   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_STDIN_TGT)) {
+            if (NULL == info->value.data.string) {
+                return PRTE_ERR_BAD_PARAM;
+            }
             if (0 == strcmp(info->value.data.string, "all")) {
                 jdata->stdin_target = PMIX_RANK_WILDCARD;
             } else if (0 == strcmp(info->value.data.string, "none")) {
@@ -691,15 +726,23 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
 
             /***   NUMBER OF DEBUGGER_DAEMONS PER NODE   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_DEBUG_DAEMONS_PER_NODE)) {
+            PMIX_VALUE_GET_NUMBER(rc, &info->value, u16, uint16_t);
+            if (PMIX_SUCCESS != rc) {
+                return PRTE_ERR_BAD_PARAM;
+            }
             PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_TOOL);
             prte_set_attribute(&jdata->attributes, PRTE_JOB_DEBUG_DAEMONS_PER_NODE,
-                               PRTE_ATTR_GLOBAL, &info->value.data.uint16, PMIX_UINT16);
+                               PRTE_ATTR_GLOBAL, &u16, PMIX_UINT16);
 
             /***   NUMBER OF DEBUGGER_DAEMONS PER PROC   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_DEBUG_DAEMONS_PER_PROC)) {
+            PMIX_VALUE_GET_NUMBER(rc, &info->value, u16, uint16_t);
+            if (PMIX_SUCCESS != rc) {
+                return PRTE_ERR_BAD_PARAM;
+            }
             PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_TOOL);
             prte_set_attribute(&jdata->attributes, PRTE_JOB_DEBUG_DAEMONS_PER_PROC,
-                               PRTE_ATTR_GLOBAL, &info->value.data.uint16, PMIX_UINT16);
+                               PRTE_ATTR_GLOBAL, &u16, PMIX_UINT16);
 
         } else if (PMIX_CHECK_KEY(info, PMIX_ENVARS_HARVESTED)) {
             prte_set_attribute(&jdata->attributes, PRTE_JOB_ENVARS_HARVESTED,
@@ -742,6 +785,13 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
         } else if (PMIX_CHECK_KEY(info, PMIX_SPAWN_TIMEOUT) ||
                    PMIX_CHECK_KEY(info, PMIX_TIMEOUT)) {
             if (PMIX_STRING == info->value.type) {
+                /* PMIX_CONVERT_TIME indexes the split it makes without
+                 * checking that there was anything to split, so a NULL
+                 * string - which PMIX_INFO_LOAD produces for a PMIX_STRING
+                 * loaded with no value - faults inside it */
+                if (NULL == info->value.data.string) {
+                    return PRTE_ERR_BAD_PARAM;
+                }
                 rc = PMIX_CONVERT_TIME(info->value.data.string);
             } else {
                 PMIX_VALUE_GET_NUMBER(i, &info->value, rc, int);
@@ -754,6 +804,13 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
 
         } else if (PMIX_CHECK_KEY(info, PMIX_JOB_TIMEOUT)) {
             if (PMIX_STRING == info->value.type) {
+                /* PMIX_CONVERT_TIME indexes the split it makes without
+                 * checking that there was anything to split, so a NULL
+                 * string - which PMIX_INFO_LOAD produces for a PMIX_STRING
+                 * loaded with no value - faults inside it */
+                if (NULL == info->value.data.string) {
+                    return PRTE_ERR_BAD_PARAM;
+                }
                 rc = PMIX_CONVERT_TIME(info->value.data.string);
             } else {
                 PMIX_VALUE_GET_NUMBER(i, &info->value, rc, int);
@@ -809,6 +866,7 @@ int prte_pmix_xfer_app(prte_job_t *jdata, pmix_app_t *papp)
     pmix_info_t *info;
     size_t m;
     int rc;
+    pmix_status_t prc;
     bool flag;
     pmix_envar_t envar;
     char cwd[PRTE_PATH_MAX];
@@ -865,12 +923,27 @@ int prte_pmix_xfer_app(prte_job_t *jdata, pmix_app_t *papp)
                                        info->value.data.string, PMIX_STRING);
 
             } else if (PMIX_CHECK_KEY(info, PMIX_WDIR)) {
+                if (NULL == info->value.data.string) {
+                    return PRTE_ERR_BAD_PARAM;
+                }
+                /* papp->cwd may already have given us one, and this directive
+                 * overrides it - so let go of the old value rather than
+                 * stranding it */
+                if (NULL != app->cwd) {
+                    free(app->cwd);
+                    app->cwd = NULL;
+                }
                 /* if this is a relative path, convert it to an absolute path */
                 if (pmix_path_is_absolute(info->value.data.string)) {
                     app->cwd = strdup(info->value.data.string);
                 } else {
-                    /* get the cwd */
-                    if (PRTE_SUCCESS != (rc = pmix_getcwd(cwd, sizeof(cwd)))) {
+                    /* get the cwd.  pmix_getcwd answers in PMIx statuses and
+                     * we answer in PRRTE codes, so convert rather than hand
+                     * our caller a code from the wrong space - it converts
+                     * what we return on the way back out to the client */
+                    prc = pmix_getcwd(cwd, sizeof(cwd));
+                    if (PMIX_SUCCESS != prc) {
+                        rc = prte_pmix_convert_status(prc);
                         prte_show_help("help-prted.txt", "cwd", true, "spawn", rc);
                         /* jdata belongs to our caller - it constructed it and
                          * will dispose of it on our error return.  Releasing
@@ -1089,6 +1162,8 @@ static void interim(int sd, short args, void *cbdata)
     prte_schizo_base_module_t *schizo;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
+    PMIX_ACQUIRE_OBJECT(cd);
+
     pmix_output_verbose(2, prte_pmix_server_globals.output,
                         "%s spawn called from proc %s with %d apps",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(requestor),
@@ -1227,9 +1302,9 @@ complete:
     PMIX_RELEASE(cd);
 }
 
-int pmix_server_spawn_fn(const pmix_proc_t *proc, const pmix_info_t job_info[], size_t ninfo,
-                         const pmix_app_t apps[], size_t napps, pmix_spawn_cbfunc_t cbfunc,
-                         void *cbdata)
+pmix_status_t pmix_server_spawn_fn(const pmix_proc_t *proc, const pmix_info_t job_info[],
+                                   size_t ninfo, const pmix_app_t apps[], size_t napps,
+                                   pmix_spawn_cbfunc_t cbfunc, void *cbdata)
 {
     prte_pmix_server_op_caddy_t *cd;
 
@@ -1248,7 +1323,7 @@ int pmix_server_spawn_fn(const pmix_proc_t *proc, const pmix_info_t job_info[], 
     prte_event_set(prte_event_base, &cd->ev, -1, PRTE_EV_WRITE, interim, cd);
     PMIX_POST_OBJECT(cd);
     prte_event_active(&cd->ev, PRTE_EV_WRITE, 1);
-    return PRTE_SUCCESS;
+    return PMIX_SUCCESS;
 }
 
 // modex callback func for connect
@@ -1264,7 +1339,7 @@ static void connect_release(pmix_status_t status,
     pmix_proc_t *procID;
     pmix_nspace_t *nspace;
     pmix_status_t rc;
-    int cnt;
+    int32_t cnt;
 
     PMIX_ACQUIRE_OBJECT(md);
 
@@ -1278,9 +1353,12 @@ static void connect_release(pmix_status_t status,
         /* prep for unpacking */
         bo.bytes = (char*)data;
         bo.size = sz;
+        /* PMIx_Data_embed COPIES the payload into pbkt, so pbkt owns heap of
+         * its own from here on and every exit below has to destruct it */
         PMIX_DATA_BUFFER_CONSTRUCT(&pbkt);
         rc = PMIx_Data_embed(&pbkt, &bo);
         if (PMIX_SUCCESS != rc) {
+            PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
             goto release;
         }
         // the payload consists of packed info containing
@@ -1321,6 +1399,7 @@ static void connect_release(pmix_status_t status,
         } else {
             rc = PMIX_SUCCESS;
         }
+        PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
     }
 
 release:

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -626,7 +626,7 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
             prte_set_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT, PRTE_ATTR_GLOBAL, &flag,
                                PMIX_BOOL);
 
-            /*** DETAILED OIUTPUT TAG */
+            /*** DETAILED OUTPUT TAG */
         } else if (PMIX_CHECK_KEY(info, PMIX_IOF_TAG_DETAILED_OUTPUT)) {
             flag = PMIX_INFO_TRUE(info);
             prte_set_attribute(&jdata->attributes, PRTE_JOB_TAG_OUTPUT_DETAILED,
@@ -1025,9 +1025,9 @@ int prte_pmix_xfer_app(prte_job_t *jdata, pmix_app_t *papp)
                         prte_set_attribute(&app->attributes, PRTE_APP_PES_PER_PROC,
                                            PRTE_ATTR_GLOBAL, &pes, PMIX_UINT16);
                     }
-                } 
+                }
                 PMIx_Argv_free(ck);
- 
+
                 /***   REQUESTED MAPPER (per-app) - no longer supported   ***/
             } else if (PMIX_CHECK_KEY(info, PMIX_MAPPER)) {
                 /* see prte_pmix_xfer_job_info(): the mapping policy is the
@@ -1382,7 +1382,7 @@ static void connect_release(pmix_status_t status,
             } else if (PMIX_CHECK_KEY(&infostat, PMIX_JOB_INFO_ARRAY)) {
                 // contains an array of job-level info
                 info = (pmix_info_t*)infostat.value.data.darray->array;
-                // npace is in first place
+                // nspace is in first place
                 nspace = info[0].value.data.nspace;
                 // register this data
                 rc = PMIx_server_register_nspace(*nspace, -1, &infostat, 1, NULL, NULL);

--- a/src/prted/pmix/pmix_server_fence.c
+++ b/src/prted/pmix/pmix_server_fence.c
@@ -164,6 +164,15 @@ static void dmodex_req(int sd, short args, void *cbdata)
         if (NULL == r) {
             continue;
         }
+        /* ...and only against an entry that names one at all.  An operation
+         * with no target proc carries the {"", PMIX_RANK_INVALID} sentinel,
+         * and an empty nspace matches everything - so a job-level fetch
+         * (rank=WILDCARD) would pair with the first monitor or publish
+         * request in the array and be parked behind an answer that is never
+         * coming. */
+        if (PMIX_NSPACE_INVALID(r->tproc.nspace)) {
+            continue;
+        }
         if (PMIX_CHECK_PROCID(&r->tproc, &req->tproc)) {
             /* save the request in the array until the
              * data is returned */

--- a/src/prted/pmix/pmix_server_fence.c
+++ b/src/prted/pmix/pmix_server_fence.c
@@ -371,14 +371,14 @@ static void dmodex_req(int sd, short args, void *cbdata)
         goto callback;
     }
     /* add any qualifiers */
-    if (PRTE_SUCCESS != (prc = PMIx_Data_pack(NULL, buf, &req->ninfo, 1, PMIX_SIZE))) {
+    if (PMIX_SUCCESS != (prc = PMIx_Data_pack(NULL, buf, &req->ninfo, 1, PMIX_SIZE))) {
         PMIX_ERROR_LOG(prc);
         pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
         PMIX_DATA_BUFFER_RELEASE(buf);
         goto callback;
     }
     if (0 < req->ninfo) {
-        if (PRTE_SUCCESS != (prc = PMIx_Data_pack(NULL, buf, req->info, req->ninfo, PMIX_INFO))) {
+        if (PMIX_SUCCESS != (prc = PMIx_Data_pack(NULL, buf, req->info, req->ninfo, PMIX_INFO))) {
             PMIX_ERROR_LOG(prc);
             pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
             PMIX_DATA_BUFFER_RELEASE(buf);

--- a/src/prted/pmix/pmix_server_gen.c
+++ b/src/prted/pmix/pmix_server_gen.c
@@ -190,7 +190,7 @@ pmix_status_t pmix_server_client_connected2_fn(const pmix_proc_t *proc,
     PMIX_POST_OBJECT(cd);
     prte_event_active(&(cd->ev), PRTE_EV_WRITE, 1);
 
-    return PRTE_SUCCESS;
+    return PMIX_SUCCESS;
 }
 
 /* Report that a tool has left us.
@@ -290,7 +290,7 @@ pmix_status_t pmix_server_client_finalized_fn(const pmix_proc_t *proc, void *ser
     PRTE_SERVER_PMIX_THREADSHIFT(proc, server_object, PRTE_SUCCESS,
                           NULL, NULL, 0, _client_finalized,
                           cbfunc, cbdata);
-    return PRTE_SUCCESS;
+    return PMIX_SUCCESS;
 }
 
 /* the fields being passed include:
@@ -326,7 +326,10 @@ static void _client_abort(int sd, short args, void *cbdata)
     prte_job_t *jdata;
     pmix_proc_t pname;
     prte_proc_t *p;
-    pmix_status_t rc;
+    /* the loop below is what normally sets this, and an empty procs array
+     * skips it entirely - release: reads it either way and hands it to the
+     * caller's completion */
+    pmix_status_t rc = PMIX_SUCCESS;
     size_t n;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
@@ -408,7 +411,7 @@ pmix_status_t pmix_server_abort_fn(const pmix_proc_t *proc, void *server_object,
     PRTE_SERVER_PMIX_THREADSHIFT(proc, server_object, status,
                                  msg, procs, nprocs, _client_abort,
                                  cbfunc, cbdata);
-    return PRTE_SUCCESS;
+    return PMIX_SUCCESS;
 }
 
 /* completion of a tool registration - executes on the PRRTE
@@ -421,7 +424,9 @@ static void tconn_reg_complete(pmix_status_t status, void *cbdata)
         PMIX_ERROR_LOG(status);
         // we can live without it
     }
-    req->toolcbfunc(req->pstatus, &req->target, req->cbdata);
+    if (NULL != req->toolcbfunc) {
+        req->toolcbfunc(req->pstatus, &req->target, req->cbdata);
+    }
 
     /* cleanup */
     PMIX_RELEASE(req);
@@ -553,14 +558,31 @@ static void _toolconn(int sd, short args, void *cbdata)
                 nspace_given = true;
 
             } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_RANK)) {
-                cd->target.rank = cd->info[n].value.data.rank;
-                rank_given = true;
+                trc = PMIx_Value_get_number(&cd->info[n].value, (void*)&cd->target.rank,
+                                            PMIX_PROC_RANK);
+                if (PMIX_SUCCESS != trc) {
+                    if (PMIX_SUCCESS == xrc) {
+                        xrc = trc;
+                    }
+                } else {
+                    rank_given = true;
+                }
 
+                /* These two are strings the connecting tool composed, and a
+                 * PMIX_STRING carrying no string survives the wire as a NULL
+                 * (the packer writes a zero length, the unpacker hands back
+                 * NULL) - so strdup'ing it unchecked let any tool segfault the
+                 * daemon it attached to.  A tool may also send the same key
+                 * twice; keep the first rather than stranding it. */
             } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_HOSTNAME)) {
-                cd->operation = strdup(cd->info[n].value.data.string);
+                if (NULL != cd->info[n].value.data.string && NULL == cd->operation) {
+                    cd->operation = strdup(cd->info[n].value.data.string);
+                }
 
             } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_CMD_LINE)) {
-                cd->cmdline = strdup(cd->info[n].value.data.string);
+                if (NULL != cd->info[n].value.data.string && NULL == cd->cmdline) {
+                    cd->cmdline = strdup(cd->info[n].value.data.string);
+                }
 
             } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_LAUNCHER)) {
                 cd->launcher = PMIX_INFO_TRUE(&cd->info[n]);
@@ -608,7 +630,9 @@ static void _toolconn(int sd, short args, void *cbdata)
      * this is not allowed */
     if (cd->scheduler) {
         if (!PRTE_PROC_IS_MASTER) {
-            cd->toolcbfunc(PMIX_ERR_NOT_SUPPORTED, NULL, cd->cbdata);
+            if (NULL != cd->toolcbfunc) {
+                cd->toolcbfunc(PMIX_ERR_NOT_SUPPORTED, NULL, cd->cbdata);
+            }
             PMIX_RELEASE(cd);
             return;
         } else {
@@ -616,7 +640,9 @@ static void _toolconn(int sd, short args, void *cbdata)
             prte_pmix_server_globals.scheduler_connected = true;
             // the scheduler always self-assigns its ID
             if (!nspace_given || !rank_given) {
-                cd->toolcbfunc(PMIX_ERR_NOT_SUPPORTED, NULL, cd->cbdata);
+                if (NULL != cd->toolcbfunc) {
+                    cd->toolcbfunc(PMIX_ERR_NOT_SUPPORTED, NULL, cd->cbdata);
+                }
                 PMIX_RELEASE(cd);
                 return;
             }
@@ -665,58 +691,59 @@ static void _toolconn(int sd, short args, void *cbdata)
     /* not the DVM master, so we have to alert the HNP that
      * a tool has connected to a daemon so the DVM doesn't
      * shut down until the tool has disconnected */
+    /* Every pack below used to log its failure and carry on, which sends the
+     * master a buffer it cannot read: the master then has no index to answer
+     * under, so the tool waits for the life of the DVM.  A relay that cannot
+     * build its request has to fail the request, not ship a truncated one. */
     PMIX_DATA_BUFFER_CREATE(buf);
-    rc = PMIx_Data_pack(NULL, buf, &command, 1, PMIX_UINT8);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
+    xrc = PMIx_Data_pack(NULL, buf, &command, 1, PMIX_UINT8);
+    if (PMIX_SUCCESS != xrc) {
+        goto packfail;
     }
     // record the request and pass the location along
     cd->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, cd);
-    rc = PMIx_Data_pack(NULL, buf, &cd->local_index, 1, PMIX_INT);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
+    xrc = PMIx_Data_pack(NULL, buf, &cd->local_index, 1, PMIX_INT);
+    if (PMIX_SUCCESS != xrc) {
+        goto packfail;
     }
     // flag if we need a jobid assigned
-    rc = PMIx_Data_pack(NULL, buf, &nspace_given, 1, PMIX_BOOL);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
+    xrc = PMIx_Data_pack(NULL, buf, &nspace_given, 1, PMIX_BOOL);
+    if (PMIX_SUCCESS != xrc) {
+        goto packfail;
     }
     // if we do, then pass along the rank so they have it
     if (!nspace_given) {
-        rc = PMIx_Data_pack(NULL, buf, &cd->target.rank, 1, PMIX_PROC_RANK);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-        }
+        xrc = PMIx_Data_pack(NULL, buf, &cd->target.rank, 1, PMIX_PROC_RANK);
     } else {
         // if not, then pass along the full procID
-        rc = PMIx_Data_pack(NULL, buf, &cd->target, 1, PMIX_PROC);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-        }
+        xrc = PMIx_Data_pack(NULL, buf, &cd->target, 1, PMIX_PROC);
+    }
+    if (PMIX_SUCCESS != xrc) {
+        goto packfail;
     }
     // pass along the cmd line
-    rc = PMIx_Data_pack(NULL, buf, &cd->cmdline, 1, PMIX_STRING);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
+    xrc = PMIx_Data_pack(NULL, buf, &cd->cmdline, 1, PMIX_STRING);
+    if (PMIX_SUCCESS != xrc) {
+        goto packfail;
     }
     // and the pid
-    rc = PMIx_Data_pack(NULL, buf, &cd->pid, 1, PMIX_PID);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
+    xrc = PMIx_Data_pack(NULL, buf, &cd->pid, 1, PMIX_PID);
+    if (PMIX_SUCCESS != xrc) {
+        goto packfail;
     }
     // and who is running it - the master records this on the tool's job so a
     // reservation the tool creates can be reached by another command the same
     // user runs. Only the master keeps a job object for a tool, so this is the
     // only chance to tell it.
     u32 = (uint32_t) cd->uid;
-    rc = PMIx_Data_pack(NULL, buf, &u32, 1, PMIX_UINT32);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
+    xrc = PMIx_Data_pack(NULL, buf, &u32, 1, PMIX_UINT32);
+    if (PMIX_SUCCESS != xrc) {
+        goto packfail;
     }
     u32 = (uint32_t) cd->gid;
-    rc = PMIx_Data_pack(NULL, buf, &u32, 1, PMIX_UINT32);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
+    xrc = PMIx_Data_pack(NULL, buf, &u32, 1, PMIX_UINT32);
+    if (PMIX_SUCCESS != xrc) {
+        goto packfail;
     }
 
     /* send it to the HNP for processing - might be myself! */
@@ -725,13 +752,22 @@ static void _toolconn(int sd, short args, void *cbdata)
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
         xrc = prte_pmix_convert_rc(rc);
-        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, cd->local_index, NULL);
-        PMIX_DATA_BUFFER_RELEASE(buf);
-        if (NULL != cd->toolcbfunc) {
-            cd->toolcbfunc(xrc, NULL, cd->cbdata);
-        }
-        PMIX_RELEASE(cd);
+        goto packfail;
     }
+    return;
+
+packfail:
+    PMIX_ERROR_LOG(xrc);
+    PMIX_DATA_BUFFER_RELEASE(buf);
+    /* the slot is only ours from the add above; the constructor leaves it -1 */
+    if (0 <= cd->local_index) {
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs,
+                                    cd->local_index, NULL);
+    }
+    if (NULL != cd->toolcbfunc) {
+        cd->toolcbfunc(xrc, NULL, cd->cbdata);
+    }
+    PMIX_RELEASE(cd);
     return;
 
 
@@ -847,6 +883,8 @@ static void lgcbfn(int sd, short args, void *cbdata)
     prte_pmix_server_op_caddy_t *cd = (prte_pmix_server_op_caddy_t *) cbdata;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
+    PMIX_ACQUIRE_OBJECT(cd);
+
     if (NULL != cd->cbfunc) {
         cd->cbfunc(cd->status, cd->cbdata);
     }
@@ -859,6 +897,8 @@ static void process_log(int sd, short args, void *cbdata)
     pmix_data_buffer_t *buf;
     pmix_status_t rc;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(req);
 
     PMIX_DATA_BUFFER_CREATE(buf);
 
@@ -1165,6 +1205,8 @@ static void pmix_server_stdin_push(int sd, short args, void *cbdata)
     bool backed_up = false;
 #endif
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_ACQUIRE_OBJECT(cd);
 
     /* a client that pushed no data at all leaves us no byte object - PMIx
      * frees it rather than handing us an empty one - and that is precisely

--- a/src/prted/pmix/pmix_server_group.c
+++ b/src/prted/pmix/pmix_server_group.c
@@ -19,7 +19,7 @@
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2020      IBM Corporation.  All rights reserved.
- * Copyright (c) 2021-2025 Nanook Consulting  All rights reserved.
+ * Copyright (c) 2021-2026 Nanook Consulting  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,31 +30,12 @@
 
 #include "prte_config.h"
 
-#ifdef HAVE_UNISTD_H
-#    include <unistd.h>
-#endif
-
-#include "src/hwloc/hwloc-internal.h"
 #include "src/pmix/pmix-internal.h"
-#include "src/util/pmix_argv.h"
 #include "src/util/pmix_output.h"
 
-#include "src/mca/errmgr/errmgr.h"
 #include "src/grpcomm/grpcomm.h"
-#include "src/mca/iof/base/base.h"
-#include "src/mca/iof/iof.h"
-#include "src/mca/plm/base/plm_private.h"
-#include "src/mca/plm/plm.h"
-#include "src/mca/plm/base/plm_private.h"
-#include "src/mca/rmaps/rmaps_types.h"
-#include "src/rml/rml.h"
-#include "src/mca/schizo/schizo.h"
-#include "src/mca/state/state.h"
 #include "src/runtime/prte_globals.h"
-#include "src/runtime/prte_locks.h"
-#include "src/threads/pmix_threads.h"
 #include "src/util/name_fns.h"
-#include "src/util/pmix_show_help.h"
 
 #include "src/prted/pmix/pmix_server_internal.h"
 

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -40,6 +40,7 @@
 #endif
 #include <pmix_server.h>
 
+#include "src/class/pmix_bitmap.h"
 #include "src/class/pmix_hotel.h"
 #include "src/event/event-internal.h"
 #include "src/mca/base/pmix_base.h"
@@ -49,6 +50,7 @@
 #include "src/util/proc_info.h"
 #include "types.h"
 
+#include "src/rml/rml_types.h"
 #include "src/runtime/prte_globals.h"
 #include "src/threads/pmix_threads.h"
 
@@ -92,6 +94,22 @@ typedef struct {
     size_t sz;
     uint32_t ndaemons;
     uint32_t nreported;
+    uint32_t nsuccess;
+    /* Which daemons a fan-out-and-count operation is waiting on, and which
+     * of them have been accounted for.  Both are indexed by daemon vpid and
+     * are used only by the monitor collective; every other request leaves
+     * them as the constructor makes them, which costs nothing - a bitmap is
+     * usable empty and set_bit grows it from nothing.
+     *
+     * Two sets rather than a counter because a daemon failure has to be
+     * accounted exactly once, and a bare count cannot say whether the daemon
+     * that just died had already reported (in which case there is nothing to
+     * adjust) or had not (in which case it never will).  Recording the
+     * identity also makes the accounting idempotent, which it has to be: the
+     * routing tree's fault handler fires twice for every death, once at
+     * LOCAL scope and again at GLOBAL. */
+    pmix_bitmap_t expected_dmns;
+    pmix_bitmap_t reported_dmns;
     pmix_data_range_t range;
     pmix_proc_t proxy;
     pmix_proc_t target;
@@ -355,6 +373,11 @@ PRTE_EXPORT extern pmix_status_t pmix_server_stdin_fn(const pmix_proc_t *source,
                                                       const pmix_info_t directives[], size_t ndirs,
                                                       const pmix_byte_object_t *bo,
                                                       pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+/* Account a daemon departure against every outstanding monitor collective.
+ * Called from the routing tree's fault handler, on the PRRTE progress thread,
+ * once at LOCAL scope and again at GLOBAL for the same death. */
+PRTE_EXPORT void prte_pmix_server_fault_handler(const prte_rml_recovery_status_t *status);
 
 PRTE_EXPORT extern pmix_status_t pmix_server_group_fn(pmix_group_operation_t op, char *gpid,
                                                       const pmix_proc_t procs[], size_t nprocs,

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -486,6 +486,14 @@ pmix_server_session_ctrl_fn(const pmix_proc_t *requestor,
                             const pmix_info_t directives[], size_t ndirs,
                             pmix_info_cbfunc_t cbfunc, void *cbdata);
 
+/* Apply a PMIX_GROUP_LEFT notification to this daemon's copy of the group
+ * registry, dropping the departing proc from the membership we hold. The
+ * info array is the generating client's own and is validated here. Runs on
+ * the PRRTE progress thread; exported so the unit test can reach it. */
+PRTE_EXPORT extern void prte_pmix_server_group_member_left(pmix_status_t code,
+                                                           const pmix_proc_t *source,
+                                                           pmix_info_t *info, size_t ninfo);
+
 /* Interpret a PMIX_ALLOC_TIME session time limit -
  * "[[[[months:]days:]hours:]minutes:]seconds", scanned from the right - and
  * return it in seconds, or -1 if the string is not a well-formed time. */

--- a/src/prted/pmix/pmix_server_job_ctrl.c
+++ b/src/prted/pmix/pmix_server_job_ctrl.c
@@ -65,7 +65,8 @@
 static pmix_status_t process_job_ctrl(const pmix_proc_t *requestor, const pmix_proc_t targets[],
                                       size_t ntargets, const pmix_info_t directives[], size_t ndirs)
 {
-    int rc, j;
+    pmix_status_t rc;
+    int prc, j;
     int32_t signum, ntgts;
     size_t m, n;
     prte_proc_t *proc;
@@ -87,6 +88,9 @@ static pmix_status_t process_job_ctrl(const pmix_proc_t *requestor, const pmix_p
                     if (PMIX_RANK_WILDCARD == targets[n].rank) {
                         /* create an object */
                         proc = PMIX_NEW(prte_proc_t);
+                        if (NULL == proc) {
+                            continue;
+                        }
                         PMIX_LOAD_PROCID(&proc->name, targets[n].nspace, PMIX_RANK_WILDCARD);
                     } else {
                         /* get the proc object for this proc */
@@ -100,8 +104,9 @@ static pmix_status_t process_job_ctrl(const pmix_proc_t *requestor, const pmix_p
                 }
                 ptrarray = &parray;
             }
-            if (PRTE_SUCCESS != (rc = prte_plm.terminate_procs(ptrarray))) {
-                PRTE_ERROR_LOG(rc);
+            prc = prte_plm.terminate_procs(ptrarray);
+            if (PRTE_SUCCESS != prc) {
+                PRTE_ERROR_LOG(prc);
             }
             if (NULL != ptrarray) {
                 /* cleanup the array */
@@ -112,8 +117,8 @@ static pmix_status_t process_job_ctrl(const pmix_proc_t *requestor, const pmix_p
                 }
                 PMIX_DESTRUCT(&parray);
             }
-            if (PMIX_SUCCESS != rc) {
-                return rc;
+            if (PRTE_SUCCESS != prc) {
+                return prte_pmix_convert_rc(prc);
             }
             return PMIX_OPERATION_SUCCEEDED;
         }
@@ -130,15 +135,22 @@ static pmix_status_t process_job_ctrl(const pmix_proc_t *requestor, const pmix_p
                     PMIX_DATA_BUFFER_RELEASE(cmd);
                     return rc;
                 }
-                if (PRTE_SUCCESS != (rc = prte_grpcomm_xcast(PRTE_RML_TAG_DAEMON, cmd))) {
-                    PRTE_ERROR_LOG(rc);
-                }
+                prc = prte_grpcomm_xcast(PRTE_RML_TAG_DAEMON, cmd);
                 PMIX_DATA_BUFFER_RELEASE(cmd);
-                if (PMIX_SUCCESS != rc) {
-                    return rc;
+                if (PRTE_SUCCESS != prc) {
+                    PRTE_ERROR_LOG(prc);
+                    return prte_pmix_convert_rc(prc);
                 }
                 return PMIX_OPERATION_SUCCEEDED;
             }
+            /* Terminating a named set of procs is PMIX_JOB_CTRL_KILL's job
+             * here; this directive only ever means the whole DVM, and with
+             * targets there is nothing for it to do.  Say so rather than
+             * falling through, which left the refusal conditional on what
+             * else happened to be in the array - a request carrying both
+             * this and a SIGNAL was answered by signalling the job and
+             * reporting success. */
+            return PMIX_ERR_NOT_SUPPORTED;
         }
 
         if (PMIX_CHECK_KEY(&directives[m], PMIX_JOB_CTRL_SIGNAL)) {
@@ -176,17 +188,32 @@ static pmix_status_t process_job_ctrl(const pmix_proc_t *requestor, const pmix_p
                 PMIX_DATA_BUFFER_RELEASE(cmd);
                 return rc;
             }
-            if (PRTE_SUCCESS != (rc = prte_grpcomm_xcast(PRTE_RML_TAG_DAEMON, cmd))) {
-                PRTE_ERROR_LOG(rc);
-            }
+            prc = prte_grpcomm_xcast(PRTE_RML_TAG_DAEMON, cmd);
             PMIX_DATA_BUFFER_RELEASE(cmd);
-            if (PMIX_SUCCESS != rc) {
-                return rc;
+            if (PRTE_SUCCESS != prc) {
+                PRTE_ERROR_LOG(prc);
+                return prte_pmix_convert_rc(prc);
             }
             return PMIX_OPERATION_SUCCEEDED;
         }
 
         if (PMIX_CHECK_KEY(&directives[m], PMIX_JOB_CTRL_DEFINE_PSET)) {
+            /* The directive is the client's, straight off the wire, and
+             * nothing between it and here checks what it holds. The name
+             * is read out of the value union below, so a value of any
+             * other type hands the packer whatever those eight bytes are
+             * as a char* and it faults in strlen - one PMIx_Job_control
+             * away, from any process attached to this daemon. A member
+             * list is equally required: the receiving daemon sizes an
+             * allocation from the count and PMIx refuses a set with no
+             * members or no name, so either would leave every daemon in
+             * the DVM logging an error while the requestor was told the
+             * operation succeeded. */
+            if (PMIX_STRING != directives[m].value.type ||
+                NULL == directives[m].value.data.string ||
+                NULL == targets || 0 == ntargets) {
+                return PMIX_ERR_BAD_PARAM;
+            }
             // goes to all daemons
             PMIX_DATA_BUFFER_CREATE(cmd);
             cmmnd = PRTE_DAEMON_DEFINE_PSET;
@@ -222,12 +249,11 @@ static pmix_status_t process_job_ctrl(const pmix_proc_t *requestor, const pmix_p
                 PMIX_DATA_BUFFER_RELEASE(cmd);
                 return rc;
             }
-            if (PRTE_SUCCESS != (rc = prte_grpcomm_xcast(PRTE_RML_TAG_DAEMON, cmd))) {
-                PRTE_ERROR_LOG(rc);
-            }
+            prc = prte_grpcomm_xcast(PRTE_RML_TAG_DAEMON, cmd);
             PMIX_DATA_BUFFER_RELEASE(cmd);
-            if (PMIX_SUCCESS != rc) {
-                return rc;
+            if (PRTE_SUCCESS != prc) {
+                PRTE_ERROR_LOG(prc);
+                return prte_pmix_convert_rc(prc);
             }
             return PMIX_OPERATION_SUCCEEDED;
         }

--- a/src/prted/pmix/pmix_server_job_ctrl.c
+++ b/src/prted/pmix/pmix_server_job_ctrl.c
@@ -30,34 +30,18 @@
 
 #include "prte_config.h"
 
-#ifdef HAVE_UNISTD_H
-#    include <unistd.h>
-#endif
-
-#include "src/hwloc/hwloc-internal.h"
 #include "src/pmix/pmix-internal.h"
-#include "src/util/pmix_argv.h"
 #include "src/util/pmix_output.h"
 
-#include "src/mca/errmgr/errmgr.h"
 #include "src/grpcomm/grpcomm.h"
-#include "src/mca/iof/base/base.h"
-#include "src/mca/iof/iof.h"
-#include "src/mca/plm/base/plm_private.h"
+#include "src/mca/errmgr/errmgr.h"
+#include "src/mca/odls/odls_types.h"
 #include "src/mca/plm/plm.h"
-#include "src/mca/plm/base/plm_private.h"
-#include "src/mca/rmaps/rmaps_types.h"
 #include "src/rml/rml.h"
-#include "src/mca/schizo/schizo.h"
-#include "src/mca/state/state.h"
 #include "src/runtime/prte_globals.h"
-#include "src/runtime/prte_locks.h"
-#include "src/threads/pmix_threads.h"
 #include "src/util/name_fns.h"
-#include "src/util/pmix_show_help.h"
 
 #include "src/prted/pmix/pmix_server_internal.h"
-
 
 /* process a job control request - runs on the PRRTE progress
  * thread, since it accesses proc objects and drives the PLM

--- a/src/prted/pmix/pmix_server_monitor.c
+++ b/src/prted/pmix/pmix_server_monitor.c
@@ -30,31 +30,14 @@
 
 #include "prte_config.h"
 
-#ifdef HAVE_UNISTD_H
-#    include <unistd.h>
-#endif
-
-#include "src/hwloc/hwloc-internal.h"
 #include "src/pmix/pmix-internal.h"
-#include "src/util/pmix_argv.h"
 #include "src/util/pmix_output.h"
 
-#include "src/mca/errmgr/errmgr.h"
 #include "src/grpcomm/grpcomm.h"
-#include "src/mca/iof/base/base.h"
-#include "src/mca/iof/iof.h"
-#include "src/mca/plm/base/plm_private.h"
-#include "src/mca/plm/plm.h"
-#include "src/mca/plm/base/plm_private.h"
-#include "src/mca/rmaps/rmaps_types.h"
+#include "src/mca/errmgr/errmgr.h"
 #include "src/rml/rml.h"
-#include "src/mca/schizo/schizo.h"
-#include "src/mca/state/state.h"
 #include "src/runtime/prte_globals.h"
-#include "src/runtime/prte_locks.h"
-#include "src/threads/pmix_threads.h"
 #include "src/util/name_fns.h"
-#include "src/util/pmix_show_help.h"
 
 #include "src/prted/pmix/pmix_server_internal.h"
 

--- a/src/prted/pmix/pmix_server_monitor.c
+++ b/src/prted/pmix/pmix_server_monitor.c
@@ -67,6 +67,47 @@
  */
 
 
+/* Tell the requesting daemon that we cannot serve its monitor request.
+ *
+ * The collective counts responses, so a daemon that goes quiet is a daemon
+ * the requestor waits on for the life of the DVM - which makes a reply the
+ * minimum we owe it even when we have nothing to say.  This packs the three
+ * fields pmix_server_monitor_resp() reads before it looks at the status:
+ * our vpid, the room number in the requestor's own tracker, and why. */
+static void send_monitor_error(pmix_rank_t dvpid, int remote_index, pmix_status_t st)
+{
+    pmix_data_buffer_t *msg;
+    pmix_status_t rc;
+    int ret;
+
+    PMIX_DATA_BUFFER_CREATE(msg);
+
+    rc = PMIx_Data_pack(NULL, msg, &prte_process_info.myproc.rank, 1, PMIX_PROC_RANK);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(msg);
+        return;
+    }
+    rc = PMIx_Data_pack(NULL, msg, &remote_index, 1, PMIX_INT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(msg);
+        return;
+    }
+    rc = PMIx_Data_pack(NULL, msg, &st, 1, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(msg);
+        return;
+    }
+
+    PRTE_RML_SEND(ret, dvpid, msg, PRTE_RML_TAG_MONITOR_RESP);
+    if (PRTE_SUCCESS != ret) {
+        PRTE_ERROR_LOG(ret);
+        PMIX_DATA_BUFFER_RELEASE(msg);
+    }
+}
+
 static void mfn(int sd, short args, void *cbdata)
 {
     prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
@@ -78,6 +119,20 @@ static void mfn(int sd, short args, void *cbdata)
     // record the number of daemons that must respond - the DVM can
     // grow or shrink, so this must be read on the progress thread
     req->ndaemons = prte_process_info.num_daemons - 1;
+
+    /* Every daemon but us answers, and the completion test lives in the
+     * response handler - so on a DVM of one there is nothing to xcast to
+     * and nothing that will ever run that test.  PMIx has already gathered
+     * this node's own contribution before up-calling (it only asks the host
+     * about participation it judges remote), so an empty success is the
+     * whole of our answer and the caller gets its local results. */
+    if (0 == req->ndaemons) {
+        if (NULL != req->infocbfunc) {
+            req->infocbfunc(PMIX_SUCCESS, NULL, 0, req->cbdata, NULL, NULL);
+        }
+        PMIX_RELEASE(req);
+        return;
+    }
 
     // cache the request
     req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
@@ -177,6 +232,9 @@ pmix_status_t pmix_server_monitor_fn(const pmix_proc_t *requestor,
 
     // create a tracking object
     req = PMIX_NEW(prte_pmix_server_req_t);
+    if (NULL == req) {
+        return PMIX_ERR_NOMEM;
+    }
     memcpy(&req->target, requestor, sizeof(pmix_proc_t));
     req->monitor = (pmix_info_t*)monitor;
     req->pstatus = error;
@@ -202,6 +260,7 @@ static void mycbfn(int sd, short args, void *cbdata)
     int ret;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
+    rc = PMIX_SUCCESS;
     PMIX_DATA_BUFFER_CREATE(msg);
 
     // pack my vpid
@@ -228,8 +287,11 @@ static void mycbfn(int sd, short args, void *cbdata)
         goto errorout;
     }
 
-    // if it failed, then nothing more to pack
-    if (PMIX_SUCCESS == rq2->status) {
+    /* if it failed, then nothing more to pack.  Gate on the same field we
+     * packed above and the receiver reads: status is a PRRTE code that mycb
+     * never sets, so this used to be permanently true and would ship results
+     * the far end had already decided not to read. */
+    if (PMIX_SUCCESS == rq2->pstatus) {
         // pack any returned info
         rc = PMIx_Data_pack(NULL, msg, &rq2->ninfo, 1, PMIX_SIZE);
         if (PMIX_SUCCESS != rc) {
@@ -257,13 +319,24 @@ static void mycbfn(int sd, short args, void *cbdata)
     }
 
 errorout:
+    /* We built no reply, so the requestor is still counting and would never
+     * reach its total.  Send it the bare refusal rather than going quiet. */
+    if (PMIX_SUCCESS != rc) {
+        send_monitor_error(req->proxy.rank, req->remote_index, rc);
+    }
+
     // execute the release callback
     if (NULL != rq2->rlcbfunc) {
         rq2->rlcbfunc(rq2->rlcbdata);
     }
 
-    // cleanup
-    pmix_pointer_array_set_item(&prte_pmix_server_globals.remote_reqs, req->remote_index, NULL);
+    /* local_index is OUR room in remote_reqs; remote_index is the
+     * requestor's room in its own local_reqs and means nothing on this
+     * array.  Clearing that one left this request's slot pointing at the
+     * object we are about to free - which prte_pmix_server_clear() then
+     * walks - and unlinked whichever unrelated peer request happened to
+     * hold the slot it named. */
+    pmix_pointer_array_set_item(&prte_pmix_server_globals.remote_reqs, req->local_index, NULL);
     PMIX_RELEASE(req);
     PMIX_RELEASE(rq2);
 }
@@ -291,11 +364,10 @@ void pmix_server_monitor_request(int status, pmix_proc_t *sender,
                                  pmix_data_buffer_t *buffer, prte_rml_tag_t tg,
                                  void *cbdata)
 {
-    pmix_status_t rc, ret;
+    pmix_status_t rc;
     pmix_rank_t dvpid;
     int32_t cnt;
     int remote_index;
-    pmix_data_buffer_t *msg;
     pmix_status_t event;
     pmix_info_t *monitor;
     size_t ndirs;
@@ -335,6 +407,10 @@ void pmix_server_monitor_request(int status, pmix_proc_t *sender,
 
     // unpack the monitor
     monitor = PMIx_Info_create(1);
+    if (NULL == monitor) {
+        rc = PMIX_ERR_NOMEM;
+        goto errorout;
+    }
     cnt = 1;
     rc = PMIx_Data_unpack(NULL, buffer, monitor, &cnt, PMIX_INFO);
     if (PMIX_SUCCESS != rc) {
@@ -362,13 +438,19 @@ void pmix_server_monitor_request(int status, pmix_proc_t *sender,
     }
     // we need two extra locations for our own directives
     PMIX_INFO_CREATE(directives, ndirs+2);
+    if (NULL == directives) {
+        PMIx_Info_free(monitor, 1);
+        rc = PMIX_ERR_NOMEM;
+        goto errorout;
+    }
     if (0 < ndirs) {
         cnt = ndirs;
         rc = PMIx_Data_unpack(NULL, buffer, directives, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIx_Info_free(monitor, 1);
-            PMIx_Info_free(directives, ndirs);
+            /* ndirs+2 was allocated - the two spare slots are ours */
+            PMIx_Info_free(directives, ndirs + 2);
             goto errorout;
         }
     }
@@ -382,6 +464,12 @@ void pmix_server_monitor_request(int status, pmix_proc_t *sender,
 
     // cache this request
     req = PMIX_NEW(prte_pmix_server_req_t);
+    if (NULL == req) {
+        PMIx_Info_free(monitor, 1);
+        PMIx_Info_free(directives, ndirs);
+        rc = PMIX_ERR_NOMEM;
+        goto errorout;
+    }
     PMIx_Load_procid(&req->proxy, prte_process_info.myproc.nspace, dvpid);
     req->monitor = monitor;
     req->moncopy = true;
@@ -405,37 +493,7 @@ void pmix_server_monitor_request(int status, pmix_proc_t *sender,
 
 errorout:
     // cannot allow the collective to hang
-    PMIX_DATA_BUFFER_CREATE(msg);
-
-    // pack my vpid
-    ret = PMIx_Data_pack(NULL, msg, &prte_process_info.myproc.rank, 1, PMIX_PROC_RANK);
-    if (PMIX_SUCCESS != ret) {
-        PMIX_ERROR_LOG(ret);
-        PMIX_DATA_BUFFER_RELEASE(msg);
-        return;
-    }
-
-    // pack the room number for the requestor's tracker
-    ret = PMIx_Data_pack(NULL, msg, &remote_index, 1, PMIX_INT);
-    if (PMIX_SUCCESS != ret) {
-        PMIX_ERROR_LOG(ret);
-        PMIX_DATA_BUFFER_RELEASE(msg);
-        return;
-    }
-    // pack an error status to indicate a problem
-    ret = PMIx_Data_pack(NULL, msg, &rc, 1, PMIX_STATUS);
-    if (PMIX_SUCCESS != ret) {
-        PMIX_ERROR_LOG(ret);
-        PMIX_DATA_BUFFER_RELEASE(msg);
-        return;
-    }
-
-    // send to the requesting daemon
-    PRTE_RML_SEND(ret, dvpid, msg, PRTE_RML_TAG_MONITOR_RESP);
-    if (PRTE_SUCCESS != ret) {
-        PRTE_ERROR_LOG(ret);
-        PMIX_DATA_BUFFER_RELEASE(msg);
-    }    
+    send_monitor_error(dvpid, remote_index, rc);
 }
 
 void pmix_server_monitor_resp(int status, pmix_proc_t *sender,
@@ -472,6 +530,20 @@ void pmix_server_monitor_resp(int status, pmix_proc_t *sender,
     if (NULL == req) {
         // bad index, or we no longer have this request
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+        return;
+    }
+    /* The index came off the wire, and the slot it names is handed out
+     * again the moment its previous occupant retires - so a response that
+     * crossed with a retirement can land on a live request of some other
+     * kind.  Accounting a report against one of those, and merging monitor
+     * results into an info array it did not allocate, corrupts a request
+     * somebody else is waiting on.  monitor is set by this file and nowhere
+     * else, which makes it the discriminator. */
+    if (NULL == req->monitor) {
+        pmix_output_verbose(2, prte_pmix_server_globals.output,
+                            "%s monitor response for index %d found a %s request - dropping it",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), local_index,
+                            (NULL == req->operation) ? "non-monitor" : req->operation);
         return;
     }
 

--- a/src/prted/pmix/pmix_server_monitor.c
+++ b/src/prted/pmix/pmix_server_monitor.c
@@ -91,17 +91,150 @@ static void send_monitor_error(pmix_rank_t dvpid, int remote_index, pmix_status_
     }
 }
 
+/* The first thing to go wrong is the useful one to report, so a later
+ * response must not overwrite it.  (pstatus is clear of the caller's own
+ * monitor code by the time any response arrives - see mfn.) */
+#define RECORD_ERROR(r, st)                 \
+    do {                                    \
+        if (PMIX_SUCCESS == (r)->pstatus) { \
+            (r)->pstatus = (st);            \
+        }                                   \
+    } while (0)
+
+/* Run the completion test for a fan-out that may just have become whole.
+ *
+ * Whole means every daemon we were waiting on has been accounted for - by
+ * answering, or by dying.  The status says which of those it was, because a
+ * caller handed a sample of half the DVM has to be able to tell.  May clear
+ * the request's slot and release it, so the caller must not touch it after. */
+static void monitor_check_complete(prte_pmix_server_req_t *req)
+{
+    pmix_status_t st;
+
+    if (req->ndaemons != req->nreported) {
+        return;
+    }
+
+    if (req->nsuccess == req->ndaemons) {
+        st = PMIX_SUCCESS;
+    } else if (0 < req->nsuccess) {
+        /* some daemons answered and some could not - the results are a
+         * sample of part of the DVM, which is what this status is for */
+        st = PMIX_ERR_PARTIAL_SUCCESS;
+    } else {
+        /* nothing came back at all - report why, not that it was partial */
+        st = (PMIX_SUCCESS == req->pstatus) ? PMIX_ERROR : req->pstatus;
+    }
+
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s monitor request complete: %u/%u answered, status %s",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                        req->nsuccess, req->ndaemons, PMIx_Error_string(st));
+
+    if (NULL != req->infocbfunc) {
+        req->infocbfunc(st, req->info, req->ninfo, req->cbdata,
+                        prte_pmix_server_req_release, req);
+    } else {
+        // nothing we can do!
+        pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs,
+                                    req->local_index, NULL);
+        PMIX_RELEASE(req);
+    }
+}
+
+/* Account a daemon departure against every monitor collective in flight.
+ *
+ * A monitor request fans out with an xcast and then counts direct replies,
+ * so nothing in it is keyed on the routing tree and nothing repairs it when
+ * the tree changes: a daemon that dies mid-collective simply never answers,
+ * and the requestor counts for the life of the DVM.  Unlike a fence, there
+ * is nothing to re-drive here - a monitor reply is a sample of live state on
+ * a node that no longer exists - so recovery is to stop waiting for it and
+ * tell the caller its sample is short.
+ *
+ * The routing tree calls this twice for the same death, at LOCAL scope and
+ * again at GLOBAL, and a rank may be named again later by an adoption notice
+ * to a new parent.  Marking the departure in reported_dmns is what makes all
+ * of that idempotent; screening against expected_dmns is what keeps a death
+ * this request never waited on from counting at all. */
+void prte_pmix_server_fault_handler(const prte_rml_recovery_status_t *status)
+{
+    prte_pmix_server_req_t *req;
+    pmix_rank_t *failed;
+    size_t i;
+    int n, bit;
+    bool lost;
+
+    if (0 == status->failed_ranks.size || NULL == status->failed_ranks.array) {
+        /* a revival, or a reshape with no deaths in it */
+        return;
+    }
+    failed = (pmix_rank_t *) status->failed_ranks.array;
+
+    for (n = 0; n < prte_pmix_server_globals.local_reqs.size; n++) {
+        req = (prte_pmix_server_req_t *)
+            pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, n);
+        if (NULL == req || NULL == req->monitor || 0 == req->ndaemons) {
+            /* not a monitor collective, or one that never fanned out */
+            continue;
+        }
+        lost = false;
+        for (i = 0; i < status->failed_ranks.size; i++) {
+            bit = (int) failed[i];
+            if (!pmix_bitmap_is_set_bit(&req->expected_dmns, bit) ||
+                pmix_bitmap_is_set_bit(&req->reported_dmns, bit)) {
+                continue;
+            }
+            pmix_bitmap_set_bit(&req->reported_dmns, bit);
+            ++req->nreported;
+            lost = true;
+        }
+        if (!lost) {
+            continue;
+        }
+        pmix_output_verbose(2, prte_pmix_server_globals.output,
+                            "%s monitor request lost a daemon: %u/%u now in",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                            req->nreported, req->ndaemons);
+        if (PMIX_SUCCESS == req->pstatus) {
+            req->pstatus = PMIX_ERR_UNREACH;
+        }
+        /* may clear slot n and release req - we do not touch it again */
+        monitor_check_complete(req);
+    }
+}
+
 static void mfn(int sd, short args, void *cbdata)
 {
     prte_pmix_server_req_t *req = (prte_pmix_server_req_t*)cbdata;
     pmix_data_buffer_t msg;
     pmix_status_t rc;
+    pmix_rank_t r;
     int ret;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
-    // record the number of daemons that must respond - the DVM can
-    // grow or shrink, so this must be read on the progress thread
-    req->ndaemons = prte_process_info.num_daemons - 1;
+    /* Record WHICH daemons must respond, not merely how many.  The xcast
+     * below reaches every daemon the routing tree still considers live, so
+     * that same predicate - a vpid inside the span that is not marked
+     * failed - is exactly the set that will answer.  This has to be read
+     * here, on the progress thread, because the DVM can grow or shrink.
+     *
+     * The identities are what let a later death be accounted for: a bare
+     * count cannot say whether the daemon that just died had already
+     * reported, and both readings of that are wrong. */
+    req->ndaemons = 0;
+    for (r = 0; r < prte_rml_base.n_dmns; r++) {
+        if (r == prte_process_info.myproc.rank ||
+            pmix_bitmap_is_set_bit(&prte_rml_base.failed_dmns, (int) r)) {
+            continue;
+        }
+        if (PMIX_SUCCESS != pmix_bitmap_set_bit(&req->expected_dmns, (int) r)) {
+            PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+            rc = PMIX_ERR_NOMEM;
+            goto errorout;
+        }
+        ++req->ndaemons;
+    }
 
     /* Every daemon but us answers, and the completion test lives in the
      * response handler - so on a DVM of one there is nothing to xcast to
@@ -162,6 +295,12 @@ static void mfn(int sd, short args, void *cbdata)
         PMIX_DATA_BUFFER_DESTRUCT(&msg);
         goto errorout;
     }
+    /* that was the caller's monitor code, and it is now on the wire.  The
+     * field is reused from here on to accumulate the collective's own
+     * result - the first non-success a daemon reports, or the reason a
+     * daemon will never report at all - so clear the caller's value out of
+     * it rather than letting an ordinary monitor code read as a failure. */
+    req->pstatus = PMIX_SUCCESS;
 
     // pack the directives, if given
     rc = PMIx_Data_pack(NULL, &msg, &req->ndirs, 1, PMIX_SIZE);
@@ -530,7 +669,24 @@ void pmix_server_monitor_resp(int status, pmix_proc_t *sender,
         return;
     }
 
-    // record that another daemon reported
+    /* Record WHICH daemon reported.  A bare count cannot tell a second copy
+     * of one daemon's response from the first, and counting one twice
+     * completes the request early - before the daemon whose slot it took is
+     * heard from.  Screening against the expected set also drops a response
+     * from a daemon this request was never waiting on. */
+    if (!pmix_bitmap_is_set_bit(&req->expected_dmns, (int) dvpid)) {
+        pmix_output_verbose(2, prte_pmix_server_globals.output,
+                            "%s monitor response from unexpected daemon %s - dropping it",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_VPID_PRINT(dvpid));
+        return;
+    }
+    if (pmix_bitmap_is_set_bit(&req->reported_dmns, (int) dvpid)) {
+        pmix_output_verbose(2, prte_pmix_server_globals.output,
+                            "%s duplicate monitor response from daemon %s - dropping it",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_VPID_PRINT(dvpid));
+        return;
+    }
+    pmix_bitmap_set_bit(&req->reported_dmns, (int) dvpid);
     ++req->nreported;
 
     /* Note that every failure below records the error on the request and
@@ -544,10 +700,14 @@ void pmix_server_monitor_resp(int status, pmix_proc_t *sender,
     rc = PMIx_Data_unpack(NULL, buffer, &rstatus, &cnt, PMIX_STATUS);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        req->pstatus = rc;
+        RECORD_ERROR(req, rc);
         goto complete;
     }
-    req->pstatus = rstatus;
+    if (PMIX_SUCCESS == rstatus) {
+        ++req->nsuccess;
+    } else {
+        RECORD_ERROR(req, rstatus);
+    }
 
     // if it succeeded, then unpack the results
     if (PMIX_SUCCESS == rstatus) {
@@ -555,7 +715,7 @@ void pmix_server_monitor_resp(int status, pmix_proc_t *sender,
         rc = PMIx_Data_unpack(NULL, buffer, &ninfo, &cnt, PMIX_SIZE);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            req->pstatus = rc;
+            RECORD_ERROR(req, rc);
             goto complete;
         }
         if (0 < ninfo) {
@@ -565,7 +725,7 @@ void pmix_server_monitor_resp(int status, pmix_proc_t *sender,
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 PMIX_INFO_FREE(info, ninfo);
-                req->pstatus = rc;
+                RECORD_ERROR(req, rc);
                 goto complete;
             }
         }
@@ -597,15 +757,6 @@ void pmix_server_monitor_resp(int status, pmix_proc_t *sender,
     }
 
 complete:
-    // if all daemons have reported, then we are complete
-    if (req->ndaemons == req->nreported) {
-        if (NULL != req->infocbfunc) {
-            req->infocbfunc(req->pstatus, req->info, req->ninfo, req->cbdata,
-                            prte_pmix_server_req_release, req);
-        } else {
-            // nothing we can do!
-            pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);
-            PMIX_RELEASE(req);
-        }
-    }
+    // if everyone we were waiting on is accounted for, then we are complete
+    monitor_check_complete(req);
 }

--- a/src/prted/pmix/pmix_server_notify.c
+++ b/src/prted/pmix/pmix_server_notify.c
@@ -152,9 +152,10 @@ static void _notify_release(int status, void *cbdata)
  * against its own copy of prte_pmix_server_globals.groups - keeping the
  * registry consistent across the DVM. This must run on the PRRTE event base
  * (the same context that creates/queries the registry); it is called from the
- * broadcast receiver below. */
-static void group_member_left(pmix_status_t code, const pmix_proc_t *source,
-                              pmix_info_t *info, size_t ninfo)
+ * broadcast receiver below. It is not static only so that test_group_left in
+ * test/unit/prted can pin the input validation. */
+void prte_pmix_server_group_member_left(pmix_status_t code, const pmix_proc_t *source,
+                                        pmix_info_t *info, size_t ninfo)
 {
     char *grpid = NULL;
     pmix_proc_t *affected = NULL;
@@ -164,11 +165,24 @@ static void group_member_left(pmix_status_t code, const pmix_proc_t *source,
     if (PMIX_GROUP_LEFT != code) {
         return;
     }
+    /* this array is the generating process's own: PMIx hands what a client
+     * passed to PMIx_Notify_event straight to the host without inspecting
+     * what any entry holds, and we then broadcast it to the whole DVM. So a
+     * value's type must be checked before the matching member of its union
+     * is read - a PMIX_GROUP_ID carrying, say, a PMIX_SIZE would otherwise
+     * hand strcmp() whatever eight bytes the caller chose, on every daemon
+     * at once. A PMIX_STRING that carries no string is the same trap in its
+     * quieter form: the packer writes a zero length and the unpacker hands
+     * back NULL */
     for (n = 0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_ID)) {
-            grpid = info[n].value.data.string;
+            if (PMIX_STRING == info[n].value.type) {
+                grpid = info[n].value.data.string;
+            }
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_EVENT_AFFECTED_PROC)) {
-            affected = info[n].value.data.proc;
+            if (PMIX_PROC == info[n].value.type) {
+                affected = info[n].value.data.proc;
+            }
         }
     }
     /* the event source is the departing proc if it wasn't called out explicitly */
@@ -176,6 +190,13 @@ static void group_member_left(pmix_status_t code, const pmix_proc_t *source,
         affected = (pmix_proc_t *) source;
     }
     if (NULL == grpid || NULL == affected) {
+        return;
+    }
+    /* PMIX_CHECK_PROCID counts an empty nspace and a wildcard rank as
+     * matching anything, so a departure that does not name a concrete
+     * identity would drop whichever member happens to sit first in the
+     * array. Procs leave a group one at a time; insist on being told which */
+    if (PMIX_NSPACE_INVALID(affected->nspace) || !PMIX_RANK_IS_VALID(affected->rank)) {
         return;
     }
     PMIX_LIST_FOREACH(ps, &prte_pmix_server_globals.groups, prte_pmix_server_pset_t) {
@@ -285,7 +306,7 @@ void pmix_server_notify(int status, pmix_proc_t *sender, pmix_data_buffer_t *buf
 
     /* keep our group membership registry consistent with any voluntary
      * departure - every daemon does this, including the originator */
-    group_member_left(code, &cd->proc, cd->info, realninfo);
+    prte_pmix_server_group_member_left(code, &cd->proc, cd->info, realninfo);
 
     /* if I am the one who broadcast it, my local clients have already been
      * notified - just release and return now that the registry is updated */

--- a/src/prted/pmix/pmix_server_notify.c
+++ b/src/prted/pmix/pmix_server_notify.c
@@ -402,7 +402,10 @@ static void _notify_event(int sd, short args, void *cbdata)
 
     if (PRTE_SUCCESS != (rc = prte_grpcomm_xcast(PRTE_RML_TAG_NOTIFICATION, &pbkt))) {
         PRTE_ERROR_LOG(rc);
-        ret = PMIX_ERROR;
+        /* rc is a PRRTE code and cd->cbfunc hands what we put here straight
+         * to a client - convert rather than flattening every failure to
+         * PMIX_ERROR, which tells the caller nothing it can act on */
+        ret = prte_pmix_convert_rc(rc);
     }
     PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
 

--- a/src/prted/pmix/pmix_server_notify.c
+++ b/src/prted/pmix/pmix_server_notify.c
@@ -30,31 +30,19 @@
 
 #include "prte_config.h"
 
-#ifdef HAVE_UNISTD_H
-#    include <unistd.h>
-#endif
+#include <string.h>
 
-#include "src/hwloc/hwloc-internal.h"
 #include "src/pmix/pmix-internal.h"
-#include "src/util/pmix_argv.h"
 #include "src/util/pmix_output.h"
 
-#include "src/mca/errmgr/errmgr.h"
 #include "src/grpcomm/grpcomm.h"
-#include "src/mca/iof/base/base.h"
-#include "src/mca/iof/iof.h"
-#include "src/mca/plm/base/plm_private.h"
-#include "src/mca/plm/plm.h"
-#include "src/mca/plm/base/plm_private.h"
-#include "src/mca/rmaps/rmaps_types.h"
-#include "src/rml/rml.h"
-#include "src/mca/schizo/schizo.h"
+#include "src/mca/errmgr/errmgr.h"
 #include "src/mca/state/state.h"
+#include "src/rml/rml.h"
 #include "src/runtime/prte_globals.h"
 #include "src/runtime/prte_locks.h"
 #include "src/threads/pmix_threads.h"
 #include "src/util/name_fns.h"
-#include "src/util/pmix_show_help.h"
 
 #include "src/prted/pmix/pmix_server_internal.h"
 
@@ -228,7 +216,7 @@ void pmix_server_notify(int status, pmix_proc_t *sender, pmix_data_buffer_t *buf
                         prte_rml_tag_t tg, void *cbdata)
 {
     prte_pmix_server_op_caddy_t *cd;
-    int cnt, rc;
+    int cnt;
     pmix_proc_t source;
     pmix_data_range_t range = PMIX_RANGE_SESSION;
     pmix_status_t code, ret;
@@ -239,9 +227,9 @@ void pmix_server_notify(int status, pmix_proc_t *sender, pmix_data_buffer_t *buf
 
     /* unpack the daemon who broadcast the event */
     cnt = 1;
-    rc = PMIx_Data_unpack(NULL, buffer, &vpid, &cnt, PMIX_PROC_RANK);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
+    ret = PMIx_Data_unpack(NULL, buffer, &vpid, &cnt, PMIX_PROC_RANK);
+    if (PMIX_SUCCESS != ret) {
+        PMIX_ERROR_LOG(ret);
         return;
     }
 
@@ -443,7 +431,7 @@ pmix_status_t pmix_server_notify_event(pmix_status_t code, const pmix_proc_t *so
 
     /* check to see if this is one we sent down */
     for (n = 0; n < ninfo; n++) {
-        if (0 == strcmp(info[n].key, "prte.notify.donotloop")) {
+        if (PMIX_CHECK_KEY(&info[n], "prte.notify.donotloop")) {
             /* yep - do not process */
             return PMIX_OPERATION_SUCCEEDED;
         }

--- a/src/prted/pmix/pmix_server_notify.c
+++ b/src/prted/pmix/pmix_server_notify.c
@@ -65,10 +65,14 @@ static void _register_events(int sd, short args, void *cbdata)
 
     PMIX_ACQUIRE_OBJECT(cd);
 
-    /* need to implement this */
+    /* deliberately empty: every notification a daemon originates is xcast to
+     * the whole DVM and handed to each daemon's own PMIx server, which
+     * filters it against its clients' registrations there - so there is
+     * nothing for the host to record. See docs/todo.rst, "event registration
+     * is accepted and discarded", for what acting on these would buy */
 
     if (NULL != cd->cbfunc) {
-        cd->cbfunc(PRTE_SUCCESS, cd->cbdata);
+        cd->cbfunc(PMIX_SUCCESS, cd->cbdata);
     }
     PMIX_RELEASE(cd);
 }
@@ -104,9 +108,9 @@ static void _deregister_events(int sd, short args, void *cbdata)
 
     PMIX_ACQUIRE_OBJECT(cd);
 
-    /* need to implement this */
+    /* deliberately empty - see _register_events above */
     if (NULL != cd->cbfunc) {
-        cd->cbfunc(PRTE_SUCCESS, cd->cbdata);
+        cd->cbfunc(PMIX_SUCCESS, cd->cbdata);
     }
     PMIX_RELEASE(cd);
 }
@@ -127,7 +131,7 @@ pmix_status_t pmix_server_deregister_events_fn(pmix_status_t *codes, size_t ncod
     prte_event_set(prte_event_base, &(cd->ev), -1, PRTE_EV_WRITE, _deregister_events, cd);
     PMIX_POST_OBJECT(cd);
     prte_event_active(&(cd->ev), PRTE_EV_WRITE, 1);
-    return PRTE_SUCCESS;
+    return PMIX_SUCCESS;
 }
 
 static void _notify_release(int status, void *cbdata)

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -107,6 +107,7 @@ static int init_server(void)
 {
     char *server;
     char input[1024], *filename;
+    size_t len;
     FILE *fp;
     pmix_status_t ret;
     pmix_info_t info[2];
@@ -157,7 +158,15 @@ static int init_server(void)
                 return PRTE_ERR_BAD_PARAM;
             }
             fclose(fp);
-            input[strlen(input) - 1] = '\0'; /* remove newline */
+            /* strip the line ending if there is one.  A file written by
+             * PMIx's own report-uri ends in a newline, but this file is
+             * whatever the user pointed us at - and chopping the last
+             * character unconditionally takes a character of the URI off a
+             * file that has none. */
+            len = strlen(input);
+            while (0 < len && ('\n' == input[len - 1] || '\r' == input[len - 1])) {
+                input[--len] = '\0';
+            }
             server = strdup(input);
         } else {
             server = strdup(prte_data_server_uri);

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -661,6 +661,7 @@ void pmix_server_keyval_client(int status, pmix_proc_t *sender,
             rc = PMIx_Data_unpack(NULL, &pbkt, &pdata[n].proc, &cnt, PMIX_PROC);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
+                PMIX_INFO_DESTRUCT(&info);
                 PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
                 ret = rc;
                 goto release;
@@ -669,6 +670,7 @@ void pmix_server_keyval_client(int status, pmix_proc_t *sender,
             rc = PMIx_Data_unpack(NULL, &pbkt, &info, &cnt, PMIX_INFO);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
+                PMIX_INFO_DESTRUCT(&info);
                 PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
                 ret = rc;
                 goto release;
@@ -677,6 +679,7 @@ void pmix_server_keyval_client(int status, pmix_proc_t *sender,
             PMIX_VALUE_XFER_DIRECT(rc, &pdata[n].value, &info.value);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
+                PMIX_INFO_DESTRUCT(&info);
                 PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
                 ret = rc;
                 goto release;
@@ -684,6 +687,10 @@ void pmix_server_keyval_client(int status, pmix_proc_t *sender,
             PMIX_INFO_DESTRUCT(&info);
         }
     }
+    /* the payload was loaded into this buffer, which owns it from that point
+     * on - every error arm above lets it go and the way out did not, so a
+     * whole lookup response leaked on each one that worked */
+    PMIX_DATA_BUFFER_DESTRUCT(&pbkt);
 
 release:
     if (0 <= room_num) {

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -202,6 +202,37 @@ static int init_server(void)
     return PRTE_SUCCESS;
 }
 
+/* Pull the range and timeout out of a publish/lookup/unpublish directive
+ * array.  The array is the requesting client's own - PMIx forwards it to the
+ * host without inspecting what any entry holds - so a value's type has to be
+ * checked before the matching member of the union is read.  Neither of these
+ * is a pointer, so the cost of getting it wrong is not a fault: it is that
+ * the range decides where the request is *sent*, so a value read out of the
+ * wrong union member routes a publish to this daemon instead of the data
+ * server, and the data is quietly put where no lookup will find it. */
+static void scan_directives(prte_pmix_server_req_t *req,
+                            const pmix_info_t info[], size_t ninfo)
+{
+    size_t n;
+    pmix_status_t rc;
+    int tmo;
+
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_RANGE)) {
+            if (PMIX_DATA_RANGE == info[n].value.type) {
+                req->range = info[n].value.data.range;
+            }
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
+            /* the data server is what honors this - it is recorded here only
+             * so that a timer on this side would have it */
+            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, tmo, int);
+            if (PMIX_SUCCESS == rc) {
+                req->timeout = tmo;
+            }
+        }
+    }
+}
+
 static void execute(int sd, short args, void *cbdata)
 {
     prte_pmix_server_req_t *req = (prte_pmix_server_req_t *) cbdata;
@@ -302,7 +333,6 @@ pmix_status_t pmix_server_publish_fn(const pmix_proc_t *proc, const pmix_info_t 
     pmix_status_t rc;
     int ret;
     uint8_t cmd = PRTE_PMIX_PUBLISH_CMD;
-    size_t n;
 
     pmix_output_verbose(1, prte_pmix_server_globals.output, "%s orted:pmix:server PUBLISH",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
@@ -321,14 +351,7 @@ pmix_status_t pmix_server_publish_fn(const pmix_proc_t *proc, const pmix_info_t 
         return PMIX_ERR_PACK_FAILURE;
     }
 
-    /* no help for it - need to search for range/persistence */
-    for (n = 0; n < ninfo; n++) {
-        if (0 == strncmp(info[n].key, PMIX_RANGE, PMIX_MAX_KEYLEN)) {
-            req->range = info[n].value.data.range;
-        } else if (0 == strncmp(info[n].key, PMIX_TIMEOUT, PMIX_MAX_KEYLEN)) {
-            req->timeout = info[n].value.data.integer;
-        }
-    }
+    scan_directives(req, info, ninfo);
 
     /* pack the name of the publisher */
     if (PMIX_SUCCESS
@@ -387,14 +410,7 @@ pmix_status_t pmix_server_lookup_fn(const pmix_proc_t *proc, char **keys, const 
         return PMIX_ERR_PACK_FAILURE;
     }
 
-    /* no help for it - need to search for range and timeout */
-    for (n = 0; n < ninfo; n++) {
-        if (0 == strncmp(info[n].key, PMIX_RANGE, PMIX_MAX_KEYLEN)) {
-            req->range = info[n].value.data.range;
-        } else if (0 == strncmp(info[n].key, PMIX_TIMEOUT, PMIX_MAX_KEYLEN)) {
-            req->timeout = info[n].value.data.integer;
-        }
-    }
+    scan_directives(req, info, ninfo);
 
     /* pack the name of the requestor */
     if (PMIX_SUCCESS
@@ -521,14 +537,7 @@ pmix_status_t pmix_server_unpublish_fn(const pmix_proc_t *proc, char **keys,
         return PMIX_ERR_PACK_FAILURE;
     }
 
-    /* no help for it - need to search for range and timeout */
-    for (n = 0; n < ninfo; n++) {
-        if (0 == strncmp(info[n].key, PMIX_RANGE, PMIX_MAX_KEYLEN)) {
-            req->range = info[n].value.data.range;
-        } else if (0 == strncmp(info[n].key, PMIX_TIMEOUT, PMIX_MAX_KEYLEN)) {
-            req->timeout = info[n].value.data.integer;
-        }
-    }
+    scan_directives(req, info, ninfo);
 
     /* pack the name of the requestor */
     if (PMIX_SUCCESS

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -48,6 +48,15 @@
 
 #include "src/prted/pmix/pmix_server_internal.h"
 
+/* The outcome of the one attach attempt.  init_server() marks itself done
+ * before it does any work, so it runs exactly once whether it succeeds or
+ * fails - and the failure has to be remembered.  Without the connection a
+ * later request is not refused, it is sent to this daemon's own data server
+ * instead: not where the caller asked for it to go, and not where the other
+ * DVM will look for it.  One error message followed by publishes that
+ * silently go nowhere useful is worse than a request that fails. */
+static int server_init_rc = PRTE_SUCCESS;
+
 /* Attach to the data server named by prte_data_server_uri.
  *
  * The server is a DVM of its own, so it is reached as a PMIx *tool
@@ -77,17 +86,21 @@ static int init_server(void);
  * effect. */
 int prte_pmix_server_init_pubsub(void)
 {
-    int ret;
-
     if (prte_pmix_server_globals.pubsub_init) {
-        return PRTE_SUCCESS;
+        /* Answer with what the one attempt actually did.  Returning success
+         * here because the attempt has been MADE is the trap described on
+         * server_init_rc above: only the request that provoked the attach
+         * learned that it failed, and every later one carried on into this
+         * daemon's own data server - not where the caller asked for it to
+         * go, and not where the other DVM will look. */
+        return server_init_rc;
     }
-    ret = init_server();
-    if (PRTE_SUCCESS != ret) {
+    server_init_rc = init_server();
+    if (PRTE_SUCCESS != server_init_rc) {
         prte_show_help("help-prted.txt", "noserver", true,
                        (NULL == prte_data_server_uri) ? "NULL" : prte_data_server_uri);
     }
-    return ret;
+    return server_init_rc;
 }
 
 static int init_server(void)
@@ -203,7 +216,8 @@ static void execute(int sd, short args, void *cbdata)
 
     PMIX_ACQUIRE_OBJECT(req);
 
-    /* we need our connection to the server */
+    /* we need our connection to the server, and every request needs it: a
+     * failed attach is remembered and re-reported rather than skipped */
     if (PRTE_SUCCESS != (rc = prte_pmix_server_init_pubsub())) {
         /* rc is a PRRTE code and what we hand back goes to a client */
         ret = prte_pmix_convert_rc(rc);

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -29,21 +29,19 @@
 
 #include "prte_config.h"
 
-#ifdef HAVE_UNISTD_H
-#    include <unistd.h>
-#endif
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
 
 #include "src/pmix/pmix-internal.h"
-#include "src/util/pmix_argv.h"
 #include "src/util/pmix_output.h"
 
 #include "src/mca/errmgr/errmgr.h"
 #include "src/rml/rml.h"
 #include "src/runtime/data_server/prte_data_server.h"
 #include "src/runtime/prte_globals.h"
-#include "src/threads/pmix_threads.h"
 #include "src/util/name_fns.h"
-#include "src/util/pmix_show_help.h"
 #include "src/util/prte_show_help.h"
 
 #include "src/prted/pmix/pmix_server_internal.h"
@@ -340,7 +338,6 @@ pmix_status_t pmix_server_publish_fn(const pmix_proc_t *proc, const pmix_info_t 
 {
     prte_pmix_server_req_t *req;
     pmix_status_t rc;
-    int ret;
     uint8_t cmd = PRTE_PMIX_PUBLISH_CMD;
 
     pmix_output_verbose(1, prte_pmix_server_globals.output, "%s orted:pmix:server PUBLISH",
@@ -353,9 +350,9 @@ pmix_status_t pmix_server_publish_fn(const pmix_proc_t *proc, const pmix_info_t 
     req->cbdata = cbdata;
 
     /* load the command */
-    ret = PMIx_Data_pack(NULL, &req->msg, &cmd, 1, PMIX_UINT8);
-    if (PMIX_SUCCESS != ret) {
-        PMIX_ERROR_LOG(ret);
+    rc = PMIx_Data_pack(NULL, &req->msg, &cmd, 1, PMIX_UINT8);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(req);
         return PMIX_ERR_PACK_FAILURE;
     }
@@ -390,14 +387,13 @@ pmix_status_t pmix_server_publish_fn(const pmix_proc_t *proc, const pmix_info_t 
     PMIX_POST_OBJECT(req);
     prte_event_active(&(req->ev), PRTE_EV_WRITE, 1);
 
-    return PRTE_SUCCESS;
+    return PMIX_SUCCESS;
 }
 
 pmix_status_t pmix_server_lookup_fn(const pmix_proc_t *proc, char **keys, const pmix_info_t info[],
                                     size_t ninfo, pmix_lookup_cbfunc_t cbfunc, void *cbdata)
 {
     prte_pmix_server_req_t *req;
-    int ret;
     uint8_t cmd = PRTE_PMIX_LOOKUP_CMD;
     size_t m, n;
     pmix_status_t rc;
@@ -413,8 +409,9 @@ pmix_status_t pmix_server_lookup_fn(const pmix_proc_t *proc, char **keys, const 
     req->cbdata = cbdata;
 
     /* load the command */
-    if (PRTE_SUCCESS != (ret = PMIx_Data_pack(NULL, &req->msg, &cmd, 1, PMIX_UINT8))) {
-        PRTE_ERROR_LOG(ret);
+    rc = PMIx_Data_pack(NULL, &req->msg, &cmd, 1, PMIX_UINT8);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(req);
         return PMIX_ERR_PACK_FAILURE;
     }
@@ -467,7 +464,7 @@ pmix_status_t pmix_server_lookup_fn(const pmix_proc_t *proc, char **keys, const 
     PMIX_POST_OBJECT(req);
     prte_event_active(&(req->ev), PRTE_EV_WRITE, 1);
 
-    return PRTE_SUCCESS;
+    return PMIX_SUCCESS;
 }
 
 pmix_status_t pmix_server_unpublish_fn(const pmix_proc_t *proc, char **keys,
@@ -475,7 +472,6 @@ pmix_status_t pmix_server_unpublish_fn(const pmix_proc_t *proc, char **keys,
                                        pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     prte_pmix_server_req_t *req;
-    int ret;
     uint8_t cmd;
     size_t m, n;
     pmix_status_t rc;
@@ -490,8 +486,9 @@ pmix_status_t pmix_server_unpublish_fn(const pmix_proc_t *proc, char **keys,
 
         /* load the command */
         cmd = PRTE_PMIX_PURGE_PROC_CMD;
-        if (PRTE_SUCCESS != (ret = PMIx_Data_pack(NULL, &req->msg, &cmd, 1, PMIX_UINT8))) {
-            PRTE_ERROR_LOG(ret);
+        rc = PMIx_Data_pack(NULL, &req->msg, &cmd, 1, PMIX_UINT8);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(req);
             return PMIX_ERR_PACK_FAILURE;
         }
@@ -528,7 +525,7 @@ pmix_status_t pmix_server_unpublish_fn(const pmix_proc_t *proc, char **keys,
         PMIX_POST_OBJECT(req);
         prte_event_active(&(req->ev), PRTE_EV_WRITE, 1);
 
-        return PRTE_SUCCESS;
+        return PMIX_SUCCESS;
     }
 
 
@@ -540,8 +537,9 @@ pmix_status_t pmix_server_unpublish_fn(const pmix_proc_t *proc, char **keys,
 
     /* load the command */
     cmd = PRTE_PMIX_UNPUBLISH_CMD;
-    if (PRTE_SUCCESS != (ret = PMIx_Data_pack(NULL, &req->msg, &cmd, 1, PMIX_UINT8))) {
-        PRTE_ERROR_LOG(ret);
+    rc = PMIx_Data_pack(NULL, &req->msg, &cmd, 1, PMIX_UINT8);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(req);
         return PMIX_ERR_PACK_FAILURE;
     }
@@ -594,7 +592,7 @@ pmix_status_t pmix_server_unpublish_fn(const pmix_proc_t *proc, char **keys,
     PMIX_POST_OBJECT(req);
     prte_event_active(&(req->ev), PRTE_EV_WRITE, 1);
 
-    return PRTE_SUCCESS;
+    return PMIX_SUCCESS;
 }
 
 void pmix_server_keyval_client(int status, pmix_proc_t *sender,
@@ -602,7 +600,8 @@ void pmix_server_keyval_client(int status, pmix_proc_t *sender,
                                prte_rml_tag_t tg, void *cbdata)
 {
     uint8_t command;
-    int rc, room_num = -1;
+    pmix_status_t rc;
+    int room_num = -1;
     int32_t cnt;
     prte_pmix_server_req_t *req = NULL;
     pmix_byte_object_t bo;
@@ -621,9 +620,10 @@ void pmix_server_keyval_client(int status, pmix_proc_t *sender,
     cnt = 1;
     rc = PMIx_Data_unpack(NULL, buffer, &room_num, &cnt, PMIX_INT);
     if (PMIX_SUCCESS != rc) {
-        PRTE_ERROR_LOG(rc);
-        ret = PMIX_ERR_UNPACK_FAILURE;
-        goto release;
+        PMIX_ERROR_LOG(rc);
+        /* nothing to answer and nobody to answer it to - the room number is
+         * how a reply finds the request that is waiting for it */
+        return;
     }
 
     /* unpack the command */

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -193,6 +193,7 @@ static void execute(int sd, short args, void *cbdata)
 {
     prte_pmix_server_req_t *req = (prte_pmix_server_req_t *) cbdata;
     int rc;
+    pmix_status_t ret;
     pmix_data_buffer_t *xfer;
     pmix_proc_t *target;
     /* the DVM's store unless the range says otherwise */
@@ -204,6 +205,8 @@ static void execute(int sd, short args, void *cbdata)
 
     /* we need our connection to the server */
     if (PRTE_SUCCESS != (rc = prte_pmix_server_init_pubsub())) {
+        /* rc is a PRRTE code and what we hand back goes to a client */
+        ret = prte_pmix_convert_rc(rc);
         goto callback;
     }
 
@@ -215,15 +218,15 @@ static void execute(int sd, short args, void *cbdata)
     PMIX_DATA_BUFFER_CREATE(xfer);
 
     /* pack the room number */
-    rc = PMIx_Data_pack(NULL, xfer, &req->local_index, 1, PMIX_INT);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
+    ret = PMIx_Data_pack(NULL, xfer, &req->local_index, 1, PMIX_INT);
+    if (PMIX_SUCCESS != ret) {
+        PMIX_ERROR_LOG(ret);
         PMIX_DATA_BUFFER_RELEASE(xfer);
         goto callback;
     }
-    rc = PMIx_Data_copy_payload(xfer, &req->msg);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
+    ret = PMIx_Data_copy_payload(xfer, &req->msg);
+    if (PMIX_SUCCESS != ret) {
+        PMIX_ERROR_LOG(ret);
         PMIX_DATA_BUFFER_RELEASE(xfer);
         goto callback;
     }
@@ -260,14 +263,17 @@ static void execute(int sd, short args, void *cbdata)
         return;
     }
     PRTE_ERROR_LOG(rc);
-    rc = prte_pmix_convert_rc(rc);
+    /* the RML takes the buffer only by succeeding - on an error return it is
+     * still ours, emptied or not (src/rml/relm/AGENTS.md) */
+    PMIX_DATA_BUFFER_RELEASE(xfer);
+    ret = prte_pmix_convert_rc(rc);
 
 callback:
     /* execute the callback to avoid having the client hang */
     if (NULL != req->opcbfunc) {
-        req->opcbfunc(rc, req->cbdata);
+        req->opcbfunc(ret, req->cbdata);
     } else if (NULL != req->lkcbfunc) {
-        req->lkcbfunc(rc, NULL, 0, req->cbdata);
+        req->lkcbfunc(ret, NULL, 0, req->cbdata);
     }
     if (stored) {
         pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs, req->local_index, NULL);

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -592,8 +592,14 @@ void pmix_server_keyval_client(int status, pmix_proc_t *sender,
     cnt = 1;
     rc = PMIx_Data_unpack(NULL, buffer, &command, &cnt, PMIX_UINT8);
     if (PMIX_SUCCESS != rc) {
-        PRTE_ERROR_LOG(rc);
-        return;
+        PMIX_ERROR_LOG(rc);
+        /* the room number came out, so there is somebody to answer - and
+         * they are a client parked in PMIx_Publish or PMIx_Lookup with
+         * nothing else in the DVM that will ever take them out of it.
+         * Returning here left the request in local_reqs and that client
+         * waiting for the life of the DVM */
+        ret = PMIX_ERR_UNPACK_FAILURE;
+        goto release;
     }
 
     /* unpack the return status */

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -303,8 +303,12 @@ static void _query(int sd, short args, void *cbdata)
                     if (NULL == jdata) {
                         continue;
                     }
-                    // if the session ID was given, then ignore jobs not from that session
-                    if (UINT32_MAX != sessionid && jdata->session->session_id != sessionid) {
+                    // if the session ID was given, then ignore jobs not from that session.
+                    // A job's session pointer is optional - the launch path falls back to
+                    // prte_default_session where it finds none - so a job that has none
+                    // belongs to no session the caller can have named
+                    if (UINT32_MAX != sessionid &&
+                        (NULL == jdata->session || jdata->session->session_id != sessionid)) {
                         continue;
                     }
                     PMIX_INFO_LIST_START(stack);
@@ -346,13 +350,19 @@ static void _query(int sd, short args, void *cbdata)
                             PMIX_INFO_LIST_RELEASE(plist);
                             goto done;
                         }
-                        /* add the proc's hostname */
-                        PMIX_INFO_LIST_ADD(rc, plist, PMIX_HOSTNAME, proct->node->name, PMIX_STRING);
-                        if (PMIX_SUCCESS != rc) {
-                            PMIX_ERROR_LOG(rc);
-                            PMIX_INFO_LIST_RELEASE(stack);
-                            PMIX_INFO_LIST_RELEASE(plist);
-                            goto done;
+                        /* add the proc's hostname.  A proc has no node until the
+                         * mapper places it, and this loop walks every job in the
+                         * array including one still being mapped - the proc table
+                         * below makes the same check and this did not */
+                        if (NULL != proct->node && NULL != proct->node->name) {
+                            PMIX_INFO_LIST_ADD(rc, plist, PMIX_HOSTNAME, proct->node->name,
+                                               PMIX_STRING);
+                            if (PMIX_SUCCESS != rc) {
+                                PMIX_ERROR_LOG(rc);
+                                PMIX_INFO_LIST_RELEASE(stack);
+                                PMIX_INFO_LIST_RELEASE(plist);
+                                goto done;
+                            }
                         }
                         /* add the proc's local rank */
                         PMIX_INFO_LIST_ADD(rc, plist, PMIX_LOCAL_RANK, &proct->local_rank, PMIX_UINT16);
@@ -539,6 +549,10 @@ static void _query(int sd, short args, void *cbdata)
                 } else {
                     /* send them ours */
                     proct = prte_get_proc_object(PRTE_PROC_MY_NAME);
+                    if (NULL == proct) {
+                        ret = PMIX_ERR_NOT_FOUND;
+                        goto done;
+                    }
                 }
                 /* get the server uri value - we can block here as we are in
                  * an PRTE progress thread */

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -1205,23 +1205,24 @@ done:
         ret = rc;
     }
     PMIX_INFO_LIST_RELEASE(results);
-    if (PMIX_ERR_NOT_SUPPORTED != ret) {
-        if (PMIX_ERR_EMPTY == rc) {
+    /* only decide the status here if no arm has already decided it.  An error
+     * an arm set is what actually happened - a malformed qualifier, a job we
+     * do not know - and reporting "not found" in its place tells the caller
+     * the DVM looked.  PMIX_ERR_NOT_SUPPORTED used to be the one error
+     * protected from this, which is how the shape of it is visible: every
+     * other error an arm could set was being thrown away with an empty
+     * result list, which is exactly what an arm that failed leaves behind */
+    if (PMIX_SUCCESS == ret) {
+        if (PMIX_ERR_EMPTY == rc || 0 == dry.size) {
             ret = PMIX_ERR_NOT_FOUND;
-        } else if (PMIX_SUCCESS == ret) {
-            if (0 == dry.size) {
-                ret = PMIX_ERR_NOT_FOUND;
-            } else if (dry.size < nkeys) {
-                /* against cd->ninfo, which a query caddy never sets, this
-                 * compared with zero and PMIX_QUERY_PARTIAL_SUCCESS could not
-                 * be reached.  The count that means something here is the
-                 * number of keys that were asked for: fewer results than that
-                 * is what partial success is for, and a caller has no other
-                 * way to learn that one of its keys went unanswered */
-                ret = PMIX_QUERY_PARTIAL_SUCCESS;
-            } else {
-                ret = PMIX_SUCCESS;
-            }
+        } else if (dry.size < nkeys) {
+            /* against cd->ninfo, which a query caddy never sets, this compared
+             * with zero and PMIX_QUERY_PARTIAL_SUCCESS could not be reached.
+             * The count that means something here is the number of keys that
+             * were asked for: fewer results than that is what partial success
+             * is for, and a caller has no other way to learn that one of its
+             * keys went unanswered */
+            ret = PMIX_QUERY_PARTIAL_SUCCESS;
         }
     }
     rcd->ninfo = dry.size;

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -1005,7 +1005,7 @@ static void _query(int sd, short args, void *cbdata)
                  * there way thru the state machine for mapping, and more jobs may
                  * be submitted at any moment.
                  */
-                p = 0;
+                nslots = 0;
                 for (k=0; k < prte_node_pool->size; k++) {
                     node = (prte_node_t*)pmix_pointer_array_get_item(prte_node_pool, k);
                     if (NULL == node) {
@@ -1031,9 +1031,12 @@ static void _query(int sd, short args, void *cbdata)
                     if (node->slots <= node->slots_inuse) {
                         continue;
                     }
-                    p += node->slots - node->slots_inuse;
+                    nslots += (uint32_t)(node->slots - node->slots_inuse);
                 }
-                PMIX_INFO_LIST_ADD(rc, results, PMIX_QUERY_AVAILABLE_SLOTS, &p, PMIX_UINT32);
+                /* the count is handed to PMIx by address, so it has to be the
+                 * width PMIx is told it is - a size_t read as a PMIX_UINT32
+                 * takes the correct four bytes only on a little-endian machine */
+                PMIX_INFO_LIST_ADD(rc, results, PMIX_QUERY_AVAILABLE_SLOTS, &nslots, PMIX_UINT32);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     goto done;

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -60,6 +60,22 @@
 
 #include "src/prted/pmix/pmix_server_internal.h"
 
+/* A query's qualifiers are the requesting client's own: PMIx forwards the
+ * array to the host without inspecting what any entry holds, so reading a
+ * fixed member of the value union is reading whatever eight bytes the caller
+ * chose to put there.  Every qualifier this function acts on other than the
+ * two numeric ones is a string that it then hands to strlen(), strcmp() or
+ * PMIx_Check_nspace(), so a mistyped one is a fault - which any process or
+ * tool attached to a daemon could produce with a single PMIx_Query_info. */
+static bool qual_string(const pmix_info_t *qual, char **str)
+{
+    if (PMIX_STRING != qual->value.type) {
+        return false;
+    }
+    *str = qual->value.data.string;
+    return true;
+}
+
 static void qrel(void *cbdata)
 {
     prte_pmix_server_op_caddy_t *cd = (prte_pmix_server_op_caddy_t *) cbdata;
@@ -133,10 +149,14 @@ static void _query(int sd, short args, void *cbdata)
                                          : "(not a string)"));
 
                 if (PMIX_CHECK_KEY(&q->qualifiers[n], PMIX_NSPACE)) {
+                    char *nsq;
+                    if (!qual_string(&q->qualifiers[n], &nsq)) {
+                        ret = PMIX_ERR_BAD_PARAM;
+                        goto done;
+                    }
                     // the nspace could be NULL, indicating that this is a
                     // wildcard request - if so, then ignore it here
-                    if (NULL == q->qualifiers[n].value.data.string ||
-                        0 == strlen(q->qualifiers[n].value.data.string)) {
+                    if (NULL == nsq || 0 == strlen(nsq)) {
                         PMIX_LOAD_NSPACE(jobid, NULL);
                         continue;
                     }
@@ -149,7 +169,7 @@ static void _query(int sd, short args, void *cbdata)
                     for (k = 0; k < prte_job_data->size; k++) {
                         jdata = (prte_job_t *) pmix_pointer_array_get_item(prte_job_data, k);
                         if (NULL != jdata) {
-                            if (PMIX_CHECK_NSPACE(q->qualifiers[n].value.data.string, jdata->nspace)) {
+                            if (PMIX_CHECK_NSPACE(nsq, jdata->nspace)) {
                                 matched = 1;
                                 break;
                             }
@@ -159,7 +179,7 @@ static void _query(int sd, short args, void *cbdata)
                         pmix_output_verbose(2, prte_pmix_server_globals.output,
                                             "%s qualifier key \"%s\" : value \"%s\" is an unknown namespace",
                                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), q->qualifiers[n].key,
-                                            q->qualifiers[n].value.data.string);
+                                            nsq);
                         ret = PMIX_ERR_BAD_PARAM;
                         goto done;
                     }
@@ -171,16 +191,21 @@ static void _query(int sd, short args, void *cbdata)
                     }
 
                 } else if (PMIX_CHECK_KEY(&q->qualifiers[n], PMIX_GROUP_ID)) {
+                    char *grpq;
+                    prte_pmix_server_pset_t *ps;
                     /* Never trust the group string that is provided.
                      * First check to see if we know about this group. If
                      * not then return an error. If so then continue on.
                      */
+                    if (!qual_string(&q->qualifiers[n], &grpq) || NULL == grpq) {
+                        ret = PMIX_ERR_BAD_PARAM;
+                        goto done;
+                    }
                     /* Make sure the qualifier group exists */
                     matched = 0;
-                    prte_pmix_server_pset_t *ps;
                     PMIX_LIST_FOREACH(ps, &prte_pmix_server_globals.groups, prte_pmix_server_pset_t)
                     {
-                        if (PMIX_CHECK_NSPACE(q->qualifiers[n].value.data.string, ps->name)) {
+                        if (NULL != ps->name && PMIX_CHECK_NSPACE(grpq, ps->name)) {
                             matched = 1;
                             break;
                         }
@@ -189,34 +214,54 @@ static void _query(int sd, short args, void *cbdata)
                         pmix_output_verbose(2, prte_pmix_server_globals.output,
                                             "%s qualifier key \"%s\" : value \"%s\" is an unknown group",
                                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), q->qualifiers[n].key,
-                                            q->qualifiers[n].value.data.string);
+                                            grpq);
                         ret = PMIX_ERR_BAD_PARAM;
                         goto done;
                     }
-                    PMIX_LOAD_NSPACE(jobid, q->qualifiers[n].value.data.string);
+                    PMIX_LOAD_NSPACE(jobid, grpq);
                     if (PMIX_NSPACE_INVALID(jobid)) {
                         ret = PMIX_ERR_BAD_PARAM;
                         goto done;
                     }
 
                 } else if (PMIX_CHECK_KEY(&q->qualifiers[n], PMIX_HOSTNAME)) {
-                    hostname = q->qualifiers[n].value.data.string;
+                    if (!qual_string(&q->qualifiers[n], &hostname)) {
+                        ret = PMIX_ERR_BAD_PARAM;
+                        goto done;
+                    }
 
                 } else if (PMIX_CHECK_KEY(&q->qualifiers[n], PMIX_NODEID)) {
                     PMIX_VALUE_GET_NUMBER(rc, &q->qualifiers[n].value, nodeid, uint32_t);
+                    if (PMIX_SUCCESS != rc) {
+                        ret = PMIX_ERR_BAD_PARAM;
+                        goto done;
+                    }
 
                 } else if (PMIX_CHECK_KEY(&q->qualifiers[n], PMIX_PSET_NAME)) {
-                    psetname = q->qualifiers[n].value.data.string;
+                    if (!qual_string(&q->qualifiers[n], &psetname)) {
+                        ret = PMIX_ERR_BAD_PARAM;
+                        goto done;
+                    }
 
                 } else if (PMIX_CHECK_KEY(&q->qualifiers[n], PMIX_SESSION_ID)) {
                     PMIX_VALUE_GET_NUMBER(rc, &q->qualifiers[n].value, sessionid, uint32_t);
+                    if (PMIX_SUCCESS != rc) {
+                        ret = PMIX_ERR_BAD_PARAM;
+                        goto done;
+                    }
 
                 } else if (PMIX_CHECK_KEY(&q->qualifiers[n], PMIX_ALLOC_ID)) {
-                    allocid = q->qualifiers[n].value.data.string;
+                    if (!qual_string(&q->qualifiers[n], (char **) &allocid)) {
+                        ret = PMIX_ERR_BAD_PARAM;
+                        goto done;
+                    }
 
 #ifdef PMIX_ALLOC_PROPERTY
                 } else if (PMIX_CHECK_KEY(&q->qualifiers[n], PMIX_ALLOC_PROPERTY)) {
-                    allocprop = q->qualifiers[n].value.data.string;
+                    if (!qual_string(&q->qualifiers[n], (char **) &allocprop)) {
+                        ret = PMIX_ERR_BAD_PARAM;
+                        goto done;
+                    }
 #endif
                 }
 

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -34,29 +34,19 @@
 
 #include "prte_config.h"
 
-#ifdef HAVE_UNISTD_H
-#    include <unistd.h>
-#endif
+#include <stdlib.h>
+#include <string.h>
 
 #include "src/hwloc/hwloc-internal.h"
 #include "src/pmix/pmix-internal.h"
-#include "src/util/pmix_argv.h"
 #include "src/util/pmix_os_path.h"
-#include "src/util/pmix_path.h"
 #include "src/util/pmix_output.h"
+#include "src/util/pmix_path.h"
 
 #include "src/mca/errmgr/errmgr.h"
-#include "src/mca/iof/iof.h"
-#include "src/mca/plm/base/plm_private.h"
-#include "src/mca/plm/plm.h"
 #include "src/mca/rmaps/rmaps_types.h"
-#include "src/rml/rml.h"
-#include "src/mca/schizo/schizo.h"
-#include "src/mca/state/state.h"
 #include "src/runtime/prte_globals.h"
-#include "src/threads/pmix_threads.h"
 #include "src/util/name_fns.h"
-#include "src/util/pmix_show_help.h"
 
 #include "src/prted/pmix/pmix_server_internal.h"
 

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -106,12 +106,17 @@ static void _query(int sd, short args, void *cbdata)
         const char *allocprop;
 #endif
     char **ans, *tmp;
+    size_t nkeys = 0;
     char *psetname;
     prte_app_context_t *app;
     prte_session_t *session;
     int matched;
     pmix_proc_info_t *procinfo;
-    pmix_data_array_t dry;
+    /* PMIx initializes this before anything in PMIx_Info_list_convert() can
+     * fail, but every path to the done: label depends on that and the early
+     * ones reach it having never touched this - so initialize it here rather
+     * than rely on the callee to initialize its caller's stack */
+    pmix_data_array_t dry = PMIX_DATA_ARRAY_STATIC_INIT;
     prte_proc_t *proct;
     pmix_proc_t *proc;
     size_t sz;
@@ -267,6 +272,7 @@ static void _query(int sd, short args, void *cbdata)
             }
         }
         for (n = 0; NULL != q->keys[n]; n++) {
+            ++nkeys;
             pmix_output_verbose(2, prte_pmix_server_globals.output,
                                 "%s processing key %s",
                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), q->keys[n]);
@@ -1215,12 +1221,16 @@ done:
         } else if (PMIX_SUCCESS == ret) {
             if (0 == dry.size) {
                 ret = PMIX_ERR_NOT_FOUND;
+            } else if (dry.size < nkeys) {
+                /* against cd->ninfo, which a query caddy never sets, this
+                 * compared with zero and PMIX_QUERY_PARTIAL_SUCCESS could not
+                 * be reached.  The count that means something here is the
+                 * number of keys that were asked for: fewer results than that
+                 * is what partial success is for, and a caller has no other
+                 * way to learn that one of its keys went unanswered */
+                ret = PMIX_QUERY_PARTIAL_SUCCESS;
             } else {
-                if (dry.size < cd->ninfo) {
-                    ret = PMIX_QUERY_PARTIAL_SUCCESS;
-                } else {
-                    ret = PMIX_SUCCESS;
-                }
+                ret = PMIX_SUCCESS;
             }
         }
     }

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -93,7 +93,6 @@ static void _query(int sd, short args, void *cbdata)
     pmix_status_t ret = PMIX_SUCCESS;
     void *results, *plist, *stack, *cache;
     pmix_pointer_array_t *alloc_nodes;
-    prte_info_item_t *kv;
     pmix_nspace_t jobid;
     prte_job_t *jdata;
     prte_node_t *node, *ndptr;
@@ -317,12 +316,15 @@ static void _query(int sd, short args, void *cbdata)
                     if (PMIX_SUCCESS != rc) {
                         PMIX_ERROR_LOG(rc);
                         PMIX_INFO_LIST_RELEASE(stack);
+                        PMIX_INFO_LIST_RELEASE(cache);
                         goto done;
                     }
                     /* add the cmd line */
                     app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, 0);
                     if (NULL == app) {
                         ret = PMIX_ERR_NOT_FOUND;
+                        PMIX_INFO_LIST_RELEASE(stack);
+                        PMIX_INFO_LIST_RELEASE(cache);
                         goto done;
                     }
                     cmdline = PMIx_Argv_join(app->argv, ' ');
@@ -333,6 +335,7 @@ static void _query(int sd, short args, void *cbdata)
                     if (PMIX_SUCCESS != rc) {
                         PMIX_ERROR_LOG(rc);
                         PMIX_INFO_LIST_RELEASE(stack);
+                        PMIX_INFO_LIST_RELEASE(cache);
                         goto done;
                     }
                     /* construct info on each process in the job */
@@ -348,6 +351,7 @@ static void _query(int sd, short args, void *cbdata)
                             PMIX_ERROR_LOG(rc);
                             PMIX_INFO_LIST_RELEASE(stack);
                             PMIX_INFO_LIST_RELEASE(plist);
+                            PMIX_INFO_LIST_RELEASE(cache);
                             goto done;
                         }
                         /* add the proc's hostname.  A proc has no node until the
@@ -361,6 +365,7 @@ static void _query(int sd, short args, void *cbdata)
                                 PMIX_ERROR_LOG(rc);
                                 PMIX_INFO_LIST_RELEASE(stack);
                                 PMIX_INFO_LIST_RELEASE(plist);
+                                PMIX_INFO_LIST_RELEASE(cache);
                                 goto done;
                             }
                         }
@@ -370,6 +375,7 @@ static void _query(int sd, short args, void *cbdata)
                             PMIX_ERROR_LOG(rc);
                             PMIX_INFO_LIST_RELEASE(stack);
                             PMIX_INFO_LIST_RELEASE(plist);
+                            PMIX_INFO_LIST_RELEASE(cache);
                             goto done;
                         }
                         /* add to the stack */
@@ -378,6 +384,7 @@ static void _query(int sd, short args, void *cbdata)
                             PMIX_ERROR_LOG(rc);
                             PMIX_INFO_LIST_RELEASE(stack);
                             PMIX_INFO_LIST_RELEASE(plist);
+                            PMIX_INFO_LIST_RELEASE(cache);
                             goto done;
                         }
                         PMIX_INFO_LIST_RELEASE(plist);
@@ -389,6 +396,7 @@ static void _query(int sd, short args, void *cbdata)
                     if (PMIX_SUCCESS != rc) {
                         PMIX_ERROR_LOG(rc);
                         PMIX_INFO_LIST_RELEASE(stack);
+                        PMIX_INFO_LIST_RELEASE(cache);
                         goto done;
                     }
                     PMIX_INFO_LIST_RELEASE(stack);
@@ -464,11 +472,9 @@ static void _query(int sd, short args, void *cbdata)
                 if (NULL != prte_hwloc_topology) {
                     char *xmlbuffer = NULL;
                     int len;
-                    kv = PMIX_NEW(prte_info_item_t);
                     /* get it from the v2 API */
                     if (0 != hwloc_topology_export_xmlbuffer(prte_hwloc_topology, &xmlbuffer, &len,
                                                              HWLOC_TOPOLOGY_EXPORT_XML_FLAG_V1)) {
-                        PMIX_RELEASE(kv);
                         continue;
                     }
                     PMIX_INFO_LIST_ADD(rc, results, PMIX_HWLOC_XML_V1, xmlbuffer, PMIX_STRING);
@@ -483,9 +489,7 @@ static void _query(int sd, short args, void *cbdata)
                 if (NULL != prte_hwloc_topology) {
                     char *xmlbuffer = NULL;
                     int len;
-                    kv = PMIX_NEW(prte_info_item_t);
                     if (0 != hwloc_topology_export_xmlbuffer(prte_hwloc_topology, &xmlbuffer, &len, 0)) {
-                        PMIX_RELEASE(kv);
                         continue;
                     }
                     PMIX_INFO_LIST_ADD(rc, results, PMIX_HWLOC_XML_V2, xmlbuffer, PMIX_STRING);
@@ -1170,6 +1174,13 @@ static void _query(int sd, short args, void *cbdata)
                 nodelist = PMIx_Argv_join(nodes, ',');
                 PMIx_Argv_free(nodes);
                 PMIX_INFO_LIST_ADD(rc, results, PMIX_QUERY_RESOLVE_NODE, nodelist, PMIX_STRING);
+                if (NULL != nodelist) {
+                    free(nodelist);
+                }
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    goto done;
+                }
 
             } else if (PMIx_Check_key(q->keys[n], PMIX_QUERY_PROC_RESOURCE_USAGE)) {
 

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -183,7 +183,8 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
 
     /* pass the session ID */
     ui32_ptr = &ui32;
-    if(prte_get_attribute(&jdata->attributes, PRTE_JOB_SESSION_ID, (void **) &ui32_ptr, PMIX_UINT32)){
+    if (prte_get_attribute(&jdata->attributes, PRTE_JOB_SESSION_ID, (void **) &ui32_ptr,
+                           PMIX_UINT32)) {
         PMIX_INFO_LIST_ADD(ret, info, PMIX_SESSION_ID, &ui32, PMIX_UINT32);
         if (PMIX_SUCCESS != ret) {
             PMIX_ERROR_LOG(ret);
@@ -262,9 +263,12 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
                         PMIX_LOAD_PROCID(&nm->name, pptr->name.nspace, pptr->name.rank);
                         pmix_list_append(&local_procs, &nm->super);
                         if (PMIX_CHECK_NSPACE(jdata->nspace, pptr->name.nspace)) {
-                            /* go ahead and register this client - since we are going to wait
-                             * for register_nspace to complete and the PMIx library serializes
-                             * the registration requests, we don't need to wait here */
+                            /* Go ahead and register this client.  The PMIx library
+                             * serializes registration requests, so this one is
+                             * ordered ahead of the register_nspace below however
+                             * long either takes - which is why neither has to be
+                             * waited for here, and why this one being fire-and-
+                             * forget does not race the namespace it belongs to. */
                             ret = PMIx_server_register_client(&pptr->name, uid, gid,
                                                               (void*)pptr, NULL, NULL);
                             if (PMIX_SUCCESS != ret && PMIX_OPERATION_SUCCEEDED != ret) {

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -142,7 +142,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
     pmix_list_t local_procs, members;
     prte_namelist_t *nm;
     size_t nmsize;
-    prte_pmix_server_pset_t *pset;
+    prte_pmix_server_pset_t *pset, *psptr;
     pmix_cpuset_t cpuset;
     uint32_t ui32, *ui32_ptr;
     pmix_data_array_t *devarray;
@@ -152,14 +152,31 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
     size_t ndist;
     pmix_topology_t topo;
     pmix_data_array_t darray, lparray;
-    bool flag, *fptr;
+    bool flag, *fptr, newpset;
 
     pmix_output_verbose(2, prte_pmix_server_globals.output,
                         "%s register nspace for %s",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_JOBID_PRINT(jdata->nspace));
 
+    /* Everything below is assembled by walking the job's map, and a job
+     * object outlives its map: the map is released when the job completes
+     * and the object itself not until cleanup_job, a later event.  A caller
+     * that reaches us in between would take the daemon down here.  The
+     * caller that can hit that window - the wildcard direct-modex arm of
+     * dmodex_req() - screens for it itself, because it owes its client an
+     * answer rather than merely a survival; this is the backstop for the
+     * rest. */
+    if (NULL == jdata->map) {
+        PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+        return PRTE_ERR_NOT_FOUND;
+    }
+
     /* setup the info list */
     PMIX_INFO_LIST_START(info);
+    if (NULL == info) {
+        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
     uid = geteuid();
     gid = getegid();
     topo.source = "hwloc";
@@ -316,7 +333,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
             free(tmp);
             PMIX_INFO_LIST_RELEASE(info);
             rc = prte_pmix_convert_status(ret);
-            return rc;
+            goto errout;
         }
         free(tmp);
         PMIX_INFO_LIST_ADD(ret, info, PMIX_NODE_MAP, &nregex, PMIX_REGEX2);
@@ -327,7 +344,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
             free(tmp);
             PMIX_INFO_LIST_RELEASE(info);
             rc = prte_pmix_convert_status(ret);
-            return rc;
+            goto errout;
         }
         free(tmp);
         PMIX_INFO_LIST_ADD(ret, info, PMIX_NODE_MAP, regex, PMIX_REGEX);
@@ -347,7 +364,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
             free(tmp);
             PMIX_INFO_LIST_RELEASE(info);
             rc = prte_pmix_convert_status(ret);
-            return rc;
+            goto errout;
         }
         free(tmp);
         PMIX_INFO_LIST_ADD(ret, info, PMIX_PROC_MAP, &pregex, PMIX_REGEX2);
@@ -358,7 +375,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
             free(tmp);
             PMIX_INFO_LIST_RELEASE(info);
             rc = prte_pmix_convert_status(ret);
-            return rc;
+            goto errout;
         }
         free(tmp);
         PMIX_INFO_LIST_ADD(ret, info, PMIX_PROC_MAP, regex, PMIX_REGEX);
@@ -409,7 +426,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
         PRTE_ERROR_LOG(rc);
         PMIX_INFO_LIST_RELEASE(info);
         rc = prte_pmix_convert_status(rc);
-        return rc;
+        goto errout;
     }
     // job session dir will have been stored in the jdata object
     PMIX_INFO_LIST_ADD(ret, info, PMIX_NSDIR, jdata->session_dir, PMIX_STRING);
@@ -505,12 +522,34 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
         if (prte_get_attribute(&app->attributes, PRTE_APP_PSET_NAME, (void **) &tmp, PMIX_STRING)
             && NULL != tmp) {
             PMIX_INFO_LIST_ADD(ret, iarray, PMIX_PSET_NAME, tmp, PMIX_STRING);
-            /* register it */
-            pset = PMIX_NEW(prte_pmix_server_pset_t);
-            pset->name = strdup(tmp);
-            PMIX_RETAIN(jdata);
-            pset->jdata = jdata;
-            pmix_list_append(&prte_pmix_server_globals.psets, &pset->super);
+            /* Have we already recorded this one?  This function is not
+             * called once per job: the wildcard arm of dmodex_req() calls it
+             * again every time a client asks a daemon that hosts none of the
+             * job's procs for job-level data the local server does not hold,
+             * which is once per such get.  The info arrays below have to be
+             * rebuilt each time - that is what the caller wants - but the
+             * registry entry is a per-job fact, and appending it again both
+             * duplicated the pset in every query answer and took a reference
+             * on the job object that nothing would ever give back. */
+            pset = NULL;
+            PMIX_LIST_FOREACH(psptr, &prte_pmix_server_globals.psets,
+                              prte_pmix_server_pset_t) {
+                if (psptr->jdata == jdata && NULL != psptr->name &&
+                    0 == strcmp(psptr->name, tmp)) {
+                    pset = psptr;
+                    break;
+                }
+            }
+            if (NULL == pset) {
+                pset = PMIX_NEW(prte_pmix_server_pset_t);
+                pset->name = strdup(tmp);
+                PMIX_RETAIN(jdata);
+                pset->jdata = jdata;
+                pmix_list_append(&prte_pmix_server_globals.psets, &pset->super);
+                newpset = true;
+            } else {
+                newpset = false;
+            }
             free(tmp);
             /* and its membership */
             PMIX_CONSTRUCT(&members, pmix_list_t);
@@ -525,24 +564,28 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
                     pmix_list_append(&members, &nm->super);
                 }
             }
-            pset->num_members = pmix_list_get_size(&members);
-            if (0 < pset->num_members) {
-                PMIX_DATA_ARRAY_CONSTRUCT(&darray, pset->num_members, PMIX_PROC);
+            nmsize = pmix_list_get_size(&members);
+            if (0 < nmsize) {
+                PMIX_DATA_ARRAY_CONSTRUCT(&darray, nmsize, PMIX_PROC);
                 procptr = (pmix_proc_t*)darray.array;
                 k = 0;
-                pset->members = (pmix_proc_t *)malloc(pset->num_members * sizeof (pmix_proc_t));
                 PMIX_LIST_FOREACH(nm, &members, prte_namelist_t) {
                     PMIX_LOAD_PROCID(&procptr[k], nm->name.nspace, nm->name.rank);
-                    PMIX_LOAD_PROCID(&pset->members[k], nm->name.nspace, nm->name.rank);
                     ++k;
                 }
                 PMIX_INFO_LIST_ADD(ret, iarray, PMIX_PSET_MEMBERS, &darray, PMIX_DATA_ARRAY);
-                PMIX_DATA_ARRAY_DESTRUCT(&darray);
-                // let the PMIx server know
-                ret = PMIx_server_define_process_set(pset->members, pset->num_members, pset->name);
-                if (PMIX_SUCCESS != ret) {
-                    PMIX_ERROR_LOG(ret);
+                if (newpset) {
+                    pset->num_members = nmsize;
+                    pset->members = (pmix_proc_t *) malloc(nmsize * sizeof(pmix_proc_t));
+                    memcpy(pset->members, procptr, nmsize * sizeof(pmix_proc_t));
+                    // let the PMIx server know
+                    ret = PMIx_server_define_process_set(pset->members, pset->num_members,
+                                                         pset->name);
+                    if (PMIX_SUCCESS != ret) {
+                        PMIX_ERROR_LOG(ret);
+                    }
                 }
+                PMIX_DATA_ARRAY_DESTRUCT(&darray);
             }
             PMIX_LIST_DESTRUCT(&members);
         }
@@ -633,7 +676,8 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
                     hwloc_bitmap_free(cpuset.bitmap);
                     PMIX_INFO_LIST_RELEASE(info);
                     PMIX_INFO_LIST_RELEASE(pmap);
-                    return prte_pmix_convert_status(ret);
+                    rc = prte_pmix_convert_status(ret);
+                    goto errout;
                 }
                 PMIX_INFO_LIST_ADD(ret, pmap, PMIX_LOCALITY_STRING, tmp, PMIX_STRING);
                 free(tmp);
@@ -679,11 +723,11 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
                 /* create and pass a proc-level session directory */
                 rc = prte_session_dir(&pptr->name);
                 if (PRTE_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
+                    PRTE_ERROR_LOG(rc);
                     PMIX_INFO_LIST_RELEASE(info);
                     PMIX_INFO_LIST_RELEASE(pmap);
                     rc = prte_pmix_convert_status(rc);
-                    return rc;
+                    goto errout;
                 }
                 pmix_asprintf(&tmp, "%s/%s", jdata->session_dir,
                                           PMIX_RANK_PRINT(pptr->name.rank));
@@ -751,6 +795,7 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
     }
     if (NULL != parent) {
         PMIX_PROC_RELEASE(parentproc);
+        parentproc = NULL;
     }
     if (0 != prte_pmix_server_globals.generate_dist) {
         PMIX_INFO_DESTRUCT(&devinfo[0]);
@@ -777,9 +822,21 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
     }
     PMIX_LIST_DESTRUCT(&local_procs);
 
-    /* register it */
+    /* register it.  A failure here has to be caught: PMIx_Info_list_convert()
+     * initializes the caller's array before anything can fail, so what an
+     * unchecked failure hands PMIx is a registration carrying no info at all
+     * - a job whose every job-level key is silently missing, reported to
+     * nobody. */
     PMIX_INFO_LIST_CONVERT(ret, info, &darray);
     PMIX_INFO_LIST_RELEASE(info);
+    if (PMIX_SUCCESS != ret) {
+        /* returns rather than joining the error tail below: by this point
+         * both argv lists are freed, the local-proc list is destructed and
+         * the proxy copy is released, so the tail would do each of them a
+         * second time */
+        PMIX_ERROR_LOG(ret);
+        return prte_pmix_convert_status(ret);
+    }
 
     /* do not block waiting for the registration - the callback
      * chain will thread-shift and then invoke the caller's callback
@@ -800,6 +857,25 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
         return rc;
     }
     return PRTE_SUCCESS;
+
+errout:
+    /* Every exit above is taken with the node and rank argv lists still
+     * built, with the local-proc list holding one object per proc on this
+     * node, and possibly with our own copy of the launch proxy in hand.
+     * None of that is visible to the caller, so a failed registration
+     * leaks all of it unless it is released here - once per job launched,
+     * on a path that is rare but not unreachable. */
+    if (NULL != list) {
+        PMIx_Argv_free(list);
+    }
+    if (NULL != procs) {
+        PMIx_Argv_free(procs);
+    }
+    if (NULL != parentproc) {
+        PMIX_PROC_RELEASE(parentproc);
+    }
+    PMIX_LIST_DESTRUCT(&local_procs);
+    return rc;
 }
 
 /* add any info that the tool couldn't self-assign. Follows the

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -878,9 +878,10 @@ errout:
     return rc;
 }
 
-/* add any info that the tool couldn't self-assign. Follows the
- * same asynchronous completion contract as
- * prte_pmix_server_register_nspace above */
+/* add any info that the tool couldn't self-assign.  Follows the same
+ * asynchronous completion contract as prte_pmix_server_register_nspace
+ * above, with one difference the caller has to tolerate: when the job is
+ * already known the callback fires synchronously, before this returns. */
 int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
                                    pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
@@ -907,6 +908,25 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         return PRTE_SUCCESS;
     }
 
+    /* The tool's rank is its own to choose, and it is not always zero - PMIx
+     * lets a tool self-assign both halves of its identity, and _toolconn()
+     * only defaults the rank when none was given.  The proc object built
+     * below has to carry that rank and sit at that subscript, because
+     * everything that later looks the tool up indexes jdata->procs by rank:
+     * in particular prte_state_base_track_procs(), which is what retires the
+     * tool's job when it departs.  Filed at zero, a tool with any other rank
+     * was never found there, so its namespace never terminated - and with
+     * it, the inheritance disposition of any allocation it had reserved.
+     *
+     * Screen the rank before building anything.  It arrived from the
+     * connecting process, and the sentinel ranks are not subscripts: handing
+     * PMIX_RANK_UNDEF to pmix_pointer_array_set_item() asks it to grow to
+     * four billion entries. */
+    if (PMIX_RANK_VALID <= cd->target.rank) {
+        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+        return PRTE_ERR_BAD_PARAM;
+    }
+
     // create a job tracker for it
     jdata = PMIX_NEW(prte_job_t);
     PMIX_LOAD_NSPACE(jdata->nspace, cd->target.nspace);
@@ -916,20 +936,51 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
      * what lets a later command of theirs reach an allocation this one made */
     jdata->uid = cd->uid;
     jdata->gid = cd->gid;
+    /* If this fails the job never entered the array, so nothing else will
+     * ever release it and the nspace we would go on to register is one no
+     * lookup can reach.  It fails for an nspace PRRTE will not accept -
+     * an empty one, which is what a tool that sent PMIX_NSPACE carrying no
+     * string leaves in cd->target - so this is reachable from the wire. */
     rc = prte_set_job_data_object(jdata);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_RELEASE(jdata);
+        return rc;
+    }
     app = PMIX_NEW(prte_app_context_t);
-    app->argv = PMIx_Argv_split(cd->cmdline, ' ');
-    app->app = strdup(app->argv[0]);
+    /* The command line is optional and it comes from the connecting process:
+     * PMIx sends PMIX_CMD_LINE only when it could read its own argv (it
+     * cannot on a system where /proc is absent or the sysctl is refused),
+     * and a tool speaking the protocol directly need not send it at all.
+     * PMIx_Argv_split() of a NULL - or of a string that is all separators -
+     * yields a NULL argv, so argv[0] was a dereference any tool could
+     * provoke on the daemon it attached to, and through the TCONN relay on
+     * the master.  Every consumer of app->app already tolerates NULL, so
+     * saying nothing is the honest answer when we were told nothing. */
+    if (NULL != cd->cmdline) {
+        app->argv = PMIx_Argv_split(cd->cmdline, ' ');
+    }
+    if (NULL != app->argv) {
+        app->app = strdup(app->argv[0]);
+    }
     app->idx = 0;
     app->num_procs = 1;
-    app->first_rank = 0;
+    /* the app's leader is its lowest global rank, which for a one-proc tool
+     * job is the tool's own rank - not necessarily zero */
+    app->first_rank = cd->target.rank;
     pmix_pointer_array_set_item(jdata->apps, 0, app);
     jdata->num_apps++;
     proc = PMIX_NEW(prte_proc_t);
-    PMIX_LOAD_PROCID(&proc->name, cd->target.nspace, 0);
+    PMIX_LOAD_PROCID(&proc->name, cd->target.nspace, cd->target.rank);
     proc->pid = cd->pid;
     proc->state = PRTE_PROC_STATE_RUNNING;
-    pmix_pointer_array_set_item(jdata->procs, 0, proc);
+    /* the sole proc of the sole app, alone on this node - say so on the job
+     * object as well as in the registration below, or a query reads the
+     * constructor's "undefined" back out of a proc we do know these about */
+    proc->app_rank = 0;
+    proc->local_rank = 0;
+    proc->node_rank = 0;
+    pmix_pointer_array_set_item(jdata->procs, cd->target.rank, proc);
     // find the node it is on - the tool is on our node, and our node is
     // whichever one carries our own daemon proc. Our vpid is not a subscript
     // into the node pool: the pool is indexed by node identity, and in a DVM
@@ -946,6 +997,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
     }
     if (NULL == node) {
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
+        PMIX_RELEASE(jdata);
         return PRTE_ERR_NOT_FOUND;
     }
     /* the node backpointer is borrowed, not retained */
@@ -959,7 +1011,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_ERROR_LOG(ret);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
     u32 = 1;
     /* pass the number of nodes in the job */
@@ -968,7 +1020,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_ERROR_LOG(ret);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
 
     /* job size */
@@ -977,7 +1029,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_ERROR_LOG(ret);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
 
     /* number of apps in this job */
@@ -986,7 +1038,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_ERROR_LOG(ret);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
 
 
@@ -999,7 +1051,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_INFO_LIST_RELEASE(ilist);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
     /* add local size for this job */
     u32 = 1;
@@ -1009,7 +1061,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_INFO_LIST_RELEASE(ilist);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
     /* pass the local ldr */
     PMIX_INFO_LIST_ADD(ret, ilist, PMIX_LOCALLDR, &cd->target.rank, PMIX_PROC_RANK);
@@ -1018,7 +1070,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_INFO_LIST_RELEASE(ilist);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
     /* add to the main payload */
     PMIX_INFO_LIST_CONVERT(ret, ilist, &darray);
@@ -1027,7 +1079,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_INFO_LIST_RELEASE(ilist);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
     PMIX_INFO_LIST_ADD(ret, joblist, PMIX_NODE_INFO_ARRAY, &darray, PMIX_DATA_ARRAY);
     if (PMIX_SUCCESS != ret) {
@@ -1035,7 +1087,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_INFO_LIST_RELEASE(ilist);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
     PMIX_DATA_ARRAY_DESTRUCT(&darray);
     PMIX_INFO_LIST_RELEASE(ilist);
@@ -1050,7 +1102,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_INFO_LIST_RELEASE(ilist);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
     /* add the app size */
     PMIX_INFO_LIST_ADD(ret, ilist, PMIX_APP_SIZE, &app->num_procs, PMIX_UINT32);
@@ -1059,7 +1111,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_INFO_LIST_RELEASE(ilist);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
     /* add the app leader */
     PMIX_INFO_LIST_ADD(ret, ilist, PMIX_APPLDR, &app->first_rank, PMIX_PROC_RANK);
@@ -1068,7 +1120,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_INFO_LIST_RELEASE(ilist);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
     /* add the cmd line */
     PMIX_INFO_LIST_ADD(ret, ilist, PMIX_APP_ARGV, cd->cmdline, PMIX_STRING);
@@ -1077,7 +1129,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_INFO_LIST_RELEASE(ilist);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
     /* add to the main payload */
     PMIX_INFO_LIST_CONVERT(ret, ilist, &darray);
@@ -1086,7 +1138,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_INFO_LIST_RELEASE(ilist);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
     PMIX_INFO_LIST_ADD(ret, joblist, PMIX_APP_INFO_ARRAY, &darray, PMIX_DATA_ARRAY);
     if (PMIX_SUCCESS != ret) {
@@ -1094,7 +1146,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_INFO_LIST_RELEASE(ilist);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
     PMIX_DATA_ARRAY_DESTRUCT(&darray);
     PMIX_INFO_LIST_RELEASE(ilist);
@@ -1109,7 +1161,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_INFO_LIST_RELEASE(ilist);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
     /* appnum */
     u32 = 0;
@@ -1119,16 +1171,17 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_INFO_LIST_RELEASE(ilist);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
-    /* app rank */
-    PMIX_INFO_LIST_ADD(ret, ilist, PMIX_APP_RANK, &proc->name.rank, PMIX_PROC_RANK);
+    /* app rank - the rank WITHIN the app, which for the only proc of the only
+     * app is zero however the tool numbered itself globally */
+    PMIX_INFO_LIST_ADD(ret, ilist, PMIX_APP_RANK, &proc->app_rank, PMIX_PROC_RANK);
     if (PMIX_SUCCESS != ret) {
         PMIX_ERROR_LOG(ret);
         PMIX_INFO_LIST_RELEASE(ilist);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
     /* local rank */
     u16 = 0;
@@ -1138,7 +1191,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_INFO_LIST_RELEASE(ilist);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
     /* node rank */
     PMIX_INFO_LIST_ADD(ret, ilist, PMIX_NODE_RANK, &u16, PMIX_UINT16);
@@ -1147,16 +1200,21 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_INFO_LIST_RELEASE(ilist);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
-    /* node ID */
-    PMIX_INFO_LIST_ADD(ret, ilist, PMIX_NODEID, &PRTE_PROC_MY_NAME->rank, PMIX_UINT32);
+    /* Node ID.  This is the node's slot in the node pool, which is its
+     * identity across the DVM - not our own vpid.  The two coincide on a DVM
+     * that has never changed shape and diverge the moment one has (a departed
+     * daemon's vpid is retired, its pool slot is not), which is the same
+     * distinction the node lookup above is written for.  Publishing the vpid
+     * told the tool about whichever node happened to sit in that slot. */
+    PMIX_INFO_LIST_ADD(ret, ilist, PMIX_NODEID, &node->index, PMIX_UINT32);
     if (PMIX_SUCCESS != ret) {
         PMIX_ERROR_LOG(ret);
         PMIX_INFO_LIST_RELEASE(ilist);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
     /* add to the main payload */
     PMIX_INFO_LIST_CONVERT(ret, ilist, &darray);
@@ -1165,7 +1223,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_INFO_LIST_RELEASE(ilist);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
     PMIX_INFO_LIST_ADD(ret, joblist, PMIX_PROC_INFO_ARRAY, &darray, PMIX_DATA_ARRAY);
     if (PMIX_SUCCESS != ret) {
@@ -1173,7 +1231,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_INFO_LIST_RELEASE(ilist);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
     PMIX_DATA_ARRAY_DESTRUCT(&darray);
     PMIX_INFO_LIST_RELEASE(ilist);
@@ -1190,7 +1248,7 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         PMIX_ERROR_LOG(ret);
         PMIX_INFO_LIST_RELEASE(joblist);
         rc = prte_pmix_convert_status(ret);
-        return rc;
+        goto errout;
     }
     PMIX_INFO_LIST_RELEASE(joblist);
 
@@ -1211,7 +1269,17 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
         /* the callback will never fire - releasing the caddy
          * also releases the info array */
         PMIX_RELEASE(rcd);
-        return rc;
+        goto errout;
     }
     return PRTE_SUCCESS;
+
+errout:
+    /* The job object went into the global array before any of this could
+     * fail, and nothing else knows it is there: the tool is about to be
+     * told its connection failed, so no client_finalized will ever retire
+     * this namespace and the DVM would carry a phantom tool job - and hold
+     * itself open for it - for the rest of the session.  Releasing it also
+     * takes it back out of the array. */
+    PMIX_RELEASE(jdata);
+    return rc;
 }

--- a/src/prted/pmix/pmix_server_session.c
+++ b/src/prted/pmix/pmix_server_session.c
@@ -1328,8 +1328,10 @@ static pmix_status_t apply_to_all(prte_pmix_server_req_t *req,
     if (NULL == prte_sessions) {
         return PMIX_ERR_NOT_FOUND;
     }
-    /* snapshot the size: terminating a session can remove it from the array,
-     * and can do so from under the walk */
+    /* Terminating a session can remove it from the array from under this
+     * walk.  That is safe as written: removal only NULLs the slot (the object
+     * itself survives for as long as we hold it), and the array never
+     * shrinks, so re-reading ->size each time is correct. */
     for (i = 0; i < prte_sessions->size; i++) {
         session = (prte_session_t *) pmix_pointer_array_get_item(prte_sessions, i);
         if (NULL == session || session == prte_default_session) {
@@ -1724,7 +1726,7 @@ static void pass_request(int sd, short args, void *cbdata)
                             "%s session ctrl: relaying to the master as local req %d",
                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), req->local_index);
         rc = prte_server_send_request(PRTE_PMIX_SESSION_CTRL, req);
-        if (PRTE_SUCCESS != rc) {
+        if (PMIX_SUCCESS != rc) {
             goto callback;
         }
         return;
@@ -1802,5 +1804,5 @@ pmix_status_t pmix_server_session_ctrl_fn(const pmix_proc_t *requestor,
     prte_event_set(prte_event_base, &req->ev, -1, PRTE_EV_WRITE, pass_request, req);
     PMIX_POST_OBJECT(req);
     prte_event_active(&req->ev, PRTE_EV_WRITE, 1);
-    return PRTE_SUCCESS;
+    return PMIX_SUCCESS;
 }

--- a/src/prted/pmix/pmix_server_session.c
+++ b/src/prted/pmix/pmix_server_session.c
@@ -27,6 +27,7 @@
 #include "prte_config.h"
 
 #include <errno.h>
+#include <limits.h>
 #include <signal.h>
 #include <string.h>
 
@@ -63,7 +64,11 @@ typedef enum {
 /* The parsed form of one request. Every pointer in here is BORROWED from the
  * caller's directive array, which PMIx keeps alive until we answer - with the
  * single exception of the nodelist/nspaces argv arrays, which we build and
- * which sessctrl_destruct frees. */
+ * which sessctrl_destruct frees.
+ *
+ * Borrowed from THAT array, and set_response() frees it: which is why
+ * set_response() may run only once per parsed request, and why nothing may
+ * read one of these pointers after it has. */
 typedef struct {
     prte_sessctrl_op_t op;
     int nops;                   /* number of operations named - >1 is an error */
@@ -109,6 +114,38 @@ static void sessctrl_destruct(prte_sessctrl_t *ctl)
         PMIx_Argv_free(ctl->nspaces);
         ctl->nspaces = NULL;
     }
+}
+
+/* Read a string out of one directive.
+ *
+ * Every value in this request came from the caller's own info array: PMIx
+ * hands what a process passed to PMIx_Session_control straight up to the host
+ * without inspecting what any entry holds, and this upcall is reachable by
+ * any application process or tool attached to any daemon.  So reading a fixed
+ * member of the value union reads whatever eight bytes the caller chose to
+ * put there - and every string taken here goes on to a strdup, a strlen or a
+ * parser, which is the fault version of the rule rather than the quiet one.
+ *
+ * Refuse a mistyped or absent value rather than treating it as not given:
+ * "not given" has a meaning for all of these and it is a different answer,
+ * not an error. */
+static pmix_status_t get_string_directive(pmix_info_t *info, char **out)
+{
+    /* Define the out-parameter before anything can fail, the way
+     * prte_ras_base_parse_node_list() does.  A caller has no business
+     * reading it without checking the status, but leaving it untouched on
+     * the refusal path makes that a garbage pointer rather than a NULL -
+     * and leaves the compiler unable to prove the caller's variable is ever
+     * written, which is what GCC's -Wmaybe-uninitialized was saying. */
+    *out = NULL;
+    if (PMIX_STRING != info->value.type || NULL == info->value.data.string) {
+        pmix_output_verbose(2, prte_pmix_server_globals.output,
+                            "%s session ctrl: directive %s carries no string",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), info->key);
+        return PMIX_ERR_BAD_PARAM;
+    }
+    *out = info->value.data.string;
+    return PMIX_SUCCESS;
 }
 
 /*****   DIRECTIVE PARSING   *****/
@@ -170,6 +207,14 @@ long prte_pmix_server_parse_session_time(const char *str)
             PMIx_Argv_free(fields);
             return -1;
         }
+        /* strtol reports only its OWN overflow; the multiply and the sum are
+         * ours, and signed overflow is undefined rather than merely wrong.
+         * "3555555555555:0:0:0:0" is inside strtol's range and outside this
+         * one. */
+        if (val > (LONG_MAX - total) / mult[n]) {
+            PMIx_Argv_free(fields);
+            return -1;
+        }
         total += val * mult[n];
     }
     PMIx_Argv_free(fields);
@@ -196,7 +241,7 @@ static pmix_status_t scan_resources(prte_sessctrl_t *ctl,
 {
     size_t n;
     pmix_status_t rc;
-    char *ndstring;
+    char *ndstring, *tstr = NULL;
 
     for (n = 0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_NODE_LIST)) {
@@ -208,20 +253,33 @@ static pmix_status_t scan_resources(prte_sessctrl_t *ctl,
             free(ndstring);
 
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_ID)) {
-            ctl->alloc_refid = info[n].value.data.string;
+            rc = get_string_directive(&info[n], &ctl->alloc_refid);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
 
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_REQ_ID)) {
-            ctl->user_refid = info[n].value.data.string;
+            rc = get_string_directive(&info[n], &ctl->user_refid);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
 
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_TIME)) {
-            ctl->timelimit = prte_pmix_server_parse_session_time(info[n].value.data.string);
+            rc = get_string_directive(&info[n], &tstr);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
+            ctl->timelimit = prte_pmix_server_parse_session_time(tstr);
             if (0 > ctl->timelimit) {
                 return PMIX_ERR_BAD_PARAM;
             }
 
 #if defined(PMIX_ALLOC_INHERITANCE)
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_ALLOC_INHERITANCE)) {
-            ctl->inheritance = info[n].value.data.uint8;
+            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, ctl->inheritance, uint8_t);
+            if (PMIX_SUCCESS != rc) {
+                return PMIX_ERR_BAD_PARAM;
+            }
             ctl->have_inheritance = true;
 #endif
 
@@ -254,7 +312,7 @@ static pmix_status_t parse_directives(prte_pmix_server_req_t *req,
 {
     size_t n;
     pmix_status_t rc;
-    char *ndstring;
+    char *ndstring, *tstr = NULL;
     pmix_data_array_t *darray;
 
     /* the caller is the requestor unless a relaying daemon named the original */
@@ -264,7 +322,10 @@ static pmix_status_t parse_directives(prte_pmix_server_req_t *req,
         pmix_info_t *info = &req->info[n];
 
         if (PMIX_CHECK_KEY(info, PMIX_SESSION_CTRL_ID)) {
-            ctl->ctrl_id = info->value.data.string;
+            rc = get_string_directive(info, &ctl->ctrl_id);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
 
         } else if (PMIX_CHECK_KEY(info, PMIX_REQUESTOR)) {
             if (PMIX_PROC != info->value.type || NULL == info->value.data.proc) {
@@ -312,6 +373,12 @@ static pmix_status_t parse_directives(prte_pmix_server_req_t *req,
             return PMIX_ERR_NOT_SUPPORTED;
 
         } else if (PMIX_CHECK_KEY(info, PMIX_PERSONALITY)) {
+            /* checked here rather than where it is read: build_session_job()
+             * splits it and hands it to the schizo proxy detector */
+            rc = get_string_directive(info, &tstr);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
             ctl->personality = info;
 
         } else if (PMIX_CHECK_KEY(info, PMIX_USERID)) {
@@ -338,13 +405,23 @@ static pmix_status_t parse_directives(prte_pmix_server_req_t *req,
             free(ndstring);
 
         } else if (PMIX_CHECK_KEY(info, PMIX_ALLOC_ID)) {
-            ctl->alloc_refid = info->value.data.string;
+            rc = get_string_directive(info, &ctl->alloc_refid);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
 
         } else if (PMIX_CHECK_KEY(info, PMIX_ALLOC_REQ_ID)) {
-            ctl->user_refid = info->value.data.string;
+            rc = get_string_directive(info, &ctl->user_refid);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
 
         } else if (PMIX_CHECK_KEY(info, PMIX_ALLOC_TIME)) {
-            ctl->timelimit = prte_pmix_server_parse_session_time(info->value.data.string);
+            rc = get_string_directive(info, &tstr);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
+            ctl->timelimit = prte_pmix_server_parse_session_time(tstr);
             if (0 > ctl->timelimit) {
                 return PMIX_ERR_BAD_PARAM;
             }
@@ -353,8 +430,13 @@ static pmix_status_t parse_directives(prte_pmix_server_req_t *req,
         } else if (PMIX_CHECK_KEY(info, PMIX_ALLOC_INHERITANCE)) {
             /* governs what becomes of the session's nodes when it is reclaimed:
              * handed back to the scheduler, or returned to the DVM's general
-             * pool. See returns_to_scheduler(). */
-            ctl->inheritance = info->value.data.uint8;
+             * pool. See returns_to_scheduler().  Read as a number rather than
+             * off a fixed union member: the destructive disposition must be
+             * one the caller asked for, not one a width mismatch produced. */
+            PMIX_VALUE_GET_NUMBER(rc, &info->value, ctl->inheritance, uint8_t);
+            if (PMIX_SUCCESS != rc) {
+                return PMIX_ERR_BAD_PARAM;
+            }
             ctl->have_inheritance = true;
 #endif
 
@@ -399,8 +481,21 @@ static pmix_status_t parse_directives(prte_pmix_server_req_t *req,
 
             /***   QUALIFIERS   ***/
         } else if (PMIX_CHECK_KEY(info, PMIX_NSPACE)) {
-            /* names a job within the session - preempt/restore target these */
-            PMIx_Argv_append_nosize(&ctl->nspaces, info->value.data.string);
+            /* Names a job within the session - preempt/restore/signal target
+             * these.  It has to name one: nspace_named() matches with
+             * PMIX_CHECK_NSPACE, which counts an EMPTY nspace as matching
+             * anything, so an empty string here does not select no job, it
+             * selects every job in the session - and then reports success
+             * rather than the PMIX_ERR_NOT_FOUND a caller who named nothing
+             * real is owed. */
+            rc = get_string_directive(info, &tstr);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
+            if ('\0' == tstr[0]) {
+                return PMIX_ERR_BAD_PARAM;
+            }
+            PMIx_Argv_append_nosize(&ctl->nspaces, tstr);
 
         } else if (PMIX_CHECK_KEY(info, PMIX_TIMEOUT)) {
             PMIX_VALUE_GET_NUMBER(rc, &info->value, ctl->timelimit, long);
@@ -656,13 +751,26 @@ static pmix_status_t session_extend(prte_session_t *session, prte_sessctrl_t *ct
     bool grew = false;
 
     if (NULL != ctl->nodelists) {
+        pmix_status_t prc = PMIX_SUCCESS;
         for (i = 0; NULL != ctl->nodelists[i]; i++) {
             ret = prte_ras_base_insert_node_string(ctl->nodelists[i], session);
             if (PRTE_SUCCESS != ret) {
                 PRTE_ERROR_LOG(ret);
-                return prte_pmix_convert_rc(ret);
+                prc = prte_pmix_convert_rc(ret);
+                break;
             }
             grew = true;
+        }
+        if (PMIX_SUCCESS != prc) {
+            /* Whatever was added is in the node pool and held by this session
+             * already, so grow onto it before reporting the failure: unlike
+             * an instantiation, there is no half-built session to unwind
+             * here, and returning without the grow strands those nodes -
+             * withheld from general use, with no daemon, usable by nobody. */
+            if (grew) {
+                prte_ras_base_activate_dvm_grow();
+            }
+            return prc;
         }
     }
     if (0 <= ctl->timelimit) {
@@ -819,15 +927,18 @@ static void set_response(prte_pmix_server_req_t *req, prte_sessctrl_t *ctl,
     if (NULL != nspace && !PMIX_NSPACE_INVALID(nspace)) {
         nresp++;
     }
-    if (0 == nresp) {
-        return;
-    }
 
     PMIX_INFO_CREATE(rinfo, nresp);
-    if (NULL != ctl->ctrl_id) {
+    if (0 < nresp && NULL == rinfo) {
+        /* nothing can be said, but the request must not be left holding the
+         * caller's directives as its answer either - fall through with the
+         * empty response the tail below installs */
+        nresp = 0;
+    }
+    if (0 < nresp && NULL != ctl->ctrl_id) {
         PMIX_INFO_LOAD(&rinfo[n++], PMIX_SESSION_CTRL_ID, ctl->ctrl_id, PMIX_STRING);
     }
-    if (NULL != session) {
+    if (0 < nresp && NULL != session) {
         PMIX_INFO_LOAD(&rinfo[n++], PMIX_SESSION_ID, &session->session_id, PMIX_UINT32);
         if (NULL != session->alloc_refid) {
             PMIX_INFO_LOAD(&rinfo[n++], PMIX_ALLOC_ID, session->alloc_refid, PMIX_STRING);
@@ -836,19 +947,27 @@ static void set_response(prte_pmix_server_req_t *req, prte_sessctrl_t *ctl,
             PMIX_INFO_LOAD(&rinfo[n++], PMIX_ALLOC_REQ_ID, session->user_refid, PMIX_STRING);
         }
     }
-    if (NULL != nspace && !PMIX_NSPACE_INVALID(nspace)) {
+    if (0 < nresp && NULL != nspace && !PMIX_NSPACE_INVALID(nspace)) {
         PMIX_INFO_LOAD(&rinfo[n++], PMIX_NSPACE, (void *) nspace, PMIX_STRING);
     }
 
-    /* the request's own array is normally borrowed from the PMIx caller and
+    /* The request's own array is normally borrowed from the PMIx caller and
      * needs no action, but one relayed from a peer owns its copy and would be
-     * stranded here */
+     * stranded here.
+     *
+     * That free is why this may run only ONCE per parsed request: every
+     * string ctl holds - ctrl_id above all - points into that array, so a
+     * second call would read the copy this one released.  It is also why the
+     * replacement happens even when there is nothing to say: leaving the old
+     * array in place answers the caller with its own directives echoed back
+     * as results, and on the relayed path leaves an array we own attached to
+     * a request whose answer has already gone out. */
     if (req->copy && NULL != req->info) {
         PMIX_INFO_FREE(req->info, req->ninfo);
     }
     req->info = rinfo;
     req->ninfo = nresp;
-    req->copy = true;
+    req->copy = (NULL != rinfo);
 }
 
 /* Carries a response array to whatever eventually finishes with it. Plain
@@ -1103,7 +1222,8 @@ error:
  * PMIX_OPERATION_IN_PROGRESS if it has taken over answering the request. */
 static pmix_status_t apply_to_session(prte_pmix_server_req_t *req,
                                       prte_sessctrl_t *ctl,
-                                      prte_session_t *session)
+                                      prte_session_t *session,
+                                      bool respond)
 {
     pmix_status_t rc = PMIX_SUCCESS;
 
@@ -1189,7 +1309,7 @@ static pmix_status_t apply_to_session(prte_pmix_server_req_t *req,
         break;
     }
 
-    if (PMIX_SUCCESS == rc) {
+    if (respond && PMIX_SUCCESS == rc) {
         set_response(req, ctl, session, NULL);
     }
     return rc;
@@ -1218,7 +1338,13 @@ static pmix_status_t apply_to_all(prte_pmix_server_req_t *req,
         if (!AUTHORIZED(session, &ctl->requestor)) {
             continue;
         }
-        rc = apply_to_session(req, ctl, session);
+        /* Do NOT let the per-session call build the answer.  It may run many
+         * times here, and set_response() may run only once per parsed
+         * request: it frees the array ctl's strings point into, so a second
+         * call reads the copy the first released - and the answer it would
+         * leave behind names whichever session happened to be served last,
+         * which is not what a request addressed to all of them asked about. */
+        rc = apply_to_session(req, ctl, session, false);
         if (PMIX_OPERATION_IN_PROGRESS == rc) {
             /* nothing in the all-sessions set can defer its answer: only an
              * instantiation does that, and instantiate is rejected above */
@@ -1230,6 +1356,10 @@ static pmix_status_t apply_to_all(prte_pmix_server_req_t *req,
         } else if (PMIX_ERR_NOT_FOUND == ret) {
             ret = PMIX_SUCCESS; /* at least one session was served */
         }
+    }
+    if (PMIX_SUCCESS == ret) {
+        /* no session is named: the request was about all of them */
+        set_response(req, ctl, NULL, NULL);
     }
     return ret;
 }
@@ -1289,10 +1419,23 @@ static pmix_status_t process_directive(prte_pmix_server_req_t *req)
         goto done;
     }
 
-    rc = apply_to_session(req, &ctl, session);
+    rc = apply_to_session(req, &ctl, session, true);
 
 done:
     sessctrl_destruct(&ctl);
+    if (PMIX_SUCCESS != rc && PMIX_OPERATION_IN_PROGRESS != rc) {
+        /* Nothing to report but the status, and what the request is still
+         * carrying is the array it arrived with - the caller's own
+         * directives, which must not go back looking like results.  (An
+         * in-progress request keeps it: the deferred half replaces it when
+         * it builds the real answer.) */
+        if (req->copy && NULL != req->info) {
+            PMIX_INFO_FREE(req->info, req->ninfo);
+        }
+        req->info = NULL;
+        req->ninfo = 0;
+        req->copy = false;
+    }
     return rc;
 }
 
@@ -1364,6 +1507,10 @@ void prte_pmix_server_session_complete(prte_session_t *session)
      * allocation id if the session carries one */
     ninfo = 2 + nresults + ((NULL == session->alloc_refid) ? 0 : 1);
     PMIX_INFO_CREATE(info, ninfo);
+    if (NULL == info) {
+        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+        return;
+    }
     PMIX_INFO_LOAD(&info[0], PMIX_SESSION_COMPLETE, NULL, PMIX_BOOL);
     PMIX_INFO_LOAD(&info[1], PMIX_SESSION_ID, &session->session_id, PMIX_UINT32);
     n = 2;

--- a/src/rml/relm/state_machine.c
+++ b/src/rml/relm/state_machine.c
@@ -266,7 +266,12 @@ int prte_relm_start_msg(
          * unload above may already have emptied it. Releasing an emptied
          * buffer is what the caller then does, and it is harmless. */
         PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
-        return ret;
+        /* ret is one of the packers' PMIx statuses and this function answers
+         * in PRRTE codes - the header says so, and every other way out of it
+         * does.  Its callers convert what they get with prte_pmix_convert_rc,
+         * so an unconverted PMIx status was converted a second time and the
+         * client behind the send was told something unrelated. */
+        return prte_pmix_convert_status(ret);
     }
     /* We took ownership of "buf" by succeeding, and the unload above moved
      * its payload out into "data" - but that leaves the container itself,
@@ -280,7 +285,7 @@ int prte_relm_start_msg(
     msg_cd->data = data;
     PRTE_PMIX_THREADSHIFT(msg_cd, prte_event_base, prte_relm_start_msg_cb);
 
-    return PMIX_SUCCESS;
+    return PRTE_SUCCESS;
 }
 
 void prte_relm_release_msg(prte_relm_msg_t* msg){

--- a/src/rml/routed_radix.c
+++ b/src/rml/routed_radix.c
@@ -38,6 +38,7 @@
 #include "src/mca/filem/filem.h"
 #include "src/mca/state/state.h"
 #include "src/rml/relm/relm.h"
+#include "src/prted/pmix/pmix_server_internal.h"
 
 
 static void resize_ranks(pmix_data_array_t* arr, size_t size){
@@ -400,6 +401,11 @@ void prte_rml_repair_routing_tree(pmix_data_array_t* failed_ranks, bool global,
     prte_grpcomm_fault_handler(s);
     prte_filem.fault_handler(s);
     prte_relm_fault_handler(s);
+    /* The PMIx server's monitor collective fans out with an xcast and counts
+     * direct replies, so it holds a set of daemons it is waiting on that
+     * nothing else repairs.  It is not called on the revival path below: it
+     * keys on deaths, not on the shape of the tree. */
+    prte_pmix_server_fault_handler(s);
 
     PMIX_DESTRUCT(&status);
 }

--- a/test/unit/prted/test_prted.c
+++ b/test/unit/prted/test_prted.c
@@ -1633,6 +1633,111 @@ static int test_departed_jobs(void)
  * wildcard member covers, and that a record is neither leaked nor dropped
  * while somebody named in it still exists.  Sending the event needs daemons.
  */
+/*
+ * PMIX_GROUP_LEFT arrives as an ordinary event notification, which means its
+ * info array is whatever the generating client passed to PMIx_Notify_event:
+ * PMIx forwards it to the host without inspecting what any entry holds, and
+ * the host then xcasts it to every daemon in the DVM.  So every value has to
+ * have its type checked before the matching member of its union is read, and
+ * the departing proc has to name a concrete identity - PMIX_CHECK_PROCID
+ * counts an empty nspace and a wildcard rank as matching anything, so a
+ * departure that names neither would drop whichever member sits first.
+ *
+ * Both mistakes were live, and both are reachable by any process attached to
+ * any daemon: a PMIX_GROUP_ID carrying a PMIX_SIZE handed strcmp() eight
+ * bytes of the caller's choosing, on every daemon at once.
+ */
+static int test_group_left(void)
+{
+    int failures = 0;
+    prte_pmix_server_pset_t *grp;
+    pmix_info_t info[2];
+    pmix_proc_t source, affected;
+    size_t bogus = 0x41;    /* a value that is a fatal pointer and a fine size */
+
+    PMIX_CONSTRUCT(&prte_pmix_server_globals.groups, pmix_list_t);
+    grp = PMIX_NEW(prte_pmix_server_pset_t);
+    grp->name = strdup("unit-test-group");
+    grp->num_members = 3;
+    PMIX_PROC_CREATE(grp->members, grp->num_members);
+    PMIX_LOAD_PROCID(&grp->members[0], "unit-test-grp@1", 0);
+    PMIX_LOAD_PROCID(&grp->members[1], "unit-test-grp@1", 1);
+    PMIX_LOAD_PROCID(&grp->members[2], "unit-test-grp@1", 2);
+    pmix_list_append(&prte_pmix_server_globals.groups, &grp->super);
+
+    /* a proc that is in no group, so a fall back to the event source cannot
+     * itself remove anything and confuse the cases below */
+    PMIX_LOAD_PROCID(&source, "unit-test-grp@9", 0);
+
+    /* a group id of the wrong type is not a group id */
+    PMIX_INFO_LOAD(&info[0], PMIX_GROUP_ID, &bogus, PMIX_SIZE);
+    PMIX_LOAD_PROCID(&affected, "unit-test-grp@1", 1);
+    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &affected, PMIX_PROC);
+    prte_pmix_server_group_member_left(PMIX_GROUP_LEFT, &source, info, 2);
+    CHECK("a mistyped group id is ignored", 3 == grp->num_members);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+
+    /* ...and neither is a PMIX_STRING that carries no string, which is what
+     * a string packed with a zero length comes back as */
+    PMIX_INFO_LOAD(&info[0], PMIX_GROUP_ID, NULL, PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &affected, PMIX_PROC);
+    prte_pmix_server_group_member_left(PMIX_GROUP_LEFT, &source, info, 2);
+    CHECK("a group id with no string is ignored", 3 == grp->num_members);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+
+    /* an affected proc of the wrong type is not a proc: the departure falls
+     * back to the event source, which belongs to no group here */
+    PMIX_INFO_LOAD(&info[0], PMIX_GROUP_ID, "unit-test-group", PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &bogus, PMIX_SIZE);
+    prte_pmix_server_group_member_left(PMIX_GROUP_LEFT, &source, info, 2);
+    CHECK("a mistyped affected proc is ignored", 3 == grp->num_members);
+    PMIX_INFO_DESTRUCT(&info[1]);
+
+    /* a departure that names no concrete identity must not stand for the
+     * first member it is compared against */
+    PMIX_LOAD_PROCID(&affected, NULL, PMIX_RANK_WILDCARD);
+    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &affected, PMIX_PROC);
+    prte_pmix_server_group_member_left(PMIX_GROUP_LEFT, &source, info, 2);
+    CHECK("a wildcard departure drops nobody", 3 == grp->num_members);
+    PMIX_INFO_DESTRUCT(&info[1]);
+
+    /* an event that is not a departure leaves the registry alone */
+    PMIX_LOAD_PROCID(&affected, "unit-test-grp@1", 1);
+    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &affected, PMIX_PROC);
+    prte_pmix_server_group_member_left(PMIX_ERR_LOST_CONNECTION, &source, info, 2);
+    CHECK("only PMIX_GROUP_LEFT is acted on", 3 == grp->num_members);
+
+    /* and the case all of that guards: rank 1 leaves, rank 2 slides down,
+     * and the members that stay keep their order */
+    prte_pmix_server_group_member_left(PMIX_GROUP_LEFT, &source, info, 2);
+    CHECK("a departing member is dropped", 2 == grp->num_members);
+    CHECK("the members that stay keep their order",
+          0 == grp->members[0].rank && 2 == grp->members[1].rank);
+
+    /* a second notice for a member already gone is a no-op, not an underflow */
+    prte_pmix_server_group_member_left(PMIX_GROUP_LEFT, &source, info, 2);
+    CHECK("a repeated departure is harmless", 2 == grp->num_members);
+    PMIX_INFO_DESTRUCT(&info[1]);
+    PMIX_INFO_DESTRUCT(&info[0]);
+
+    /* a departure from a group we do not hold */
+    PMIX_INFO_LOAD(&info[0], PMIX_GROUP_ID, "unit-test-other", PMIX_STRING);
+    PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &affected, PMIX_PROC);
+    prte_pmix_server_group_member_left(PMIX_GROUP_LEFT, &source, info, 2);
+    CHECK("an unknown group is left alone", 2 == grp->num_members);
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+
+    PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.groups);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_group_left\n");
+    }
+    return failures;
+}
+
 static int test_connections(void)
 {
     int failures = 0;
@@ -1822,6 +1927,7 @@ int main(void)
     failures += test_departed_jobs();
     failures += test_monitor_accounting();
     failures += test_connections();
+    failures += test_group_left();
     failures += test_prefix_normalization();
     failures += test_singleton_id();
     failures += test_xfer_job_info();

--- a/test/unit/prted/test_prted.c
+++ b/test/unit/prted/test_prted.c
@@ -1294,6 +1294,58 @@ static int test_session_time(void)
  * remembers what it was told and that it stays bounded - a persistent DVM
  * runs jobs without end.
  */
+/*
+ * prte_pmix_server_req_t's constructor.
+ *
+ * PMIX_NEW mallocs and does not zero, so a field the constructor forgets
+ * holds whatever the previous occupant of that memory left behind.  The
+ * field that matters most is tproc: the loops that decide which request an
+ * arriving answer belongs to match on it, and an operation that names no
+ * target proc at all - monitor, publish/lookup, spawn, tool connection -
+ * never writes it.  Those loops screen such a request by testing its
+ * nspace for PMIx's "invalid", which only works because the constructor
+ * puts the sentinel there.
+ *
+ * The recycling half of this test is the part that catches the bug: it
+ * releases a request that DID name a target before allocating another,
+ * which the allocator satisfies from the same block - so a constructor
+ * that leaves tproc alone hands the new request the dead one's identity.
+ */
+static int test_request_tracker(void)
+{
+    int failures = 0;
+    prte_pmix_server_req_t *req;
+    pmix_proc_t real, wild;
+
+    PMIX_LOAD_PROCID(&real, "unit-test-tracker", 3);
+    PMIX_LOAD_PROCID(&wild, "unit-test-tracker", PMIX_RANK_WILDCARD);
+
+    req = PMIX_NEW(prte_pmix_server_req_t);
+    CHECK("a new request names no target proc", PMIX_NSPACE_INVALID(req->tproc.nspace));
+    CHECK("...with an invalid rank", PMIX_RANK_INVALID == req->tproc.rank);
+    CHECK("...so it matches no real proc", !PMIX_CHECK_PROCID(&req->tproc, &real));
+    CHECK("...it is on neither request array",
+          -1 == req->local_index && -1 == req->remote_index);
+    CHECK("...and it owns no info array", !req->copy && NULL == req->info);
+    /* the sentinel is not sufficient on its own, which is why the matching
+     * loops screen for it: an empty nspace matches every namespace, so a
+     * job-level fetch (rank=WILDCARD) does pair with an untargeted request */
+    CHECK("a job-level fetch would match it", PMIX_CHECK_PROCID(&req->tproc, &wild));
+
+    /* leave a real identity in the allocator, then take the block back */
+    PMIX_XFER_PROCID(&req->tproc, &real);
+    PMIX_RELEASE(req);
+    req = PMIX_NEW(prte_pmix_server_req_t);
+    CHECK("a recycled request does not inherit the last one's target",
+          PMIX_NSPACE_INVALID(req->tproc.nspace) && PMIX_RANK_INVALID == req->tproc.rank);
+    PMIX_RELEASE(req);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_request_tracker\n");
+    }
+    return failures;
+}
+
 static int test_departed_jobs(void)
 {
     int failures = 0;
@@ -1543,6 +1595,7 @@ int main(void)
         return 1;
     }
 
+    failures += test_request_tracker();
     failures += test_departed_jobs();
     failures += test_connections();
     failures += test_prefix_normalization();

--- a/test/unit/prted/test_prted.c
+++ b/test/unit/prted/test_prted.c
@@ -1738,6 +1738,147 @@ static int test_group_left(void)
     return failures;
 }
 
+/*
+ * A PMIx_Query_info's qualifiers reach the host exactly as the requesting
+ * process wrote them: PMIx forwards the array without inspecting what any
+ * entry holds.  Six of the ones _query() acts on are strings it goes on to
+ * hand to strlen(), strcmp() or PMIx_Check_nspace(), so a qualifier carrying
+ * a value of some other type gave those functions whatever eight bytes the
+ * caller chose as a pointer - which any process or tool attached to any
+ * daemon could send.
+ *
+ * The query is driven through the real upcall rather than through the shifted
+ * handler, because the upcall is what a client reaches and because the answer
+ * this pins is the one the client is given: a malformed qualifier is
+ * PMIX_ERR_BAD_PARAM, not a fault and not the PMIX_ERR_NOT_FOUND that the
+ * status decision at the end of the handler used to overwrite it with.
+ */
+static pmix_status_t qstatus;
+static bool qdone;
+
+static void query_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo,
+                         void *cbdata, pmix_release_cbfunc_t release_fn, void *release_cbdata)
+{
+    PRTE_HIDE_UNUSED_PARAMS(info, ninfo, cbdata);
+    qstatus = status;
+    qdone = true;
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+}
+
+static pmix_status_t run_query(pmix_query_t *q)
+{
+    pmix_proc_t requestor;
+    pmix_status_t rc;
+    int spins = 0;
+
+    PMIX_LOAD_PROCID(&requestor, "unit-test-query", 0);
+    qstatus = PMIX_SUCCESS;
+    qdone = false;
+    rc = pmix_server_query_fn(&requestor, q, 1, query_cbfunc, NULL);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+    /* the upcall posts to the event base and this thread is the one that
+     * drives it, so turn it until the handler has answered */
+    while (!qdone && spins < 1000) {
+        prte_event_loop(prte_event_base, PRTE_EVLOOP_ONCE | PRTE_EVLOOP_NONBLOCK);
+        ++spins;
+    }
+    if (!qdone) {
+        return PMIX_ERR_TIMEOUT;
+    }
+    return qstatus;
+}
+
+static int test_query_qualifiers(void)
+{
+    int failures = 0;
+    pmix_query_t q;
+    size_t bogus = 0x41;    /* a fatal pointer and a perfectly good size */
+    bool made_array = false;
+    prte_job_t *jdata = NULL;
+
+    if (NULL == prte_job_data) {
+        prte_job_data = PMIX_NEW(pmix_pointer_array_t);
+        pmix_pointer_array_init(prte_job_data, 8, INT32_MAX, 8);
+        made_array = true;
+    }
+    /* the namespace qualifier is checked against the jobs we know about */
+    jdata = PMIX_NEW(prte_job_t);
+    PMIX_LOAD_NSPACE(jdata->nspace, "unit-test-query@1");
+    if (PRTE_SUCCESS != prte_set_job_data_object(jdata)) {
+        fprintf(stderr, "FAIL [test_query_qualifiers]: could not register a job\n");
+        PMIX_RELEASE(jdata);
+        return 1;
+    }
+
+    /* a mistyped qualifier is refused, not read */
+    PMIX_QUERY_CONSTRUCT(&q);
+    PMIx_Argv_append_nosize(&q.keys, PMIX_QUERY_NAMESPACES);
+    PMIX_INFO_CREATE(q.qualifiers, 1);
+    q.nqual = 1;
+    PMIX_INFO_LOAD(&q.qualifiers[0], PMIX_HOSTNAME, &bogus, PMIX_SIZE);
+    CHECK("a mistyped hostname qualifier is refused", PMIX_ERR_BAD_PARAM == run_query(&q));
+    PMIX_QUERY_DESTRUCT(&q);
+
+    PMIX_QUERY_CONSTRUCT(&q);
+    PMIx_Argv_append_nosize(&q.keys, PMIX_QUERY_NAMESPACES);
+    PMIX_INFO_CREATE(q.qualifiers, 1);
+    q.nqual = 1;
+    PMIX_INFO_LOAD(&q.qualifiers[0], PMIX_NSPACE, &bogus, PMIX_SIZE);
+    CHECK("a mistyped nspace qualifier is refused", PMIX_ERR_BAD_PARAM == run_query(&q));
+    PMIX_QUERY_DESTRUCT(&q);
+
+    PMIX_QUERY_CONSTRUCT(&q);
+    PMIx_Argv_append_nosize(&q.keys, PMIX_QUERY_NAMESPACES);
+    PMIX_INFO_CREATE(q.qualifiers, 1);
+    q.nqual = 1;
+    PMIX_INFO_LOAD(&q.qualifiers[0], PMIX_ALLOC_ID, &bogus, PMIX_SIZE);
+    CHECK("a mistyped allocation id qualifier is refused", PMIX_ERR_BAD_PARAM == run_query(&q));
+    PMIX_QUERY_DESTRUCT(&q);
+
+    /* a numeric qualifier that is not a number is refused too - it used to
+     * leave the id at its "not given" sentinel and be silently ignored */
+    PMIX_QUERY_CONSTRUCT(&q);
+    PMIx_Argv_append_nosize(&q.keys, PMIX_QUERY_NAMESPACES);
+    PMIX_INFO_CREATE(q.qualifiers, 1);
+    q.nqual = 1;
+    PMIX_INFO_LOAD(&q.qualifiers[0], PMIX_NODEID, "not-a-number", PMIX_STRING);
+    CHECK("a non-numeric nodeid qualifier is refused", PMIX_ERR_BAD_PARAM == run_query(&q));
+    PMIX_QUERY_DESTRUCT(&q);
+
+    /* an unknown namespace is a bad parameter and stays one: the status
+     * decision at the end used to replace any error but NOT_SUPPORTED with
+     * NOT_FOUND, because a failed arm leaves an empty result list behind */
+    PMIX_QUERY_CONSTRUCT(&q);
+    PMIx_Argv_append_nosize(&q.keys, PMIX_QUERY_NAMESPACES);
+    PMIX_INFO_CREATE(q.qualifiers, 1);
+    q.nqual = 1;
+    PMIX_INFO_LOAD(&q.qualifiers[0], PMIX_NSPACE, "unit-test-query@nope", PMIX_STRING);
+    CHECK("an unknown namespace is reported as such", PMIX_ERR_BAD_PARAM == run_query(&q));
+    PMIX_QUERY_DESTRUCT(&q);
+
+    /* ...and a key this DVM does not implement still says so */
+    PMIX_QUERY_CONSTRUCT(&q);
+    PMIx_Argv_append_nosize(&q.keys, "prte.unit.test.no.such.key");
+    CHECK("an unrecognized key is not supported", PMIX_ERR_NOT_SUPPORTED == run_query(&q));
+    PMIX_QUERY_DESTRUCT(&q);
+
+    pmix_pointer_array_set_item(prte_job_data, jdata->index, NULL);
+    PMIX_RELEASE(jdata);
+    if (made_array) {
+        PMIX_RELEASE(prte_job_data);
+        prte_job_data = NULL;
+    }
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_query_qualifiers\n");
+    }
+    return failures;
+}
+
 static int test_connections(void)
 {
     int failures = 0;
@@ -1927,6 +2068,7 @@ int main(void)
     failures += test_departed_jobs();
     failures += test_monitor_accounting();
     failures += test_connections();
+    failures += test_query_qualifiers();
     failures += test_group_left();
     failures += test_prefix_normalization();
     failures += test_singleton_id();

--- a/test/unit/prted/test_prted.c
+++ b/test/unit/prted/test_prted.c
@@ -1425,6 +1425,150 @@ static int test_request_tracker(void)
     return failures;
 }
 
+/* The monitor collective's accounting for a daemon that dies mid-flight.
+ *
+ * The request fans out with an xcast and then counts direct replies, so
+ * nothing in it is keyed on the routing tree and nothing repairs it when the
+ * tree changes - a daemon that dies simply never answers.  What closes that
+ * is prte_pmix_server_fault_handler(), and the two things it has to get right
+ * are both invisible in a single-shot test: the routing tree calls it TWICE
+ * for one death (LOCAL scope, then GLOBAL), and it must not account a rank
+ * this particular request was never waiting on.
+ *
+ * The recovery status is filled in by hand rather than constructed, because
+ * its constructor reads the live routing tree, which no unit test has. */
+static pmix_status_t mon_status;
+static int mon_calls;
+
+static void mon_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo,
+                       void *cbdata, pmix_release_cbfunc_t release_fn,
+                       void *release_cbdata)
+{
+    PRTE_HIDE_UNUSED_PARAMS(info, ninfo, cbdata, release_fn, release_cbdata);
+    /* deliberately does NOT invoke release_fn: that thread-shifts onto an
+     * event base nothing is driving here.  The test owns the request. */
+    mon_status = status;
+    ++mon_calls;
+}
+
+static prte_pmix_server_req_t *mon_req(pmix_info_t *monitor, pmix_rank_t nexpect)
+{
+    prte_pmix_server_req_t *req;
+    pmix_rank_t r;
+
+    req = PMIX_NEW(prte_pmix_server_req_t);
+    req->monitor = monitor;      /* moncopy stays false - we own it */
+    req->infocbfunc = mon_cbfunc;
+    for (r = 1; r <= nexpect; r++) {
+        pmix_bitmap_set_bit(&req->expected_dmns, (int) r);
+    }
+    req->ndaemons = nexpect;
+    req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
+    return req;
+}
+
+static void mon_reported(prte_pmix_server_req_t *req, pmix_rank_t r, bool ok)
+{
+    pmix_bitmap_set_bit(&req->reported_dmns, (int) r);
+    ++req->nreported;
+    if (ok) {
+        ++req->nsuccess;
+    }
+}
+
+static void mon_drop(prte_pmix_server_req_t *req)
+{
+    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs,
+                                req->local_index, NULL);
+    PMIX_RELEASE(req);
+}
+
+static int test_monitor_accounting(void)
+{
+    int failures = 0;
+    prte_pmix_server_req_t *req;
+    prte_rml_recovery_status_t st;
+    pmix_rank_t failed[2];
+    pmix_info_t monitor;
+    uint32_t nrep;
+
+    PMIX_CONSTRUCT(&prte_pmix_server_globals.local_reqs, pmix_pointer_array_t);
+    pmix_pointer_array_init(&prte_pmix_server_globals.local_reqs, 8, INT32_MAX, 8);
+    PMIX_INFO_LOAD(&monitor, PMIX_MONITOR_HEARTBEAT, NULL, PMIX_BOOL);
+
+    memset(&st, 0, sizeof(st));
+    st.failed_ranks.array = failed;
+    st.failed_ranks.type = PMIX_PROC_RANK;
+
+    /* one of three answered, the other two died: the caller is holding a
+     * sample of part of the DVM and has to be told so */
+    req = mon_req(&monitor, 3);
+    mon_reported(req, 1, true);
+    mon_calls = 0;
+    mon_status = PMIX_SUCCESS;
+    failed[0] = 2;
+    failed[1] = 3;
+    st.failed_ranks.size = 2;
+    prte_pmix_server_fault_handler(&st);
+    CHECK("losing the last outstanding daemons completes the request", 1 == mon_calls);
+    CHECK("...with partial success", PMIX_ERR_PARTIAL_SUCCESS == mon_status);
+
+    /* the tree reports every death twice - LOCAL scope then GLOBAL - and the
+     * request is still on the array when the second call arrives, because the
+     * release it was handed thread-shifts.  A second completion here would
+     * answer the client twice and release the request under it. */
+    nrep = req->nreported;
+    prte_pmix_server_fault_handler(&st);
+    CHECK("the second notice for the same death is a no-op", 1 == mon_calls);
+    /* assert the accounting directly, not just that it did not complete
+     * twice: an over-count sails past the equality test in the completion
+     * check and would leave this looking clean while the request could
+     * never again be completed by anything */
+    CHECK("...and does not count the same death twice", nrep == req->nreported);
+    mon_drop(req);
+
+    /* nobody answered at all - "partial" would be a lie, so the status says
+     * why instead */
+    req = mon_req(&monitor, 2);
+    mon_calls = 0;
+    failed[0] = 1;
+    failed[1] = 2;
+    st.failed_ranks.size = 2;
+    prte_pmix_server_fault_handler(&st);
+    CHECK("losing every daemon completes the request", 1 == mon_calls);
+    CHECK("...and does not call that a partial success",
+          PMIX_SUCCESS != mon_status && PMIX_ERR_PARTIAL_SUCCESS != mon_status);
+    mon_drop(req);
+
+    /* a death this request was never waiting on must not be counted: doing so
+     * completes it early, before the daemons it IS waiting on have answered */
+    req = mon_req(&monitor, 1);
+    mon_calls = 0;
+    failed[0] = 7;
+    st.failed_ranks.size = 1;
+    prte_pmix_server_fault_handler(&st);
+    CHECK("an unrelated daemon's death is not accounted", 0 == mon_calls);
+    CHECK("...and leaves the request waiting", 0 == req->nreported);
+    mon_drop(req);
+
+    /* a request that never fanned out has no expected set to consult */
+    req = mon_req(&monitor, 0);
+    mon_calls = 0;
+    failed[0] = 1;
+    st.failed_ranks.size = 1;
+    prte_pmix_server_fault_handler(&st);
+    CHECK("a request that never fanned out is left alone", 0 == mon_calls);
+    mon_drop(req);
+
+    PMIX_INFO_DESTRUCT(&monitor);
+    PMIX_DESTRUCT(&prte_pmix_server_globals.local_reqs);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_monitor_accounting\n");
+    }
+    return failures;
+}
+
 static int test_departed_jobs(void)
 {
     int failures = 0;
@@ -1676,6 +1820,7 @@ int main(void)
 
     failures += test_request_tracker();
     failures += test_departed_jobs();
+    failures += test_monitor_accounting();
     failures += test_connections();
     failures += test_prefix_normalization();
     failures += test_singleton_id();

--- a/test/unit/prted/test_prted.c
+++ b/test/unit/prted/test_prted.c
@@ -1334,6 +1334,15 @@ static const struct {
     {"-5",                     -1},
     {"5s",                     -1},
     {"1:2:3:4:5:6",            -1},   /* one field too many */
+    /* Inside strtol's range and outside the accumulator's.  strtol reports
+     * only its own overflow, so a month count this large used to be
+     * multiplied by 2592000 and summed as signed - undefined, and in
+     * practice a plausible-looking duration for a session that would then
+     * be reclaimed at the wrong moment. */
+    {"3558399705577:0:0:0:0",  -1},
+    {"3558399705576:0:0:0:0",  3558399705576L * 2592000L},  /* the largest that fits */
+    {"9223372036854775807",    9223372036854775807L},  /* LONG_MAX: seconds, x1 */
+    {"9223372036854775808",    -1},   /* past LONG_MAX: strtol's own overflow */
 };
 
 static int test_session_time(void)

--- a/test/unit/prted/test_prted.c
+++ b/test/unit/prted/test_prted.c
@@ -1400,12 +1400,23 @@ static int test_request_tracker(void)
      * job-level fetch (rank=WILDCARD) does pair with an untargeted request */
     CHECK("a job-level fetch would match it", PMIX_CHECK_PROCID(&req->tproc, &wild));
 
+    /* mdxcbfunc is the other field the matching loops key on, and it carries
+     * more weight than tproc does: pmix_server_dmdx_resp() uses it to tell a
+     * direct-modex request from everything else sharing local_reqs - the
+     * scheduler relays record a REAL requestor in tproc, so the sentinel
+     * check above does not screen them - and having decided, it CALLS it.
+     * A stale one left in a recycled block is therefore not a mismatch but a
+     * jump through a dangling function pointer. */
+    CHECK("a new request carries no modex callback", NULL == req->mdxcbfunc);
+
     /* leave a real identity in the allocator, then take the block back */
     PMIX_XFER_PROCID(&req->tproc, &real);
+    req->mdxcbfunc = (pmix_modex_cbfunc_t) 0x1;
     PMIX_RELEASE(req);
     req = PMIX_NEW(prte_pmix_server_req_t);
     CHECK("a recycled request does not inherit the last one's target",
           PMIX_NSPACE_INVALID(req->tproc.nspace) && PMIX_RANK_INVALID == req->tproc.rank);
+    CHECK("...nor the last one's modex callback", NULL == req->mdxcbfunc);
     PMIX_RELEASE(req);
 
     if (0 == failures) {

--- a/test/unit/prted/test_prted.c
+++ b/test/unit/prted/test_prted.c
@@ -319,6 +319,45 @@ static int test_xfer_job_info(void)
     CHECK("xfer/empty", PRTE_SUCCESS == prte_pmix_xfer_job_info(jdata, NULL, 0));
     PMIX_RELEASE(jdata);
 
+    /* A directive whose value is a PMIX_STRING carrying no string is what
+     * PMIX_INFO_LOAD produces from a NULL - an ordinary thing for an
+     * application to hand PMIx_Spawn, and something PMIx itself treats as
+     * legal.  The branches that parse such a value rather than pass it on
+     * to a NULL-tolerant callee used to dereference it, so a client could
+     * segfault the daemon it was attached to with one spawn request.  Each
+     * of these must come back as a refusal, and must come back at all. */
+    jdata = fresh_job();
+    PMIX_INFO_LOAD(&info[0], PMIX_STDIN_TGT, NULL, PMIX_STRING);
+    CHECK("xfer/null-stdin-tgt", PRTE_SUCCESS != prte_pmix_xfer_job_info(jdata, info, 1));
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_RELEASE(jdata);
+
+    jdata = fresh_job();
+    PMIX_INFO_LOAD(&info[0], PMIX_SPAWN_TIMEOUT, NULL, PMIX_STRING);
+    CHECK("xfer/null-spawn-timeout", PRTE_SUCCESS != prte_pmix_xfer_job_info(jdata, info, 1));
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_RELEASE(jdata);
+
+    jdata = fresh_job();
+    PMIX_INFO_LOAD(&info[0], PMIX_JOB_TIMEOUT, NULL, PMIX_STRING);
+    CHECK("xfer/null-job-timeout", PRTE_SUCCESS != prte_pmix_xfer_job_info(jdata, info, 1));
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_RELEASE(jdata);
+
+    jdata = fresh_job();
+    PMIX_INFO_LOAD(&info[0], PMIX_PARENT_ID, NULL, PMIX_PROC);
+    CHECK("xfer/null-parent-id", PRTE_SUCCESS != prte_pmix_xfer_job_info(jdata, info, 1));
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_RELEASE(jdata);
+
+    /* ...and a key whose value we only ever hand onward stays a no-op: the
+     * guard above must not have turned every empty value into a refusal */
+    jdata = fresh_job();
+    PMIX_INFO_LOAD(&info[0], PMIX_ALLOC_ID, NULL, PMIX_STRING);
+    CHECK("xfer/null-passthrough", PRTE_SUCCESS == prte_pmix_xfer_job_info(jdata, info, 1));
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_RELEASE(jdata);
+
     return failures;
 }
 
@@ -394,6 +433,35 @@ static int test_xfer_app(void)
     app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, 1);
     CHECK("app/multi-idx", NULL != app && 1 == app->idx);
     CHECK("app/multi-cmd", NULL != app && 0 == strcmp(app->app, "b"));
+    PMIX_APP_DESTRUCT(&papp);
+    PMIX_RELEASE(jdata);
+
+    /* PMIX_WDIR overrides whatever pmix_app_t.cwd already gave us, so the
+     * earlier value has to be let go rather than stranded - and a WDIR
+     * carrying no string at all must be refused rather than dereferenced */
+    jdata = fresh_job();
+    PMIX_APP_CONSTRUCT(&papp);
+    papp.cmd = strdup("c");
+    papp.cwd = strdup("/tmp");
+    papp.maxprocs = 1;
+    PMIX_INFO_CREATE(papp.info, 1);
+    papp.ninfo = 1;
+    PMIX_INFO_LOAD(&papp.info[0], PMIX_WDIR, "/usr", PMIX_STRING);
+    CHECK("app/wdir-rc", PRTE_SUCCESS == prte_pmix_xfer_app(jdata, &papp));
+    app = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, 0);
+    CHECK("app/wdir-override", NULL != app && NULL != app->cwd
+                               && 0 == strcmp(app->cwd, "/usr"));
+    PMIX_APP_DESTRUCT(&papp);
+    PMIX_RELEASE(jdata);
+
+    jdata = fresh_job();
+    PMIX_APP_CONSTRUCT(&papp);
+    papp.cmd = strdup("d");
+    papp.maxprocs = 1;
+    PMIX_INFO_CREATE(papp.info, 1);
+    papp.ninfo = 1;
+    PMIX_INFO_LOAD(&papp.info[0], PMIX_WDIR, NULL, PMIX_STRING);
+    CHECK("app/wdir-null", PRTE_SUCCESS != prte_pmix_xfer_app(jdata, &papp));
     PMIX_APP_DESTRUCT(&papp);
     PMIX_RELEASE(jdata);
 

--- a/test/unit/prted/test_prted.c
+++ b/test/unit/prted/test_prted.c
@@ -1879,6 +1879,84 @@ static int test_query_qualifiers(void)
     return failures;
 }
 
+/* prte_pmix_server_register_tool() builds the daemon's job object for a
+ * connecting tool out of what that tool sent, which is untrusted input from
+ * the wire.  Everything past the checks below needs a live PMIx server, so
+ * this pins the three decisions it makes before reaching one. */
+static int test_tool_registration(void)
+{
+    int failures = 0;
+    prte_pmix_server_req_t *req;
+    prte_job_t *jdata;
+    bool made_array = false;
+    int rc;
+
+    if (NULL == prte_job_data) {
+        prte_job_data = PMIX_NEW(pmix_pointer_array_t);
+        pmix_pointer_array_init(prte_job_data, 8, INT32_MAX, 8);
+        made_array = true;
+    }
+
+    /* A tool chooses its own rank, and the sentinel ranks are not
+     * subscripts: the proc object is filed in jdata->procs at the tool's
+     * rank, so PMIX_RANK_UNDEF would ask the pointer array to grow to four
+     * billion entries.  Refused before anything is built. */
+    req = PMIX_NEW(prte_pmix_server_req_t);
+    PMIX_LOAD_PROCID(&req->target, "unit-test-tool@1", PMIX_RANK_UNDEF);
+    req->cmdline = strdup("a-tool --with args");
+    rc = prte_pmix_server_register_tool(req, NULL, NULL);
+    CHECK("a sentinel rank is refused", PRTE_ERR_BAD_PARAM == rc);
+    CHECK("...and no job object was left behind",
+          NULL == prte_get_job_data_object(req->target.nspace));
+    PMIX_RELEASE(req);
+
+    /* A tool that sent PMIX_NSPACE carrying no string leaves an empty
+     * namespace here, which PRRTE will not file.  That return used to be
+     * ignored, so the job object was neither in the array nor released and
+     * the namespace registered was one no lookup could reach. */
+    req = PMIX_NEW(prte_pmix_server_req_t);
+    PMIX_LOAD_NSPACE(req->target.nspace, NULL);
+    req->target.rank = 0;
+    rc = prte_pmix_server_register_tool(req, NULL, NULL);
+    CHECK("an empty namespace is refused", PRTE_SUCCESS != rc);
+    PMIX_RELEASE(req);
+
+    /* A namespace we already hold is answered at once - and the caller has
+     * to tolerate the callback firing before the call returns, which is why
+     * this one is passed none. */
+    jdata = PMIX_NEW(prte_job_t);
+    PMIX_LOAD_NSPACE(jdata->nspace, "unit-test-tool@2");
+    if (PRTE_SUCCESS != prte_set_job_data_object(jdata)) {
+        fprintf(stderr, "FAIL [test_tool_registration]: could not register a job\n");
+        PMIX_RELEASE(jdata);
+        if (made_array) {
+            PMIX_RELEASE(prte_job_data);
+            prte_job_data = NULL;
+        }
+        return failures + 1;
+    }
+    req = PMIX_NEW(prte_pmix_server_req_t);
+    PMIX_LOAD_PROCID(&req->target, "unit-test-tool@2", 0);
+    rc = prte_pmix_server_register_tool(req, NULL, NULL);
+    CHECK("a namespace already known is accepted without rebuilding it",
+          PRTE_SUCCESS == rc);
+    CHECK("...and the job object we had is the one still there",
+          jdata == prte_get_job_data_object(req->target.nspace));
+    PMIX_RELEASE(req);
+
+    pmix_pointer_array_set_item(prte_job_data, jdata->index, NULL);
+    PMIX_RELEASE(jdata);
+    if (made_array) {
+        PMIX_RELEASE(prte_job_data);
+        prte_job_data = NULL;
+    }
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_tool_registration\n");
+    }
+    return failures;
+}
+
 static int test_connections(void)
 {
     int failures = 0;
@@ -2068,6 +2146,7 @@ int main(void)
     failures += test_departed_jobs();
     failures += test_monitor_accounting();
     failures += test_connections();
+    failures += test_tool_registration();
     failures += test_query_qualifiers();
     failures += test_group_left();
     failures += test_prefix_normalization();


### PR DESCRIPTION
Every source file in `src/prted/pmix` has now been through the file-by-file
review pass: read the code, verify each finding adversarially, fix what
survives, and write what the review established into the directory's
`AGENTS.md`. This is the whole of that pass — 14 files, one commit per
logical change.

## The problem this directory has

`src/prted/pmix` is where PMIx calls *up* into PRRTE, so almost everything in
it is reached directly from a client, a tool, or a peer daemon's relay. Two
consequences ran through nearly every file:

**Values arriving from a client were read without checking their type.** PMIx
hands the host what a process passed to `PMIx_Spawn`, `PMIx_Job_control`,
`PMIx_Notify_event`, `PMIx_Session_control` or a query without inspecting what
any entry holds, so reading a fixed member of the value union reads whatever
eight bytes the caller chose to put there. Where that member is a string —
and it usually is — the next thing that happens is a `strdup`, a `strlen` or a
parser. The result was that an ordinary application process, or any tool that
could attach to any daemon, could segfault the daemon it was attached to with
a single well-formed PMIx call. That was true in the tool connection, in job
control, in event notification, in publish/lookup, in the query qualifiers,
and — worst placed of all, because it is read during the parse before anything
has asked who is calling — in session control's `PMIX_ALLOC_TIME`.

**A request that could not be served was often not answered.** The relays in
here carry the requester's index so a reply can find its way home, and a
handler that logged a failure and returned left a peer daemon, and the client
behind it, waiting for the life of the DVM. Several did.

## What is in here

Roughly, by weight:

- **Client- and tool-triggerable daemon crashes** in the tool connection,
  spawn directive translation, job control, event notification, query
  qualifiers, session control, and the wildcard direct-modex arm.
- **Requests that were dropped rather than answered** — a relay that could not
  build its request, a monitor collective whose last responder failed to
  unpack, a timed-out request that stayed armed and later answered under an
  index its peer had reused.
- **Lifetime bugs** — a use-after-free left on `remote_reqs`, a reference
  cycle, several leaks that repeat per job or per request, and a request
  tracker whose constructor left the field three matching loops key on holding
  the previous occupant's identity.
- **Status-space crossings** — PRRTE codes handed to callers reading PMIx ones
  and the reverse, including one conversion run in the wrong direction.
- **A monitor collective that could not survive a daemon dying under it**, now
  wired into the same fault dispatch every other in-flight collective uses.

The last two commits are this session's: `pmix_server_register_fns.c` and
`pmix_server_session.c`. Each individual commit message says what broke, how,
and what fixes it.

## Docs

`src/prted/pmix/AGENTS.md` grew by about 500 lines — not a changelog, but the
invariants the review had to establish in order to judge the code, including
the ones that turned out to be *refutations*. Those are the most valuable part:
they are what stops the next reader re-deriving them.

`docs/todo.rst` records where the pass has now reached, what it deliberately
did **not** do, and two gaps in coverage the fixes leave behind.

One `AGENTS.md` correction is worth calling out separately: the directory guide
claimed that with `prte_pmix_lazy_procdata` "a daemon publishes only the procs
it hosts". It does not — `docs/todo.rst` already said in terms that the
withholding half was never implemented, and the code agrees. The guide now
matches both.

## Testing

- `make check` — clean. `test/unit/prted` gained ~600 lines: the request
  tracker's constructor, the monitor collective's accounting, the departed-jobs
  list, the group-departure validator, the connected-assemblage registry, the
  query qualifier validation and status decision (driven through the real
  upcall with the test thread turning the event base), and tool registration.
- Warning-free build with `--enable-debug`.
- `contrib/dockerswarm` multi-node suite — running as of opening this; result
  to follow in a comment.
- Docs build clean under `sphinx-build -W`.

## Scope note

Two files outside the directory are touched: `src/rml/routed_radix.c` and
`src/rml/relm/state_machine.c`, which is where the monitor collective's fault
handler had to be called from. Nothing else in `src/prted` — `prte.c`,
`prted_comm.c`, `prte_app_parse.c`, `prun_common.c` — was reviewed here, and
`docs/todo.rst` says so.
