### PR TITLE
Reclaim the session object when a reservation is torn down

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -513,6 +513,19 @@ section for where each half lives.
 > through the reservation too, since the only namespace allowed to name it no
 > longer exists. `run-tests.sh` skips the cases that assert the released-pool
 > behavior when the capability is absent (`pmix_cap`).
+>
+> **A job spawned into the reservation can outlive it, and that is the case
+> worth knowing about.** The disposition fires when the *owning* namespace
+> terminates, so a `prun --alloc-id` job from a different namespace is still
+> running at the moment its session is torn down — and teardown *releases*
+> the `prte_session_t`, because deregistering it puts the object beyond every
+> later sweep. What keeps that from handing the surviving job a dangling
+> pointer is that `prte_job_t::session` is a counted reference. The failure,
+> if it ever stops being one, does not show up at the teardown: it shows up
+> when that job *retires*, because retiring is where the master reads
+> `jdata->session` again. "elastic DVM: a reservation torn down under a live
+> job" is that case, and its assertions are ordered to say which of the two
+> moments went wrong.
 
 **Shrink** (`elastic shrink node3`): phase-1 `PMIX_SUCCESS`, then phase-2
 `PMIX_DVM_IS_READY`, plus a **"PRRTE has lost communication with a remote

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -7604,6 +7604,98 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     fi
     cleanup_swarm
 
+    banner "elastic DVM: a reservation torn down under a live job"
+    # Tearing a reservation down RELEASES the prte_session_t: teardown
+    # deregisters it from prte_sessions, which puts it beyond every later
+    # sweep, so teardown is the only place left that can reclaim it. That is
+    # safe only because prte_job_t::session and ::target_sessions are counted
+    # references -- and this is the case that proves it has to be, because it
+    # is the one where a job is still running in a reservation at the moment
+    # the reservation goes away.
+    #
+    # The shape: the elastic client grows a reservation and holds it open
+    # with a short job of its own, a SECOND job from a different namespace is
+    # spawned into that reservation by --alloc-id, and then the client exits.
+    # Its exit terminates the owning namespace, which fires the reservation's
+    # inheritance disposition -- teardown -- while the second job is still
+    # running. That job then has to run to completion and retire normally,
+    # and retiring is precisely when the master reads jdata->session again
+    # (state_dvm's release path removes the job from session->jobs and hands
+    # the session to prte_pmix_server_session_job_terminated). With the
+    # job-side pointer borrowed rather than counted, that read is of freed
+    # memory and it takes the HNP with it.
+    #
+    # Gated on PMIX_CAP_TOOL_FINALIZED for the same reason the departing-tool
+    # case above is: without it the host is never told the tool went, the
+    # disposition never runs, no teardown ever happens, and every assertion
+    # below would pass without having tested anything.
+    cleanup_swarm
+    RUN 'nohup prte --daemonize --prtemca prte_elastic_mode 1 >/tmp/prte.out 2>&1 & sleep 8' >/dev/null
+    if ! RUN 'pgrep -x prte >/dev/null'; then
+        bad "could not start an elastic DVM for the reservation-teardown test"
+    elif ! pmix_cap PMIX_CAP_TOOL_FINALIZED; then
+        skp "teardown under a live job (PMIx predates PMIX_CAP_TOOL_FINALIZED)"
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    else
+        RUN 'rm -f /tmp/resv-own.out /tmp/resv-late.out' >/dev/null 2>&1
+        # the owner's own job is what keeps the reservation alive long enough
+        # to spawn into; it has to outlast that spawn and no longer
+        RUN_BG /tmp/resv-own.out "timeout 120 elastic grow node2:2,node3:2 -- sleep 20"
+        for _ in $(seq 1 40); do
+            RUN 'grep -q "^>>> SPAWNED" /tmp/resv-own.out' >/dev/null 2>&1 && break
+            sleep 2
+        done
+        aid=$(RUN 'sed -n "s/^>>> ALLOC_ID //p" /tmp/resv-own.out' | tr -d '\r')
+        if [ -z "$aid" ]; then
+            bad "no allocation id from the background grow: $(RUN 'tr "\n" " " < /tmp/resv-own.out' | tail -c 200)"
+        else
+            ok "the grow handed back an allocation id ($aid)"
+            # a job in the reservation from a namespace that does NOT own it,
+            # long enough to outlive the owner
+            RUN_BG /tmp/resv-late.out \
+                "{ timeout 120 prun --alloc-id $aid -np 1 sleep 45; echo LATE-JOB-RC=\$?; }"
+            sleep 8
+            RUN 'pgrep -x prun >/dev/null' \
+                && ok "a second namespace is running in the reservation" \
+                || bad "the second job never started: $(RUN 'tr "\n" " " < /tmp/resv-late.out' | tail -c 200)"
+
+            # wait for the owner to finish and exit - that is the teardown
+            for _ in $(seq 1 40); do
+                RUN 'pgrep -x elastic >/dev/null' >/dev/null 2>&1 || break
+                sleep 2
+            done
+            RUN 'pgrep -x elastic >/dev/null' >/dev/null 2>&1 \
+                && bad "the owning tool never exited, so no teardown happened" \
+                || ok "the owning tool exited, tearing its reservation down"
+            sleep 3
+            RUN 'pgrep -x prte >/dev/null' \
+                && ok "the HNP survived a teardown under a live job" \
+                || bad "the HNP died when the reservation was torn down"
+
+            # the job has to reach its own end, and be accounted for there
+            for _ in $(seq 1 40); do
+                RUN 'grep -q LATE-JOB-RC /tmp/resv-late.out' >/dev/null 2>&1 && break
+                sleep 2
+            done
+            RUN 'grep -q "^LATE-JOB-RC=0" /tmp/resv-late.out' >/dev/null 2>&1 \
+                && ok "the job outlived its reservation and completed" \
+                || bad "the job did not complete cleanly: $(RUN 'tr "\n" " " < /tmp/resv-late.out' | tail -c 200)"
+            RUN 'pgrep -x prte >/dev/null' \
+                && ok "the HNP survived the job's termination" \
+                || bad "the HNP died retiring a job whose session had gone"
+
+            # and the nodes came back to the general pool, which is what the
+            # disposition asked for - so the DVM is still usable afterwards
+            out=$(RUN 'timeout 60 prun --host node2:1,node3:1 -np 2 --map-by node hostname' 2>&1)
+            [ "$(echo "$out" | grep -cE '^node[23]$')" = 2 ] \
+                && ok "the released nodes are usable from the general pool" \
+                || bad "the DVM did not survive usable: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        fi
+        RUN 'pkill -x elastic' >/dev/null 2>&1
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    fi
+    cleanup_swarm
+
     banner "elastic DVM: grow AFTER a shrink completes (phase-two event)"
     # A grow launches a daemon onto every node that lacks one -- which after a
     # shrink includes the shrunk node, since releasing the reservation reverts

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -107,26 +107,6 @@ which nodes, and the daemon-launch path would have to fan out through more
 than one.  At minimum it needs a launcher affinity recorded per node and
 honored by ``prte_plm_base_setup_virtual_machine``.
 
-**A torn-down reservation leaks its session object.**
-``prte_ras_base_teardown_reservation`` (``src/mca/ras/base/ras_base_allocate.c``)
-gives a reservation's nodes back, drops its owners and its retained owner
-job, and removes it from ``prte_sessions`` so nothing can look it up or
-target it again — but it does not release the ``prte_session_t`` itself, and
-deregistering it also puts it beyond ``prte_finalize``'s sweep over that
-array, which is the only thing that would have reclaimed it.  Releasing it
-there is not safe as things stand: ``prte_job_t::session`` and
-``::target_sessions`` are borrowed pointers taken without a reference, so a
-job still running in the reservation — the reason the object is kept in the
-first place — would be left holding a dangling one.  The leak is one small
-object per reservation ever torn down, which an elastic DVM does once per
-grow, so it is bounded by the DVM's lifetime and by how much it grows.
-Fixing it properly means deciding who owns a session: either those job-side
-pointers become counted references, or teardown clears them (and the mapper's
-session filtering has to be correct for a job whose session has gone).  The
-one consequence that *was* fixable in isolation has been: the session's time
-limit is now disarmed at teardown, so a stale timer can no longer terminate
-jobs on a reservation that no longer exists.
-
 **``register_nspace()`` checks the list it is building, not the entries it
 puts in it.**  ``prte_pmix_server_register_nspace``
 (``src/prted/pmix/pmix_server_register_fns.c``) makes roughly forty

--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -183,7 +183,7 @@ static int rte_init(int argc, char **argv)
     }
 
     /* Set the session of the daemon job to the default session */
-    jdata->session = prte_default_session;
+    prte_set_job_session(jdata, prte_default_session);
 
     /* mark that the daemons have reported as we are the
      * only ones in the system right now, and we definitely

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -165,7 +165,7 @@ static int resolve_spawn_targets(prte_job_t *jdata, pmix_proc_t *requestor,
 {
     char *p, *start, saved;
     prte_session_t *s, **tlist = NULL, *primary = NULL;
-    size_t ntl = 0;
+    size_t ntl = 0, ntk;
     bool done = false;
 
     start = target_str;
@@ -228,10 +228,16 @@ static int resolve_spawn_targets(prte_job_t *jdata, pmix_proc_t *requestor,
         start = p + 1;
     }
 
+    /* Take the job's counted reference on each target only now that the set is
+     * final: every failure exit above frees a list nothing has retained yet,
+     * so there is nothing for those paths to give back. */
+    for (ntk = 0; ntk < ntl; ntk++) {
+        PMIX_RETAIN(tlist[ntk]);
+    }
     jdata->target_sessions = tlist;
     jdata->num_target_sessions = ntl;
     /* primary session: first targeted, or default if only invalid was named */
-    jdata->session = (NULL != primary) ? primary : prte_default_session;
+    prte_set_job_session(jdata, (NULL != primary) ? primary : prte_default_session);
     return PRTE_SUCCESS;
 }
 
@@ -824,7 +830,7 @@ moveon:
          * the parent's child list and the global job pool), so the error
          * paths below must NOT free it out from under them */
         own_jdata = false;
-        jdata->session = session;
+        prte_set_job_session(jdata, session);
         pmix_pointer_array_add(jdata->session->jobs, jdata);
 
         /* get the parent's job object */

--- a/src/mca/ras/AGENTS.md
+++ b/src/mca/ras/AGENTS.md
@@ -498,7 +498,7 @@ elastic-DVM or PMIx_Allocation code:
 | `prte_ras_base_complete_request()` | The heavy reservation router. For `PMIX_ALLOC_NEW`/`EXTEND` it resolves the destination `prte_session_t` (honoring `PMIX_ALLOC_TARGET`/`SHARE`/`INHERITANCE`/`ID`/`REQ_ID`), parses `PMIX_ALLOC_NODE_LIST`, inserts the nodes, and attaches them to the reservation (`add_nodes_to_session`). For `PMIX_ALLOC_RELEASE` it tears down a named reservation or xcasts a `PRTE_DAEMON_SHRINK_CMD`. Marks `PRTE_JOB_EXTEND_DVM` and re-launches daemons for grows. |
 | `prte_ras_base_release_allocation()` | Session-destruct hook: cycles modules whose `release_allocation` matches `session->alloc_module`. |
 | `prte_ras_base_shrink_complete()` | Offers a drained `prte_shrink_campaign_t` to every module's `shrink_complete`. |
-| `prte_ras_base_teardown_reservation()` | Drop a reservation's hold on its nodes (clear `node->session` back to the default pool), deregister it, and — if `return_to_scheduler` — shrink its daemon-carrying nodes out of the DVM. |
+| `prte_ras_base_teardown_reservation()` | Drop a reservation's hold on its nodes (clear `node->session` back to the default pool), deregister it, release the registry's reference on it, and — if `return_to_scheduler` — shrink its daemon-carrying nodes out of the DVM. |
 | `prte_ras_base_check_reservations_on_term()` | On namespace termination, fire each reservation's inheritance disposition (`PMIX_ALLOC_INHERIT_NONE`/`CHILD`/`CHILD_DEFAULT`/`DEFAULT`). |
 
 ### A request's directives arrive from a client and are typed by a client
@@ -530,15 +530,17 @@ types; a PMIx older than that refuses the documented spelling.
 ### What a failed request must leave behind
 
 - **A `PMIX_ALLOC_NEW` that fails after `ras_base_prepare_grow()` created its
-  reservation unwinds it** (`prte_ras_base_teardown_reservation` +
-  `PMIX_RELEASE`, exactly as `pmix_server_session.c` unwinds a half-built
-  session). Otherwise the requester is told the request failed, never learns
-  the allocation id, and can therefore never release a reservation that is
-  still registered and still holding a reference on the owner job. Nodes an
-  earlier `PMIX_ALLOC_NODE_LIST` already contributed stay in the pool — a
-  pool index is a `PMIX_NODEID` and is never reused — and revert to the
-  general pool still marked `PRTE_NODE_STATE_ADDED`, so the next grow adopts
-  them, which is the right answer for nodes the allocator did grant.
+  reservation unwinds it** (`prte_ras_base_teardown_reservation`, exactly as
+  `pmix_server_session.c` unwinds a half-built session — teardown drops the
+  registry's reference, which for a reservation that never launched anything
+  is the only one it has). Otherwise the requester is told the request failed,
+  never learns the allocation id, and can therefore never release a
+  reservation that is still registered and still holding a reference on the
+  owner job. Nodes an earlier `PMIX_ALLOC_NODE_LIST` already contributed stay
+  in the pool — a pool index is a `PMIX_NODEID` and is never reused — and
+  revert to the general pool still marked `PRTE_NODE_STATE_ADDED`, so the
+  next grow adopts them, which is the right answer for nodes the allocator
+  did grant.
 - **A request that parked the DVM must give it back.**
   `prte_ras_base_add_hosts()` clears `prte_dvm_ready` and its caller parks the
   requesting job in `prte_cache`; only the grow's `VM_READY` re-entry
@@ -563,24 +565,34 @@ types; a PMIx older than that refuses the documented spelling.
   The guard lives in `ras_base_send_dvm_shrink`, which is the one place every
   caller passes through.
 
-### Tearing a reservation down does not free it
+### Tearing a reservation down releases it — which is why the job side counts
 
 `prte_ras_base_teardown_reservation()` gives the nodes back, drops the owners
-and the retained owner job, disarms the session's time limit, and removes the
-session from `prte_sessions` — but it does **not** release the
-`prte_session_t`. It cannot: `prte_job_t::session` and `::target_sessions`
-are borrowed pointers taken without a reference, so a job still running in
-the reservation would be left holding a dangling one. Deregistering also puts
-the object beyond `prte_finalize`'s sweep over `prte_sessions`, so it is
-genuinely leaked, one small object per reservation ever torn down. `docs/todo.rst`
-records what fixing it properly needs. Disarming the timer *is* done here and
-is load-bearing: the limit is on a lifetime that has just ended, and a timer
-left armed fires `session_timeout_cb()` on a reservation that no longer
-exists and terminates whatever jobs are still recorded in `session->jobs`.
+and the retained owner job, disarms the session's time limit, removes the
+session from `prte_sessions`, **and releases it**. The release has to happen
+here: deregistering puts the object beyond `prte_finalize`'s sweep over
+`prte_sessions`, so nothing later would ever reclaim it.
 
-The two callers that *can* release — `pmix_server_session.c`'s `error:` path
-and the grow unwind above — do so because the session they are discarding was
-built moments earlier and no job has ever seen it.
+That is only safe because the job-side pointers into a session —
+`prte_job_t::session` and every entry of `::target_sessions` — are **counted**
+references (`prte_set_job_session()` takes them; `prte_job_destruct` gives
+them back). A reservation is routinely torn down while jobs are still running
+in it: `prte_ras_base_check_reservations_on_term()` fires the disposition when
+the *owning* namespace terminates, and jobs spawned into the reservation by
+someone else can still be alive. Those jobs keep the object valid for as long
+as they can read it, and the last one to go is what frees it. Both halves are
+pinned by `test_teardown_reservation()` in `test/unit/ras/test_ras.c`.
+
+Two consequences worth knowing. The release is conditioned on the session
+still being registered, which makes teardown idempotent — a second teardown
+drops no second reference. And a caller that reads the session *after*
+teardown must hold its own reference across the call: `reclaim_session()` does
+exactly that, because it still has to report completion to the scheduler.
+
+Disarming the timer is load-bearing for the same lifetime reason: the limit is
+on a lifetime that has just ended, and a timer left armed fires
+`session_timeout_cb()` on a reservation that no longer exists and terminates
+whatever jobs are still recorded in `session->jobs`.
 
 **A reservation requested by a tool lives and dies with that tool**, and
 that hangs on the daemon being told when the tool goes. It is not a child,

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -1332,17 +1332,25 @@ void prte_ras_base_teardown_reservation(prte_session_t *session,
     session->timeout.tv_sec = 0;
     session->timeout.tv_usec = 0;
 
-    /* Deregister so the reservation can no longer be looked up / targeted.
-     * The session OBJECT is deliberately not released: prte_job_t::session
-     * and ::target_sessions are borrowed pointers, so a job still running in
-     * this reservation would be left holding a dangling one.  That leaks the
-     * object - deregistering also puts it out of reach of prte_finalize's
-     * sweep over prte_sessions, which is the only thing that would have
-     * reclaimed it.  See "a torn-down reservation leaks its session object"
-     * in docs/todo.rst for what fixing it properly needs. */
+    /* Deregister so the reservation can no longer be looked up or targeted,
+     * and give up the reference the registry held.  Deregistering also puts
+     * the object out of reach of prte_finalize's sweep over prte_sessions,
+     * so this is the only thing left that can reclaim it - which is why the
+     * release has to happen here rather than being left for later.
+     *
+     * It is safe to let the object go because the job-side pointers into it
+     * are counted: a job still running in this reservation - the very case
+     * that used to make releasing it impossible - holds its own reference,
+     * and the object survives until the last such job is destroyed.  See
+     * prte_job_t::session and prte_set_job_session().
+     *
+     * Conditioning this on the session still being registered is what makes
+     * the call idempotent: a second teardown of the same reservation drops
+     * no second reference. */
     if (0 <= session->index) {
         pmix_pointer_array_set_item(prte_sessions, session->index, NULL);
         session->index = -1;
+        PMIX_RELEASE(session);
     }
 
     if (return_to_scheduler && NULL != ranks && 0 < m) {
@@ -1866,8 +1874,10 @@ unwind:
      * PRTE_NODE_STATE_ADDED, so the next grow brings them into the DVM, which
      * is the right answer for a node the allocator did grant us. */
     if (created) {
+        /* teardown deregisters the reservation and drops the registry's
+         * reference with it, which is the only one a never-launched
+         * reservation has */
         prte_ras_base_teardown_reservation(dest, false);
-        PMIX_RELEASE(dest);
     }
 }
 

--- a/src/prted/pmix/pmix_server_session.c
+++ b/src/prted/pmix/pmix_server_session.c
@@ -687,6 +687,12 @@ static void reclaim_session(prte_session_t *session)
      * pointer to it */
     arm_session_timer(session, 0);
 
+    /* Hold the session across the teardown: teardown gives up the registry's
+     * reference, and for a reservation no job is left in - which is exactly
+     * when we are called - that can be the last one.  The completion report
+     * below still has to read the session's id and results. */
+    PMIX_RETAIN(session);
+
     /* Do the PRRTE-side teardown first, while we are on the thread that owns
      * these objects. Only then report completion, so the statement we make to
      * the scheduler - "all resources have been recovered" - is already true
@@ -694,6 +700,8 @@ static void reclaim_session(prte_session_t *session)
     prte_ras_base_teardown_reservation(session, returns_to_scheduler(session));
 
     prte_pmix_server_session_complete(session);
+
+    PMIX_RELEASE(session);
 }
 
 /* Terminate every job in the session. The session itself is reclaimed once
@@ -1224,9 +1232,10 @@ static pmix_status_t session_instantiate(prte_pmix_server_req_t *req,
     return PMIX_OPERATION_IN_PROGRESS;
 
 error:
-    /* unwind the half-built session, returning any nodes it took */
+    /* Unwind the half-built session, returning any nodes it took.  Teardown
+     * deregisters it and drops the registry's reference, which - the session
+     * having never launched anything - is the only one it has. */
     prte_ras_base_teardown_reservation(session, false);
-    PMIX_RELEASE(session);
     return rc;
 }
 
@@ -1342,10 +1351,11 @@ static pmix_status_t apply_to_all(prte_pmix_server_req_t *req,
     if (NULL == prte_sessions) {
         return PMIX_ERR_NOT_FOUND;
     }
-    /* Terminating a session can remove it from the array from under this
-     * walk.  That is safe as written: removal only NULLs the slot (the object
-     * itself survives for as long as we hold it), and the array never
-     * shrinks, so re-reading ->size each time is correct. */
+    /* Terminating a session removes it from the array from under this walk,
+     * and may free the object with it.  That is safe as written because the
+     * walk re-reads the slot from the array on every iteration and never
+     * touches `session` again after handing it to apply_to_session; the array
+     * itself never shrinks, so re-reading ->size each time is correct. */
     for (i = 0; i < prte_sessions->size; i++) {
         session = (prte_session_t *) pmix_pointer_array_get_item(prte_sessions, i);
         if (NULL == session || session == prte_default_session) {

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -1698,7 +1698,7 @@ static int prep_singleton(const char *name)
     }
     jdata = PMIX_NEW(prte_job_t);
     PMIX_LOAD_NSPACE(jdata->nspace, nspace);
-    jdata->session = prte_default_session;
+    prte_set_job_session(jdata, prte_default_session);
     rc = prte_set_job_data_object(jdata);
     if (PRTE_SUCCESS != rc) {
         PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);

--- a/src/runtime/AGENTS.md
+++ b/src/runtime/AGENTS.md
@@ -118,11 +118,11 @@ This is the part that bites. The rules, and the reason for each:
 | `job->procs[]`, `job->apps[]` | yes | the job owns them |
 | `node->procs[]`, `node->daemon` | yes | the node owns them |
 | `proc->node` | **no** — borrowed | retaining it would close a cycle with `node->procs`/`node->daemon`; neither side could ever reach zero, so nothing would be freed. `prte_node_destruct` clears the backpointer on every proc it knows about, so a proc that outlives its node points at NULL rather than at freed memory. |
-| `node->session` | **no** — borrowed | same reason, against `session->nodes`. `prte_ras_base_release_allocation` clears it when a reservation is torn down. |
+| `node->session` | **no** — borrowed | same reason, against `session->nodes`. `prte_ras_base_teardown_reservation` clears it when a reservation is torn down, and `session_des` clears it on every node it still holds. |
 | `session->nodes[]` | yes | a reservation withholds its nodes |
 | `session->jobs[]` | **no** — borrowed | a job's lifetime is governed by the global job pool, not by the session it ran in |
 | `session->owner_job` | yes | |
-| `job->target_sessions[]` | **no** — borrowed | owned via `prte_set_session_object`; the destructor frees only the array |
+| `job->session`, `job->target_sessions[]` | yes | a reservation is torn down while the jobs that ran in it may still be alive, and teardown deregisters the session — putting it out of reach of every later sweep. So the registry cannot be the last owner, and the job side has to keep the object valid for as long as it can read it. Set with `prte_set_job_session()`; `prte_job_destruct` releases the primary and every target. No cycle: `session->jobs[]` borrows. |
 | `node->topology` | yes | a topology outlives any one node pointing at it |
 | `map->nodes[]` | yes | `prte_job_map_destruct` releases every node it holds — so anything that *puts* a node in a map must retain it |
 
@@ -302,8 +302,15 @@ exits first — but it is the only trace such a hang leaves.
 ## Session teardown at finalize
 
 `prte_finalize` releases the sessions, and the node pool goes with them.
-Three constraints fix the order, and all three have to hold:
+Four constraints fix the order, and all four have to hold:
 
+0. **Jobs before the sessions.** `job->session` and `job->target_sessions[]`
+   are counted references, so a session is not reclaimed until the last job
+   naming it has gone. Sweeping `prte_job_data` first is what makes the
+   session sweep the last word on every session — without it, constraint 2
+   below silently stops being true: `prte_default_session` would survive its
+   own release (the daemon job still names it) and the node pool would be
+   carried away later, by the job sweep, after `ras` had already closed.
 1. **Sessions before the pool.** A reservation holds a *counted* reference
    on each of its nodes, so it has to give those back while the nodes are
    still alive.

--- a/src/runtime/prte_finalize.c
+++ b/src/runtime/prte_finalize.c
@@ -122,6 +122,55 @@ int prte_finalize(void)
      * function, so this just gives the trackers back. */
     prte_worker_pool_finalize();
 
+    /* Release the jobs before the sessions they ran in.  prte_job_t::session
+     * and ::target_sessions are COUNTED references (a reservation is torn
+     * down while its jobs may still be alive, so the job side has to keep
+     * the object valid), which means a session is not reclaimed until the
+     * last job pointing at it has gone.  Sweeping the job pool first is what
+     * makes the session sweep below the last word on every session - in
+     * particular it is what keeps prte_default_session's release the thing
+     * that carries the node pool away, as the comment there says.
+     *
+     * Nodes survive this loop regardless: the pool holds its own reference on
+     * every one of them, so a job map releasing its nodes here cannot be the
+     * last word on any of them. */
+    for (n = 0; n < prte_job_data->size; n++) {
+        jdata = (prte_job_t *) pmix_pointer_array_get_item(prte_job_data, n);
+        if (NULL == jdata) {
+            continue;
+        }
+        // Empty the children list before any job object is destroyed: a job
+        // released while still linked into another job's children list trips
+        // the list-item assert. Each entry carries the reference taken when
+        // it was appended, so removing it means releasing it - the job pool
+        // still holds the reference that keeps the child alive until this
+        // loop reaches it.
+        PMIX_LIST_FOREACH_SAFE(child_jdata, next_jdata, &jdata->children, prte_job_t)
+        {
+            pmix_list_remove_item(&jdata->children, &child_jdata->super);
+            PMIX_RELEASE(child_jdata);
+        }
+        /* clean up any app contexts as they refcount the jdata object */
+        for (i=0; i < jdata->apps->size; i++) {
+            app = (prte_app_context_t*)pmix_pointer_array_get_item(jdata->apps, i);
+            if (NULL != app) {
+                pmix_pointer_array_set_item(jdata->apps, i, NULL);
+                PMIX_RELEASE(app);
+            }
+        }
+        // clean up any procs
+        for (i=0; i < jdata->procs->size; i++) {
+            p = (prte_proc_t*)pmix_pointer_array_get_item(jdata->procs, i);
+            if (NULL != p) {
+                pmix_pointer_array_set_item(jdata->procs, i, NULL);
+                PMIX_RELEASE(p);
+            }
+        }
+        pmix_pointer_array_set_item(prte_job_data, n, NULL);
+        PMIX_RELEASE(jdata);
+    }
+    PMIX_RELEASE(prte_job_data);
+
     /* Tear the sessions down, and with them the node pool.
      *
      * Order matters in three ways. A reservation holds a COUNTED reference on
@@ -184,43 +233,6 @@ int prte_finalize(void)
     if (PRTE_PROC_IS_MASTER) {
         (void) pmix_mca_base_framework_close(&prte_ras_base_framework);
     }
-
-    for (n = 0; n < prte_job_data->size; n++) {
-        jdata = (prte_job_t *) pmix_pointer_array_get_item(prte_job_data, n);
-        if (NULL == jdata) {
-            continue;
-        }
-        // Empty the children list before any job object is destroyed: a job
-        // released while still linked into another job's children list trips
-        // the list-item assert. Each entry carries the reference taken when
-        // it was appended, so removing it means releasing it - the job pool
-        // still holds the reference that keeps the child alive until this
-        // loop reaches it.
-        PMIX_LIST_FOREACH_SAFE(child_jdata, next_jdata, &jdata->children, prte_job_t)
-        {
-            pmix_list_remove_item(&jdata->children, &child_jdata->super);
-            PMIX_RELEASE(child_jdata);
-        }
-        /* clean up any app contexts as they refcount the jdata object */
-        for (i=0; i < jdata->apps->size; i++) {
-            app = (prte_app_context_t*)pmix_pointer_array_get_item(jdata->apps, i);
-            if (NULL != app) {
-                pmix_pointer_array_set_item(jdata->apps, i, NULL);
-                PMIX_RELEASE(app);
-            }
-        }
-        // clean up any procs
-        for (i=0; i < jdata->procs->size; i++) {
-            p = (prte_proc_t*)pmix_pointer_array_get_item(jdata->procs, i);
-            if (NULL != p) {
-                pmix_pointer_array_set_item(jdata->procs, i, NULL);
-                PMIX_RELEASE(p);
-            }
-        }
-        pmix_pointer_array_set_item(prte_job_data, n, NULL);
-        PMIX_RELEASE(jdata);
-    }
-    PMIX_RELEASE(prte_job_data);
 
     for (n = 0; n < prte_node_topologies->size; n++) {
         topo = (prte_topology_t *) pmix_pointer_array_get_item(prte_node_topologies, n);

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -439,6 +439,25 @@ int prte_set_session_object(prte_session_t *session)
     return PRTE_SUCCESS;
 }
 
+void prte_set_job_session(prte_job_t *jdata, prte_session_t *session)
+{
+    prte_session_t *old;
+
+    if (NULL == jdata || jdata->session == session) {
+        return;
+    }
+    /* retain BEFORE releasing: the two may be the same object reached by
+     * different paths, and dropping the last reference first would free it */
+    old = jdata->session;
+    if (NULL != session) {
+        PMIX_RETAIN(session);
+    }
+    jdata->session = session;
+    if (NULL != old) {
+        PMIX_RELEASE(old);
+    }
+}
+
 prte_proc_t *prte_get_proc_object(const pmix_proc_t *proc)
 {
     prte_job_t *jdata;
@@ -826,12 +845,25 @@ static void prte_job_destruct(prte_job_t *job)
     if (NULL != job->traces) {
         PMIx_Argv_free(job->traces);
     }
-    /* target_sessions holds borrowed session pointers - free only the array */
+    /* Both the primary session and every target carry a counted reference -
+     * see prte_job_t::session.  Dropping them here is what finally reclaims a
+     * reservation that was torn down while this job was still running in it:
+     * teardown deregisters the session and gives up the registry's reference,
+     * and the last job to let go is what frees the object. */
     if (NULL != job->target_sessions) {
+        for (n = 0; n < (int) job->num_target_sessions; n++) {
+            if (NULL != job->target_sessions[n]) {
+                PMIX_RELEASE(job->target_sessions[n]);
+            }
+        }
         free(job->target_sessions);
         job->target_sessions = NULL;
     }
     job->num_target_sessions = 0;
+    if (NULL != job->session) {
+        PMIX_RELEASE(job->session);
+        job->session = NULL;
+    }
     PMIX_DESTRUCT(&job->cli);
 }
 

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -424,7 +424,11 @@ typedef struct prte_job_t {
     /* offset to the total number of procs so shared memory
      * components can potentially connect to any spawned jobs*/
     pmix_rank_t offset;
-    /* session this job is running in */
+    /* Session this job is running in.  A COUNTED reference: a reservation is
+     * torn down while the jobs that ran in it may still be alive, and the
+     * job-side pointer has to keep the object it names valid for as long as
+     * the job can read it.  Set with prte_set_job_session(), released by the
+     * job destructor.  There is no cycle to fear - session->jobs[] borrows. */
     prte_session_t *session;
     /* app_context array for this job */
     pmix_pointer_array_t *apps;
@@ -502,9 +506,9 @@ typedef struct prte_job_t {
     /* Sessions this job may map onto, resolved from PRTE_JOB_SPAWN_TARGET on the
      * HNP after the ownership check. HNP-local; never packed (rebuilt from the
      * attribute if ever needed). Defaults to { jdata->session } when no spawn
-     * target was given. target_sessions holds borrowed session pointers (owned
-     * via prte_set_session_object, not by the job), so the destructor frees only
-     * the array, not the sessions it points at. */
+     * target was given. Each entry is a COUNTED reference, for the same reason
+     * jdata->session is; the destructor releases every entry and then frees
+     * the array. */
     prte_session_t **target_sessions;
     size_t num_target_sessions;
     /* track the number of stack traces recv'd */
@@ -578,6 +582,11 @@ PRTE_EXPORT prte_session_t *prte_get_session_object_from_id(const char *id);
 PRTE_EXPORT prte_session_t *prte_get_session_object_from_refid(const char *refid);
 
 PRTE_EXPORT int prte_set_session_object(prte_session_t *session);
+
+/* Point a job at the session it runs in, maintaining the reference count on
+ * both the outgoing and the incoming session.  Every assignment to
+ * prte_job_t::session must go through this. */
+PRTE_EXPORT void prte_set_job_session(prte_job_t *jdata, prte_session_t *session);
 
 /* True if nspace is in session->owners, or session is the default session,
  * or nspace is the scheduler. */

--- a/test/unit/ras/test_ras.c
+++ b/test/unit/ras/test_ras.c
@@ -1779,6 +1779,85 @@ static int test_spawn_alloc(void)
     return failures;
 }
 
+
+/* A reservation torn down while a job is still running in it.
+ *
+ * Teardown deregisters the session, which puts it beyond every later sweep
+ * over prte_sessions - so teardown is the only place left that can give the
+ * registry's reference back, and it has to.  That is safe only because the
+ * job-side pointers into a session are counted: the job that is still
+ * running in the reservation holds its own reference, and the object stays
+ * valid for as long as anything can read it.  Both halves are checked here,
+ * because either one alone is a defect - without the release the object
+ * leaks once per reservation ever torn down, and without the job's reference
+ * the release hands a running job a dangling pointer. */
+static int test_teardown_reservation(void)
+{
+    int failures = 0;
+    prte_session_t *s;
+    prte_job_t *jdata;
+    prte_node_t *nd;
+    int idx;
+
+    s = PMIX_NEW(prte_session_t);
+    s->session_id = 4242;
+    s->alloc_refid = strdup("prte-unit-test.4242");
+    s->flags |= PRTE_SESSION_FLAG_RESERVED;
+    CHECK("teardown/register", PRTE_SUCCESS == prte_set_session_object(s));
+    idx = s->index;
+    CHECK("teardown/registry holds the only reference",
+          1 == s->super.obj_reference_count);
+
+    /* a reservation withholds nodes: give it one, counted, with the
+     * backpointer that is what actually withholds it */
+    nd = PMIX_NEW(prte_node_t);
+    nd->name = strdup("prte-unit-test-reserved");
+    nd->state = PRTE_NODE_STATE_UP;
+    nd->slots = 1;
+    nd->index = pmix_pointer_array_add(prte_node_pool, nd);
+    nd->session = s;
+    PMIX_RETAIN(nd);
+    pmix_pointer_array_add(s->nodes, nd);
+
+    /* a job running in the reservation */
+    jdata = PMIX_NEW(prte_job_t);
+    PMIX_LOAD_NSPACE(jdata->nspace, "prte-unit-test-resv-job");
+    prte_set_job_session(jdata, s);
+    CHECK("teardown/job takes a reference", 2 == s->super.obj_reference_count);
+    CHECK("teardown/job names the session", s == jdata->session);
+    pmix_pointer_array_add(s->jobs, jdata);
+
+    /* our own handle, so the object can still be inspected afterwards */
+    PMIX_RETAIN(s);
+
+    prte_ras_base_teardown_reservation(s, false);
+
+    CHECK("teardown/deregistered", -1 == s->index);
+    CHECK("teardown/not findable", NULL == prte_get_session_object(4242));
+    CHECK("teardown/slot cleared",
+          NULL == pmix_pointer_array_get_item(prte_sessions, idx));
+    CHECK("teardown/node back in the general pool", NULL == nd->session);
+    CHECK("teardown/no longer reserved",
+          0 == (s->flags & PRTE_SESSION_FLAG_RESERVED));
+    /* the registry's reference is gone; the job's and ours remain */
+    CHECK("teardown/registry reference given back",
+          2 == s->super.obj_reference_count);
+    CHECK("teardown/job can still read its session",
+          4242 == jdata->session->session_id);
+
+    /* the running job is now the only thing keeping the object alive */
+    PMIX_RELEASE(jdata);
+    CHECK("teardown/job gives its reference back",
+          1 == s->super.obj_reference_count);
+
+    /* and dropping ours is what frees it - nothing else is left to */
+    PMIX_RELEASE(s);
+
+    pmix_pointer_array_set_item(prte_node_pool, nd->index, NULL);
+    PMIX_RELEASE(nd);
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0;
@@ -1830,6 +1909,7 @@ int main(void)
     failures += test_activate_hosts();
     failures += test_activate_nodes();
     failures += test_spawn_alloc();
+    failures += test_teardown_reservation();
     /* after test_select(), which opens the framework and latches a
      * selection made with no SLURM allocation in the environment -- so
      * nothing has called slurm's init() before this does */


### PR DESCRIPTION
## The problem

`prte_ras_base_teardown_reservation()` gives a reservation's nodes back and removes the session from `prte_sessions`, but never releases the `prte_session_t`. Deregistering is what makes that permanent — `prte_finalize`'s sweep over that array was the only thing left that would have reclaimed the object, and deregistering puts it beyond that sweep.

It goes per reservation ever torn down, which an elastic DVM does once per grow, and it is more than the struct itself: the two pointer arrays, the allocation/user reference strings, and — for a scheduler-instantiated session — `session->results`, which accumulates one `pmix_info_t` for **every job that ran in the session** and is freed only by the destructor. For the same reason the `ras` module's `release_allocation` hook was never reached for a torn-down reservation, only for one that survived to finalize. (That last one is dormant today; no component implements the entry point.)

This was recorded in `docs/todo.rst` as unfixable in isolation, because `prte_job_t::session` and `::target_sessions` were borrowed pointers and a reservation is routinely torn down while jobs are still running in it — the inheritance disposition fires when the *owning* namespace terminates, and jobs another namespace spawned into the reservation can outlive that. Such a job would have been left holding a dangling pointer.

## The fix

Make the job side count. Every assignment to `jdata->session` goes through a new `prte_set_job_session()`, which maintains the reference on both the outgoing and incoming session; `resolve_spawn_targets()` retains each entry of the target set; `prte_job_destruct` gives them all back. There is no cycle to close — `session->jobs[]` borrows in the other direction, as `ras/slurm`'s session stack already demonstrates for its own handle.

Teardown can then release, conditioned on the session still being registered so a second teardown drops no second reference. The two unwind paths that used to release a half-built session themselves no longer do; `reclaim_session()` holds its own reference across the teardown, because it still has to read the session to report completion to the scheduler.

Clearing the back-pointers instead was the other option and does not work: a spawned job is given its session in `plm_base_receive` *before* `prte_plm_base_setup_job` puts it in `prte_job_data`, so a job parked in `prte_cache` is invisible to any scan of the job pool.

`prte_finalize` now sweeps the job pool before the sessions. With counted references the old order silently stopped being correct — the daemon job names `prte_default_session`, so releasing that session would no longer be what carries the node pool away, and the pool teardown would land after the `ras` framework had closed.

## Testing

- `test_teardown_reservation()` in `test/unit/ras/test_ras.c` pins both halves: teardown gives the registry's reference back, and a job still running in the reservation keeps the object valid until it is destroyed. Verified to fail (and only on those two assertions) with the release commented back out.
- Clean warning-free `--enable-debug` build; `make check` 23/23; `make -C test/offline check-offline` 2449 pass / 0 fail; live DVM lifecycle and `examples/dynamic` spawn+connect.
- A multi-node case, "elastic DVM: a reservation torn down under a live job" in `contrib/dockerswarm/run-tests.sh`: the elastic client grows a reservation, a second namespace is spawned into it by `--alloc-id`, and the client then exits so the inheritance disposition tears the reservation down under that live job. 7/7 in the swarm, and 20/0/0 across the four adjacent elastic cases so it does not disturb its neighbours.

  Built with the job pointer borrowed rather than counted, it reports the *teardown* as fine and then fails at the job's retirement — `LATE-JOB-RC=195`, HNP gone, DVM unusable — which is the mechanism the second commit's message describes.