### PR TITLE
Serve the order in which the DVM acquired its allocations

### DIFF
--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -924,14 +924,19 @@ static void _query(int sd, short args, void *cbdata)
                     ret = PMIX_ERR_NOT_FOUND;
                     goto done;
                 }
-                if (NULL != allocprop && !PMIx_Check_key(allocprop, PMIX_ALLOC_RELEASABLE)) {
-                    ret = PMIX_ERR_NOT_FOUND;
-                    goto done;
-                }
                 PMIX_INFO_LIST_START(proplist);
-                /* If we added the session dynamically to extend the DVM, we can release it fully */
-                releasable = PRTE_FLAG_TEST(session, PRTE_SESSION_FLAG_DYNAMIC);
-                PMIX_INFO_LIST_ADD(rc, proplist, PMIX_ALLOC_RELEASABLE, &releasable, PMIX_BOOL);
+                rc = PMIX_SUCCESS;
+                /* a named property selects it; naming none returns all */
+                if (NULL == allocprop || PMIx_Check_key(allocprop, PMIX_ALLOC_RELEASABLE)) {
+                    /* If we added the session dynamically to extend the DVM, we can release it fully */
+                    releasable = PRTE_FLAG_TEST(session, PRTE_SESSION_FLAG_DYNAMIC);
+                    PMIX_INFO_LIST_ADD(rc, proplist, PMIX_ALLOC_RELEASABLE, &releasable, PMIX_BOOL);
+                }
+                if (PMIX_SUCCESS == rc &&
+                    (NULL == allocprop || PMIx_Check_key(allocprop, PMIX_ALLOC_SEQUENCE))) {
+                    PMIX_INFO_LIST_ADD(rc, proplist, PMIX_ALLOC_SEQUENCE,
+                                       &session->acquisition, PMIX_UINT32);
+                }
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_INFO_LIST_RELEASE(proplist);
@@ -939,6 +944,10 @@ static void _query(int sd, short args, void *cbdata)
                 }
                 PMIX_INFO_LIST_CONVERT(rc, proplist, &dry);
                 PMIX_INFO_LIST_RELEASE(proplist);
+                if (PMIX_ERR_EMPTY == rc) {
+                    ret = PMIX_ERR_NOT_FOUND;
+                    goto done;
+                }
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     goto done;

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -398,6 +398,11 @@ prte_session_t *prte_get_session_object_from_refid(const char *refid)
     return NULL;
 }
 
+/* Monotonic, never reused: a released session's slot is handed to the next
+ * one registered, so position in prte_sessions says nothing about age. Every
+ * session is registered exactly once, so stamping here covers every path. */
+static uint32_t prte_session_acquisitions = 0;
+
 int prte_set_session_object(prte_session_t *session)
 {
     prte_session_t *session_ptr;
@@ -430,6 +435,7 @@ int prte_set_session_object(prte_session_t *session)
         session->index = save;
         pmix_pointer_array_set_item(prte_sessions, save, session);
     }
+    session->acquisition = ++prte_session_acquisitions;
     return PRTE_SUCCESS;
 }
 
@@ -1060,6 +1066,7 @@ static void session_con(prte_session_t *s)
     PMIX_LOAD_PROCID(&s->requestor, NULL, PMIX_RANK_INVALID);
     s->owner_uid = PRTE_INVALID_UID;
     s->inheritance = PRTE_INHERIT_DEFAULT_VALUE;
+    s->acquisition = 0;
 }
 static void session_des(prte_session_t *s)
 {

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -292,6 +292,9 @@ typedef struct{
      * the struct compiles against a PMIx that lacks the type; defaults to the
      * value of PMIX_ALLOC_INHERIT_DEFAULT. */
     uint8_t inheritance;
+    /* Order in which this DVM acquired its allocations, from 1; 0 until the
+     * session is registered. Served as PMIX_ALLOC_SEQUENCE. */
+    uint32_t acquisition;
 } prte_session_t;
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_session_t);
 


### PR DESCRIPTION
PMIX_ALLOC_SEQUENCE [was added in openpmix cf95d9c70](https://github.com/openpmix/openpmix/pull/4204). Stamp each session with an acquisition number in prte_set_session_object - the one function every session is registered through - and serve it from the PMIX_QUERY_ALLOC_PROPERTIES arm.

That arm now gates each property on the PMIX_ALLOC_PROPERTY qualifier, so naming one property returns that one rather than all of them. A qualifier naming a property PRRTE does not serve leaves the list empty and answers PMIX_ERR_NOT_FOUND, as before.

Credits: AccelCom @ Barcelona Supercomputing Center