### PR TITLE
Deep review of src/prted: the tool front ends and the daemon dispatcher

### DIFF
--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -462,6 +462,11 @@ does.
    * - ``src/prted/pmix``
      - 2026-08-25
      - nothing
+   * - ``src/prted`` (excluding ``pmix/``)
+     - 2026-08-25
+     - nothing.  All four of ``prte.c``, ``prted_comm.c``,
+       ``prte_app_parse.c`` and ``prun_common.c``; with the row above it,
+       the directory is now reviewed end to end.
    * - ``src/event``
      - 2026-07-31
      - nothing
@@ -499,14 +504,6 @@ is not a marginal case.
    * - subsystem
      - last reviewed
      - since
-   * - ``src/prted`` (excluding ``pmix/``)
-     - 2026-07-30
-     - 23 commits, +677/-154.  ``prte.c``, ``prted_comm.c``,
-       ``prte_app_parse.c`` and ``prun_common.c``.  The PMIx server host
-       module underneath it has since had a review of its own and is listed
-       above; this row is what is left, and the churn in it is the
-       spawn-tree wait, the shrink departure timer and the ``--prefix``
-       normalizers.
    * - ``src/mca/ras``
      - 2026-07-26
      - 44 commits, +2,093/-494.  Elastic extend/release, the SLURM

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -236,6 +236,38 @@ odls consults ahead of its MCA value.  There is already a per-job
 follow; what is absent is the DVM-wide equivalent and the decision about
 which of the two should win.
 
+**A tool forwards signals from the signal handler itself, which is not
+async-signal-safe.**  Every forwardable signal is forwarded by default, and
+both tool bodies take them with ``signal()`` and do the work in the handler:
+``signal_forward_callback()`` in ``src/prted/prun_common.c`` calls
+``PMIx_Job_control``, and its counterpart in ``src/prted/prte.c`` calls
+``PMIx_Job_control_nb``.  Neither is async-signal-safe - both take locks,
+allocate, and write to a socket - and neither is the ``fprintf`` beside
+them.
+
+Note what the non-blocking form did and did not fix.  Moving ``prte.c`` to
+``PMIx_Job_control_nb`` removed a *different* deadlock: the blocking call
+was made from the thread that drives ``prte_event_base``, and waited for a
+completion only that thread could produce.  This one is still open, and it
+is open in both files.  Neither PMIx nor PRRTE blocks signals in its
+progress threads, so the kernel may deliver to any thread - including one
+already inside PMIx holding the lock the handler is about to want.  The
+window is real rather than theoretical: the main thread is inside PMIx for
+the whole of ``PMIx_Spawn``, which covers mapping and launching the job.
+
+The fix is not a smaller call.  It is to stop doing the work in the
+handler: the handler should ``write()`` a byte to a self-pipe - which is
+async-signal-safe and is already the pattern ``prte.c``'s
+``abort_signal_callback()`` uses for ctrl-c, via ``term_pipe`` - and the
+forwarding should happen on a thread that can safely make the call.  That
+is easy in ``prte.c``, which drives an event base and can take a signal
+event on it.  It is the harder half in ``prun_common.c``, whose main thread
+spends the job parked in ``PRTE_PMIX_WAIT_THREAD``: it has no event base of
+its own, so it needs either one or a thread whose job is to drain that
+pipe.  Because the answer differs between the two files and changes how
+every PRRTE tool takes a signal, it is recorded here rather than done
+alongside an unrelated fix.
+
 **Two resource-usage queries are recognized and answer nothing.**
 ``PMIX_QUERY_PROC_RESOURCE_USAGE`` and ``PMIX_QUERY_NODE_RESOURCE_USAGE``
 have arms of their own in ``_query()``

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -218,6 +218,24 @@ considerably more machinery than the broadcast it saves.  It has not been
 judged worth it, and the empty arms are the record of the decision rather
 than of an oversight.
 
+**A launcher's fork/exec agent directive is read and dropped.**  A tool that
+launches ``prte`` through PMIx may hand it launch directives, and the one
+``prte()`` (``src/prted/prte.c``) ever looked for was
+``PMIX_FORKEXEC_AGENT``: it did the ``PMIx_Get``, released the value, and
+carried on, so the directive had no effect and nothing said so.  The ``Get``
+has been removed, since keeping it made the code read as though the
+directive were honored.
+
+Honoring it is more than restoring the call.  The agent is used by whichever
+daemon forks the process, and each daemon reads its own from its own MCA
+state (``odls_base_exec_agent``, ``prte_odls_globals.exec_agent``) — so a
+value learned by the HNP has to be propagated, either into the daemons'
+environment at launch or as an attribute on the daemon job object that the
+odls consults ahead of its MCA value.  There is already a per-job
+``PRTE_JOB_EXEC_AGENT`` for the application job, which is the shape to
+follow; what is absent is the DVM-wide equivalent and the decision about
+which of the two should win.
+
 **Two resource-usage queries are recognized and answer nothing.**
 ``PMIX_QUERY_PROC_RESOURCE_USAGE`` and ``PMIX_QUERY_NODE_RESOURCE_USAGE``
 have arms of their own in ``_query()``

--- a/src/mca/odls/pdefault/AGENTS.md
+++ b/src/mca/odls/pdefault/AGENTS.md
@@ -185,9 +185,28 @@ Runs in the forked child; `__prte_attribute_noreturn__`. In order:
    arm also falls back on a runtime failure: the syscall can be present
    at build time and refused at run time by an older kernel or a seccomp
    policy.
-6. Restore default signal handlers (`SIGTERM/INT/HUP/PIPE/CHLD`) and
-   unblock all signals — the event library may have left them altered, and
-   an app must not inherit a blocked SIGTERM.
+6. Restore the default disposition of **every** signal and unblock them
+   all — the event library may have left them altered, and an app must not
+   inherit a blocked SIGTERM.
+
+   It has to be every signal, not the handful the daemon itself traps.
+   `execve` resets a *handled* signal to its default on its own, but an
+   *ignored* one stays ignored across it — and libevent's kqueue backend
+   implements a signal event by setting that signal to `SIG_IGN`
+   (everything but `SIGCHLD`; see its `kqueue.c`). The daemon registers a
+   signal event for every signal it is willing to forward, which by
+   default is all of them, so on macOS and the BSDs every application
+   PRRTE launched started life with `SIGUSR1`, `SIGUSR2`, `SIGALRM`,
+   `SIGCONT` and the rest already ignored, and a forwarded signal arrived
+   and was silently discarded. Linux hid it: libevent's epoll backend
+   uses a real handler there, which `execve` resets. `SIGKILL` and
+   `SIGSTOP` cannot be changed and simply fail, which is harmless.
+
+   The one-line check is `prterun -n 1 <prog>` where `<prog>` calls
+   `sigaction(sig, NULL, &oa)` and prints whether each disposition is
+   `SIG_DFL`; every one of them must be. Note that a Linux-only harness
+   cannot see this at all, so a container test for it would pass
+   vacuously.
 7. `chdir(cd->wdir)` to the app's working directory.
 8. If `PRTE_JOB_STOP_ON_EXEC`: `ptrace(PRTE_TRACEME, …)` so the app stops at
    `execve` for a debugger to attach.

--- a/src/mca/odls/pdefault/odls_pdefault_module.c
+++ b/src/mca/odls/pdefault/odls_pdefault_module.c
@@ -138,6 +138,12 @@
 #include "src/prted/pmix/pmix_server.h"
 #include "odls_pdefault.h"
 
+/* the highest signal number this platform defines, used to sweep every
+ * signal back to its default disposition before we exec */
+#ifndef _NSIG
+#    define _NSIG 32
+#endif
+
 /*
  * Module functions (function pointers used in a struct)
  */
@@ -362,17 +368,28 @@ static void do_child(prte_odls_spawn_caddy_t *cd, int write_fd, int gate_fd)
 #endif
 
     /* Set signal handlers back to the default.  Do this close to
-       the exev() because the event library may (and likely will)
+       the exec() because the event library may (and likely will)
        reset them.  If we don't do this, the event library may
        have left some set that, at least on some OS's, don't get
        reset via fork() or exec().  Hence, the launched process
-       could be unkillable (for example). */
+       could be unkillable (for example).
 
-    set_handler_default(SIGTERM);
-    set_handler_default(SIGINT);
-    set_handler_default(SIGHUP);
-    set_handler_default(SIGPIPE);
-    set_handler_default(SIGCHLD);
+       Every signal has to be covered, not just the handful the daemon
+       itself traps.  exec() resets a *handled* signal to its default, but
+       an *ignored* one stays ignored across it - and libevent's kqueue
+       backend implements signal events by setting the signal to SIG_IGN
+       (everything except SIGCHLD; see kqueue.c).  The daemon registers a
+       signal event for every signal it is willing to forward, which by
+       default is all of them, so on macOS and the BSDs every process PRRTE
+       launched came up with SIGUSR1, SIGUSR2, SIGALRM, SIGCONT and the
+       rest already ignored.  A forwarded signal then arrived at the
+       application and was silently discarded: the whole --forward-signals
+       path reached the app and did nothing.  SIGKILL and SIGSTOP cannot be
+       changed and simply fail here, which is harmless. */
+
+    for (i = 1; i < _NSIG; i++) {
+        set_handler_default(i);
+    }
 
     /* Unblock all signals, for many of the same reasons that we
        set the default handlers, above.  This is noticable on

--- a/src/prted/AGENTS.md
+++ b/src/prted/AGENTS.md
@@ -448,6 +448,13 @@ them. `--get-stack-traces` silently did nothing, because the DVM reads the
 value and not the key's presence. Do not share a scratch variable across
 blocks here; set what you are about to send.
 
+**There is no `--daemonize` arm to the session handling, and re-adding one
+is not a fix.** Neither `prun` nor `prterun` offers the option (it was
+removed from `prterun`), so the fork-and-wait that used to sit at the top of
+`prun_common()` — pipe, `prte_daemon_init_callback()`, `wait_dvm()`,
+`prte_state_base.parent_fd` — could not be reached, and nothing on the tool
+side ever wrote the 'K' its parent was waiting for.
+
 **"The job" means the whole spawn tree, and the `PMIX_EVENT_JOB_END`
 handler is deliberately *not* filtered to our own namespace.** A job
 spawned by ours outlives it by default, so our job's termination is not

--- a/src/prted/AGENTS.md
+++ b/src/prted/AGENTS.md
@@ -319,13 +319,45 @@ prefix keys. Written on any later app it stays with that app, and the apps
 that gave none fall back to the defaults: saying nothing is not the same as
 agreeing.
 
-**Every exit from `prte_parse_locals()` owns `temp_argv` and `env`.** It has
-three: the `create_app()` failure inside the segment loop, the one after it
-for the trailing segment, and the success path. Only the last released both,
-so any command line whose *final* segment fails to parse leaked them —
+**Every exit from `prte_parse_locals()` owns `temp_argv`.** It has three:
+the `create_app()` failure inside the segment loop, the one after it for the
+trailing segment, and the success path. Only the last released it, so any
+command line whose *final* segment fails to parse leaked it —
 `--display map --display cpus` is enough, because a repeated option is
-refused right there. `env` is filled in by `create_app()` and belongs to us
-whether or not it then failed.
+refused right there. (There used to be an `env` array here too, threaded
+through `create_app()` as the "base environment" an appfile's recursive
+parse would need. There is no recursion — `prte_parse_appfile()` folds an
+appfile into the command line before any of this runs — and `create_app()`
+had long since stopped writing through the parameter, so it was always
+NULL. It is gone.)
+
+**`create_app()` owns `results` and `app` on every path, and the only exit
+that releases them is `cleanup:`.** Six error paths used a bare
+`return PRTE_ERR_FATAL` instead and leaked a fully-parsed command line plus
+a half-built app apiece. It also must not return the last
+`PMIX_INFO_LIST_ADD`'s status by accident: those failures are not acted on
+where they happen, so the success path sets `rc` explicitly before handing
+the app over — otherwise the caller gets an error together with
+`made_app == true` and drops the app it was just given.
+
+**Each prefix conflict check must count its own option.** The three blocks
+(`--prefix`, `--pmix-prefix`, `--app-prefix`) each take
+`pmix_cmd_line_get_ninsts()` — which is just `PMIx_Argv_count(opt->values)`
+— and walk `opt->values` up to it. The `--pmix-prefix` block passed
+`PRTE_CLI_PREFIX`, so it skipped the check entirely whenever no `--prefix`
+was given (conflicting `--pmix-prefix` values were silently accepted, first
+one wins) and walked past the terminator whenever more `--prefix` values
+were given than `--pmix-prefix` ones. `--prefix /x --prefix /x
+--pmix-prefix /y` segfaulted the tool. `test/unit/prted` covers all three.
+
+**A command-line value that has to be a number must be checked for being
+one.** `strtol` returns 0 for a string with no digits in it, and 0 is a
+meaningful value in several places here — for `-n` it is the spelling of
+"let the mapping policy compute the count", so `-n four` launched some
+other number of processes and said nothing. The idiom used throughout is a
+leading-`isdigit`, full consumption of the string, `errno`, and a range
+check against the field the value lands in (`maxprocs` is an `int`, so
+`-n 4294967297` must be refused rather than truncated to 1).
 
 `prun_common()` is the tool body: `PMIx_tool_init` (with whatever DVM
 search directive the user gave), register event handlers for job

--- a/src/prted/AGENTS.md
+++ b/src/prted/AGENTS.md
@@ -140,6 +140,36 @@ does not drive a PRRTE event base, so the classic
 `PRTE_PMIX_WAIT_THREAD` / `PRTE_PMIX_WAKEUP_THREAD` pair is correct there
 and is used throughout. Do not "fix" it to match `prte.c`.
 
+**And the exception does not travel.** The same code moved into `prte.c`
+is a hang, and moving it is easy because the two files do many of the same
+things and `prterun` is the tool wearing `prte.c`'s body. The rule in
+`prte.c` is absolute: **no blocking PMIx call may be made from the thread
+that drives `prte_event_base`** — not just the `PMIx_Notify_event` case the
+top-level `AGENTS.md` describes. `prte` *is* the PMIx server, so a call
+like `PMIx_Job_control` is handed straight to our own host module, which
+thread-shifts the work back onto `prte_event_base`; the blocking form then
+waits inside `PMIX_WAIT_THREAD` for a completion only this thread could
+produce, and the whole DVM master stops — no RML, no timers, no PMIx
+replies, forever.
+
+That is not hypothetical: `signal_forward_callback()` did exactly this,
+and every forwardable signal is forwarded by default, so one
+`kill -USR1 <prterun>` wedged the run permanently. It now uses
+`PMIx_Job_control_nb`. Note what the non-blocking form then requires:
+**PMIx borrows the targets and directives arrays rather than copying them**,
+and reads them on its own thread long after the call returns, so neither may
+live on the caller's stack. The completion callback frees them, and may run
+on either thread, so it must touch nothing but the allocation.
+
+The other half of that function is worth knowing before you write anything
+that names "our" job: **a persistent DVM has no job of its own, and an empty
+namespace is not a safe way to say so.** `spawnednspace` is only set on the
+`prterun` path. Handed to the job-control path an empty namespace is packed
+into the daemon command verbatim, and `prted_comm.c` reads an empty
+namespace as *every* job — so a signal sent to a shared persistent `prte`
+would have been delivered to every process in the DVM, other users' jobs
+included. Check for it explicitly.
+
 ---
 
 ## `prte.c` — the HNP body
@@ -191,6 +221,32 @@ relative to `prte_init()`.
   inside the event loop.
 - **`prte_event_reinit()` after `--daemonize`.** The event base is opened
   before the fork and some backends (kqueue on macOS) do not survive it.
+- **The `--dvm <keyword>` values are keywords, not prefixes.** The block
+  that rewrites the `--dvm` option's key into the one `prun_common()`
+  expects tests `file:`, `uri:`, `pid:` and `ns:` as prefixes, which they
+  are, and then `system`, `system-first` and `search`, which are not.
+  Testing those three with `strncasecmp(..., 6)` made `system-first`
+  unreachable — it matches `system` in its first six characters, so the
+  earlier arm always won — and `--dvm system-first` silently became
+  `--dvm system`, failing outright wherever it was supposed to fall back.
+  They are matched exactly now; keep it that way, and note that each
+  keyword must be rewritten to the key that actually carries its meaning
+  (`system-first` is `PRTE_CLI_SYS_SERVER_FIRST`, which becomes
+  `PMIX_CONNECT_SYSTEM_FIRST` — it is not a namespace).
+
+- **`PRTE_UPDATE_EXIT_STATUS` discards a zero.** It only writes when the
+  new status is non-zero, so `PRTE_UPDATE_EXIT_STATUS(rc)` on a path where
+  `rc` still holds `PRTE_SUCCESS` is a no-op and the tool exits 0 having
+  failed. Three failure paths did this. Pass the failure you actually
+  detected, and if you have nothing better, `PRTE_ERR_FATAL`.
+
+- **`prte_parse_appfile()` is the `--app` reader**, extracted so it can be
+  unit-tested. `PMIx_Argv_split` returns **NULL**, not an empty array, for
+  a string that yields no tokens, so a blank line in an appfile — entirely
+  ordinary — segfaulted the tool on `split[0]`. Such a line is skipped
+  whole rather than merely contributing no words: emitting the `:`
+  delimiter for it would hand the parser an empty app context.
+
 - **`prep_singleton()` builds a job by hand.** It fabricates a
   `prte_job_t`/`prte_app_context_t`/`prte_proc_t` and registers the
   nspace, so a singleton can `PMIx_Init` against this DVM. It is the only
@@ -331,7 +387,8 @@ correctly. Do not move the close back out to `prun.c`/`prte.c`.
 
 **Unit — `test/unit/prted/` (`make check`).** Everything in here that can
 be exercised without a DVM: the `--prefix` normalizer, the `--singleton`
-identifier parser, `prte_pmix_xfer_job_info()`'s directive handling
+identifier parser, the `--app` appfile reader (including the blank lines
+that used to crash it), `prte_pmix_xfer_job_info()`'s directive handling
 (including its conflict rejection and its cache-the-unknown default),
 `prte_pmix_xfer_app()`'s translation and — importantly — its ownership
 contract with the caller's job object, and the job-info cache. Extend it

--- a/src/prted/AGENTS.md
+++ b/src/prted/AGENTS.md
@@ -162,13 +162,32 @@ live on the caller's stack. The completion callback frees them, and may run
 on either thread, so it must touch nothing but the allocation.
 
 The other half of that function is worth knowing before you write anything
-that names "our" job: **a persistent DVM has no job of its own, and an empty
-namespace is not a safe way to say so.** `spawnednspace` is only set on the
-`prterun` path. Handed to the job-control path an empty namespace is packed
-into the daemon command verbatim, and `prted_comm.c` reads an empty
-namespace as *every* job — so a signal sent to a shared persistent `prte`
-would have been delivered to every process in the DVM, other users' jobs
+that names "our" job: **an empty namespace is not a safe way to say "no
+job".** Handed to the job-control path it is packed into the daemon command
+verbatim, and `prted_comm.c` reads an empty namespace as *every* job — so
+the signal is delivered to every process in the DVM, other users' jobs
 included. Check for it explicitly.
+
+There are two ways to arrive there with one, and both are live. In `prte.c`
+a persistent DVM has no job of its own, so `spawnednspace` is only ever set
+on the `prterun` path. In `prun_common.c` it is a *window*: the forwardable
+signals are taken with `signal()` before the tool has connected to anything,
+and `spawnednspace` is not written until `PMIx_Spawn` returns — so a
+`SIGTSTP` or a `kill -USR1` that lands while the tool is still connecting,
+still parsing, or still inside the spawn finds it empty. Both
+`signal_forward_callback()`s refuse an empty namespace now; keep it that way,
+and note that the window is not small — the spawn covers the whole mapping
+and launch of the job.
+
+**And the borrowed-array rule above is about a pure server, not about
+`prun`.** `prun_common.c`'s `defhandler()` hands `PMIx_Job_control_nb`
+a `pmix_proc_t` and a `pmix_info_t` on its own stack, and that is correct:
+the entry point only borrows the arrays and defers the pack when the caller
+is the host's server. A tool or launcher peer — which is what `prun` is,
+and what `PMIX_LAUNCHER` in its `PMIx_tool_init` makes it — takes
+`pmix_job_control_relay()` instead, which packs both arrays into the message
+before it returns. Do not "fix" that call by heap-allocating its arguments,
+and do not read `prun`'s pattern as licence for the same thing in `prte.c`.
 
 ---
 
@@ -369,18 +388,65 @@ were given than `--pmix-prefix` ones. `--prefix /x --prefix /x
 one.** `strtol` returns 0 for a string with no digits in it, and 0 is a
 meaningful value in several places here — for `-n` it is the spelling of
 "let the mapping policy compute the count", so `-n four` launched some
-other number of processes and said nothing. The idiom used throughout is a
-leading-`isdigit`, full consumption of the string, `errno`, and a range
-check against the field the value lands in (`maxprocs` is an `int`, so
-`-n 4294967297` must be refused rather than truncated to 1).
+other number of processes and said nothing. The idiom is a leading-`isdigit`,
+full consumption of the string, `errno`, and a range check against the field
+the value lands in (`maxprocs` is an `int`, so `-n 4294967297` must be
+refused rather than truncated to 1), and it is packaged as
+`prte_parse_uint_option()` in [`../util/prte_cmd_line.c`](../util/prte_cmd_line.c)
+— reach for that rather than writing the fourth copy. `--timeout`,
+`--spawn-timeout`, `--max-restarts`, `--wait-to-connect`,
+`--num-connect-retries` and `--stdin`'s rank all went through a bare
+`strtol` and quietly meant something else; `--stdin garbage` sent the
+tool's stdin to rank 0.
+
+The same goes for a value that has to be a **truth**: `prte_cli_bool_value()`
+refuses one that is neither, because the test underneath reports anything it
+does not recognize as false — so `--gpu-support maybe` meant "no GPU
+support".
 
 `prun_common()` is the tool body: `PMIx_tool_init` (with whatever DVM
 search directive the user gave), register event handlers for job
-termination and debugger events, `PMIx_Spawn_nb`, push stdin, wait, then
+termination and debugger events, `PMIx_Spawn`, push stdin, wait, then
 report the job's exit status. Signal forwarding is done with
 `PMIx_Job_control(PMIX_JOB_CTRL_SIGNAL)` against the spawned nspace,
 which is what eventually arrives at `prted_comm.c`'s
 `SIGNAL_LOCAL_PROCS`.
+
+**Its return value IS the tool's exit status**, and `rc` holds
+`PRTE_SUCCESS` for most of the function's length — it is left there by the
+last thing that succeeded. So a `goto DONE` that does not assign `rc` first
+reports success: a command line the tool had just *refused*, and a spawn
+that was never attempted, both came back 0. Assign the failure you actually
+detected. (`PRTE_UPDATE_EXIT_STATUS` cannot rescue this — it discards a
+zero, and `prterun`'s proxy path `exit()`s the return value directly without
+consulting `prte_exit_status` at all.)
+
+**Every `PMIx_Register_event_handler()` here is followed by a wait on the
+lock its `regcbfunc` will wake, so every one of them must check the
+return.** The entry point refuses an uninitialized or shutting-down
+library, and a failed allocation, *in front of* the thread-shift that
+eventually calls the callback — so on those returns the wait is permanent.
+`PMIx_Deregister_event_handler()` is the same. Only `PMIX_SUCCESS` promises
+a callback; anything else means there is nothing to wait for.
+
+**Only one handler is ever deregistered, and which one is positional.**
+`regcbfunc` writes a single file-scope `evid`, so the id the teardown
+deregisters is whichever registration ran *last* — the job-termination
+handler. The default, launch-failed and ready-for-debug handlers stay
+registered until `PMIx_tool_finalize`. That is why the release lock they
+carry may not be destructed at the end of the wait: it lives on
+`prun_common()`'s stack, and a handler firing after `PRTE_PMIX_DESTRUCT_LOCK`
+locks a destroyed mutex. It is destructed after the finalize, which is the
+point past which no handler can run.
+
+**`prte_prun_parse_common_cli()` is shared by all three tools, and they do
+not offer the same options.** `--enable-recovery` and `--continuous` are in
+`prun`'s option table only, so for `prte` and `prterun` those two blocks
+never run — which is how the `flag` they set came to be read, uninitialized,
+by the `--get-stack-traces` and `--report-state-on-timeout` blocks below
+them. `--get-stack-traces` silently did nothing, because the DVM reads the
+value and not the key's presence. Do not share a scratch variable across
+blocks here; set what you are about to send.
 
 **"The job" means the whole spawn tree, and the `PMIX_EVENT_JOB_END`
 handler is deliberately *not* filtered to our own namespace.** A job
@@ -438,8 +504,15 @@ identifier parser, the `--app` appfile reader (including the blank lines
 that used to crash it), `prte_pmix_xfer_job_info()`'s directive handling
 (including its conflict rejection and its cache-the-unknown default),
 `prte_pmix_xfer_app()`'s translation and — importantly — its ownership
-contract with the caller's job object, and the job-info cache. Extend it
-whenever you add a decision that does not need a live runtime.
+contract with the caller's job object, the job-info cache,
+`prte_parse_uint_option()`, and `prte_prun_parse_common_cli()`'s
+job-directive decisions. Extend it whenever you add a decision that does
+not need a live runtime.
+
+Note what the last of those has to do to be worth anything: it sets
+`prte_tool_actual` per case, because that is what `schizo->parse_cli()`
+picks its option table from, and a case written against the wrong tool's
+table fails in the parse and proves nothing about the code under test.
 
 **Offline mapper harness.** Not relevant here unless you touch how job
 directives reach the mapper — but if you change `prte_pmix_xfer_job_info`,

--- a/src/prted/AGENTS.md
+++ b/src/prted/AGENTS.md
@@ -267,7 +267,6 @@ a string in `get_prted_comm_cmd_str()`.
 | `KILL_LOCAL_PROCS` | Kill the named procs, or all of them if the list is empty. |
 | `SIGNAL_LOCAL_PROCS` | Deliver a signal to the named **job**'s local procs. |
 | `ADD_LOCAL_PROCS` / `DVM_ADD_PROCS` | Hand the launch message to `odls.launch_local_procs`. |
-| `ABORT_PROCS_CALLED` | An app called `PMIx_Abort`; terminate the listed procs (deduplicated against everything already ordered to die). |
 | `DEFINE_PSET` | Register a process set with the local PMIx server. |
 | `EXIT_CMD` | Orderly shutdown once our children and routing children are gone. |
 | `HALT_VM_CMD` | Abnormal shutdown; notify attached tools, then terminate. |
@@ -287,10 +286,26 @@ Rules that this switch has broken before and will break again:
 - **`break` inside a `for` inside a `case` leaves the loop, not the
   switch.** The `GET_STACK_TRACES` case relies on this deliberately;
   read carefully before adding one.
+- **`GET_STACK_TRACES` is the one command that does block the loop**, and
+  knowingly: it `popen`s `gstack` against each local proc and reads it to
+  EOF, on the progress thread. It is a diagnostic reached from
+  `--timeout --get-stack-traces`, when the daemon is already in trouble
+  and the traces matter more than its latency. Do not take it as licence
+  for anything else here, and do not add work to it.
 - **Do not block.** See the thread rule above — a command that must wait
   on PMIx is written as a continuation, not as a wait on a lock.
 - **Do not assume the daemon job object exists.** `prte_get_job_data_object`
   can return NULL during teardown.
+- **A `case` with no sender is dead, and there is no compatibility reason
+  to keep one.** `ABORT_PROCS_CALLED` was such a case for a long time: an
+  app calling `PMIx_Abort` reaches `pmix_server_abort_fn` and is answered
+  entirely inside `prted/pmix` (`_client_abort` activates
+  `PRTE_PROC_STATE_CALLED_ABORT`), and nothing anywhere packed the daemon
+  command. Its ~100 lines carried a file-static array of every proc ever
+  ordered to die, retained and never emptied, which on a persistent DVM
+  would have grown for the life of the daemon. Before adding a command
+  here, grep for something that packs it; before keeping one, grep the
+  same way.
 
 ### The shrink path is subtler than it looks
 

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -829,7 +829,7 @@ PRTE_EXPORT int prte(int argc, char *argv[])
             goto DONE;
         }
         /* did they provide an app? */
-        if (PMIX_SUCCESS != rc || 0 == pmix_list_get_size(&apps)) {
+        if (PRTE_SUCCESS != rc || 0 == pmix_list_get_size(&apps)) {
             if (proxyrun) {
                 prte_show_help("help-prun.txt", "prun:executable-not-specified", true,
                                prte_tool_basename, prte_tool_basename);
@@ -984,13 +984,13 @@ PRTE_EXPORT int prte(int argc, char *argv[])
             if (NULL == param) {
                 param = strdup(iprteinfo->info.value.data.string);
             } else if (0 != strcmp(param, iprteinfo->info.value.data.string)) {
-                    // we have non-matching prefixes
-                    prte_show_help("help-plm-base.txt", "multiple-prefixes", true,
-                                   prte_tool_basename, PRTE_CLI_PREFIX,
-                                   PRTE_CLI_PREFIX, "PRRTE", PRTE_CLI_PREFIX,
-                                   param, iprteinfo->info.value.data.string);
-                    PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
-                    goto DONE;
+                // we have non-matching prefixes
+                prte_show_help("help-plm-base.txt", "multiple-prefixes", true,
+                               prte_tool_basename, PRTE_CLI_PREFIX,
+                               PRTE_CLI_PREFIX, "PRRTE", PRTE_CLI_PREFIX,
+                               param, iprteinfo->info.value.data.string);
+                PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
+                goto DONE;
             }
         }
     }
@@ -1077,13 +1077,13 @@ PRTE_EXPORT int prte(int argc, char *argv[])
             if (NULL == param) {
                 param = strdup(iprteinfo->info.value.data.string);
             } else if (0 != strcmp(param, iprteinfo->info.value.data.string)) {
-                    // we have non-matching prefixes
-                    prte_show_help("help-plm-base.txt", "multiple-prefixes", true,
-                                   prte_tool_basename, PRTE_CLI_PMIX_PREFIX,
-                                   PRTE_CLI_PMIX_PREFIX, "PMIx", PRTE_CLI_PMIX_PREFIX,
-                                   param, iprteinfo->info.value.data.string);
-                    PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
-                    goto DONE;
+                // we have non-matching prefixes
+                prte_show_help("help-plm-base.txt", "multiple-prefixes", true,
+                               prte_tool_basename, PRTE_CLI_PMIX_PREFIX,
+                               PRTE_CLI_PMIX_PREFIX, "PMIx", PRTE_CLI_PMIX_PREFIX,
+                               param, iprteinfo->info.value.data.string);
+                PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
+                goto DONE;
             }
         }
     }
@@ -1853,8 +1853,11 @@ static void epipe_signal_callback(int fd, short args, void *cbdata)
 
     sigpipe_error_count++;
 
-    if (10 < sigpipe_error_count) {
-        /* time to abort */
+    /* Say this - and try to abort - exactly once.  clean_abort() does not
+     * necessarily abort: under --keepalive it declines, because the DVM is
+     * to outlive everything but its parent.  Calling it again on every
+     * subsequent SIGPIPE simply reprinted "aborting" forever. */
+    if (11 == sigpipe_error_count) {
         pmix_output(0, "%s: SIGPIPE detected - aborting", prte_tool_basename);
         clean_abort(0, 0, NULL);
     }

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -118,6 +118,14 @@ typedef struct {
     size_t ninfo;
 } mylock_t;
 
+/* A forwarded signal's job-control request.  PMIx borrows the target and
+ * directive arrays for the life of the operation, so they cannot be the
+ * caller's stack - see signal_forward_callback(). */
+typedef struct {
+    pmix_proc_t proc;
+    pmix_info_t info;
+} prte_sigfwd_t;
+
 static pmix_nspace_t spawnednspace;
 static pmix_proc_t myproc;
 static bool signals_set = false;
@@ -174,6 +182,7 @@ static void parent_died_fn(size_t evhdlr_registration_id, pmix_status_t status,
     // shift this into our event base
     cd = PMIX_NEW(prte_pmix_server_req_t);
     prte_event_set(prte_event_base, &(cd->ev), -1, PRTE_EV_WRITE, clean_abort, cd);
+    PMIX_POST_OBJECT(cd);
     prte_event_active(&(cd->ev), PRTE_EV_WRITE, 1);
 }
 
@@ -322,6 +331,54 @@ int prte_parse_singleton_id(const char *name, pmix_nspace_t nspace, pmix_rank_t 
     return PRTE_SUCCESS;
 }
 
+/* Read an appfile and append its contents to a command line.  Each line of
+ * the file is one app context, so the lines are joined with the ":"
+ * delimiter the parser expects.
+ *
+ * A blank line - or one holding nothing but spaces - splits to no tokens at
+ * all, and PMIx_Argv_split reports that by returning NULL rather than an
+ * empty array, so the result must be checked before it is indexed: a single
+ * empty line in an appfile used to segfault the tool right here.  Such a
+ * line is skipped entirely rather than merely contributing no words,
+ * because emitting the delimiter for it would hand the parser an empty app
+ * context.
+ */
+int prte_parse_appfile(const char *path, char ***pargv, int *pargc)
+{
+    FILE *fp;
+    char *line, **split;
+    size_t n;
+    bool first = true;
+
+    if (NULL == path || NULL == pargv || NULL == pargc) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+    fp = fopen(path, "r");
+    if (NULL == fp) {
+        return PRTE_ERR_FILE_OPEN_FAILURE;
+    }
+    while (NULL != (line = pmix_getline(fp))) {
+        split = PMIx_Argv_split(line, ' ');
+        free(line);
+        if (NULL == split) {
+            continue;
+        }
+        if (!first) {
+            // add a colon delimiter
+            PMIx_Argv_append_nosize(pargv, ":");
+            ++(*pargc);
+        }
+        for (n = 0; NULL != split[n]; n++) {
+            PMIx_Argv_append_nosize(pargv, split[n]);
+            ++(*pargc);
+        }
+        PMIx_Argv_free(split);
+        first = false;
+    }
+    fclose(fp);
+    return PRTE_SUCCESS;
+}
+
 PRTE_EXPORT int prte(int argc, char *argv[])
 {
     int rc = 1, i;
@@ -339,7 +396,7 @@ PRTE_EXPORT int prte(int argc, char *argv[])
     int pargc;
     prte_job_t *jdata;
     prte_app_context_t *dapp;
-    bool proxyrun = false, first;
+    bool proxyrun = false;
     void *jinfo;
     pmix_proc_t pname;
     pmix_value_t *val;
@@ -532,15 +589,17 @@ PRTE_EXPORT int prte(int argc, char *argv[])
             prte_show_help("help-prterun.txt", "multiple-default-hostfiles", true, param);
             return 1;
          }
-        if (!pmix_path_is_absolute(opt->values[0])) {
-            param = pmix_os_path(false, cwd, opt->values[0], NULL);
-        } else {
-            param = opt->values[0];
-        }
         if (NULL != prte_default_hostfile) {
             free(prte_default_hostfile);
         }
-        prte_default_hostfile = strdup(param);
+        /* take ownership of the path directly - copying it through a
+         * temporary and then strdup'ing that leaked the temporary, as the
+         * relative case builds a fresh string with pmix_os_path() */
+        if (!pmix_path_is_absolute(opt->values[0])) {
+            prte_default_hostfile = pmix_os_path(false, cwd, opt->values[0], NULL);
+        } else {
+            prte_default_hostfile = strdup(opt->values[0]);
+        }
         prte_default_hostfile_given = true;
     }
 
@@ -556,28 +615,11 @@ PRTE_EXPORT int prte(int argc, char *argv[])
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_APPFILE);
     if (NULL != opt) {
         // parse the file and add its context to the argv array
-        fp = fopen(opt->values[0], "r");
-        if (NULL == fp) {
+        rc = prte_parse_appfile(opt->values[0], &pargv, &pargc);
+        if (PRTE_SUCCESS != rc) {
             prte_show_help("help-prun.txt", "appfile-failure", true, opt->values[0]);
             return 1;
         }
-        first = true;
-        while (NULL != (param = pmix_getline(fp))) {
-            if (!first) {
-                // add a colon delimiter
-                PMIx_Argv_append_nosize(&pargv, ":");
-                ++pargc;
-            }
-            // break the line down into parts
-            split = PMIx_Argv_split(param, ' ');
-            for (n=0; NULL != split[n]; n++) {
-                PMIx_Argv_append_nosize(&pargv, split[n]);
-                ++pargc;
-            }
-            PMIx_Argv_free(split);
-            first = false;
-        }
-        fclose(fp);
     }
 
     /* decide if we are to use a persistent DVM, or act alone */
@@ -611,16 +653,16 @@ PRTE_EXPORT int prte(int argc, char *argv[])
                 cptr = strdup(&opt->values[0][3]);
                 free(opt->values[0]);
                 opt->values[0] = cptr;
-            } else if (0 == strncasecmp(opt->values[0], "system", 6)) {
-                /* direct to search for a system server */
-                free(opt->key);
-                opt->key = strdup(PRTE_CLI_SYS_SERVER_ONLY);
-            } else if (0 == strncasecmp(opt->values[0], "system-first", 6)) {
+            } else if (0 == strcasecmp(opt->values[0], "system-first")) {
                 /* direct to search for a system server first, and then
                  * take the first available DVM */
                 free(opt->key);
-                opt->key = strdup(PRTE_CLI_NAMESPACE);
-            } else if (0 != strncasecmp(opt->values[0], "search", 6)) {
+                opt->key = strdup(PRTE_CLI_SYS_SERVER_FIRST);
+            } else if (0 == strcasecmp(opt->values[0], "system")) {
+                /* direct to search for a system server */
+                free(opt->key);
+                opt->key = strdup(PRTE_CLI_SYS_SERVER_ONLY);
+            } else if (0 != strcasecmp(opt->values[0], "search")) {
                 /* "search" would mean to look for first available DVM,
                  * so we wouldn't have to adjust anything as the opt
                  * key is already set to PRTE_CLI_DVM, which will be
@@ -652,6 +694,11 @@ PRTE_EXPORT int prte(int argc, char *argv[])
     }
 
     /** RUN INDEPENDENTLY */
+
+    /* -v was accepted and never read: "verbose" was a file-scope bool
+     * hardwired to false, so every "if (verbose)" below it was dead and the
+     * option did nothing at all */
+    verbose = pmix_cmd_line_is_taken(&results, PRTE_CLI_VERBOSE);
 
     /* if we were given a keepalive pipe, set up to monitor it now */
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_KEEPALIVE);
@@ -743,6 +790,29 @@ PRTE_EXPORT int prte(int argc, char *argv[])
             return 1;
         }
         prte_pmix_server_globals.singleton = strdup(opt->values[0]);
+    }
+
+    /* Check the stdin target now, while we can still refuse it.  Anything
+     * that is neither "all" nor "none" has to be a bare rank: strtoul
+     * would otherwise read a misspelled value as rank 0, and our stdin
+     * would be pushed to a process the user never named - the DVM's own
+     * copy of the directive lands on the same silent 0, so nothing further
+     * down would question it either. */
+    opt = pmix_cmd_line_get_param(&results, PRTE_CLI_STDIN);
+    if (NULL != opt &&
+        0 != strcmp(opt->values[0], "all") &&
+        0 != strcmp(opt->values[0], "none")) {
+        char *endp = NULL;
+
+        errno = 0;
+        (void) strtoul(opt->values[0], &endp, 10);
+        if (!isdigit((unsigned char) opt->values[0][0]) ||
+            NULL == endp || '\0' != *endp || 0 != errno) {
+            prte_show_help("help-prun.txt", "bad-option-input", true,
+                           prte_tool_basename, "--" PRTE_CLI_STDIN,
+                           opt->values[0], "all, none, or a rank");
+            return 1;
+        }
     }
 
     /* default to a persistent DVM */
@@ -877,20 +947,17 @@ PRTE_EXPORT int prte(int argc, char *argv[])
     PMIX_INFO_DESTRUCT(&info);
     PRTE_PMIX_DESTRUCT_LOCK(&mylock.lock);
 
-    /* check for launch directives in case we were launched by a
-     * tool wanting to direct our operation - this needs to be
-     * done prior to starting the DVM as it may include instructions
-     * on the daemon executable, the fork/exec agent to be used by
-     * the daemons, or other directives impacting the DVM itself. */
-    PMIX_LOAD_PROCID(&pname, myproc.nspace, PMIX_RANK_WILDCARD);
-    PMIX_INFO_LOAD(&info, PMIX_OPTIONAL, NULL, PMIX_BOOL);
-    /*  Have to cycle over directives we support*/
-    ret = PMIx_Get(&pname, PMIX_FORKEXEC_AGENT, &info, 1, &val);
-    PMIX_INFO_DESTRUCT(&info);
-    if (PMIX_SUCCESS == ret) {
-        /* set our fork/exec agent */
-        PMIX_VALUE_RELEASE(val);
-    }
+    /* This is where launch directives from a tool wanting to direct our
+     * operation would be picked up - before the DVM starts, since they may
+     * name the daemon executable, the fork/exec agent the daemons are to
+     * use, or something else about the DVM itself.
+     *
+     * Nothing is read here today.  The one directive that used to be was
+     * PMIX_FORKEXEC_AGENT, and the value was released without being acted
+     * on, so the tool's directive was silently ignored - the Get is gone
+     * rather than left looking like it does something.  Making it work is
+     * not a line here: every daemon reads its exec agent from its own MCA
+     * state, so the value has to reach them.  See docs/todo.rst. */
 
     /* start the DVM */
 
@@ -1250,16 +1317,29 @@ PRTE_EXPORT int prte(int argc, char *argv[])
         } else {
             char *leftover;
             int outpipe;
-            /* see if it is an integer pipe */
+            /* See if it is an integer pipe.  It has to start with a digit
+             * to be one: strtol accepts leading whitespace and a sign and
+             * returns 0 for a string with no digits at all, so an empty
+             * --report-pid value used to write our pid onto file
+             * descriptor 0 and then close our own stdin. */
             leftover = NULL;
             outpipe = strtol(opt->values[0], &leftover, 10);
-            if (NULL == leftover || 0 == strlen(leftover)) {
+            if (isdigit((unsigned char) opt->values[0][0]) &&
+                (NULL == leftover || 0 == strlen(leftover))) {
                 /* stitch together the var names and URI */
                 pmix_asprintf(&leftover, "%lu", (unsigned long) getpid());
                 /* output to the pipe */
                 rc = pmix_fd_write(outpipe, strlen(leftover) + 1, leftover);
                 free(leftover);
                 close(outpipe);
+                if (PRTE_SUCCESS != rc) {
+                    /* whoever handed us the pipe is waiting for this and
+                     * has no other way to learn that it never arrived */
+                    pmix_output(0, "Unable to report my PID on pipe %d: %s",
+                                outpipe, prte_strerror(rc));
+                    PRTE_UPDATE_EXIT_STATUS(rc);
+                    goto DONE;
+                }
             } else {
                 /* must be a file */
                 fp = fopen(opt->values[0], "w");
@@ -1287,16 +1367,27 @@ PRTE_EXPORT int prte(int argc, char *argv[])
     ret = PMIx_Get(&pname, PMIX_LAUNCH_DIRECTIVES, &info, 1, &val);
     PMIX_INFO_DESTRUCT(&info);
     if (PMIX_SUCCESS == ret) {
-        iptr = (pmix_info_t *) val->data.darray->array;
-        ninfo = val->data.darray->size;
-        for (n = 0; n < ninfo; n++) {
-            PMIX_INFO_LIST_XFER(ret, jinfo, &iptr[n]);
+        /* Whoever launched us supplied this, so its type is not ours to
+         * assume: reading a value of any other type as a data array walks
+         * whatever else the value union happens to hold. */
+        if (PMIX_DATA_ARRAY != val->type || NULL == val->data.darray ||
+            PMIX_INFO != val->data.darray->type) {
+            pmix_output(0, "%s: ignoring launch directives given as %s - "
+                        "they must be an array of info",
+                        prte_tool_basename, PMIx_Data_type_string(val->type));
+        } else {
+            iptr = (pmix_info_t *) val->data.darray->array;
+            ninfo = val->data.darray->size;
+            for (n = 0; n < ninfo; n++) {
+                PMIX_INFO_LIST_XFER(ret, jinfo, &iptr[n]);
+            }
         }
         PMIX_VALUE_RELEASE(val);
     }
 
     ret = prte_prun_parse_common_cli(jinfo, &results, schizo, &apps);
     if (PRTE_SUCCESS != ret) {
+        PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
         goto DONE;
     }
 
@@ -1307,7 +1398,10 @@ PRTE_EXPORT int prte(int argc, char *argv[])
         ninfo = 0;
     } else if (PMIX_SUCCESS != ret) {
         PMIX_ERROR_LOG(ret);
-        PRTE_UPDATE_EXIT_STATUS(rc);
+        /* report the failure, not "rc" - which is still PRTE_SUCCESS here,
+         * and PRTE_UPDATE_EXIT_STATUS discards a zero, so the launcher
+         * exited 0 having spawned nothing */
+        PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
         goto DONE;
     } else {
         iptr = (pmix_info_t *) darray.array;
@@ -1337,7 +1431,7 @@ PRTE_EXPORT int prte(int argc, char *argv[])
                 papps[n].ninfo = 0;
             } else {
                 PMIX_ERROR_LOG(ret);
-                PRTE_UPDATE_EXIT_STATUS(rc);
+                PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
                 goto DONE;
             }
         } else {
@@ -1683,24 +1777,69 @@ static int prep_singleton(const char *name)
     return rc;
 }
 
+/* Release the request PMIx borrowed from us.  This may run on either our
+ * own progress thread (the normal completion, arriving back through our
+ * job_control upcall) or the PMIx one (an early failure inside PMIx), so it
+ * must touch nothing but the allocation it is handed. */
+static void sigfwd_cbfunc(pmix_status_t status, pmix_info_t *info, size_t ninfo,
+                          void *cbdata, pmix_release_cbfunc_t release_fn,
+                          void *release_cbdata)
+{
+    prte_sigfwd_t *sf = (prte_sigfwd_t *) cbdata;
+    PRTE_HIDE_UNUSED_PARAMS(status, info, ninfo);
+
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+    PMIX_INFO_DESTRUCT(&sf->info);
+    free(sf);
+}
+
 static void signal_forward_callback(int signum, short args, void *cbdata)
 {
     pmix_status_t rc;
-    pmix_proc_t proc;
-    pmix_info_t info;
+    prte_sigfwd_t *sf;
     PRTE_HIDE_UNUSED_PARAMS(args, cbdata);
+
+    /* A persistent DVM has no job of its own, so there is nothing here to
+     * forward a signal to - and "nothing" must not be spelled as an empty
+     * namespace.  That is what we would hand the job-control path, which
+     * packs it into the daemon command verbatim, and an empty namespace
+     * there means *every* job: one signal to a shared persistent DVM would
+     * be delivered to every process in it, including jobs belonging to
+     * other users. */
+    if (0 == strlen(spawnednspace)) {
+        return;
+    }
 
     if (verbose) {
         fprintf(stderr, "%s: Forwarding signal %d to job\n", prte_tool_basename, signum);
     }
 
-    /* send the signal out to the processes */
-    PMIX_LOAD_PROCID(&proc, spawnednspace, PMIX_RANK_WILDCARD);
-    PMIX_INFO_LOAD(&info, PMIX_JOB_CTRL_SIGNAL, &signum, PMIX_INT);
-    rc = PMIx_Job_control(&proc, 1, &info, 1, NULL, NULL);
-    if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+    /* Send the signal out to the processes.  This has to be the
+     * non-blocking form.  We run on the thread that drives prte_event_base,
+     * and we are ourselves the PMIx server that will be asked to carry the
+     * request out: PMIx hands it to our own job_control upcall, which
+     * thread-shifts the actual work back onto this very event base.  The
+     * blocking form therefore waits for a completion that only this thread
+     * can produce, and a single forwarded signal - every forwardable signal
+     * is forwarded by default - wedged the DVM master permanently.
+     *
+     * PMIx borrows both arrays rather than copying them, and reads them
+     * long after this call returns, so neither may live on our stack. */
+    sf = (prte_sigfwd_t *) malloc(sizeof(prte_sigfwd_t));
+    if (NULL == sf) {
+        return;
+    }
+    PMIX_LOAD_PROCID(&sf->proc, spawnednspace, PMIX_RANK_WILDCARD);
+    PMIX_INFO_LOAD(&sf->info, PMIX_JOB_CTRL_SIGNAL, &signum, PMIX_INT);
+    rc = PMIx_Job_control_nb(&sf->proc, 1, &sf->info, 1, sigfwd_cbfunc, sf);
+    if (PMIX_SUCCESS != rc) {
+        /* the callback will not fire, so the request is ours to release */
         fprintf(stderr, "Signal %d could not be sent to job %s (returned %s)", signum,
                 spawnednspace, PMIx_Error_string(rc));
+        PMIX_INFO_DESTRUCT(&sf->info);
+        free(sf);
     }
 }
 

--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -32,6 +32,7 @@
 #include "constants.h"
 
 #include <ctype.h>
+#include <limits.h>
 #include <stddef.h>
 #include <stdio.h>
 #ifdef HAVE_UNISTD_H
@@ -187,6 +188,11 @@ static int add_envar_directives(prte_pmix_app_t *app,
         key = ordered[k].key;
 
         if (0 == strcmp(key, PRTE_CLI_FWD_ENVAR)) {
+            /* Construct the envar before every use.  Forwarding a variable
+             * has no separator, but the field is packed and shipped with
+             * the rest of the directive, so leaving it whatever was on the
+             * stack put an uninitialized byte into the launch message. */
+            PMIX_ENVAR_CONSTRUCT(&envt);
             param = strdup(ordered[k].value);
             /* if there is an '=' in it, then they are setting a value */
             if (NULL != (value = strchr(param, '='))) {
@@ -204,6 +210,7 @@ static int add_envar_directives(prte_pmix_app_t *app,
                         if (0 == strncmp(environ[i], param, strlen(param))) {
                             // this is a var to fwd
                             // extract the name and value
+                            PMIX_ENVAR_CONSTRUCT(&envt);
                             ptr = strdup(environ[i]);
                             value = strchr(ptr, '=');
                             *value = '\0';
@@ -222,6 +229,7 @@ static int add_envar_directives(prte_pmix_app_t *app,
                         prte_show_help("help-schizo-base.txt", "missing-envar-param", true, param);
                         free(param);
                     } else {
+                        PMIX_ENVAR_CONSTRUCT(&envt);
                         envt.envar = param;
                         envt.value = strdup(value);
                         PMIX_INFO_LIST_ADD(rc, app->info, PMIX_SET_ENVAR, &envt, PMIX_ENVAR);
@@ -235,6 +243,8 @@ static int add_envar_directives(prte_pmix_app_t *app,
             /* these two store the variable's name and the value as SEPARATE
              * occurrences, given one immediately after the other */
             bool prepend = (0 == strcmp(key, PMIX_CLI_PREPEND_ENVAR));
+
+            PMIX_ENVAR_CONSTRUCT(&envt);
             param = strdup(ordered[k].value);
             if (k + 1 >= nordered || 0 != strcmp(ordered[k + 1].key, key)) {
                 // the value it edits with is missing
@@ -300,28 +310,19 @@ done:
 }
 
 /*
- * This function takes a "char ***app_env" parameter to handle the
- * specific case:
+ * Build one app context from one segment of the command line.
  *
- *   prun --mca foo bar -app appfile
- *
- * That is, we'll need to keep foo=bar, but the presence of the app
- * file will cause an invocation of parse_appfile(), which will cause
- * one or more recursive calls back to create_app().  Since the
- * foo=bar value applies globally to all apps in the appfile, we need
- * to pass in the "base" environment (that contains the foo=bar value)
- * when we parse each line in the appfile.
- *
- * This is really just a special case -- when we have a simple case like:
- *
- *   prun --mca foo bar -np 4 hostname
- *
- * Then the upper-level function (parse_locals()) calls create_app()
- * with a NULL value for app_env, meaning that there is no "base"
- * environment that the app needs to be created from.
+ * There used to be a "char ***app_env" parameter here, described as the
+ * base environment to carry across the recursive create_app() calls that an
+ * appfile produced.  There is no recursion any more - an appfile is read
+ * into the command line up front, by prte_parse_appfile() in prte.c, before
+ * any of this runs - and this function had long since stopped writing
+ * through the parameter, so the caller's variable was always NULL and
+ * everything it was plumbed through was a no-op.  It is gone rather than
+ * left looking load-bearing.
  */
 static int create_app(prte_schizo_base_module_t *schizo, char **argv,
-                      prte_pmix_app_t **app_ptr, bool *made_app, char ***app_env,
+                      prte_pmix_app_t **app_ptr, bool *made_app,
                       char ***hostfiles, char ***hosts, pmix_list_t *jobdata)
 {
     char cwd[PRTE_PATH_MAX];
@@ -332,7 +333,6 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
     pmix_cli_result_t results;
     char *tval;
     prte_info_item_t *iptr;
-    PRTE_HIDE_UNUSED_PARAMS(app_env);
 
     *made_app = false;
 
@@ -520,12 +520,36 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
     /* check for bozo error */
     opt = pmix_cmd_line_get_param(&results, PRTE_CLI_NP);
     if (NULL != opt) {
-        count = strtol(opt->values[0], NULL, 10);
+        char *npend = NULL;
+        long nprocs;
+
+        /* A value that is not a number at all reads as 0, which is the
+         * spelling of "let the mapping policy compute it" - so "-n four"
+         * quietly launched some other number of processes rather than
+         * being refused.  maxprocs is an int, so a value that does not fit
+         * one has to go the same way: truncating it silently turns, say,
+         * 4294967297 into 1. */
+        errno = 0;
+        nprocs = strtol(opt->values[0], &npend, 10);
+        if (!isdigit((unsigned char) opt->values[0][0]) ||
+            NULL == npend || '\0' != *npend || 0 != errno ||
+            nprocs > (long) INT_MAX) {
+            prte_show_help("help-prun.txt", "bad-option-input", true,
+                           prte_tool_basename, "--" PRTE_CLI_NP,
+                           opt->values[0], "a number of processes");
+            rc = PRTE_ERR_FATAL;
+            goto cleanup;
+        }
+        count = (int) nprocs;
+        /* the leading-digit test above already refuses a sign, so this is
+         * unreachable from the command line - it is kept because the check
+         * is what the message names and the two must not drift apart */
         if (0 > count) {
             prte_show_help("help-prun.txt", "prun:negative-nprocs", true,
                            prte_tool_basename,
-                           app->app.argv[0], count, NULL);
-            return PRTE_ERR_FATAL;
+                           app->app.argv[0], count);
+            rc = PRTE_ERR_FATAL;
+            goto cleanup;
         }
         /* we don't require that the user provide --np or -n because
          * the cmd line might stipulate a mapping policy that computes
@@ -548,7 +572,8 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
                                        prte_tool_basename, PRTE_CLI_PREFIX,
                                        PRTE_CLI_PREFIX, "PRRTE", PRTE_CLI_PREFIX,
                                        param, opt->values[i]);
-                        return PRTE_ERR_FATAL;
+                        rc = PRTE_ERR_FATAL;
+                        goto cleanup;
                     }
                 }
             }
@@ -559,8 +584,13 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
 
         opt = pmix_cmd_line_get_param(&results, PRTE_CLI_PMIX_PREFIX);
         if (NULL != opt) {
-            // only allow one instance of it, or all must be the same
-            if (1 < (count = pmix_cmd_line_get_ninsts(&results, PRTE_CLI_PREFIX))) {
+            /* Only allow one instance of it, or all must be the same.
+             * Count THIS option's values: counting PRTE_CLI_PREFIX's here
+             * both skipped the check whenever no --prefix was given, and
+             * walked opt->values past its terminator when more --prefix
+             * values were given than --pmix-prefix ones - "--prefix /x
+             * --prefix /x --pmix-prefix /y" segfaulted on the NULL. */
+            if (1 < (count = pmix_cmd_line_get_ninsts(&results, PRTE_CLI_PMIX_PREFIX))) {
                 param = NULL;
                 for (i=0; i < count; i++) {
                     if (NULL == param) {
@@ -570,7 +600,8 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
                                        prte_tool_basename, PRTE_CLI_PMIX_PREFIX,
                                        PRTE_CLI_PMIX_PREFIX, "PMIx", PRTE_CLI_PMIX_PREFIX,
                                        param, opt->values[i]);
-                        return PRTE_ERR_FATAL;
+                        rc = PRTE_ERR_FATAL;
+                        goto cleanup;
                     }
                 }
             }
@@ -641,7 +672,8 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
                     prte_show_help("help-plm-base.txt", "multiple-app-prefixes", true,
                                    prte_tool_basename, PRTE_CLI_APP_PREFIX,
                                    PRTE_CLI_APP_PREFIX, param, opt->values[i]);
-                    return PRTE_ERR_FATAL;
+                    rc = PRTE_ERR_FATAL;
+                    goto cleanup;
                 }
             }
         }
@@ -659,7 +691,8 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
             prte_show_help("help-plm-base.txt", "prefix-conflict", true,
                            prte_tool_basename, PRTE_CLI_APP_PREFIX, opt2->values[0],
                            PRTE_CLI_NO_APP_PREFIX);
-            return PRTE_ERR_FATAL;
+            rc = PRTE_ERR_FATAL;
+            goto cleanup;
         }
         PMIX_INFO_LIST_ADD(rc, app->info, PMIX_PREFIX, NULL, PMIX_STRING);
     } else if (NULL != getenv("PMIX_APP_NO_PREFIX")) {
@@ -668,7 +701,8 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
             prte_show_help("help-plm-base.txt", "prefix-conflict", true,
                            prte_tool_basename, PRTE_CLI_APP_PREFIX, opt2->values[0],
                            "PMIX_APP_NO_PREFIX");
-            return PRTE_ERR_FATAL;
+            rc = PRTE_ERR_FATAL;
+            goto cleanup;
         }
         // allow the cmd line to override the environment
         PMIX_INFO_LIST_ADD(rc, app->info, PMIX_PREFIX, NULL, PMIX_STRING);
@@ -710,6 +744,12 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
         app->rtos = PMIx_Argv_join(opt->values, ',');
     }
 
+    /* The app is made.  Say so unconditionally rather than returning
+     * whatever the last PMIX_INFO_LIST_ADD happened to leave in rc: a
+     * failure from any of them is not acted on where it happens, so a stale
+     * one here would hand the caller an error alongside made_app == true -
+     * and the caller, seeing the error, drops the app it was just given. */
+    rc = PRTE_SUCCESS;
     *app_ptr = app;
     app = NULL;
     *made_app = true;
@@ -853,7 +893,7 @@ int prte_parse_locals(prte_schizo_base_module_t *schizo,
                       pmix_cli_result_t *results)
 {
     int i, rc;
-    char **temp_argv, **env;
+    char **temp_argv;
     prte_pmix_app_t *app;
     bool made_app;
 
@@ -861,28 +901,17 @@ int prte_parse_locals(prte_schizo_base_module_t *schizo,
     temp_argv = NULL;
     PMIx_Argv_append_nosize(&temp_argv, argv[0]);
 
-    /* NOTE: This bogus env variable is necessary in the calls to
-     create_app(), below.  See comment immediately before the
-     create_app() function for an explanation. */
-
-    env = NULL;
     for (i = 1; NULL != argv[i]; ++i) {
         if (0 == strcmp(argv[i], ":")) {
             /* Make an app with this argv */
             if (PMIx_Argv_count(temp_argv) > 1) {
-                if (NULL != env) {
-                    PMIx_Argv_free(env);
-                    env = NULL;
-                }
                 app = NULL;
-                rc = create_app(schizo, temp_argv, &app, &made_app, &env,
+                rc = create_app(schizo, temp_argv, &app, &made_app,
                                 hostfiles, hosts, jobdata);
                 if (PRTE_SUCCESS != rc) {
-                    /* Assume that the error message has already been
-                     printed; create_app may still have filled in "env"
-                     before it failed, and it belongs to us either way */
+                    /* assume that the error message has already been
+                     printed */
                     PMIx_Argv_free(temp_argv);
-                    PMIx_Argv_free(env);
                     return rc;
                 }
                 if (made_app) {
@@ -901,15 +930,14 @@ int prte_parse_locals(prte_schizo_base_module_t *schizo,
 
     if (PMIx_Argv_count(temp_argv) > 1) {
         app = NULL;
-        rc = create_app(schizo, temp_argv, &app, &made_app, &env,
+        rc = create_app(schizo, temp_argv, &app, &made_app,
                         hostfiles, hosts, jobdata);
         if (PRTE_SUCCESS != rc) {
-            /* this return used to skip the two frees below entirely, so
-             * any command line that fails its final segment leaked both -
+            /* this return used to skip the free below entirely, so any
+             * command line that fails its final segment leaked temp_argv -
              * "--display map --display cpus" is enough, since a repeated
              * option is refused here */
             PMIx_Argv_free(temp_argv);
-            PMIx_Argv_free(env);
             return rc;
         }
         if (made_app) {
@@ -917,9 +945,6 @@ int prte_parse_locals(prte_schizo_base_module_t *schizo,
         }
     }
 
-    if (NULL != env) {
-        PMIx_Argv_free(env);
-    }
     PMIx_Argv_free(temp_argv);
 
     /* every segment has now been seen, so it can be decided whether the

--- a/src/prted/prted.h
+++ b/src/prted/prted.h
@@ -78,6 +78,11 @@ PRTE_EXPORT void prte_strip_trailing_pathsep(char *param);
  * parts.  Returns PRTE_ERR_BAD_PARAM if the value is not of that form. */
 PRTE_EXPORT int prte_parse_singleton_id(const char *name, pmix_nspace_t nspace,
                                         pmix_rank_t *rank);
+
+/* Append the contents of an appfile to a command line, one app context per
+ * line, joined with the ":" delimiter.  Blank lines are ignored.  Returns
+ * PRTE_ERR_FILE_OPEN_FAILURE if the file cannot be read. */
+PRTE_EXPORT int prte_parse_appfile(const char *path, char ***pargv, int *pargc);
 END_C_DECLS
 
 #endif /* PRTED_H */

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -880,18 +880,24 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
                 }
                 /* close */
                 pclose(fp);
-                /* transfer this load */
+                /* Transfer this load.  PMIx_Data_unload hands us ownership
+                 * of the payload and PMIx_Data_pack copies it into the
+                 * answer, so the byte object is ours to release either way -
+                 * the error arm above does exactly that, and this one used
+                 * to leak one process's entire stack trace per process per
+                 * request. */
                 ret = PMIx_Data_unload(&data, &pbo);
                 if (PMIX_SUCCESS != ret) {
                     PMIX_ERROR_LOG(ret);
                     PMIX_DATA_BUFFER_DESTRUCT(&data);
                     break;
                 }
-                if (PMIX_SUCCESS != PMIx_Data_pack(NULL, answer, &pbo, 1, PMIX_BYTE_OBJECT)) {
-                    PMIX_DATA_BUFFER_DESTRUCT(&data);
+                ret = PMIx_Data_pack(NULL, answer, &pbo, 1, PMIX_BYTE_OBJECT);
+                PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
+                PMIX_DATA_BUFFER_DESTRUCT(&data);
+                if (PMIX_SUCCESS != ret) {
                     break;
                 }
-                PMIX_DATA_BUFFER_DESTRUCT(&data);
             }
         }
         if (NULL != gstack_exec) {

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -83,8 +83,6 @@
  */
 static const char *get_prted_comm_cmd_str(int command);
 
-static pmix_pointer_array_t *procs_prev_ordered_to_terminate = NULL;
-
 /*
  * Continuations for the three daemon commands that cannot finish until PMIx
  * has finished something for us.
@@ -307,10 +305,7 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
     pmix_pointer_array_t procarray;
     prte_proc_t *proct;
     char *cmd_str = NULL;
-    pmix_pointer_array_t *procs_to_kill = NULL;
-    int32_t num_procs, num_new_procs = 0, p;
-    prte_proc_t *cur_proc = NULL, *prev_proc = NULL;
-    bool found = false;
+    int32_t num_procs;
     FILE *fp;
     char gscmd[256], path[1035], *pathptr;
     char string[256], *string_ptr = string;
@@ -318,7 +313,7 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
     char *tmp;
     pmix_rank_t *ranks;
     prte_daemon_caddy_t *cd;
-    PRTE_HIDE_UNUSED_PARAMS(status, tag, cbdata);
+    PRTE_HIDE_UNUSED_PARAMS(status, sender, tag, cbdata);
 
     /* unpack the command */
     n = 1;
@@ -465,105 +460,6 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
                                  "%s prted:comm:add_procs failed to launch on error %s",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_ERROR_NAME(ret)));
         }
-        break;
-
-    case PRTE_DAEMON_ABORT_PROCS_CALLED:
-        if (prte_debug_daemons_flag) {
-            pmix_output(0, "%s prted_cmd: received abort_procs report",
-                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
-        }
-
-        /* Number of processes */
-        n = 1;
-        ret = PMIx_Data_unpack(NULL, buffer, &num_procs, &n, PMIX_INT32);
-        if (PMIX_SUCCESS != ret) {
-            PRTE_ERROR_LOG(ret);
-            goto CLEANUP;
-        }
-
-        /* Retrieve list of processes */
-        procs_to_kill = PMIX_NEW(pmix_pointer_array_t);
-        pmix_pointer_array_init(procs_to_kill, num_procs, INT32_MAX, 2);
-
-        /* Keep track of previously terminated, so we don't keep ordering the
-         * same processes to die.
-         */
-        if (NULL == procs_prev_ordered_to_terminate) {
-            procs_prev_ordered_to_terminate = PMIX_NEW(pmix_pointer_array_t);
-            pmix_pointer_array_init(procs_prev_ordered_to_terminate, num_procs + 1, INT32_MAX, 8);
-        }
-
-        num_new_procs = 0;
-        for (i = 0; i < num_procs; ++i) {
-            cur_proc = PMIX_NEW(prte_proc_t);
-
-            n = 1;
-            ret = PMIx_Data_unpack(NULL, buffer, &(cur_proc->name), &n, PMIX_PROC);
-            if (PMIX_SUCCESS != ret) {
-                PMIX_ERROR_LOG(ret);
-                PMIX_RELEASE(cur_proc);
-                goto ABORT_PROC_CLEANUP;
-            }
-
-            /* See if duplicate */
-            found = false;
-            for (p = 0; p < procs_prev_ordered_to_terminate->size; ++p) {
-                if (NULL
-                    == (prev_proc = (prte_proc_t *)
-                            pmix_pointer_array_get_item(procs_prev_ordered_to_terminate, p))) {
-                    continue;
-                }
-                if (PMIX_CHECK_PROCID(&cur_proc->name, &prev_proc->name)) {
-                    found = true;
-                    break;
-                }
-            }
-
-            PMIX_OUTPUT_VERBOSE(
-                (2, prte_debug_output,
-                 "%s prted:comm:abort_procs Application %s requests term. of %s (%2d of %2d) %3s.",
-                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(sender),
-                 PRTE_NAME_PRINT(&(cur_proc->name)), i, num_procs, (found ? "Dup" : "New")));
-
-            /* If not a duplicate, then add to the to_kill list */
-            if (!found) {
-                pmix_pointer_array_add(procs_to_kill, (void *) cur_proc);
-                PMIX_RETAIN(cur_proc);
-                pmix_pointer_array_add(procs_prev_ordered_to_terminate, (void *) cur_proc);
-                num_new_procs++;
-            } else {
-                /* nobody took a reference to it */
-                PMIX_RELEASE(cur_proc);
-            }
-            cur_proc = NULL;
-        }
-
-        /*
-         * Send the request to terminate
-         */
-        if (num_new_procs > 0) {
-            PMIX_OUTPUT_VERBOSE((2, prte_debug_output,
-                                 "%s prted:comm:abort_procs Terminating application requested "
-                                 "processes (%2d / %2d).",
-                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), num_new_procs, num_procs));
-            prte_plm.terminate_procs(procs_to_kill);
-        } else {
-            PMIX_OUTPUT_VERBOSE((2, prte_debug_output,
-                                 "%s prted:comm:abort_procs No new application processes to "
-                                 "terminating from request (%2d / %2d).",
-                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), num_new_procs, num_procs));
-        }
-    ABORT_PROC_CLEANUP:
-        /* terminate_procs copies what it needs, so release our tracking
-         * array and the references it holds */
-        for (p = 0; p < procs_to_kill->size; ++p) {
-            cur_proc = (prte_proc_t *) pmix_pointer_array_get_item(procs_to_kill, p);
-            if (NULL != cur_proc) {
-                PMIX_RELEASE(cur_proc);
-            }
-        }
-        PMIX_RELEASE(procs_to_kill);
-        procs_to_kill = NULL;
         break;
 
         /****    DEFINE PSET    ****/

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -344,8 +344,11 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
         PMIX_CONSTRUCT(&procarray, pmix_pointer_array_t);
         pmix_pointer_array_init(&procarray, num_replies, PRTE_GLOBAL_ARRAY_MAX_SIZE, 16);
 
-        /* unpack the proc names into the array */
+        /* unpack the proc names into the array - reset the count first
+         * rather than inheriting whatever the command unpack left in it */
+        n = 1;
         while (PMIX_SUCCESS == (ret = PMIx_Data_unpack(NULL, buffer, &proc, &n, PMIX_PROC))) {
+            n = 1;
             proct = PMIX_NEW(prte_proc_t);
             PMIX_LOAD_PROCID(&proct->name, proc.nspace, proc.rank);
 

--- a/src/prted/prun_common.c
+++ b/src/prted/prun_common.c
@@ -298,7 +298,8 @@ static void evhandler(size_t evhdlr_registration_id, pmix_status_t status,
                 /* the application's own status - preferred over the
                  * termination reason when we come to exit */
                 xcode = info[n].value.data.integer;
-            } else if (0 == strncmp(info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN)) {
+            } else if (0 == strncmp(info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN) &&
+                       NULL != info[n].value.data.proc) {
                 PMIX_LOAD_NSPACE(jobid, info[n].value.data.proc->nspace);
             } else if (0 == strncmp(info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
                 lock = (prte_pmix_lock_t *) info[n].value.data.ptr;
@@ -368,7 +369,14 @@ static void evhandler(size_t evhdlr_registration_id, pmix_status_t status,
         /* save the status */
         lock->status = status_from_tree;
         if (NULL != tree_msg) {
-            lock->msg = tree_msg;
+            /* first message wins, here as everywhere else - the default
+             * handler may already have put one here, and overwriting it
+             * would drop both the message and its allocation */
+            if (NULL == lock->msg) {
+                lock->msg = tree_msg;
+            } else {
+                free(tree_msg);
+            }
             tree_msg = NULL;
         }
         /* release the lock */
@@ -407,7 +415,9 @@ static void launch_failed_cbfunc(size_t evhdlr_registration_id, pmix_status_t st
 
     for (n = 0; n < ninfo; n++) {
         if (PMIX_CHECK_KEY(&info[n], PMIX_EVENT_AFFECTED_PROC)) {
-            rank = info[n].value.data.proc->rank;
+            if (NULL != info[n].value.data.proc) {
+                rank = info[n].value.data.proc->rank;
+            }
         } else if (PMIX_CHECK_KEY(&info[n], PMIX_HOSTNAME)) {
             nodename = info[n].value.data.string;
         } else if (PMIX_CHECK_KEY(&info[n], "prte.launch.failed.app")) {
@@ -473,6 +483,41 @@ static void setupcbfunc(pmix_status_t status, pmix_info_t info[], size_t ninfo,
     PRTE_PMIX_WAKEUP_THREAD(&mylock->lock);
 }
 
+/* Resolve "--stdin": the two words, or a rank.
+ *
+ * A value that is none of those is REFUSED rather than read as strtoul's
+ * zero, which would quietly send our stdin to rank 0.  This has to be
+ * asked before the spawn - once the job is running, refusing the command
+ * line leaves it running with nobody to report it - so the validation is
+ * done in prte_prun_parse_common_cli() and the answer is computed again
+ * here, from the same string, once we have a namespace to aim it at.
+ * prte's own path has an equivalent check of its own; prun and
+ * "prterun --dvm" reach this one. */
+static int stdin_target_rank(pmix_cli_result_t *results, pmix_rank_t *rank)
+{
+    pmix_cli_item_t *opt;
+    unsigned long ulval;
+
+    *rank = 0;
+    opt = pmix_cmd_line_get_param(results, PRTE_CLI_STDIN);
+    if (NULL == opt) {
+        return PRTE_SUCCESS;
+    }
+    if (0 == strcmp(opt->values[0], "all")) {
+        *rank = PMIX_RANK_WILDCARD;
+        return PRTE_SUCCESS;
+    }
+    if (0 == strcmp(opt->values[0], "none")) {
+        *rank = PMIX_RANK_INVALID;
+        return PRTE_SUCCESS;
+    }
+    if (PRTE_SUCCESS != prte_parse_uint_option(opt->values[0], PMIX_RANK_VALID - 1, &ulval)) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+    *rank = (pmix_rank_t) ulval;
+    return PRTE_SUCCESS;
+}
+
 static int wait_pipe[2];
 
 static int wait_dvm(pid_t pid)
@@ -507,7 +552,7 @@ int prun_common(pmix_cli_result_t *results,
     pmix_list_t apps, jobdata;
     prte_info_item_t *iprteinfo;
     prte_pmix_app_t *app;
-    void *tinfo, *jinfo;
+    void *tinfo, *jinfo = NULL;
     pmix_info_t info, *iptr;
     pmix_proc_t pname;
     pmix_status_t ret;
@@ -527,12 +572,25 @@ int prun_common(pmix_cli_result_t *results,
     pmix_status_t code;
     pmix_proc_t parent;
     pmix_cli_item_t *opt;
+    unsigned long ulval;
     PRTE_HIDE_UNUSED_PARAMS(pargc);
 
     /* init the globals */
+    /* "-v" was accepted and never read here: "verbose" is a file-scope bool
+     * hardwired to false, so every "if (verbose)" below it was dead and the
+     * option did nothing at all.  prte.c had the same defect and reads its
+     * own copy now; this is the one prun and "prterun --dvm" run. */
+    verbose = pmix_cmd_line_is_taken(results, PRTE_CLI_VERBOSE);
     PMIX_CONSTRUCT(&apps, pmix_list_t);
     PMIX_CONSTRUCT(&forwarded_signals, pmix_list_t);
-    gethostname(hostname, sizeof(hostname));
+    /* this only names the tool to PMIx, so a host that will not tell us
+     * its name is not fatal - but the buffer has to be readable either
+     * way, and gethostname leaves it untouched when it fails */
+    hostname[0] = '\0';
+    if (0 != gethostname(hostname, sizeof(hostname))) {
+        hostname[0] = '\0';
+    }
+    hostname[sizeof(hostname) - 1] = '\0';
 
     /* detach from controlling terminal
      * otherwise, remain attached so output can get to us
@@ -575,7 +633,9 @@ int prun_common(pmix_cli_result_t *results,
                                   PRTE_GLOBAL_ARRAY_BLOCK_SIZE);
     if (PRTE_SUCCESS != ret) {
         PRTE_ERROR_LOG(ret);
-        return rc;
+        /* NOT rc: it holds the SUCCESS the signal setup just returned, so
+         * returning it told our caller the tool had done its job */
+        return ret;
     }
 
     /* setup options */
@@ -589,10 +649,14 @@ int prun_common(pmix_cli_result_t *results,
         PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_TOOL_NSPACE, param, PMIX_STRING);
         free(param);
     }
+    rank = 0;
     if (NULL != (param = getenv("PMIX_RANK"))) {
-        rank = strtoul(param, NULL, 10);
-    } else {
-        rank = 0;
+        /* whatever set this in our environment is a PMIx launcher, so it is
+         * well formed - but strtoul reads anything else as rank 0, which is
+         * a real rank, so take it only when it is one */
+        if (PRTE_SUCCESS == prte_parse_uint_option(param, PMIX_RANK_VALID - 1, &ulval)) {
+            rank = (pmix_rank_t) ulval;
+        }
     }
     PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_TOOL_RANK, &rank, PMIX_PROC_RANK);
 
@@ -608,13 +672,25 @@ int prun_common(pmix_cli_result_t *results,
 
     opt = pmix_cmd_line_get_param(results, PRTE_CLI_WAIT_TO_CONNECT);
     if (NULL != opt) {
-        ui32 = strtol(opt->values[0], NULL, 10);
+        if (PRTE_SUCCESS != prte_parse_uint_option(opt->values[0], UINT32_MAX, &ulval)) {
+            prte_show_help("help-prun.txt", "bad-option-input", true, prte_tool_basename,
+                           "--" PRTE_CLI_WAIT_TO_CONNECT, opt->values[0], "a number of seconds");
+            PMIX_INFO_LIST_RELEASE(tinfo);
+            return PRTE_ERR_BAD_PARAM;
+        }
+        ui32 = (uint32_t) ulval;
         PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_CONNECT_RETRY_DELAY, &ui32, PMIX_UINT32);
     }
 
     opt = pmix_cmd_line_get_param(results, PRTE_CLI_NUM_CONNECT_RETRIES);
     if (NULL != opt) {
-        ui32 = strtol(opt->values[0], NULL, 10);
+        if (PRTE_SUCCESS != prte_parse_uint_option(opt->values[0], UINT32_MAX, &ulval)) {
+            prte_show_help("help-prun.txt", "bad-option-input", true, prte_tool_basename,
+                           "--" PRTE_CLI_NUM_CONNECT_RETRIES, opt->values[0], "a number of retries");
+            PMIX_INFO_LIST_RELEASE(tinfo);
+            return PRTE_ERR_BAD_PARAM;
+        }
+        ui32 = (uint32_t) ulval;
         PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_CONNECT_MAX_RETRIES, &ui32, PMIX_UINT32);
     }
 
@@ -683,7 +759,16 @@ int prun_common(pmix_cli_result_t *results,
     if (PMIX_SUCCESS != (ret = PMIx_tool_init(&myproc, iptr, ninfo))) {
         fprintf(stderr, "%s failed to initialize, likely due to no DVM being available\n",
                 prte_tool_basename);
-        exit(1);
+        PMIX_INFO_FREE(iptr, ninfo);
+        /* return rather than exit(): our caller has teardown of its own to
+         * do - it is holding the pid file it was asked to write, and it
+         * expects the ess framework we close here to have been closed by
+         * whoever reached this function.  There is nothing to finalize:
+         * PMIx never came up. */
+        (void) pmix_mca_base_framework_close(&prte_ess_base_framework);
+        /* 1, not a PRTE code: our return IS the tool's exit status, and
+         * this is the commonest failure a script driving us will see */
+        return 1;
     }
     PMIX_INFO_FREE(iptr, ninfo);
 
@@ -695,8 +780,15 @@ int prun_common(pmix_cli_result_t *results,
     PMIX_INFO_LOAD(&iptr[1], PMIX_EVENT_RETURN_OBJECT, &rellock, PMIX_POINTER);
     PMIX_INFO_LOAD(&iptr[0], PMIX_EVENT_HDLR_NAME, "DEFAULT", PMIX_STRING);
     PRTE_PMIX_CONSTRUCT_LOCK(&lock);
-    PMIx_Register_event_handler(NULL, 0, iptr, 2, defhandler, regcbfunc, &lock);
-    PRTE_PMIX_WAIT_THREAD(&lock);
+    /* Only a PMIX_SUCCESS return means the callback we are about to park
+     * on will be made: the entry point refuses an uninitialized or
+     * shutting-down library, and a failed allocation, in front of the
+     * thread-shift that would eventually call regcbfunc.  Waiting anyway
+     * is a permanent hang in place of an error. */
+    ret = PMIx_Register_event_handler(NULL, 0, iptr, 2, defhandler, regcbfunc, &lock);
+    if (PMIX_SUCCESS == ret) {
+        PRTE_PMIX_WAIT_THREAD(&lock);
+    }
     PRTE_PMIX_DESTRUCT_LOCK(&lock);
     PMIX_INFO_FREE(iptr, 2);
 
@@ -716,8 +808,10 @@ int prun_common(pmix_cli_result_t *results,
     PMIX_INFO_LOAD(&iptr[0], PMIX_EVENT_HDLR_NAME, "LAUNCH-FAILED", PMIX_STRING);
     code = PMIX_ERR_JOB_FAILED_TO_LAUNCH;
     PRTE_PMIX_CONSTRUCT_LOCK(&lock);
-    PMIx_Register_event_handler(&code, 1, iptr, 1, launch_failed_cbfunc, regcbfunc, &lock);
-    PRTE_PMIX_WAIT_THREAD(&lock);
+    ret = PMIx_Register_event_handler(&code, 1, iptr, 1, launch_failed_cbfunc, regcbfunc, &lock);
+    if (PMIX_SUCCESS == ret) {
+        PRTE_PMIX_WAIT_THREAD(&lock);
+    }
     PRTE_PMIX_DESTRUCT_LOCK(&lock);
     PMIX_INFO_FREE(iptr, 1);
 
@@ -731,10 +825,20 @@ int prun_common(pmix_cli_result_t *results,
     ret = PMIx_Get(&pname, PMIX_LAUNCH_DIRECTIVES, &info, 1, &val);
     PMIX_INFO_DESTRUCT(&info);
     if (PMIX_SUCCESS == ret) {
-        iptr = (pmix_info_t *) val->data.darray->array;
-        ninfo = val->data.darray->size;
-        for (n = 0; n < ninfo; n++) {
-            PMIX_INFO_LIST_XFER(ret, jinfo, &iptr[n]);
+        /* Whoever launched us supplied this, so its type is not ours to
+         * assume: reading a value of any other type as a data array walks
+         * whatever else the value union happens to hold. */
+        if (PMIX_DATA_ARRAY != val->type || NULL == val->data.darray ||
+            PMIX_INFO != val->data.darray->type) {
+            pmix_output(0, "%s: ignoring launch directives given as %s - "
+                        "they must be an array of info",
+                        prte_tool_basename, PMIx_Data_type_string(val->type));
+        } else {
+            iptr = (pmix_info_t *) val->data.darray->array;
+            ninfo = val->data.darray->size;
+            for (n = 0; n < ninfo; n++) {
+                PMIX_INFO_LIST_XFER(ret, jinfo, &iptr[n]);
+            }
         }
         PMIX_VALUE_RELEASE(val);
     }
@@ -759,8 +863,10 @@ int prun_common(pmix_cli_result_t *results,
                                         &mylock);
     if (PMIX_SUCCESS != ret) {
         PMIX_ERROR_LOG(ret);
+        PMIX_INFO_FREE(iptr, ninfo);
         PRTE_PMIX_DESTRUCT_LOCK(&mylock.lock);
         PRTE_UPDATE_EXIT_STATUS(ret);
+        rc = ret;
         goto DONE;
     }
     PRTE_PMIX_WAIT_THREAD(&mylock.lock);
@@ -803,23 +909,47 @@ int prun_common(pmix_cli_result_t *results,
     /* bozo check */
     if (0 == pmix_list_get_size(&apps)) {
         pmix_output(0, "No application specified!");
+        PMIX_LIST_DESTRUCT(&apps);
+        rc = PRTE_ERR_BAD_PARAM;
         goto DONE;
     }
 
     ret = prte_prun_parse_common_cli(jinfo, results, schizo, &apps);
     if (PRTE_SUCCESS != ret) {
+        /* rc still holds the SUCCESS of the parse above, and it is what we
+         * return - so a command line we have just REFUSED left the tool
+         * exiting 0 without having launched anything */
+        PMIX_LIST_DESTRUCT(&apps);
+        rc = ret;
         goto DONE;
     }
 
     /* convert the job info into an array */
     PMIX_INFO_LIST_CONVERT(ret, jinfo, &darray);
+    if (PMIX_SUCCESS != ret) {
+        /* the list is never empty here - NOTIFY_COMPLETION alone sees to
+         * that - so this is a real failure, and going on with the empty
+         * array the convert leaves behind would launch the job with none
+         * of the directives the user asked for */
+        PMIX_ERROR_LOG(ret);
+        PMIX_LIST_DESTRUCT(&apps);
+        rc = ret;
+        goto DONE;
+    }
     iptr = (pmix_info_t *) darray.array;
     ninfo = darray.size;
     PMIX_INFO_LIST_RELEASE(jinfo);
+    jinfo = NULL;
 
     /* convert the apps to an array */
     napps = pmix_list_get_size(&apps);
     PMIX_APP_CREATE(papps, napps);
+    if (NULL == papps) {
+        PMIX_LIST_DESTRUCT(&apps);
+        PMIX_INFO_FREE(iptr, ninfo);
+        rc = PRTE_ERR_OUT_OF_RESOURCE;
+        goto DONE;
+    }
     n = 0;
     PMIX_LIST_FOREACH(app, &apps, prte_pmix_app_t)
     {
@@ -828,7 +958,17 @@ int prun_common(pmix_cli_result_t *results,
         papps[n].env = PMIx_Argv_copy(app->app.env);
         papps[n].cwd = strdup(app->app.cwd);
         papps[n].maxprocs = app->app.maxprocs;
+        /* an app that carries no directives of its own is ordinary, and
+         * the convert reports it as EMPTY after zeroing the array - but
+         * anything else has lost directives that were given */
         PMIX_INFO_LIST_CONVERT(ret, app->info, &darray);
+        if (PMIX_SUCCESS != ret && PMIX_ERR_EMPTY != ret) {
+            PMIX_ERROR_LOG(ret);
+            PMIX_LIST_DESTRUCT(&apps);
+            PMIX_INFO_FREE(iptr, ninfo);
+            rc = ret;
+            goto DONE;
+        }
         papps[n].info = (pmix_info_t *) darray.array;
         papps[n].ninfo = darray.size;
         ++n;
@@ -840,6 +980,11 @@ int prun_common(pmix_cli_result_t *results,
     }
 
     ret = PMIx_Spawn(iptr, ninfo, papps, napps, spawnednspace);
+    /* the blocking form has packed everything it needed by the time it
+     * returns, and iptr is about to be reused for the next registration */
+    PMIX_INFO_FREE(iptr, ninfo);
+    iptr = NULL;
+    ninfo = 0;
     if (PMIX_SUCCESS != ret) {
         /* SILENT is the DVM saying it has already explained itself - it is
          * how every refusal that comes with a show_help message is reported.
@@ -862,26 +1007,18 @@ int prun_common(pmix_cli_result_t *results,
     ++n;
     PMIX_LOAD_PROCID(&pname, spawnednspace, PMIX_RANK_WILDCARD);
     PMIX_INFO_LOAD(&iptr[n], PMIX_EVENT_AFFECTED_PROC, &pname, PMIX_PROC);
-    PMIx_Register_event_handler(&code, 1, iptr, 2, debug_cbfunc, regcbfunc,
-                                (void *) &lock);
-    PRTE_PMIX_WAIT_THREAD(&lock);
+    ret = PMIx_Register_event_handler(&code, 1, iptr, 2, debug_cbfunc, regcbfunc,
+                                      (void *) &lock);
+    if (PMIX_SUCCESS == ret) {
+        PRTE_PMIX_WAIT_THREAD(&lock);
+    }
     PRTE_PMIX_DESTRUCT_LOCK(&lock);
     PMIX_INFO_FREE(iptr, 2);
 
-    /* check what user wants us to do with stdin */
+    /* check what user wants us to do with stdin - the value was refused
+     * before the spawn if it was not one we can act on */
     PMIX_LOAD_NSPACE(pname.nspace, spawnednspace);
-    opt = pmix_cmd_line_get_param(results, PRTE_CLI_STDIN);
-    if (NULL != opt) {
-        if (0 == strcmp(opt->values[0], "all")) {
-            pname.rank = PMIX_RANK_WILDCARD;
-        } else if (0 == strcmp(opt->values[0], "none")) {
-            pname.rank = PMIX_RANK_INVALID;
-        } else {
-            pname.rank = strtoul(opt->values[0], NULL, 10);
-        }
-    } else {
-        pname.rank = 0;
-    }
+    (void) stdin_target_rank(results, &pname.rank);
     if (PMIX_RANK_INVALID != pname.rank) {
         PMIX_INFO_CREATE(iptr, 1);
         PMIX_INFO_LOAD(&iptr[0], PMIX_IOF_PUSH_STDIN, NULL, PMIX_BOOL);
@@ -905,7 +1042,6 @@ int prun_common(pmix_cli_result_t *results,
      * events we most needed.  We take every job end the session reports and
      * sort out which are ours in the handler, where the spawn-tree root the
      * DVM stamps on each one makes that a string compare. */
-    ret = PMIX_EVENT_JOB_END;
     /* setup the info */
     ninfo = 2;
     PMIX_INFO_CREATE(iptr, ninfo);
@@ -915,11 +1051,22 @@ int prun_common(pmix_cli_result_t *results,
     PMIX_INFO_LOAD(&iptr[1], PMIX_EVENT_RETURN_OBJECT, &rellock, PMIX_POINTER);
     /* do the registration */
     PRTE_PMIX_CONSTRUCT_LOCK(&lock);
-    PMIx_Register_event_handler(&ret, 1, iptr, ninfo, evhandler, regcbfunc, &lock);
-    PRTE_PMIX_WAIT_THREAD(&lock);
+    code = PMIX_EVENT_JOB_END;
+    ret = PMIx_Register_event_handler(&code, 1, iptr, ninfo, evhandler, regcbfunc, &lock);
+    if (PMIX_SUCCESS == ret) {
+        PRTE_PMIX_WAIT_THREAD(&lock);
+    }
     PRTE_PMIX_DESTRUCT_LOCK(&lock);
     /* the registration copied these */
     PMIX_INFO_FREE(iptr, ninfo);
+    if (PMIX_SUCCESS != ret) {
+        /* nothing will tell us the job ended, so there is nothing to wait
+         * for - say so rather than blocking on an event that cannot come */
+        pmix_output(0, "%s: failed to register for job termination: %s",
+                    prte_tool_basename, PMIx_Error_string(ret));
+        rc = ret;
+        goto DONE;
+    }
 
     if (verbose) {
         pmix_output(0, "JOB %s EXECUTING", PRTE_JOBID_PRINT(spawnednspace));
@@ -939,10 +1086,11 @@ int prun_common(pmix_cli_result_t *results,
 
     /* deregister our event handler */
     PRTE_PMIX_CONSTRUCT_LOCK(&lock);
-    PMIx_Deregister_event_handler(evid, opcbfunc, &lock);
-    PRTE_PMIX_WAIT_THREAD(&lock);
+    ret = PMIx_Deregister_event_handler(evid, opcbfunc, &lock);
+    if (PMIX_SUCCESS == ret) {
+        PRTE_PMIX_WAIT_THREAD(&lock);
+    }
     PRTE_PMIX_DESTRUCT_LOCK(&lock);
-    PRTE_PMIX_DESTRUCT_LOCK(&rellock);
 
     /* Report any child job that ended non-zero while "report child jobs
      * separately" was in effect.  Held until here rather than said as it
@@ -970,8 +1118,11 @@ int prun_common(pmix_cli_result_t *results,
     PMIX_INFO_DESTRUCT(&info);
 
 DONE:
-    /* the release lock is about to leave scope */
-    release_lock = NULL;
+    /* the job spec, on a path that never got as far as converting it */
+    if (NULL != jinfo) {
+        PMIX_INFO_LIST_RELEASE(jinfo);
+        jinfo = NULL;
+    }
     /* an abort message we never got to hand to a waiter - the DVM went away
      * before the tree drained */
     if (NULL != tree_msg) {
@@ -1014,6 +1165,18 @@ DONE:
         pmix_output(0, "PMIx_tool_finalize() failed. Status = %d", ret);
     }
 
+    /* Only NOW is the release lock finished with.  It is on our stack, and
+     * the default event handler holds a pointer to it that is never
+     * deregistered - so destroying it while PMIx could still deliver an
+     * event left that handler locking a destroyed mutex.  The window is
+     * narrow (a lost connection between the job's end and our teardown),
+     * which is exactly the interval in which losing the DVM is likeliest.
+     * The finalize above is the point after which no handler can run.
+     * Destructing here also frees any message the lock was still carrying,
+     * which the lost-connection exit above used to walk away from. */
+    release_lock = NULL;
+    PRTE_PMIX_DESTRUCT_LOCK(&rellock);
+
     /* Our caller makes this our exit status.  If the DVM told us what the
      * application exited with, that is the answer - a launcher reports the
      * status of what it launched, which is what prterun does and what any
@@ -1043,6 +1206,7 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
     pmix_cli_item_t *opt, opt2;
     int ret, i, ntargets;
     uint32_t ui32;
+    unsigned long ulval;
     bool flag;
     prte_pmix_app_t *app;
     char *param;
@@ -1115,6 +1279,14 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
     /* check what user wants us to do with stdin */
     opt = pmix_cmd_line_get_param(results, PRTE_CLI_STDIN);
     if (NULL != opt) {
+        pmix_rank_t stdintgt;
+
+        if (PRTE_SUCCESS != stdin_target_rank(results, &stdintgt)) {
+            prte_show_help("help-prun.txt", "bad-option-input", true, prte_tool_basename,
+                           "--" PRTE_CLI_STDIN, opt->values[0], "all, none, or a rank");
+            PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
+            return PRTE_ERR_BAD_PARAM;
+        }
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_STDIN_TGT, opt->values[0], PMIX_STRING);
     }
 
@@ -1139,7 +1311,13 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
     /* record the max restarts */
     opt = pmix_cmd_line_get_param(results, PRTE_CLI_MAX_RESTARTS);
     if (NULL != opt) {
-        ui32 = strtol(opt->values[0], NULL, 10);
+        if (PRTE_SUCCESS != prte_parse_uint_option(opt->values[0], UINT32_MAX, &ulval)) {
+            prte_show_help("help-prun.txt", "bad-option-input", true, prte_tool_basename,
+                           "--" PRTE_CLI_MAX_RESTARTS, opt->values[0], "a number of restarts");
+            PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
+            return PRTE_ERR_BAD_PARAM;
+        }
+        ui32 = (uint32_t) ulval;
         PMIX_LIST_FOREACH(app, apps, prte_pmix_app_t)
         {
             PMIX_INFO_LIST_ADD(ret, app->info, PMIX_MAX_RESTARTS, &ui32, PMIX_UINT32);
@@ -1163,14 +1341,32 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
     i = 0;
     opt = pmix_cmd_line_get_param(results, PRTE_CLI_TIMEOUT);
     if (NULL != opt) {
-        i = strtol(opt->values[0], NULL, 10);
+        if (PRTE_SUCCESS != prte_parse_uint_option(opt->values[0], INT_MAX, &ulval)) {
+            prte_show_help("help-prun.txt", "bad-option-input", true, prte_tool_basename,
+                           "--" PRTE_CLI_TIMEOUT, opt->values[0], "a number of seconds");
+            PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
+            return PRTE_ERR_BAD_PARAM;
+        }
+        i = (int) ulval;
     } else if (NULL != (param = getenv("MPIEXEC_TIMEOUT"))) {
-        i = strtol(param, NULL, 10);
+        if (PRTE_SUCCESS != prte_parse_uint_option(param, INT_MAX, &ulval)) {
+            prte_show_help("help-prun.txt", "bad-option-input", true, prte_tool_basename,
+                           "MPIEXEC_TIMEOUT", param, "a number of seconds");
+            PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
+            return PRTE_ERR_BAD_PARAM;
+        }
+        i = (int) ulval;
     }
     if (0 != i) {
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_JOB_TIMEOUT, &i, PMIX_INT);
     }
 
+    /* these two are the bare presence of an option: the value they carry is
+     * the assertion the user made by writing it.  They used to be handed
+     * "flag" as it stood, which is set only by the recovery and continuous
+     * blocks above - so on any command line that gave neither, the DVM was
+     * told to take stack traces "false" and --get-stack-traces did nothing */
+    flag = true;
     if (pmix_cmd_line_is_taken(results, PRTE_CLI_STACK_TRACES)) {
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_TIMEOUT_STACKTRACES, &flag, PMIX_BOOL);
     }
@@ -1179,7 +1375,13 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
     }
     opt = pmix_cmd_line_get_param(results, PRTE_CLI_SPAWN_TIMEOUT);
     if (NULL != opt) {
-        i = strtol(opt->values[0], NULL, 10);
+        if (PRTE_SUCCESS != prte_parse_uint_option(opt->values[0], INT_MAX, &ulval)) {
+            prte_show_help("help-prun.txt", "bad-option-input", true, prte_tool_basename,
+                           "--" PRTE_CLI_SPAWN_TIMEOUT, opt->values[0], "a number of seconds");
+            PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
+            return PRTE_ERR_BAD_PARAM;
+        }
+        i = (int) ulval;
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_SPAWN_TIMEOUT, &i, PMIX_INT);
     }
     opt = pmix_cmd_line_get_param(results, PRTE_CLI_DO_NOT_AGG_HELP);
@@ -1193,13 +1395,19 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_MEM_ALLOC_KIND, opt->values[0], PMIX_STRING);
     }
 
-    pmix_info_t info;
     opt = pmix_cmd_line_get_param(results, PRTE_CLI_GPU_SUPPORT);
     if (NULL != opt) {
-        // they could be enabling or disabling it
-        info.value.type = PMIX_STRING;
-        info.value.data.string = opt->values[0];
-        flag = PMIX_INFO_TRUE(&info);
+        /* they could be enabling or disabling it - but the truth test
+         * underneath reports anything it does not recognize as FALSE, so
+         * "--gpu-support maybe" quietly meant "no GPU support".  Refuse a
+         * value that is neither, the way every other boolean option here
+         * does */
+        if (PRTE_SUCCESS != prte_cli_bool_value(opt->values[0], &flag)) {
+            prte_show_help("help-prun.txt", "bad-option-input", true, prte_tool_basename,
+                           "--" PRTE_CLI_GPU_SUPPORT, opt->values[0], "true or false");
+            PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
+            return PRTE_ERR_BAD_PARAM;
+        }
         PMIX_INFO_LIST_ADD(ret, jinfo, PMIX_GPU_SUPPORT, &flag, PMIX_BOOL);
     }
 
@@ -1273,6 +1481,21 @@ static void signal_forward_callback(int signum)
     pmix_status_t rc;
     pmix_proc_t proc;
     pmix_info_t info;
+
+    /* We are installed before the tool has connected to anything, let alone
+     * spawned, and every forwardable signal is forwarded by default - so a
+     * SIGTSTP or a "kill -USR1" that lands while we are still connecting or
+     * still inside PMIx_Spawn finds spawnednspace empty.  An empty namespace
+     * is not a safe way to say "no job": the job-control path packs it
+     * verbatim and prted_comm.c reads it as EVERY job, so on a shared
+     * persistent DVM we would deliver the signal to other people's work. */
+    if ('\0' == spawnednspace[0]) {
+        if (verbose) {
+            fprintf(stderr, "%s: signal %d received before the job was spawned - not forwarded\n",
+                    prte_tool_basename, signum);
+        }
+        return;
+    }
 
     if (verbose) {
         fprintf(stderr, "%s: Forwarding signal %d to job\n", prte_tool_basename, signum);

--- a/src/prted/prun_common.c
+++ b/src/prted/prun_common.c
@@ -51,9 +51,6 @@
 #ifdef HAVE_SYS_TYPES_H
 #    include <sys/types.h>
 #endif /* HAVE_SYS_TYPES_H */
-#ifdef HAVE_SYS_WAIT_H
-#    include <sys/wait.h>
-#endif /* HAVE_SYS_WAIT_H */
 #ifdef HAVE_SYS_TIME_H
 #    include <sys/time.h>
 #endif /* HAVE_SYS_TIME_H */
@@ -70,7 +67,6 @@
 #include "src/mca/prteinstalldirs/prteinstalldirs.h"
 #include "src/pmix/pmix-internal.h"
 #include "src/threads/pmix_mutex.h"
-#include "src/util/daemon_init.h"
 #include "src/util/pmix_argv.h"
 #include "src/util/pmix_basename.h"
 #include "src/util/prte_cmd_line.h"
@@ -95,8 +91,6 @@
 #include "src/runtime/prte_globals.h"
 #include "src/runtime/prte_quit.h"
 #include "src/runtime/runtime.h"
-
-#include "src/prted/prted.h"
 
 typedef struct {
     prte_pmix_lock_t lock;
@@ -151,7 +145,6 @@ static child_status_t *child_statuses = NULL;
 static size_t evid = INT_MAX;
 static pmix_proc_t myproc;
 static bool verbose = false;
-static pmix_list_t forwarded_signals;
 
 static void signal_forward_callback(int signal);
 
@@ -518,30 +511,6 @@ static int stdin_target_rank(pmix_cli_result_t *results, pmix_rank_t *rank)
     return PRTE_SUCCESS;
 }
 
-static int wait_pipe[2];
-
-static int wait_dvm(pid_t pid)
-{
-    char reply;
-    int rc;
-    int status;
-
-    close(wait_pipe[1]);
-    do {
-        rc = read(wait_pipe[0], &reply, 1);
-    } while (0 > rc && EINTR == errno);
-
-    if (1 == rc && 'K' == reply) {
-        return 0;
-    } else if (0 == rc) {
-        waitpid(pid, &status, 0);
-        if (WIFEXITED(status)) {
-            return WEXITSTATUS(status);
-        }
-    }
-    return 255;
-}
-
 int prun_common(pmix_cli_result_t *results,
                 prte_schizo_base_module_t *schizo,
                 int pargc, char **pargv)
@@ -564,7 +533,6 @@ int prun_common(pmix_cli_result_t *results,
     uint32_t ui32;
     pid_t pid;
     prte_ess_base_signal_t *sig;
-    prte_event_list_item_t *evitm;
     pmix_value_t *val;
     pmix_data_array_t darray;
     char hostname[PRTE_PATH_MAX];
@@ -582,7 +550,6 @@ int prun_common(pmix_cli_result_t *results,
      * own copy now; this is the one prun and "prterun --dvm" run. */
     verbose = pmix_cmd_line_is_taken(results, PRTE_CLI_VERBOSE);
     PMIX_CONSTRUCT(&apps, pmix_list_t);
-    PMIX_CONSTRUCT(&forwarded_signals, pmix_list_t);
     /* this only names the tool to PMIx, so a host that will not tell us
      * its name is not fatal - but the buffer has to be readable either
      * way, and gethostname leaves it untouched when it fails */
@@ -592,24 +559,15 @@ int prun_common(pmix_cli_result_t *results,
     }
     hostname[sizeof(hostname) - 1] = '\0';
 
-    /* detach from controlling terminal
-     * otherwise, remain attached so output can get to us
-     */
-    if (pmix_cmd_line_is_taken(results, PRTE_CLI_DAEMONIZE)) {
-        if (0 > pipe(wait_pipe)) {
-            return PRTE_ERROR;
-        }
-        prte_state_base.parent_fd = wait_pipe[1];
-        prte_daemon_init_callback(NULL, wait_dvm);
-        close(wait_pipe[0]);
-    } else {
 #if defined(HAVE_SETSID)
-        /* see if we were directed to separate from current session */
-        if (pmix_cmd_line_is_taken(results, PRTE_CLI_SET_SID)) {
-            setsid();
-        }
-#endif
+    /* see if we were directed to separate from current session.  There is
+     * no --daemonize arm to this: neither prun nor prterun offers the
+     * option (it was removed from prterun), so the fork-and-wait that used
+     * to sit here could not be reached. */
+    if (pmix_cmd_line_is_taken(results, PRTE_CLI_SET_SID)) {
+        setsid();
     }
+#endif
 
     /** setup callbacks for signals we should forward */
     opt = pmix_cmd_line_get_param(results, PRTE_CLI_FWD_SIGNALS);
@@ -1134,11 +1092,6 @@ DONE:
         child_statuses = cstmp->next;
         free(cstmp);
     }
-    PMIX_LIST_FOREACH(evitm, &forwarded_signals, prte_event_list_item_t)
-    {
-        prte_event_signal_del(&evitm->ev);
-    }
-    PMIX_LIST_DESTRUCT(&forwarded_signals);
     if (NULL != papps) {
         PMIX_APP_FREE(papps, napps);
     }

--- a/src/util/prte_cmd_line.c
+++ b/src/util/prte_cmd_line.c
@@ -18,6 +18,7 @@
 #include "prte_config.h"
 #include "constants.h"
 
+#include <ctype.h>
 #include <errno.h>
 #include <limits.h>
 #include <stdio.h>
@@ -202,4 +203,38 @@ bool prte_parse_umask(const char *value, mode_t *mask)
     }
     *mask = (mode_t) ul;
     return true;
+}
+
+int prte_parse_uint_option(const char *value, unsigned long limit,
+                           unsigned long *result)
+{
+    char *endptr;
+    unsigned long ul;
+
+    if (NULL == value || NULL == result) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+    *result = 0;
+
+    /* A leading digit is what separates a number from everything else a
+     * user might type: strtoul() would otherwise accept leading white
+     * space and a sign, so "-1" would wrap into a very large value and
+     * " 2" would be read as 2 - and an empty string would come back as a
+     * perfectly successful zero. */
+    if (!isdigit((unsigned char) value[0])) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+    errno = 0;
+    endptr = NULL;
+    ul = strtoul(value, &endptr, 10);
+    if (0 != errno || NULL == endptr || '\0' != endptr[0]) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+    /* the caller names the field the value has to fit: truncating into it
+     * silently turns a value the user chose into a different one */
+    if (ul > limit) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+    *result = ul;
+    return PRTE_SUCCESS;
 }

--- a/src/util/prte_cmd_line.h
+++ b/src/util/prte_cmd_line.h
@@ -360,6 +360,28 @@ PRTE_EXPORT int prte_load_appfile(const char *filename, char ***argv);
  */
 PRTE_EXPORT bool prte_parse_umask(const char *value, mode_t *mask);
 
+/**
+ * Interpret a command-line option value that has to be a non-negative
+ * decimal number.
+ *
+ * strtoul() reports a perfectly successful zero for a string with no
+ * digits in it, and zero is meaningful almost everywhere PRRTE asks for a
+ * number - "no timeout", "let the mapping policy compute the count",
+ * "rank 0".  So a misspelled value does not fail; it quietly means
+ * something else.  This refuses anything that is not a complete run of
+ * digits, and anything that does not fit the field the caller is going
+ * to store it in.
+ *
+ * @param value   the option's value
+ * @param limit   the largest value the caller's field can hold
+ * @param result  filled in on success, zero otherwise
+ *
+ * @retval PRTE_SUCCESS
+ * @retval PRTE_ERR_BAD_PARAM  not a number, or larger than @c limit
+ */
+PRTE_EXPORT int prte_parse_uint_option(const char *value, unsigned long limit,
+                                       unsigned long *result);
+
 END_C_DECLS
 
 #endif /* PRTE_CMD_LINE_H */

--- a/test/unit/prted/test_prted.c
+++ b/test/unit/prted/test_prted.c
@@ -1036,6 +1036,147 @@ static int check_envar_app(const char *desc, prte_pmix_app_t *app,
     return failures;
 }
 
+/*
+ * The --prefix / --pmix-prefix / --app-prefix conflict checks in
+ * create_app(), driven through prte_parse_locals().
+ *
+ * The pmix-prefix check counted instances of PRTE_CLI_PREFIX while walking
+ * PRTE_CLI_PMIX_PREFIX's values.  That both skipped the check whenever no
+ * --prefix was given - so conflicting --pmix-prefix values were silently
+ * accepted and the first one used - and walked the value array past its
+ * NULL terminator whenever more --prefix values were given than
+ * --pmix-prefix ones, which segfaulted the tool.
+ */
+typedef struct {
+    const char *desc;
+    const char *argv[12];
+    bool accept;
+    const char *prte_prefix;  /* expected PRTE_PREFIX in jobdata, or NULL */
+    const char *pmix_prefix;  /* expected PMIX_PREFIX in jobdata, or NULL */
+} prefix_case_t;
+
+static prefix_case_t prefix_cases[] = {
+    {"prefix/two-prte-one-pmix",
+     {"prterun", "--prefix", "/opt/x", "--prefix", "/opt/x",
+      "--pmix-prefix", "/opt/y", "hostname", NULL},
+     true, "/opt/x", "/opt/y"},
+    {"prefix/pmix-conflict",
+     {"prterun", "--pmix-prefix", "/opt/a", "--pmix-prefix", "/opt/b",
+      "hostname", NULL},
+     false, NULL, NULL},
+    {"prefix/pmix-repeat-agrees",
+     {"prterun", "--pmix-prefix", "/opt/a", "--pmix-prefix", "/opt/a",
+      "hostname", NULL},
+     true, NULL, "/opt/a"},
+    {"prefix/prte-conflict",
+     {"prterun", "--prefix", "/opt/a", "--prefix", "/opt/b",
+      "hostname", NULL},
+     false, NULL, NULL},
+    {"prefix/prte-repeat-agrees",
+     {"prterun", "--prefix", "/opt/a", "--prefix", "/opt/a",
+      "hostname", NULL},
+     true, "/opt/a", NULL},
+    {NULL, {NULL}, false, NULL, NULL}
+};
+
+static const char *find_jobdata(pmix_list_t *jobdata, const char *key)
+{
+    prte_info_item_t *item;
+
+    PMIX_LIST_FOREACH(item, jobdata, prte_info_item_t) {
+        if (PMIx_Check_key(item->info.key, key)) {
+            return item->info.value.data.string;
+        }
+    }
+    return NULL;
+}
+
+static int test_prefix_conflicts(void)
+{
+    prte_schizo_base_module_t *schizo;
+    prefix_case_t *c;
+    pmix_list_t apps, jobdata;
+    const char *got;
+    int failures = 0, rc;
+    char buf[128];
+
+    schizo = envar_test_schizo();
+    if (NULL == schizo) {
+        return 1;
+    }
+
+    for (c = prefix_cases; NULL != c->desc; c++) {
+        PMIX_CONSTRUCT(&apps, pmix_list_t);
+        PMIX_CONSTRUCT(&jobdata, pmix_list_t);
+        rc = prte_parse_locals(schizo, &apps, (char **) c->argv,
+                               NULL, NULL, &jobdata, NULL);
+        snprintf(buf, sizeof(buf), "%s/rc", c->desc);
+        CHECK(buf, c->accept == (PRTE_SUCCESS == rc));
+        if (c->accept && PRTE_SUCCESS == rc) {
+            got = find_jobdata(&jobdata, "PRTE_PREFIX");
+            snprintf(buf, sizeof(buf), "%s/prte-prefix", c->desc);
+            CHECK(buf, (NULL == c->prte_prefix)
+                           ? (NULL == got)
+                           : (NULL != got && 0 == strcmp(got, c->prte_prefix)));
+            got = find_jobdata(&jobdata, PMIX_PREFIX);
+            snprintf(buf, sizeof(buf), "%s/pmix-prefix", c->desc);
+            CHECK(buf, (NULL == c->pmix_prefix)
+                           ? (NULL == got)
+                           : (NULL != got && 0 == strcmp(got, c->pmix_prefix)));
+        }
+        PMIX_LIST_DESTRUCT(&jobdata);
+        PMIX_LIST_DESTRUCT(&apps);
+    }
+
+    return failures;
+}
+
+/*
+ * "-n <value>" has to be a number that fits an int.  Anything else read as
+ * 0 through strtol, which is the spelling of "let the mapping policy decide"
+ * - so a misspelled count silently launched some other number of processes.
+ */
+static int test_nprocs(void)
+{
+    prte_schizo_base_module_t *schizo;
+    pmix_list_t apps;
+    prte_pmix_app_t *app;
+    int failures = 0, rc;
+    size_t n;
+    const char *bad[] = {"four", "", "2x", " 2", "-1", "4294967297", NULL};
+    const char *good_argv[] = {"prterun", "-n", "6", "hostname", NULL};
+
+    schizo = envar_test_schizo();
+    if (NULL == schizo) {
+        return 1;
+    }
+
+    for (n = 0; NULL != bad[n]; n++) {
+        const char *argv[] = {"prterun", "-n", bad[n], "hostname", NULL};
+        char buf[96];
+
+        PMIX_CONSTRUCT(&apps, pmix_list_t);
+        rc = prte_parse_locals(schizo, &apps, (char **) argv,
+                               NULL, NULL, NULL, NULL);
+        snprintf(buf, sizeof(buf), "nprocs/reject-\"%s\"", bad[n]);
+        CHECK(buf, PRTE_SUCCESS != rc);
+        PMIX_LIST_DESTRUCT(&apps);
+    }
+
+    PMIX_CONSTRUCT(&apps, pmix_list_t);
+    rc = prte_parse_locals(schizo, &apps, (char **) good_argv,
+                           NULL, NULL, NULL, NULL);
+    CHECK("nprocs/accept-rc", PRTE_SUCCESS == rc);
+    CHECK("nprocs/accept-count", 1 == pmix_list_get_size(&apps));
+    if (1 == pmix_list_get_size(&apps)) {
+        app = (prte_pmix_app_t *) pmix_list_get_first(&apps);
+        CHECK("nprocs/accept-value", 6 == app->app.maxprocs);
+    }
+    PMIX_LIST_DESTRUCT(&apps);
+
+    return failures;
+}
+
 static int test_envar_order(int *nskipped)
 {
     prte_schizo_base_module_t *schizo;
@@ -2274,6 +2415,8 @@ int main(void)
     failures += test_job_info_cache();
     failures += test_session_time();
     failures += test_directive_distribution();
+    failures += test_prefix_conflicts();
+    failures += test_nprocs();
     failures += test_envar_order(&skipped);
     failures += test_envar_order_permutations(&skipped);
     failures += test_envar_order_mpmd(&skipped);

--- a/test/unit/prted/test_prted.c
+++ b/test/unit/prted/test_prted.c
@@ -57,6 +57,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include "constants.h"
 #include "src/event/event-internal.h"
@@ -65,6 +66,7 @@
 #include "src/runtime/prte_globals.h"
 #include "src/runtime/runtime.h"
 #include "src/util/proc_info.h"
+#include "src/util/pmix_environ.h"
 
 #include "src/mca/rmaps/base/base.h"
 #include "src/mca/rmaps/rmaps_types.h"
@@ -180,6 +182,112 @@ static int test_singleton_id(void)
           PRTE_SUCCESS != prte_parse_singleton_id("myapp.0", nspace, NULL));
     CHECK("singleton/empty",
           PRTE_SUCCESS != prte_parse_singleton_id("", nspace, &rank));
+
+    return failures;
+}
+
+/*
+ * prte_parse_appfile() -- the "--app <file>" reader.
+ *
+ * Each line of the file becomes one app context, and the lines are joined
+ * with the ":" delimiter the command-line parser expects.  A blank line
+ * splits to no tokens at all, which PMIx_Argv_split reports by returning
+ * NULL rather than an empty array; indexing that unconditionally segfaulted
+ * the tool, and a blank line in an appfile is entirely ordinary.
+ */
+static int write_appfile(const char *path, const char *contents)
+{
+    FILE *fp = fopen(path, "w");
+
+    if (NULL == fp) {
+        return -1;
+    }
+    fputs(contents, fp);
+    fclose(fp);
+    return 0;
+}
+
+static int test_appfile(void)
+{
+    int failures = 0;
+    char path[PRTE_PATH_MAX];
+    char **argv;
+    int argc;
+
+    snprintf(path, sizeof(path), "%s/prte_test_appfile.%lu",
+             pmix_tmp_directory(), (unsigned long) getpid());
+
+    /* two app contexts become two segments joined by ":" */
+    if (0 != write_appfile(path, "-n 2 ./alpha\n-n 4 ./beta\n")) {
+        fprintf(stderr, "appfile: could not write %s\n", path);
+        return 1;
+    }
+    argv = NULL;
+    argc = 0;
+    CHECK("appfile/rc", PRTE_SUCCESS == prte_parse_appfile(path, &argv, &argc));
+    CHECK("appfile/count", 7 == argc);
+    CHECK("appfile/count-matches", argc == (int) PMIx_Argv_count(argv));
+    CHECK("appfile/first", NULL != argv && 0 == strcmp(argv[0], "-n"));
+    CHECK("appfile/exec1", NULL != argv && 0 == strcmp(argv[2], "./alpha"));
+    CHECK("appfile/delim", NULL != argv && 0 == strcmp(argv[3], ":"));
+    CHECK("appfile/exec2", NULL != argv && 0 == strcmp(argv[6], "./beta"));
+    PMIx_Argv_free(argv);
+
+    /* Blank lines - leading, interior, trailing - and whitespace-only lines
+     * are skipped entirely.  They must not crash, and must not contribute a
+     * delimiter either, which would produce an empty app context. */
+    if (0 != write_appfile(path, "\n-n 2 ./alpha\n\n   \n-n 4 ./beta\n\n")) {
+        fprintf(stderr, "appfile: could not write %s\n", path);
+        return 1;
+    }
+    argv = NULL;
+    argc = 0;
+    CHECK("appfile/blank-rc", PRTE_SUCCESS == prte_parse_appfile(path, &argv, &argc));
+    CHECK("appfile/blank-count", 7 == argc);
+    CHECK("appfile/blank-exec1", NULL != argv && 0 == strcmp(argv[2], "./alpha"));
+    CHECK("appfile/blank-delim", NULL != argv && 0 == strcmp(argv[3], ":"));
+    CHECK("appfile/blank-exec2", NULL != argv && 0 == strcmp(argv[6], "./beta"));
+    PMIx_Argv_free(argv);
+
+    /* a file of nothing but blank lines yields nothing at all */
+    if (0 != write_appfile(path, "\n\n  \n\n")) {
+        fprintf(stderr, "appfile: could not write %s\n", path);
+        return 1;
+    }
+    argv = NULL;
+    argc = 0;
+    CHECK("appfile/allblank-rc", PRTE_SUCCESS == prte_parse_appfile(path, &argv, &argc));
+    CHECK("appfile/allblank-count", 0 == argc);
+    CHECK("appfile/allblank-argv", NULL == argv);
+
+    /* the caller's existing argv is appended to, not replaced */
+    if (0 != write_appfile(path, "./gamma\n")) {
+        fprintf(stderr, "appfile: could not write %s\n", path);
+        return 1;
+    }
+    argv = NULL;
+    argc = 0;
+    PMIx_Argv_append_nosize(&argv, "prterun");
+    argc = 1;
+    CHECK("appfile/append-rc", PRTE_SUCCESS == prte_parse_appfile(path, &argv, &argc));
+    CHECK("appfile/append-count", 2 == argc);
+    CHECK("appfile/append-kept", NULL != argv && 0 == strcmp(argv[0], "prterun"));
+    CHECK("appfile/append-added", NULL != argv && 0 == strcmp(argv[1], "./gamma"));
+    PMIx_Argv_free(argv);
+
+    unlink(path);
+
+    /* degenerate inputs */
+    argv = NULL;
+    argc = 0;
+    CHECK("appfile/missing",
+          PRTE_SUCCESS != prte_parse_appfile(path, &argv, &argc));
+    CHECK("appfile/null-path",
+          PRTE_SUCCESS != prte_parse_appfile(NULL, &argv, &argc));
+    CHECK("appfile/null-argv",
+          PRTE_SUCCESS != prte_parse_appfile("/dev/null", NULL, &argc));
+    CHECK("appfile/null-argc",
+          PRTE_SUCCESS != prte_parse_appfile("/dev/null", &argv, NULL));
 
     return failures;
 }
@@ -2160,6 +2268,7 @@ int main(void)
     failures += test_group_left();
     failures += test_prefix_normalization();
     failures += test_singleton_id();
+    failures += test_appfile();
     failures += test_xfer_job_info();
     failures += test_xfer_app();
     failures += test_job_info_cache();

--- a/test/unit/prted/test_prted.c
+++ b/test/unit/prted/test_prted.c
@@ -73,6 +73,7 @@
 #include "src/mca/schizo/base/base.h"
 #include "src/mca/state/base/base.h"
 #include "src/prted/prted.h"
+#include "src/util/prte_cmd_line.h"
 #include "src/prted/pmix/pmix_server.h"
 #include "src/prted/pmix/pmix_server_internal.h"
 
@@ -2340,6 +2341,168 @@ static int test_connections(void)
     return failures;
 }
 
+/*
+ * prte_parse_uint_option(): the numeric option values.
+ *
+ * strtoul() reports success and zero for a string with no digits in it, and
+ * zero is meaningful at nearly every place PRRTE asks for a number - "no
+ * timeout", "rank 0", "let the mapping policy decide" - so a misspelled
+ * value did not fail, it quietly meant something else.
+ */
+static int test_uint_option(void)
+{
+    int failures = 0;
+    unsigned long v;
+    size_t n;
+    const char *bad[] = {"four", "", "2x", " 2", "-1", "+2", "0x10", "1 ", NULL};
+
+    for (n = 0; NULL != bad[n]; n++) {
+        v = 12345;
+        CHECK(bad[n][0] ? bad[n] : "<empty>",
+              PRTE_SUCCESS != prte_parse_uint_option(bad[n], UINT32_MAX, &v));
+        CHECK("bad/zeroed", 0 == v);
+    }
+
+    CHECK("good/0", PRTE_SUCCESS == prte_parse_uint_option("0", 100, &v) && 0 == v);
+    CHECK("good/7", PRTE_SUCCESS == prte_parse_uint_option("7", 100, &v) && 7 == v);
+    CHECK("good/limit", PRTE_SUCCESS == prte_parse_uint_option("100", 100, &v) && 100 == v);
+    /* the caller names the field the value has to fit: silently truncating
+     * into it turns the value the user chose into a different one */
+    CHECK("over/limit", PRTE_SUCCESS != prte_parse_uint_option("101", 100, &v));
+    CHECK("over/int", PRTE_SUCCESS != prte_parse_uint_option("4294967297", UINT32_MAX, &v));
+    CHECK("null", PRTE_SUCCESS != prte_parse_uint_option(NULL, 100, &v));
+
+    return failures;
+}
+
+/* is KEY in the converted job info, and is it true? */
+static int jinfo_true(pmix_data_array_t *da, const char *key, bool *found)
+{
+    pmix_info_t *info;
+    size_t n;
+
+    *found = false;
+    if (NULL == da->array) {
+        return 0;
+    }
+    info = (pmix_info_t *) da->array;
+    for (n = 0; n < da->size; n++) {
+        if (PMIx_Check_key(info[n].key, key)) {
+            *found = true;
+            return PMIX_INFO_TRUE(&info[n]) ? 1 : 0;
+        }
+    }
+    return 0;
+}
+
+/*
+ * prte_prun_parse_common_cli(): the job-level directives a tool builds from
+ * its command line, for prun, prterun and prte alike.
+ *
+ *  - --get-stack-traces and --report-state-on-timeout are the bare presence
+ *    of an option, and were handed a "flag" that only the --enable-recovery
+ *    and --continuous blocks above them ever assigned.  On any command line
+ *    that gave neither - which is every command line that asks only for
+ *    stack traces - the DVM was told to take them "false", and the option
+ *    did nothing.  The DVM reads the value, not the key's presence.
+ *
+ *  - a value that has to be a number has to be checked for being one, or
+ *    the option is silently dropped (--timeout) or aimed somewhere else
+ *    (--stdin, which would have gone to rank 0).
+ */
+typedef struct {
+    const char *desc;
+    const char *tool;       /* which tool's option table to parse against */
+    const char *argv[8];
+    bool accept;
+    const char *truekey;    /* directive that must be present AND true */
+} common_cli_case_t;
+
+static common_cli_case_t common_cli_cases[] = {
+    {"stacktraces", "prterun", {"prterun", "--get-stack-traces", "hostname", NULL},
+     true, PMIX_TIMEOUT_STACKTRACES},
+    {"reportstate", "prterun", {"prterun", "--report-state-on-timeout", "hostname", NULL},
+     true, PMIX_TIMEOUT_REPORT_STATE},
+    /* --enable-recovery and --continuous are the only two blocks that ever
+     * wrote the shared "flag", and they exist only in prun's option table -
+     * so for prterun the value read below them was ALWAYS uninitialized.
+     * Check both tools: prun with the writer present, and prun without it. */
+    {"stacktraces/prun", "prun", {"prun", "--get-stack-traces", "hostname", NULL},
+     true, PMIX_TIMEOUT_STACKTRACES},
+    {"stacktraces/prun+recovery", "prun",
+     {"prun", "--enable-recovery", "--get-stack-traces", "hostname", NULL},
+     true, PMIX_TIMEOUT_STACKTRACES},
+    {"timeout/good", "prterun", {"prterun", "--timeout", "10", "hostname", NULL}, true, NULL},
+    {"timeout/word", "prterun", {"prterun", "--timeout", "ten", "hostname", NULL}, false, NULL},
+    {"timeout/empty", "prterun", {"prterun", "--timeout", "", "hostname", NULL}, false, NULL},
+    {"spawn-timeout/word", "prterun",
+     {"prterun", "--spawn-timeout", "soon", "hostname", NULL}, false, NULL},
+    {"stdin/all", "prterun", {"prterun", "--stdin", "all", "hostname", NULL}, true, NULL},
+    {"stdin/none", "prterun", {"prterun", "--stdin", "none", "hostname", NULL}, true, NULL},
+    {"stdin/rank", "prterun", {"prterun", "--stdin", "3", "hostname", NULL}, true, NULL},
+    {"stdin/word", "prterun", {"prterun", "--stdin", "second", "hostname", NULL}, false, NULL},
+    {NULL, NULL, {NULL}, false, NULL}
+};
+
+static int test_common_cli(void)
+{
+    prte_schizo_base_module_t *schizo;
+    common_cli_case_t *c;
+    pmix_cli_result_t results;
+    pmix_list_t apps;
+    pmix_data_array_t darray;
+    pmix_status_t prc;
+    int failures = 0, rc;
+    bool found, istrue;
+    char buf[128];
+    char *saved_actual;
+
+    schizo = envar_test_schizo();
+    if (NULL == schizo) {
+        return 1;
+    }
+    /* parse_cli picks its option table off prte_tool_actual, and the two
+     * tools do not offer the same options */
+    saved_actual = prte_tool_actual;
+
+    for (c = common_cli_cases; NULL != c->desc; c++) {
+        void *jinfo;
+
+        prte_tool_actual = (char *) c->tool;
+        PMIX_CONSTRUCT(&results, pmix_cli_result_t);
+        rc = schizo->parse_cli((char **) c->argv, &results, PMIX_CLI_SILENT);
+        snprintf(buf, sizeof(buf), "%s/parse", c->desc);
+        CHECK(buf, PRTE_SUCCESS == rc);
+        if (PRTE_SUCCESS != rc) {
+            PMIX_DESTRUCT(&results);
+            continue;
+        }
+
+        PMIX_CONSTRUCT(&apps, pmix_list_t);
+        PMIX_INFO_LIST_START(jinfo);
+        rc = prte_prun_parse_common_cli(jinfo, &results, schizo, &apps);
+        snprintf(buf, sizeof(buf), "%s/rc", c->desc);
+        CHECK(buf, c->accept == (PRTE_SUCCESS == rc));
+
+        if (c->accept && PRTE_SUCCESS == rc && NULL != c->truekey) {
+            PMIX_INFO_LIST_CONVERT(prc, jinfo, &darray);
+            istrue = jinfo_true(&darray, c->truekey, &found);
+            snprintf(buf, sizeof(buf), "%s/present", c->desc);
+            CHECK(buf, PMIX_SUCCESS == prc && found);
+            snprintf(buf, sizeof(buf), "%s/true", c->desc);
+            CHECK(buf, istrue);
+            PMIX_DATA_ARRAY_DESTRUCT(&darray);
+        }
+
+        PMIX_INFO_LIST_RELEASE(jinfo);
+        PMIX_LIST_DESTRUCT(&apps);
+        PMIX_DESTRUCT(&results);
+    }
+    prte_tool_actual = saved_actual;
+
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0, skipped = 0;
@@ -2417,6 +2580,8 @@ int main(void)
     failures += test_directive_distribution();
     failures += test_prefix_conflicts();
     failures += test_nprocs();
+    failures += test_uint_option();
+    failures += test_common_cli();
     failures += test_envar_order(&skipped);
     failures += test_envar_order_permutations(&skipped);
     failures += test_envar_order_mpmd(&skipped);


### PR DESCRIPTION
A file-by-file review of the four `.c` files directly under `src/prted/` —
`prte.c`, `prte_app_parse.c`, `prted_comm.c` and `prun_common.c` — plus the
one `odls/pdefault` fix that came out of it. Each file was audited through
five separate lenses (memory and lifetime, threading and the PMIx boundary,
error paths, portability and representation, contracts), and every finding
above LOW was adversarially verified before being acted on. Each commit is
one logical change and explains why in its message.

## The problems, roughly in order of how much they cost a user

**A forwarded signal wedged the DVM master permanently.** `prte.c`'s
`signal_forward_callback()` made a *blocking* `PMIx_Job_control` from the
thread that drives `prte_event_base`. `prte` is the PMIx server, so the call
is handed to our own host module, which thread-shifts the work back onto
that same base — and the blocking form then waits for a completion only the
parked thread could produce. Every forwardable signal is forwarded by
default, so one `kill -USR1 <prterun>` stopped everything: no RML, no
timers, no PMIx replies, forever.

**A signal aimed at one job was delivered to all of them.** The same
function on a persistent DVM has no job of its own, and handed the job
control path an empty namespace — which `prted_comm.c` reads as *every*
job. `prun_common.c` has the same defect as a *window*: its signal handlers
are installed before the tool has connected, and `spawnednspace` is not
written until `PMIx_Spawn` returns, so a `SIGTSTP` or `kill -USR1` arriving
during connect, parse, map or launch went to every job in the DVM —
other users' work included on a shared one.

**A child inherited whatever signal disposition the launcher had.**
`odls/pdefault` reset only the signal *mask* before exec, not the
dispositions, so any signal the daemon had set to `SIG_IGN` stayed ignored
in the application.

**Command lines that were refused exited 0.** `prun_common()`'s return value
*is* the tool's exit status, and `rc` holds `PRTE_SUCCESS` through most of
the function, so a `goto DONE` that did not assign it reported success —
for a command line the tool had just rejected and a spawn that was never
attempted. `PRTE_UPDATE_EXIT_STATUS` cannot rescue this: it discards a
zero, and prterun's proxy path `exit()`s the value directly. Three paths in
`prte.c` did the same thing.

**Options that were accepted and then ignored.** `--get-stack-traces` and
`--report-state-on-timeout` passed a `flag` that only the `--enable-recovery`
and `--continuous` blocks above them ever assigned — and those two options
exist in `prun`'s schizo table alone, so for `prte` and `prterun` the value
sent was always uninitialized. The DVM reads the value, not the key's
presence, so the option did nothing. `-v` was accepted and never read in
both `prte.c` and `prun_common.c`. `--dvm system-first` was tested with
`strncasecmp(..., 6)` against `system`, so the earlier arm always won and it
silently became `--dvm system`.

**Values that had to be numbers were not checked for being numbers.**
`strtol` reports a perfectly successful zero for a string with no digits in
it, and zero is meaningful at nearly every one of these: `-n four` launched
some other number of processes, `--timeout ten` ran without a timeout,
`--stdin second` sent stdin to rank 0. The idiom is now
`prte_parse_uint_option()` in `src/util/prte_cmd_line.c` rather than a
fourth hand-inlined copy.

**Crashes on ordinary input.** A blank line in an `--app` appfile segfaulted
the tool (`PMIx_Argv_split` returns NULL, not an empty array).
`--prefix /x --prefix /x --pmix-prefix /y` segfaulted it too — the
`--pmix-prefix` conflict check counted `--prefix`'s instances, so it walked
past the terminator, and skipped the check entirely whenever no `--prefix`
was given.

**Hangs where an error belonged.** Every `PMIx_Register_event_handler()` in
`prun_common.c` is followed by a wait on the lock its callback will wake,
and none checked the return — but the entry point refuses an uninitialized
or shutting-down library, and a failed allocation, *in front of* the
thread-shift that would eventually make that callback. Same for
`PMIx_Deregister_event_handler()`.

**A use-after-free at teardown.** The release lock lives on
`prun_common()`'s stack and the default event handler holds a pointer to it
that is never deregistered, so destructing it at the end of the wait left
that handler locking a destroyed mutex — in exactly the interval where
losing the DVM is likeliest.

**Leaks and dead weight.** A per-proc stack-trace leak in `prted_comm.c`; a
dead daemon command (`ABORT_PROCS_CALLED`, which nothing has packed for
years) carrying a file-static array of every proc ever ordered to die,
retained and never emptied, that would have grown for the life of a
persistent DVM; several `prte_parse_locals()`/`create_app()` error paths
that leaked a fully-parsed command line and a half-built app; and in
`prun_common.c` a `--daemonize` path that no tool can reach and a
`forwarded_signals` list that is constructed, walked at teardown, and never
appended to.

## What is new besides fixes

- `prte_parse_uint_option()` and the existing `prte_parse_pid_option()` /
  `prte_cli_bool_value()` / `prte_parse_umask()` now live together in
  `src/util/prte_cmd_line.c` — the option *values* more than one tool has to
  interpret, each of which had a defect no test could reach while it was
  open-coded in a `main()`.
- `test/unit/prted/` gains coverage for the prefix normalizer, the singleton
  identifier parser, the appfile reader (including the blank lines that used
  to crash it), the prefix conflict checks, `-n`, `prte_parse_uint_option()`
  and `prte_prun_parse_common_cli()`'s job directives. The last of these
  sets `prte_tool_actual` per case, because that is what `schizo->parse_cli()`
  picks its option table from and the three tools do not offer the same
  options.
- `src/prted/AGENTS.md` and `src/mca/odls/pdefault/AGENTS.md` record what
  this review had to work out — including the refutations, which are the
  part most likely to be re-litigated. The most useful one: the "PMIx
  borrows the targets and directives arrays" rule applies to a *pure
  server*, so `prun`'s stack arrays are correct where `prte.c`'s would not
  be, because a tool or launcher peer takes `pmix_job_control_relay()` and
  packs before returning.
- `docs/todo.rst` picks up the items this review found but did not close.

## Testing

Built warning-free with `--enable-debug`; `make check` passes (22 test
binaries, including the extended `test_prted`); the `show_help` /
schizo option-table cross-check is clean. The `--get-stack-traces`
regression was verified to actually fail the new test when the fix is
reverted. Live smoke tested end to end (`prte --daemonize` → `prun -n 4
hostname` → `pterm`), along with the refusal paths, a non-zero application
exit status, and `-v`, with no stale session directories left behind.