### PR TITLE
Keep a nameless job out of errmgr/dvm's two failure policies

### DIFF
--- a/src/mca/errmgr/dvm/AGENTS.md
+++ b/src/mca/errmgr/dvm/AGENTS.md
@@ -57,7 +57,10 @@ Fires when a job is activated into an error state. Flow:
    rather than retaining and dereferencing it: a crash inside the handler
    whose job is to report crashes is the worst possible outcome here.
 3. Copy `caddy->job_state` into `jdata->state`.
-4. **Two policies, chosen by whose job it is:**
+4. **A job with no namespace is answered and dropped, before anything else.**
+   See the section below — this test has to come first, because *both* of
+   the policies underneath it are wrong for such a job.
+5. **Two policies, chosen by whose job it is:**
 
    **The daemon job itself** (`nspace == PRTE_PROC_MY_NAME->nspace`) —
    the DVM is in trouble:
@@ -201,12 +204,66 @@ so a replacement can be mapped.
 
 ---
 
+## A job with no namespace must not enter either policy
+
+An empty namespace is PMIx's **wildcard**: `PMIx_Check_nspace()` returns
+true if *either* side is invalid. A `prte_job_t` that failed before
+`prte_plm_base_create_jobid()` named it therefore matches the daemon
+namespace, and both of `job_errors`' arms do the wrong thing with it:
+
+| arm | what it does to a nameless job |
+|-----|-------------------------------|
+| daemon (`nspace == mine`) | `NEVER_LAUNCHED` is in its list, so it disables routing and activates `PRTE_JOB_STATE_DAEMONS_TERMINATED` — which is `prte_quit`. One application's failure takes the **whole DVM** down. |
+| everything else | hands `_terminate_job()` that same empty namespace, which every daemon's odls reads as **every local proc**. |
+
+Testing the namespace properly is therefore not the fix on its own — it
+just moves the damage from the first row to the second. `job_errors`
+screens for `PMIX_NSPACE_INVALID(jdata->nspace)` *before* either arm and
+answers the requester directly with `prte_plm_base_spawn_response()`,
+which routes on the job's originator and room number rather than on its
+name. Nothing is running under such a job and nothing downstream can
+address it, so an answer is the whole of what is owed.
+
+`prte_plm_base_setup_job()` is where this arises: it activates
+`NEVER_LAUNCHED` on two paths that run *before* the job is named.
+`prte_plm_base_spawn_alloc_failed()` and the `dvm_held` unwind in
+`prte_ras_base_modify()` avoid the state machine for the same reason and
+call `prte_plm_base_spawn_response()` directly.
+
+**The pattern is still present in `state_dvm.c`'s `check_complete()`**,
+which opens `if (NULL == jdata || PMIX_CHECK_NSPACE(jdata->nspace, ...))`
+and would likewise take a nameless job for the daemon job and call
+`prte_plm.terminate_orteds()`. Nothing reaches it with one today — the
+screen above is upstream of every route there — and hardening it in
+isolation is not obviously an improvement, because a nameless job would
+then fall through to the normal completion path (reservation dispositions,
+`dvm_notify`, `cleanup_job`) which is no better equipped for it. Left as
+is, deliberately; do not "fix" it without deciding what that path should
+do.
+
+---
+
 ## Helpers
 
 ### `_terminate_job(nspace)`
 Builds a one-element proc array holding `{nspace, PMIX_RANK_WILDCARD}`
 and calls `prte_plm.terminate_procs()` — the standard "kill this whole
 job" call.
+
+**It refuses an invalid namespace, and that guard is not decoration.** The
+command it builds is xcast to every daemon, and
+`prte_odls_base_default_kill_local_procs()` *skips its namespace filter*
+when the nspace is invalid:
+
+```c
+if (!PMIX_NSPACE_INVALID(proc->name.nspace) &&
+    !PMIX_CHECK_NSPACE(proc->name.nspace, child->name.nspace)) {
+    continue;
+}
+```
+
+So `{"", RANK_WILDCARD}` does not terminate nothing — it terminates every
+application process on every node in the DVM.
 
 ### `check_send_notification(jdata, proc, event)`
 Emits a PMIx event to the *surviving* procs of a recoverable/continuous

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -119,6 +119,18 @@ static void _terminate_job(pmix_nspace_t jobid)
     pmix_pointer_array_t procs;
     prte_proc_t pobj;
 
+    /* An empty namespace is PMIx's WILDCARD, and this function's whole
+     * output is a {nspace, RANK_WILDCARD} kill sent to every daemon in the
+     * DVM.  prte_odls_base_default_kill_local_procs() skips its namespace
+     * filter for an invalid nspace, so such a command does not terminate
+     * nothing - it terminates every application process on every node.
+     * There is no job here to terminate; say so rather than aiming at all of
+     * them. */
+    if (PMIX_NSPACE_INVALID(jobid)) {
+        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+        return;
+    }
+
     prte_pmix_server_connection_job_failed(jobid);
 
     PMIX_CONSTRUCT(&procs, pmix_pointer_array_t);
@@ -171,6 +183,37 @@ static void job_errors(int fd, short args, void *cbdata)
                          "%s errmgr:dvm: job %s reported state %s",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_JOBID_PRINT(jdata->nspace),
                          prte_job_state_to_str(jobstate));
+
+    /* A job that failed before it was given a namespace has never launched:
+     * nothing is running under it and nothing downstream can address it.  It
+     * must not go any further into the machine, because an empty namespace is
+     * PMIx's WILDCARD - PMIX_CHECK_NSPACE answers true against anything - so
+     * the daemon test below takes such a job for the DAEMON job, and that arm
+     * ends in PRTE_JOB_STATE_DAEMONS_TERMINATED, which is prte_quit.  One
+     * application's failure would take the whole DVM down with it.
+     *
+     * Testing the namespace properly is not the fix on its own, either: the
+     * arm below that hands _terminate_job() the same empty namespace, which
+     * every daemon's odls reads as "every local proc".  Both arms are wrong
+     * for a job with no name.
+     *
+     * All that is owed here is an answer to whoever asked for it, and
+     * prte_plm_base_spawn_response() delivers that by the job's originator
+     * and room number rather than by its name.  prte_plm_base_spawn_alloc_failed()
+     * reaches for it directly for exactly the same reason.
+     *
+     * prte_plm_base_setup_job() is where this arises: it activates
+     * NEVER_LAUNCHED on two paths that run before prte_plm_base_create_jobid()
+     * has named the job. */
+    if (PMIX_NSPACE_INVALID(jdata->nspace)) {
+        rc = prte_pmix_convert_job_state_to_error(jobstate);
+        rc = prte_plm_base_spawn_response(rc, jdata);
+        if (PRTE_SUCCESS != rc) {
+            PRTE_ERROR_LOG(rc);
+        }
+        PMIX_RELEASE(caddy);
+        return;
+    }
 
     if (PMIX_CHECK_NSPACE(jdata->nspace, PRTE_PROC_MY_NAME->nspace)) {
         if (PRTE_JOB_STATE_FAILED_TO_START == jdata->state

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -944,15 +944,14 @@ respond:
         if (NULL != req->jdata) {
             /* Answer the requester directly rather than through the state
              * machine.  This job has not been through prte_plm.spawn(), so it
-             * has no namespace yet - and PMIX_CHECK_NSPACE counts an empty
-             * nspace as matching anything, so errmgr/dvm's job_errors() takes
-             * it for the DAEMON job, never sends a spawn response, and leaves
-             * the tool waiting for the life of the DVM.  Its other branch
-             * would be worse: it hands _terminate_job() that same empty
-             * namespace, which prted_comm.c reads as EVERY job.  A job with
-             * no name does not belong in the state machine at all; what the
-             * requester is owed is an answer, and this is the call that
-             * gives it. */
+             * has no namespace yet, and there is nothing for the state
+             * machine to do with one: nothing is running under it and nothing
+             * downstream can address it.  All that is owed is an answer, and
+             * prte_plm_base_spawn_response() delivers it by the job's
+             * originator and room number rather than by its name -
+             * prte_plm_base_spawn_alloc_failed() reaches for it directly for
+             * the same reason.  (errmgr/dvm's job_errors() also handles a
+             * nameless job now, and safely; this does not depend on that.) */
             prte_plm_base_spawn_response(prte_pmix_convert_job_state_to_error(PRTE_JOB_STATE_ALLOC_FAILED),
                                          req->jdata);
         }


### PR DESCRIPTION
Follow-on from #2735. An empty namespace is PMIx's **wildcard** —
`PMIx_Check_nspace()` returns true if *either* side is invalid — and
`errmgr/dvm`'s `job_errors()` splits on exactly that test to decide whether a
failure belongs to the daemon job or to an application job.

A `prte_job_t` that fails before `prte_plm_base_create_jobid()` has named it
therefore matches the daemon namespace, and **both** arms then do the wrong
thing with it.

The daemon arm is the dangerous one. `NEVER_LAUNCHED` is in its list, so it
disables routing and activates `PRTE_JOB_STATE_DAEMONS_TERMINATED` — which
`state_dvm` registers as `prte_quit`. One application job failing before it
was named takes the entire DVM down, and its requester is never told
anything.

Testing the namespace properly is not the fix on its own, because it only
moves the damage to the other arm: that one hands `_terminate_job()` the same
empty namespace, and the command it xcasts is `{nspace, RANK_WILDCARD}`.
`prte_odls_base_default_kill_local_procs()` *skips* its namespace filter when
the nspace is invalid —

```c
if (!PMIX_NSPACE_INVALID(proc->name.nspace) &&
    !PMIX_CHECK_NSPACE(proc->name.nspace, child->name.nspace)) {
    continue;
}
```

— so rather than terminating nothing it terminates every application process
on every node in the DVM.

So `job_errors()` screens for an invalid namespace *before* either arm. Such
a job has never launched: nothing is running under it and nothing downstream
can address it, so the whole of what is owed is an answer to whoever asked,
and `prte_plm_base_spawn_response()` delivers that by the job's originator and
room number rather than by its name. `prte_plm_base_spawn_alloc_failed()`
already reaches for it directly for exactly this reason.

`_terminate_job()` gets the guard as well. It is the primitive that would do
the damage, its argument comes from a caller that may not have checked, and
what it builds goes to every daemon in the DVM.

## How it is reached

`prte_plm_base_setup_job()` activates `NEVER_LAUNCHED` on two paths that run
before the job is named. Neither is easy to provoke — one wants the jobid
space exhausted — but they are live code, and the `ras` add-hosts unwind
merged in #2735 reached the same state through a job that had not yet been
through `prte_plm.spawn()`. That unwind calls `spawn_response()` directly, so
it was never exposed; this PR makes the state-machine route safe for anything
that takes it in future, which matters because
`PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED)` is the idiom
`src/mca/ras/AGENTS.md` tells contributors to use.

## Verification

`job_errors()` is static and only reachable through the full state machine, so
there is no unit test for it that would not require standing up most of
`prte_init()`. It was verified live instead, by temporarily routing the ras
add-hosts failure back through `PRTE_ACTIVATE_JOB_STATE` — a genuine nameless
job on a real path:

- before: the tool hung indefinitely
- after: the tool is answered `PMIX_ERR_JOB_ALLOC_FAILED` in about two
  seconds and the DVM stays up and runs further jobs

Also: clang and gcc `--enable-debug` builds warning-free, `make check` 22/22
on both, and a live `prte` / `prun -n 2` / refused add-hostfile / successful
`slots=+2` grow / `pterm` pass with the HNP printing nothing but one
`DVM ready`.

## Left alone, deliberately

The same shape survives in `state_dvm.c`'s `check_complete()`, which opens
`if (NULL == jdata || PMIX_CHECK_NSPACE(jdata->nspace, ...))`. Nothing reaches
it with a nameless job today — the screen added here is upstream of every
route to it — and hardening it in isolation is not obviously an improvement,
since a nameless job would then fall through to the normal completion path
(reservation dispositions, `dvm_notify`, `cleanup_job`) which is no better
equipped for it. The reasoning is recorded in
`src/mca/errmgr/dvm/AGENTS.md` so the next person does not have to rederive
it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrGH373vzWpkiwf9mKuX3u
