### PR TITLE
Relay a query a daemon cannot answer to the DVM master

### DIFF
--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -650,6 +650,18 @@ build_linux() {
                 /prrte-src/contrib/dockerswarm/peerinfo.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
+            # slotinfo: every rank asks its own daemon how big the allocation
+            # is.  The answer is a property of the DVM, so every rank must get
+            # the same one -- but slot counts and node state are written only
+            # on the master and the nidmap does not ship them, so a daemon
+            # answering out of its own node pool reports zero and reports it
+            # as success.  Needs ranks on daemons other than the master to
+            # show up at all, which is why it lives here.
+            echo ">>>> slotinfo (allocation query relay) test client"
+            gcc -O0 -g -o /opt/prte/prte/bin/slotinfo \
+                /prrte-src/contrib/dockerswarm/slotinfo.c \
+                -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
+
             # Open MPI, if a checkout was bind-mounted.  This is the only
             # thing in the harness that produces a modex an application
             # actually reads back: every other client here puts data because

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -2550,6 +2550,8 @@ test_runtime() {
 PT=/opt/prte/prte/bin/proctable
 # ...and the client that asks a peer where it is, for the same reason.
 PI=/opt/prte/prte/bin/peerinfo
+# ...and the client that asks its own daemon how big the allocation is.
+SI=/opt/prte/prte/bin/slotinfo
 
 # Cross-check one peerinfo run.  Every rank prints a SELF line about itself
 # and a PEER line about each of the others, in the same field order, so the
@@ -2871,6 +2873,67 @@ test_pmix() {
             bad "the check fails with the derivation off, so it is not testing the derivation: $(echo "$mism" | head -2 | tr '\n' ' ' | tail -c 400)"
         fi
         RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    fi
+    cleanup_swarm
+
+    banner "prted: an allocation query is answered the same on every node"
+    # PMIX_NUM_SLOTS and PMIX_QUERY_AVAILABLE_SLOTS describe the DVM, so every
+    # rank must get the same answer whichever daemon it asked.  They cannot be
+    # answered from a prted's own state: the nidmap ships node names, aliases,
+    # daemon vpids and pool slots and nothing else, so slots, slots_max,
+    # slots_inuse and node state are all still at their constructed defaults
+    # on every daemon but the master.  Answering there returns zero -- and
+    # returns it as PMIX_SUCCESS, so the client cannot tell.  The daemon now
+    # relays such keys to the master and merges the reply with what it could
+    # answer itself.
+    #
+    # The assertion is a cross-check rather than a spot value for the same
+    # reason as the peer lookups above: the failure is not "no answer" but a
+    # plausible wrong one.  One rank per node, and every rank has to agree.
+    cleanup_swarm
+    if ! RUN "test -x $SI"; then
+        skp "slotinfo client not installed -- re-run ./build.sh"
+    elif ! prted_dvm_start 'node1:2,node2:2,node3:2,node4:2'; then
+        bad "could not start a DVM for the allocation-query test"
+        cleanup_swarm
+    else
+        out=$(PRUN "--host node1:1,node2:1,node3:1,node4:1 -n 4 --map-by node $SI" 2>&1)
+        n=$(echo "$out" | tr -d '\r' | grep -c '^SLOTS ')
+        [ "$n" = 4 ] \
+            && ok "all 4 ranks got an answer for PMIX_NUM_SLOTS" \
+            || bad "$n of 4 ranks were answered: $(echo "$out" | tr '\n' ' ' | tail -c 400)"
+        # the run must actually span nodes or the case is vacuous - a single
+        # node would put every rank on the master and never relay anything
+        hosts=$(echo "$out" | tr -d '\r' | awk '$1=="SLOTS" {print $2}' | sort -u | grep -c '^node')
+        [ "${hosts:-0}" -ge 2 ] \
+            && ok "...from $hosts different nodes (so daemons other than the master answered)" \
+            || bad "the job did not span nodes -- this case would be vacuous"
+        # zero is the shape of the bug: a daemon reading its own node pool
+        n=$(echo "$out" | tr -d '\r' | awk '$1=="SLOTS" && $3+0==0 {c++} END {print c+0}')
+        [ "$n" = 0 ] \
+            && ok "...and no rank was told the allocation has zero slots" \
+            || bad "$n rank(s) were told zero slots: $(echo "$out" | tr -d '\r' | grep '^SLOTS ' | tr '\n' ' ' | tail -c 300)"
+        # ...and they must agree, which is what says the relayed answer is the
+        # master's own rather than each daemon's guess
+        n=$(echo "$out" | tr -d '\r' | awk '$1=="SLOTS" {print $3}' | sort -u | wc -l | tr -d ' ')
+        [ "$n" = 1 ] \
+            && ok "...and every rank was given the same number" \
+            || bad "ranks disagree about the slot count: $(echo "$out" | tr -d '\r' | grep '^SLOTS ' | tr '\n' ' ' | tail -c 300)"
+        # the second key in the same query - a request that mixes keys has to
+        # come back whole, not just the half the master answered
+        n=$(echo "$out" | tr -d '\r' | grep -c '^AVAIL ')
+        [ "$n" = 4 ] \
+            && ok "...and the other key in the same query was answered too" \
+            || bad "$n of 4 ranks got PMIX_QUERY_AVAILABLE_SLOTS: $(echo "$out" | tr '\n' ' ' | tail -c 400)"
+        n=$(echo "$out" | tr -d '\r' | awk '$1=="AVAIL" {print $3}' | sort -u | wc -l | tr -d ' ')
+        [ "$n" = 1 ] \
+            && ok "...consistently" \
+            || bad "ranks disagree about the available slots: $(echo "$out" | tr -d '\r' | grep '^AVAIL ' | tr '\n' ' ' | tail -c 300)"
+        n=$(echo "$out" | tr -d '\r' | grep -c '^ERROR ')
+        [ "$n" = 0 ] \
+            && ok "...and no rank reported a query failure" \
+            || bad "$n rank(s) failed the query: $(echo "$out" | tr -d '\r' | grep '^ERROR ' | tr '\n' ' ' | tail -c 300)"
+        RUN "timeout -k 5 30 pterm --dvm-uri file:$PRTED_URI" >/dev/null 2>&1
     fi
     cleanup_swarm
 

--- a/contrib/dockerswarm/slotinfo.c
+++ b/contrib/dockerswarm/slotinfo.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * slotinfo -- ask the daemon we are connected to about the allocation.
+ *
+ * Prints one line per key, tagged with the node the asking rank is on:
+ *
+ *   SLOTS <host> <n>          PMIX_NUM_SLOTS, no qualifier
+ *   AVAIL <host> <n>          PMIX_QUERY_AVAILABLE_SLOTS
+ *   ERROR <host> <key> <why>  the query failed
+ *
+ * Why this exists: the answers are properties of the DVM, so every rank must
+ * get the same ones no matter which daemon it happens to be talking to.  A
+ * prted holds only the identity half of the node pool - the nidmap ships node
+ * names, aliases, daemon vpids and pool slots, never slot counts or node
+ * state - so a daemon answering out of its own copy reports every node as
+ * having zero slots, and reports it as success.  The rank that lands on the
+ * master gets the true count, every other rank gets 0, and nothing anywhere
+ * says a word about it.  That is invisible on one node, which is why this
+ * test is here rather than in test/unit: it takes a DVM whose ranks are on
+ * daemons other than the master to see it at all.
+ *
+ * The daemon now relays such a query to the master (PRTE_RML_TAG_QUERY) and
+ * merges the answer with whatever it could answer itself, so the assertion
+ * the harness makes is simply that every rank agrees, and that the number is
+ * not zero.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <pmix.h>
+
+static pmix_proc_t myproc;
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_query_t *query;
+    pmix_info_t *results = NULL;
+    size_t nresults = 0, n;
+    char host[256];
+    uint32_t val;
+    int ret = 0;
+
+    (void) argc;
+    (void) argv;
+
+    if (0 != gethostname(host, sizeof(host))) {
+        strncpy(host, "unknown", sizeof(host) - 1);
+        host[sizeof(host) - 1] = '\0';
+    }
+
+    rc = PMIx_Init(&myproc, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "ERROR PMIx_Init: %s\n", PMIx_Error_string(rc));
+        return 1;
+    }
+
+    /* Both keys in ONE query, deliberately: they are answered by different
+     * arms, and a request that mixes keys is exactly what the relay has to
+     * keep whole.  Anything the daemon can answer itself must still come
+     * back alongside what only the master can answer. */
+    PMIX_QUERY_CREATE(query, 1);
+    PMIx_Argv_append_nosize(&query[0].keys, PMIX_NUM_SLOTS);
+    PMIx_Argv_append_nosize(&query[0].keys, PMIX_QUERY_AVAILABLE_SLOTS);
+
+    rc = PMIx_Query_info(query, 1, &results, &nresults);
+    if (PMIX_SUCCESS != rc && PMIX_QUERY_PARTIAL_SUCCESS != rc) {
+        printf("ERROR %s query %s\n", host, PMIx_Error_string(rc));
+        fflush(stdout);
+        ret = 1;
+        goto done;
+    }
+
+    for (n = 0; n < nresults; n++) {
+        if (PMIX_CHECK_KEY(&results[n], PMIX_NUM_SLOTS)) {
+            PMIX_VALUE_GET_NUMBER(rc, &results[n].value, val, uint32_t);
+            if (PMIX_SUCCESS != rc) {
+                printf("ERROR %s %s bad-type\n", host, PMIX_NUM_SLOTS);
+                ret = 1;
+                continue;
+            }
+            printf("SLOTS %s %u\n", host, val);
+        } else if (PMIX_CHECK_KEY(&results[n], PMIX_QUERY_AVAILABLE_SLOTS)) {
+            PMIX_VALUE_GET_NUMBER(rc, &results[n].value, val, uint32_t);
+            if (PMIX_SUCCESS != rc) {
+                printf("ERROR %s %s bad-type\n", host, PMIX_QUERY_AVAILABLE_SLOTS);
+                ret = 1;
+                continue;
+            }
+            printf("AVAIL %s %u\n", host, val);
+        }
+    }
+    fflush(stdout);
+
+done:
+    if (NULL != results) {
+        PMIX_INFO_FREE(results, nresults);
+    }
+    PMIX_QUERY_FREE(query, 1);
+    PMIx_Finalize(NULL, 0);
+    return ret;
+}

--- a/src/include/constants.h
+++ b/src/include/constants.h
@@ -228,6 +228,7 @@ enum {
     PRTE_ERR_SLURM_SHRINK_FAILURE = (PRTE_ERR_BASE - 155),
     PRTE_ERR_PRELOAD_CONFLICT = (PRTE_ERR_BASE - 156),
     PRTE_ERR_SLURM_UPDATE_FAILURE = (PRTE_ERR_BASE - 157),
+    PRTE_ERR_NOT_AUTHORITATIVE = (PRTE_ERR_BASE - 158),
 
     /* Not an error code.  Nothing returns it, nothing tests for it, and
      * prte_strerror() deliberately has no case for it: it is one past the
@@ -249,7 +250,7 @@ enum {
      * it evaluated to PRTE_SUCCESS.  This one has consumers, and a test
      * that notices when it lies.
      */
-    PRTE_ERR_MAX = (PRTE_ERR_BASE - 158)
+    PRTE_ERR_MAX = (PRTE_ERR_BASE - 159)
 };
 
 END_C_DECLS

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -683,6 +683,59 @@ hazards. Four things about it that are not local to any one arm:
 
 ## Info-array expansion
 
+### A daemon must not answer out of state it does not have
+
+A prted holds the *identity* half of the DVM's node table and nothing
+else. The nidmap ships node names, aliases, daemon vpids and pool slots
+(see [`src/util/nidmap.c`](../../util/nidmap.c)) — never `slots`,
+`slots_max`, `slots_inuse` or node `state`, because every writer of those
+runs only on the master: the `ras` components, the hostfile and
+`dash_host` parsers, `plm_base_setup_virtual_machine()`. `prte_sessions`
+on a prted likewise holds the default session and nothing more. An arm
+that reads either on a daemon gets a default-constructed **zero, returned
+as `PMIX_SUCCESS`** — a wrong answer no caller can tell from a right one.
+The rank that happens to land on the master gets the truth; every other
+rank gets nothing, silently.
+
+So such an arm does not read that state directly. It goes through
+`prte_get_allocated_nodes()`, `prte_get_allocation_session()` or
+`prte_get_allocation_sessions()`
+([`src/runtime/prte_globals.c`](../../runtime/prte_globals.c)), which
+succeed on the master and return `PRTE_ERR_NOT_AUTHORITATIVE` anywhere
+else. An arm that gets that back jumps to the `defer:` label at the foot
+of the key loop; at `done:` the deferred keys go to the master on
+`PRTE_RML_TAG_QUERY`, and its reply is merged into the results gathered
+locally, so the client sees one answer covering every key it asked for.
+
+**The decision is made by the read, never by a list of keys.** Which keys
+need the master is not knowable in advance, and a written-down list goes
+stale the first time someone adds one — silently, because the stale case
+returns a plausible zero rather than failing. Which *reads* cannot be
+satisfied locally is exactly the three accessors above, and that is
+enforced where it is used. A key added tomorrow that reads capacity is
+relayed with no edit here; one that reads only what the nidmap and the
+launch message already deliver stays local with no edit either.
+[`test/unit/check_query_authority.py`](../../../test/unit/check_query_authority.py)
+fails `make check` if this file reaches that state any other way.
+
+Deferral is per **key**, not per query and not per request, because the
+things a daemon must answer for *itself* can arrive in the same
+`PMIx_Query_info` as a key only the master can answer: `PMIX_HWLOC_XML_V1`
+and `_V2` export this node's topology, an unqualified `PMIX_SERVER_URI` is
+this daemon's own URI, and `PMIX_QUERY_LOCAL_PROC_TABLE` means the procs
+this daemon is hosting. Relaying a whole query would answer those about
+the master.
+
+The master answers with the same `_query()`: `pmix_server_query_request()`
+rebuilds a caddy and posts it, and there nothing defers, so it completes
+locally. The relay uses the tracker pattern described under
+[The relay pattern](#the-relay-pattern), and carries the *original*
+requestor so the master defaults the query to the right job rather than to
+the asking daemon. `contrib/dockerswarm`'s `slotinfo` client is the
+regression test: on one node every rank is on the master, and the bug
+cannot be seen at all.
+
+
 Several relays add an entry (usually `PMIX_REQUESTOR`) to an info array
 before passing it on. The idiom is three steps and all three are
 required:

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -1344,6 +1344,10 @@ void pmix_server_start(void)
     PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_SCHED_RESP,
                   PRTE_RML_PERSISTENT, pmix_server_alloc_request_resp, NULL);
 
+    /* setup recv for the master's answer to a query we could not answer */
+    PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_QUERY_RESP,
+                  PRTE_RML_PERSISTENT, pmix_server_query_resp, NULL);
+
     /* setup recv for monitor request */
     PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_MONITOR_REQUEST,
                   PRTE_RML_PERSISTENT, pmix_server_monitor_request, NULL);
@@ -1367,6 +1371,10 @@ void pmix_server_start(void)
         /* setup recv for scheduler requests */
         PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_SCHED,
                       PRTE_RML_PERSISTENT, pmix_server_sched, NULL);
+        /* setup recv for queries relayed by a daemon - slot counts, node
+         * state and the session table live only here */
+        PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_QUERY,
+                      PRTE_RML_PERSISTENT, pmix_server_query_request, NULL);
         /* setup recv for the membership of connected assemblages, which is
          * held here because we are the one process that sees every proc in
          * the DVM terminate */
@@ -1393,12 +1401,14 @@ void pmix_server_finalize(void)
     PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_NOTIFICATION);
     PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_TCONN_RESP);
     PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_SCHED_RESP);
+    PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_QUERY_RESP);
     PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_MONITOR_REQUEST);
     PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_MONITOR_RESP);
     PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_LOGGING_RESP);
     if (PRTE_PROC_IS_MASTER) {
         PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_LOGGING);
         PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_SCHED);
+        PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_QUERY);
         PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_CONNECTED);
     }
 
@@ -3124,6 +3134,9 @@ static void rqcon(prte_pmix_server_req_t *p)
     p->infocbfunc = NULL;
     p->cbdata = NULL;
     p->rlcbdata = NULL;
+    p->qcaddy = NULL;
+    p->qresults = NULL;
+    p->nkeys = 0;
 }
 static void rqdes(prte_pmix_server_req_t *p)
 {

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -131,6 +131,16 @@ typedef struct {
     pmix_info_cbfunc_t infocbfunc;
     void *cbdata;
     void *rlcbdata;
+    /* A PMIx query relayed to the DVM master because this daemon does not
+     * hold the state it asks for - see pmix_server_queries.c.  On the asking
+     * daemon these carry the client's caddy, the results already gathered
+     * locally (a PMIx info list the master's reply is merged into), and the
+     * number of keys the client asked for, which is what partial success is
+     * measured against.  On the master, qcaddy holds the caddy whose unpacked
+     * query array must be freed once the answer has been sent. */
+    void *qcaddy;
+    void *qresults;
+    size_t nkeys;
 } prte_pmix_server_req_t;
 PMIX_CLASS_DECLARATION(prte_pmix_server_req_t);
 
@@ -430,6 +440,16 @@ PRTE_EXPORT extern void pmix_server_notify(int status, pmix_proc_t *sender,
 PRTE_EXPORT extern void pmix_server_tconn_return(int status, pmix_proc_t *sender,
                                                  pmix_data_buffer_t *buffer, prte_rml_tag_t tg,
                                                  void *cbdata);
+
+/* A query a daemon cannot answer, relayed to the DVM master, and the answer
+ * coming back - see the block comment in pmix_server_queries.c */
+PRTE_EXPORT extern void pmix_server_query_request(int status, pmix_proc_t *sender,
+                                                  pmix_data_buffer_t *buffer, prte_rml_tag_t tg,
+                                                  void *cbdata);
+
+PRTE_EXPORT extern void pmix_server_query_resp(int status, pmix_proc_t *sender,
+                                               pmix_data_buffer_t *buffer, prte_rml_tag_t tg,
+                                               void *cbdata);
 
 PRTE_EXPORT extern int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
                                                       pmix_op_cbfunc_t cbfunc, void *cbdata);

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -45,6 +45,7 @@
 
 #include "src/mca/errmgr/errmgr.h"
 #include "src/mca/rmaps/rmaps_types.h"
+#include "src/rml/rml.h"
 #include "src/runtime/prte_globals.h"
 #include "src/util/name_fns.h"
 
@@ -75,19 +76,185 @@ static void qrel(void *cbdata)
     PMIX_RELEASE(cd);
 }
 
+/* ==================================================================== *
+ * Queries a daemon cannot answer
+ *
+ * A prted holds the identity half of the DVM's node table and nothing
+ * else - the nidmap ships node names, aliases, daemon vpids and pool
+ * slots, never slot counts or node state - and holds no session but the
+ * default one.  A key whose answer comes out of either therefore has to
+ * be asked of the DVM master.
+ *
+ * Which keys those are is deliberately not written down anywhere.  Such
+ * a list is a point-in-time snapshot that goes stale the first time
+ * someone adds a key, and a stale entry does not fail loudly: it returns
+ * a default-constructed zero that reads exactly like a real answer.  So
+ * the decision is made by the *read* instead.  A branch reaches
+ * allocation state only through prte_get_allocated_nodes() and its two
+ * companions, which succeed on the master and return
+ * PRTE_ERR_NOT_AUTHORITATIVE anywhere else; a branch that gets that back
+ * jumps to the "defer" label and its key is forwarded.  A key added
+ * tomorrow that reads capacity is relayed with no edit here, and one
+ * that reads only what the nidmap and the launch message already deliver
+ * stays local with no edit either.
+ *
+ * Deferral is per key, not per query and not per request, because the
+ * three things a daemon must answer for *itself* can arrive in the same
+ * PMIx_Query_info as a key only the master can answer: PMIX_HWLOC_XML_*
+ * exports this node's topology, an unqualified PMIX_SERVER_URI is this
+ * daemon's own URI, and PMIX_QUERY_LOCAL_PROC_TABLE means the procs this
+ * daemon is hosting.  Relaying a whole query would answer those about
+ * the master.
+ * ==================================================================== */
+
+/* Finish a query: convert what was gathered, decide the status, and hand
+ * it to the client.  Reached either directly, when every key was answered
+ * here, or from the master's reply once its results have been merged in. */
+static void query_complete(prte_pmix_server_op_caddy_t *cd, void *results,
+                           size_t nkeys, pmix_status_t ret)
+{
+    prte_pmix_server_op_caddy_t *rcd;
+    pmix_status_t rc;
+    /* PMIx initializes this before anything in PMIx_Info_list_convert() can
+     * fail, but every path here depends on that and the early ones arrive
+     * having never touched it - so initialize it here rather than rely on
+     * the callee to initialize its caller's stack */
+    pmix_data_array_t dry = PMIX_DATA_ARRAY_STATIC_INIT;
+
+    rcd = PMIX_NEW(prte_pmix_server_op_caddy_t);
+    PMIX_INFO_LIST_CONVERT(rc, results, &dry);
+    if (PMIX_SUCCESS != rc && PMIX_ERR_EMPTY != rc) {
+        PMIX_ERROR_LOG(rc);
+        ret = rc;
+    }
+    PMIX_INFO_LIST_RELEASE(results);
+    /* only decide the status here if no arm has already decided it.  An error
+     * an arm set is what actually happened - a malformed qualifier, a job we
+     * do not know - and reporting "not found" in its place tells the caller
+     * the DVM looked.  PMIX_ERR_NOT_SUPPORTED used to be the one error
+     * protected from this, which is how the shape of it is visible: every
+     * other error an arm could set was being thrown away with an empty
+     * result list, which is exactly what an arm that failed leaves behind */
+    if (PMIX_SUCCESS == ret) {
+        if (PMIX_ERR_EMPTY == rc || 0 == dry.size) {
+            ret = PMIX_ERR_NOT_FOUND;
+        } else if (dry.size < nkeys) {
+            /* against cd->ninfo, which a query caddy never sets, this compared
+             * with zero and PMIX_QUERY_PARTIAL_SUCCESS could not be reached.
+             * The count that means something here is the number of keys that
+             * were asked for: fewer results than that is what partial success
+             * is for, and a caller has no other way to learn that one of its
+             * keys went unanswered */
+            ret = PMIX_QUERY_PARTIAL_SUCCESS;
+        }
+    }
+    rcd->ninfo = dry.size;
+    rcd->info = (pmix_info_t *) dry.array;
+    // memory allocated in the data array will be free'd when rcd is released
+    cd->infocbfunc(ret, rcd->info, rcd->ninfo, cd->cbdata, qrel, rcd);
+    PMIX_RELEASE(cd);
+}
+
+/* Record one key for the master, carrying the qualifiers of the query it
+ * came from - they are what select the job, node or allocation it is
+ * asking about, so the key is meaningless without them. */
+static void defer_key(pmix_query_t *dq, size_t *ndq, pmix_query_t *q, char *key)
+{
+    pmix_query_t *d = &dq[*ndq];
+    size_t i;
+
+    PMIx_Argv_append_nosize(&d->keys, key);
+    if (NULL != q->qualifiers && 0 < q->nqual) {
+        PMIX_INFO_CREATE(d->qualifiers, q->nqual);
+        for (i = 0; i < q->nqual; i++) {
+            PMIX_INFO_XFER(&d->qualifiers[i], &q->qualifiers[i]);
+        }
+        d->nqual = q->nqual;
+    }
+    ++(*ndq);
+}
+
+/* Send the deferred keys to the master.  The results gathered locally ride
+ * on the tracker and are merged with the master's reply, so the client sees
+ * one answer covering every key it asked for. */
+static pmix_status_t relay_query(prte_pmix_server_op_caddy_t *cd, void *results,
+                                 size_t nkeys, pmix_query_t *dq, size_t ndq)
+{
+    prte_pmix_server_req_t *req;
+    pmix_data_buffer_t *buf;
+    pmix_status_t rc;
+    int ret;
+
+    req = PMIX_NEW(prte_pmix_server_req_t);
+    pmix_asprintf(&req->operation, "QUERY");
+    req->qcaddy = cd;
+    req->qresults = results;
+    req->nkeys = nkeys;
+    req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
+
+    PMIX_DATA_BUFFER_CREATE(buf);
+    /* our tracking room number, which the master echoes back */
+    rc = PMIx_Data_pack(NULL, buf, &req->local_index, 1, PMIX_INT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto error;
+    }
+    /* the client that asked - the master defaults a query to the requestor's
+     * own job, so answering as ourselves would answer about the wrong one */
+    rc = PMIx_Data_pack(NULL, buf, &cd->proct, 1, PMIX_PROC);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto error;
+    }
+    rc = PMIx_Data_pack(NULL, buf, &ndq, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto error;
+    }
+    rc = PMIx_Data_pack(NULL, buf, dq, ndq, PMIX_QUERY);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto error;
+    }
+
+    PRTE_RML_RELIABLE_SEND(ret, PRTE_PROC_MY_HNP->rank, buf, PRTE_RML_TAG_QUERY);
+    if (PRTE_SUCCESS != ret) {
+        PRTE_ERROR_LOG(ret);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        rc = prte_pmix_convert_rc(ret);
+        goto error_sent;
+    }
+    return PMIX_SUCCESS;
+
+error:
+    PMIX_DATA_BUFFER_RELEASE(buf);
+error_sent:
+    /* nothing will answer this tracker, and the caller is about to complete
+     * the query itself - so let go of the caddy and the results it holds */
+    req->qcaddy = NULL;
+    req->qresults = NULL;
+    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs,
+                                req->local_index, NULL);
+    PMIX_RELEASE(req);
+    return rc;
+}
+
 static void _query(int sd, short args, void *cbdata)
 {
     prte_pmix_server_op_caddy_t *cd = (prte_pmix_server_op_caddy_t *) cbdata;
-    prte_pmix_server_op_caddy_t *rcd;
     pmix_query_t *q;
     pmix_status_t ret = PMIX_SUCCESS;
     void *results, *plist, *stack, *cache;
-    pmix_pointer_array_t *alloc_nodes;
+    pmix_pointer_array_t *alloc_nodes, *dvm_nodes, *alloc_sessions;
     pmix_nspace_t jobid;
     prte_job_t *jdata;
     prte_node_t *node, *ndptr;
-    int j, k, rc;
+    int j, k, rc, prc;
     size_t m, n, p;
+    /* keys this daemon cannot answer, bound for the master.  Sized to the
+     * total number of keys asked for, so a deferral never has to grow it. */
+    pmix_query_t *dq = NULL;
+    size_t ndq = 0, nq_alloc = 0;
     uint32_t key, nodeid, sessionid = UINT32_MAX, nslots;
     char **nspaces, *hostname, *uri;
     char *cmdline;
@@ -117,6 +284,24 @@ static void _query(int sd, short args, void *cbdata)
     pmix_output_verbose(2, prte_pmix_server_globals.output,
                         "%s processing query",
                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME));
+
+    /* On the master nothing ever defers, so do not pay for the array there.
+     * Elsewhere, count the keys first: a deferral must not fail, and a
+     * fixed-size array bounded by the key count cannot. */
+    if (!PRTE_PROC_IS_MASTER) {
+        for (m = 0; m < cd->nqueries; m++) {
+            q = &cd->queries[m];
+            if (NULL == q->keys) {
+                continue;
+            }
+            for (n = 0; NULL != q->keys[n]; n++) {
+                ++nq_alloc;
+            }
+        }
+        if (0 < nq_alloc) {
+            PMIX_QUERY_CREATE(dq, nq_alloc);
+        }
+    }
 
     PMIX_INFO_LIST_START(results);
 
@@ -809,15 +994,14 @@ static void _query(int sd, short args, void *cbdata)
                 prte_topology_t *topo;
                 int len;
 
-                if (NULL == allocid) {
-                    alloc_nodes = prte_node_pool;
-                } else {
-                    session = prte_get_session_object_from_id(allocid);
-                    if (NULL == session) {
-                        ret = PMIX_ERR_NOT_FOUND;
-                        goto done;
-                    }
-                    alloc_nodes = session->nodes;
+                /* slot counts and node state live only on the master */
+                prc = prte_get_allocated_nodes(allocid, &alloc_nodes);
+                if (PRTE_ERR_NOT_AUTHORITATIVE == prc) {
+                    goto defer;
+                }
+                if (PRTE_SUCCESS != prc) {
+                    ret = prte_pmix_convert_rc(prc);
+                    goto done;
                 }
                 PMIX_INFO_LIST_START(nodelist);
                 p = 0;
@@ -879,10 +1063,20 @@ static void _query(int sd, short args, void *cbdata)
             } else if (PMIx_Check_key(q->keys[n], PMIX_QUERY_ALLOC_IDS)) {
                 void *alloclist;
 
+                /* the session table is the master's - a daemon holds only
+                 * the default session, so it would answer "none" */
+                prc = prte_get_allocation_sessions(&alloc_sessions);
+                if (PRTE_ERR_NOT_AUTHORITATIVE == prc) {
+                    goto defer;
+                }
+                if (PRTE_SUCCESS != prc) {
+                    ret = prte_pmix_convert_rc(prc);
+                    goto done;
+                }
                 PMIX_INFO_LIST_START(alloclist);
-                if (NULL != prte_sessions) {
-                    for (k = 0; k < prte_sessions->size; k++) {
-                        session = (prte_session_t *) pmix_pointer_array_get_item(prte_sessions, k);
+                if (NULL != alloc_sessions) {
+                    for (k = 0; k < alloc_sessions->size; k++) {
+                        session = (prte_session_t *) pmix_pointer_array_get_item(alloc_sessions, k);
                         if (NULL == session || NULL == session->alloc_refid) {
                             continue;
                         }
@@ -915,13 +1109,12 @@ static void _query(int sd, short args, void *cbdata)
                 void *proplist;
                 bool releasable;
 
-                if (NULL == allocid) {
-                    ret = PMIX_ERR_BAD_PARAM;
-                    goto done;
+                prc = prte_get_allocation_session(allocid, &session);
+                if (PRTE_ERR_NOT_AUTHORITATIVE == prc) {
+                    goto defer;
                 }
-                session = prte_get_session_object_from_id(allocid);
-                if (NULL == session) {
-                    ret = PMIX_ERR_NOT_FOUND;
+                if (PRTE_SUCCESS != prc) {
+                    ret = prte_pmix_convert_rc(prc);
                     goto done;
                 }
                 PMIX_INFO_LIST_START(proplist);
@@ -964,6 +1157,16 @@ static void _query(int sd, short args, void *cbdata)
                 /* the slots allocated to a specific node, if one was named,
                  * otherwise the total across the allocation
                  */
+                /* every arm below reads node->slots, which the nidmap does
+                 * not ship - so settle authority once, before any of them */
+                prc = prte_get_allocated_nodes(allocid, &alloc_nodes);
+                if (PRTE_ERR_NOT_AUTHORITATIVE == prc) {
+                    goto defer;
+                }
+                if (PRTE_SUCCESS != prc) {
+                    ret = prte_pmix_convert_rc(prc);
+                    goto done;
+                }
                 if (NULL != hostname) {
                     node = prte_node_match(NULL, hostname);
                     if (NULL == node) {
@@ -972,23 +1175,20 @@ static void _query(int sd, short args, void *cbdata)
                     }
                     nslots = (uint32_t) node->slots;
                 } else if (UINT32_MAX != nodeid) {
-                    node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, nodeid);
+                    /* a nodeid is a slot in the DVM-wide pool, not in the
+                     * allocation the qualifier named */
+                    prc = prte_get_allocated_nodes(NULL, &dvm_nodes);
+                    if (PRTE_SUCCESS != prc) {
+                        ret = prte_pmix_convert_rc(prc);
+                        goto done;
+                    }
+                    node = (prte_node_t *) pmix_pointer_array_get_item(dvm_nodes, nodeid);
                     if (NULL == node) {
                         ret = PMIX_ERR_NOT_FOUND;
                         goto done;
                     }
                     nslots = (uint32_t) node->slots;
                 } else {
-                    if (NULL == allocid) {
-                        alloc_nodes = prte_node_pool;
-                    } else {
-                        session = prte_get_session_object_from_id(allocid);
-                        if (NULL == session) {
-                            ret = PMIX_ERR_NOT_FOUND;
-                            goto done;
-                        }
-                        alloc_nodes = session->nodes;
-                    }
                     nslots = 0;
                     for (k = 0; k < alloc_nodes->size; k++) {
                         node = (prte_node_t *) pmix_pointer_array_get_item(alloc_nodes, k);
@@ -1010,9 +1210,20 @@ static void _query(int sd, short args, void *cbdata)
                  * there way thru the state machine for mapping, and more jobs may
                  * be submitted at any moment.
                  */
+                /* slots, slots_inuse, slots_max and node state are all
+                 * master-only - a daemon would report every node as empty
+                 * and every filter as inert */
+                prc = prte_get_allocated_nodes(NULL, &alloc_nodes);
+                if (PRTE_ERR_NOT_AUTHORITATIVE == prc) {
+                    goto defer;
+                }
+                if (PRTE_SUCCESS != prc) {
+                    ret = prte_pmix_convert_rc(prc);
+                    goto done;
+                }
                 nslots = 0;
-                for (k=0; k < prte_node_pool->size; k++) {
-                    node = (prte_node_t*)pmix_pointer_array_get_item(prte_node_pool, k);
+                for (k=0; k < alloc_nodes->size; k++) {
+                    node = (prte_node_t*)pmix_pointer_array_get_item(alloc_nodes, k);
                     if (NULL == node) {
                         continue;
                     }
@@ -1203,43 +1414,39 @@ static void _query(int sd, short args, void *cbdata)
                 ret = PMIX_ERR_NOT_SUPPORTED;
                 goto done;
             }
+            continue;
+
+        defer:
+            /* this key wants state only the master holds - see the block
+             * comment above query_complete().  The array was sized to hold
+             * every key, so this cannot overrun. */
+            pmix_output_verbose(2, prte_pmix_server_globals.output,
+                                "%s deferring key %s to the DVM master",
+                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), q->keys[n]);
+            defer_key(dq, &ndq, q, q->keys[n]);
         } // for
     }     // for
 
 done:
-    rcd = PMIX_NEW(prte_pmix_server_op_caddy_t);
-    PMIX_INFO_LIST_CONVERT(rc, results, &dry);
-    if (PMIX_SUCCESS != rc && PMIX_ERR_EMPTY != rc) {
-        PMIX_ERROR_LOG(rc);
-        ret = rc;
-    }
-    PMIX_INFO_LIST_RELEASE(results);
-    /* only decide the status here if no arm has already decided it.  An error
-     * an arm set is what actually happened - a malformed qualifier, a job we
-     * do not know - and reporting "not found" in its place tells the caller
-     * the DVM looked.  PMIX_ERR_NOT_SUPPORTED used to be the one error
-     * protected from this, which is how the shape of it is visible: every
-     * other error an arm could set was being thrown away with an empty
-     * result list, which is exactly what an arm that failed leaves behind */
-    if (PMIX_SUCCESS == ret) {
-        if (PMIX_ERR_EMPTY == rc || 0 == dry.size) {
-            ret = PMIX_ERR_NOT_FOUND;
-        } else if (dry.size < nkeys) {
-            /* against cd->ninfo, which a query caddy never sets, this compared
-             * with zero and PMIX_QUERY_PARTIAL_SUCCESS could not be reached.
-             * The count that means something here is the number of keys that
-             * were asked for: fewer results than that is what partial success
-             * is for, and a caller has no other way to learn that one of its
-             * keys went unanswered */
-            ret = PMIX_QUERY_PARTIAL_SUCCESS;
+    if (0 < ndq) {
+        if (PMIX_SUCCESS == ret) {
+            rc = relay_query(cd, results, nkeys, dq, ndq);
+            if (PMIX_SUCCESS == rc) {
+                /* the client is answered when the master replies */
+                PMIX_QUERY_FREE(dq, nq_alloc);
+                return;
+            }
+            /* we never reached the master, so say why rather than reporting
+             * the empty result as "not found" */
+            ret = rc;
         }
     }
-    rcd->ninfo = dry.size;
-    rcd->info = (pmix_info_t*)dry.array;
-    // memory allocated in the data array will be free'd when rcd is released
-    cd->infocbfunc(ret, rcd->info, rcd->ninfo, cd->cbdata, qrel, rcd);
-    PMIX_RELEASE(cd);
+    if (NULL != dq) {
+        PMIX_QUERY_FREE(dq, nq_alloc);
+    }
+    query_complete(cd, results, nkeys, ret);
 }
+
 
 pmix_status_t pmix_server_query_fn(pmix_proc_t *proct, pmix_query_t *queries, size_t nqueries,
                                    pmix_info_cbfunc_t cbfunc, void *cbdata)
@@ -1263,4 +1470,274 @@ pmix_status_t pmix_server_query_fn(pmix_proc_t *proct, pmix_query_t *queries, si
     prte_event_active(&(cd->ev), PRTE_EV_WRITE, 1);
 
     return PMIX_SUCCESS;
+}
+
+/* ---- the master's half of a relayed query ---------------------------- */
+
+/* Ship the master's answer back to the daemon that asked.  Runs on the PRRTE
+ * progress thread: query_complete() invokes it from _query, which is itself
+ * an event handler, so there is nothing to thread-shift. */
+static void send_query_resp(pmix_status_t status, pmix_info_t *info, size_t ninfo,
+                            void *cbdata, pmix_release_cbfunc_t release_fn,
+                            void *release_cbdata)
+{
+    prte_pmix_server_req_t *req = (prte_pmix_server_req_t *) cbdata;
+    prte_pmix_server_op_caddy_t *cd = (prte_pmix_server_op_caddy_t *) req->qcaddy;
+    pmix_data_buffer_t *buf;
+    pmix_status_t rc;
+    int ret;
+
+    PMIX_DATA_BUFFER_CREATE(buf);
+    rc = PMIx_Data_pack(NULL, buf, &status, 1, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        goto cleanup;
+    }
+    /* the asking daemon's room number, not ours */
+    rc = PMIx_Data_pack(NULL, buf, &req->remote_index, 1, PMIX_INT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        goto cleanup;
+    }
+    rc = PMIx_Data_pack(NULL, buf, &ninfo, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+        goto cleanup;
+    }
+    if (0 < ninfo) {
+        rc = PMIx_Data_pack(NULL, buf, info, ninfo, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(buf);
+            goto cleanup;
+        }
+    }
+
+    pmix_output_verbose(2, prte_pmix_server_globals.output,
+                        "%s sending query response to %s for their req %d",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                        PRTE_NAME_PRINT(&req->proxy), req->remote_index);
+    PRTE_RML_RELIABLE_SEND(ret, req->proxy.rank, buf, PRTE_RML_TAG_QUERY_RESP);
+    if (PRTE_SUCCESS != ret) {
+        PRTE_ERROR_LOG(ret);
+        PMIX_DATA_BUFFER_RELEASE(buf);
+    }
+
+cleanup:
+    /* every exit comes through here - a pack failure that returned early
+     * would strand the asking daemon's client for the life of the DVM */
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+    /* the queries were unpacked into this caddy and are ours to free; the
+     * caddy itself is released by query_complete() as we return */
+    if (NULL != cd && NULL != cd->queries) {
+        PMIX_QUERY_FREE(cd->queries, cd->nqueries);
+        cd->queries = NULL;
+        cd->nqueries = 0;
+    }
+    req->qcaddy = NULL;
+    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs,
+                                req->local_index, NULL);
+    PMIX_RELEASE(req);
+}
+
+/* A daemon could not answer some keys and has sent them here.  Answer them
+ * with the very same _query() the daemon ran - on the master the accessors
+ * always succeed, so nothing defers and it completes locally. */
+void pmix_server_query_request(int status, pmix_proc_t *sender,
+                               pmix_data_buffer_t *buffer,
+                               prte_rml_tag_t tg, void *cbdata)
+{
+    prte_pmix_server_op_caddy_t *cd;
+    prte_pmix_server_req_t *req;
+    pmix_query_t *queries = NULL;
+    pmix_proc_t source;
+    size_t nqueries = 0;
+    pmix_status_t rc;
+    int32_t cnt;
+    int refid;
+    PRTE_HIDE_UNUSED_PARAMS(status, tg, cbdata);
+
+    /* unpack the asking daemon's room number first - with it we can at least
+     * send back an error it can match to a waiting client */
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &refid, &cnt, PMIX_INT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return;
+    }
+
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &source, &cnt, PMIX_PROC);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto error;
+    }
+
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &nqueries, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto error;
+    }
+    if (0 == nqueries) {
+        rc = PMIX_ERR_BAD_PARAM;
+        goto error;
+    }
+    PMIX_QUERY_CREATE(queries, nqueries);
+    cnt = nqueries;
+    rc = PMIx_Data_unpack(NULL, buffer, queries, &cnt, PMIX_QUERY);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_QUERY_FREE(queries, nqueries);
+        queries = NULL;
+        goto error;
+    }
+
+    req = PMIX_NEW(prte_pmix_server_req_t);
+    pmix_asprintf(&req->operation, "QUERY");
+    req->remote_index = refid;
+    PMIX_PROC_LOAD(&req->proxy, sender->nspace, sender->rank);
+    req->local_index = pmix_pointer_array_add(&prte_pmix_server_globals.local_reqs, req);
+
+    cd = PMIX_NEW(prte_pmix_server_op_caddy_t);
+    /* answer about the job of the client that originally asked, not ours */
+    memcpy(&cd->proct, &source, sizeof(pmix_proc_t));
+    cd->queries = queries;
+    cd->nqueries = nqueries;
+    cd->infocbfunc = send_query_resp;
+    cd->cbdata = req;
+    req->qcaddy = cd;
+
+    /* post it rather than calling inline: _query reaches back into the RML
+     * to answer, and we are still inside the RML's dispatch */
+    prte_event_set(prte_event_base, &(cd->ev), -1, PRTE_EV_WRITE, _query, cd);
+    PMIX_POST_OBJECT(cd);
+    prte_event_active(&(cd->ev), PRTE_EV_WRITE, 1);
+    return;
+
+error:
+    /* the daemon is holding a tracker under refid and nothing else will ever
+     * complete it - an error reply is what releases its client */
+    {
+        pmix_data_buffer_t *reply;
+        size_t none = 0;
+        int ret;
+
+        PMIX_DATA_BUFFER_CREATE(reply);
+        /* the empty info count keeps this reply the same shape as a real
+         * one, so the receiver unpacks one format rather than guessing
+         * which it got from the status */
+        if (PMIX_SUCCESS != PMIx_Data_pack(NULL, reply, &rc, 1, PMIX_STATUS) ||
+            PMIX_SUCCESS != PMIx_Data_pack(NULL, reply, &refid, 1, PMIX_INT) ||
+            PMIX_SUCCESS != PMIx_Data_pack(NULL, reply, &none, 1, PMIX_SIZE)) {
+            PMIX_DATA_BUFFER_RELEASE(reply);
+            return;
+        }
+        PRTE_RML_RELIABLE_SEND(ret, sender->rank, reply, PRTE_RML_TAG_QUERY_RESP);
+        if (PRTE_SUCCESS != ret) {
+            PRTE_ERROR_LOG(ret);
+            PMIX_DATA_BUFFER_RELEASE(reply);
+        }
+    }
+}
+
+/* ---- the asking daemon's half ---------------------------------------- */
+
+/* The master has answered the keys we deferred.  Merge its results into the
+ * ones we gathered locally and complete the client's query - it asked once
+ * and gets one answer covering every key. */
+void pmix_server_query_resp(int status, pmix_proc_t *sender,
+                            pmix_data_buffer_t *buffer,
+                            prte_rml_tag_t tg, void *cbdata)
+{
+    prte_pmix_server_req_t *req;
+    prte_pmix_server_op_caddy_t *cd;
+    pmix_info_t *info = NULL;
+    size_t ninfo = 0, n;
+    pmix_status_t ret, rc;
+    int32_t cnt;
+    int req_index;
+    PRTE_HIDE_UNUSED_PARAMS(status, sender, tg, cbdata);
+
+    /* the status is already a PMIx value - it is the one we report */
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &ret, &cnt, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        ret = rc;
+    }
+
+    /* fall through on the above in the hope the room number still unpacks,
+     * which is the only thing that lets us answer the waiting client */
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &req_index, &cnt, PMIX_INT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return;
+    }
+
+    req = pmix_pointer_array_get_item(&prte_pmix_server_globals.local_reqs, req_index);
+    if (NULL == req || NULL == req->qcaddy) {
+        /* the index came off the wire, but it is OUR index echoed back, so a
+         * miss means the request was retired early and whoever waits on it
+         * waits forever.  Say so rather than returning in silence. */
+        pmix_output_verbose(2, prte_pmix_server_globals.output,
+                            "%s query response names local req %d, which is gone",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), req_index);
+        return;
+    }
+    cd = (prte_pmix_server_op_caddy_t *) req->qcaddy;
+
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &ninfo, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        ret = rc;
+        ninfo = 0;
+        goto complete;
+    }
+    if (0 < ninfo) {
+        PMIX_INFO_CREATE(info, ninfo);
+        cnt = ninfo;
+        rc = PMIx_Data_unpack(NULL, buffer, info, &cnt, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_INFO_FREE(info, ninfo);
+            ret = rc;
+            ninfo = 0;
+            goto complete;
+        }
+        for (n = 0; n < ninfo; n++) {
+            PMIX_INFO_LIST_XFER(rc, req->qresults, &info[n]);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                ret = rc;
+                break;
+            }
+        }
+        PMIX_INFO_FREE(info, ninfo);
+    }
+
+complete:
+    /* query_complete() owns the list and the caddy from here.  "Nothing to
+     * report" from the master is not the answer to the client's whole
+     * request - keys this daemon answered are in the list - so hand those
+     * two statuses back to the accounting there, which weighs the merged
+     * result against every key that was asked for and lands on partial
+     * success or, if the list really is empty, not-found.  Any other error
+     * says something specific went wrong and is reported as it stands. */
+    if (PMIX_QUERY_PARTIAL_SUCCESS == ret || PMIX_ERR_NOT_FOUND == ret) {
+        ret = PMIX_SUCCESS;
+    }
+    query_complete(cd, req->qresults, req->nkeys, ret);
+    req->qcaddy = NULL;
+    req->qresults = NULL;
+    pmix_pointer_array_set_item(&prte_pmix_server_globals.local_reqs,
+                                req->local_index, NULL);
+    PMIX_RELEASE(req);
 }

--- a/src/rml/rml_types.h
+++ b/src/rml/rml_types.h
@@ -228,6 +228,18 @@ typedef void (*prte_rml_buffer_callback_fn_t)(int status, pmix_proc_t *peer,
  * which is where it is held - see src/prted/pmix/pmix_server_connect.c */
 #define PRTE_RML_TAG_CONNECTED            83
 
+/* A PMIx query a daemon cannot answer, on its way to the DVM master, and the
+ * master's answer coming back.  A prted holds only the identity half of the
+ * node pool - the nidmap ships names, aliases, daemon vpids and pool slots,
+ * never slot counts or node state - and holds no session but the default
+ * one, so a query that reads either has to be asked where those live.  See
+ * pmix_server_queries.c.  Distinct from PRTE_RML_TAG_SCHED, which is the
+ * scheduler command channel: a query is not a scheduler request, and
+ * pmix_server_sched() demultiplexes on a command byte a query has no value
+ * for. */
+#define PRTE_RML_TAG_QUERY                85
+#define PRTE_RML_TAG_QUERY_RESP           86
+
 #define PRTE_RML_TAG_MAX                 100
 
 #define PRTE_RML_TAG_NTOH(t) ntohl(t)

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -370,6 +370,54 @@ prte_session_t *prte_get_session_object_from_id(const char *id)
     return NULL;
 }
 
+/* See the block comment in prte_globals.h.  These three are the gate between
+ * code that wants allocation state and the fact that only the master has it. */
+int prte_get_allocated_nodes(const char *allocid, pmix_pointer_array_t **nodes)
+{
+    prte_session_t *session;
+
+    *nodes = NULL;
+    if (!PRTE_PROC_IS_MASTER) {
+        return PRTE_ERR_NOT_AUTHORITATIVE;
+    }
+    if (NULL == allocid) {
+        *nodes = prte_node_pool;
+        return PRTE_SUCCESS;
+    }
+    session = prte_get_session_object_from_id(allocid);
+    if (NULL == session) {
+        return PRTE_ERR_NOT_FOUND;
+    }
+    *nodes = session->nodes;
+    return PRTE_SUCCESS;
+}
+
+int prte_get_allocation_session(const char *allocid, prte_session_t **session)
+{
+    *session = NULL;
+    if (!PRTE_PROC_IS_MASTER) {
+        return PRTE_ERR_NOT_AUTHORITATIVE;
+    }
+    if (NULL == allocid) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+    *session = prte_get_session_object_from_id(allocid);
+    if (NULL == *session) {
+        return PRTE_ERR_NOT_FOUND;
+    }
+    return PRTE_SUCCESS;
+}
+
+int prte_get_allocation_sessions(pmix_pointer_array_t **sessions)
+{
+    *sessions = NULL;
+    if (!PRTE_PROC_IS_MASTER) {
+        return PRTE_ERR_NOT_AUTHORITATIVE;
+    }
+    *sessions = prte_sessions;
+    return PRTE_SUCCESS;
+}
+
 prte_session_t *prte_get_session_object_from_refid(const char *refid)
 {
     prte_session_t *session;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -583,6 +583,35 @@ PRTE_EXPORT prte_session_t *prte_get_session_object_from_refid(const char *refid
 
 PRTE_EXPORT int prte_set_session_object(prte_session_t *session);
 
+/* Reach allocation state that only the DVM master holds.
+ *
+ * A prted's node pool carries a node's *identity* and nothing else: the
+ * nidmap ships names, aliases, daemon vpids and pool slots (see
+ * src/util/nidmap.c), and no writer of prte_node_t::slots, slots_max,
+ * slots_inuse or state runs anywhere but the master - the ras components,
+ * the hostfile and dash_host parsers, and plm_base_setup_virtual_machine()
+ * are all master-only.  Likewise prte_sessions on a prted holds the default session
+ * and nothing more, because every other session is created by the master's
+ * allocation paths.  So a daemon reading either gets a default-constructed
+ * zero that is indistinguishable from a real answer.
+ *
+ * These are the only sanctioned way into that state.  On the master they
+ * succeed and hand back exactly what a direct read would have; anywhere else
+ * they return PRTE_ERR_NOT_AUTHORITATIVE having touched nothing, which is the
+ * caller's cue to ask the master instead.  Answering from here rather than
+ * from a list of "keys that need the master" is deliberate: the set of such
+ * keys is not knowable in advance, but the set of *reads* that cannot be
+ * satisfied locally is exactly this, and it is enforced at the point of use.
+ *
+ * A NULL allocid means the DVM-wide allocation.  Do not reach past these to
+ * prte_node_pool or prte_sessions for capacity or session state - a checker
+ * run by "make check" fails the build if pmix_server_queries.c does. */
+PRTE_EXPORT int prte_get_allocated_nodes(const char *allocid,
+                                         pmix_pointer_array_t **nodes);
+PRTE_EXPORT int prte_get_allocation_session(const char *allocid,
+                                            prte_session_t **session);
+PRTE_EXPORT int prte_get_allocation_sessions(pmix_pointer_array_t **sessions);
+
 /* Point a job at the session it runs in, maintaining the reference count on
  * both the outgoing and the incoming session.  Every assignment to
  * prte_job_t::session must go through this. */

--- a/src/util/error.c
+++ b/src/util/error.c
@@ -448,6 +448,9 @@ const char *prte_strerror(int errnum)
     case PRTE_ERR_SLURM_UPDATE_FAILURE:
         retval = "Request to update Slurm job failed";
         break;
+    case PRTE_ERR_NOT_AUTHORITATIVE:
+        retval = "This process does not hold the authoritative copy of the requested data";
+        break;
     default:
         retval = "Unknown error";
     }

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -4,10 +4,11 @@
 
 SUBDIRS = rmaps runtime errmgr ess event filem grpcomm hwloc include odls iof plm pmix prted rml ras schizo state tools util
 
-# A source scan rather than a program, so it is distributed as-is and
-# needs no configure substitution - see the header of the script. It is
-# kept identical to the copy in PMIx (test/unit/check_static_init.pl);
-# fix one and copy it across rather than letting the two drift.
-dist_check_SCRIPTS = check_static_init.pl
+# Source scans rather than programs, so they are distributed as-is and
+# need no configure substitution - see the header of each script.
+# check_static_init.pl is kept identical to the copy in PMIx
+# (test/unit/check_static_init.pl); fix one and copy it across rather
+# than letting the two drift.
+dist_check_SCRIPTS = check_static_init.pl check_query_authority.py
 
-TESTS = check_static_init.pl
+TESTS = check_static_init.pl check_query_authority.py

--- a/test/unit/check_query_authority.py
+++ b/test/unit/check_query_authority.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# A daemon must not answer a query out of state it does not have.
+#
+# A prted holds the identity half of the DVM's node table and nothing
+# else: the nidmap ships node names, aliases, daemon vpids and pool slots
+# (src/util/nidmap.c), and every writer of prte_node_t::slots, slots_max,
+# slots_inuse and state runs only on the DVM master - ras/*, the hostfile
+# and dash_host parsers, plm_base_setup_virtual_machine().  prte_sessions
+# on a prted likewise holds the default session and nothing more.  A
+# branch of _query() that reads either on a daemon gets a
+# default-constructed zero, which is indistinguishable from a real answer
+# and is returned to the client as one.
+#
+# pmix_server_queries.c therefore reaches that state only through the
+# accessors in src/runtime/prte_globals.c, which return
+# PRTE_ERR_NOT_AUTHORITATIVE off the master so the key can be relayed to
+# it.  This checks that it still does.  The rule cannot be enforced by
+# the compiler - the fields are ordinary members of a struct the file
+# legitimately uses for node *identity* - so it is enforced here.
+#
+# Deliberately not a list of query keys.  Which keys need the master is
+# not knowable in advance and goes stale the moment someone adds one;
+# which *reads* cannot be satisfied locally is exactly the set below.
+
+import os
+import re
+import sys
+
+# fields of prte_node_t that the nidmap does not ship
+CAPACITY = ("slots", "slots_max", "slots_inuse")
+# the session table, which a daemon holds only the default entry of
+SESSIONS = "prte_sessions"
+# the sanctioned ways in
+ACCESSORS = ("prte_get_allocated_nodes",
+             "prte_get_allocation_session",
+             "prte_get_allocation_sessions")
+
+TARGET = os.path.join("src", "prted", "pmix", "pmix_server_queries.c")
+
+
+def find_top():
+    top = os.path.dirname(os.path.dirname(os.path.dirname(
+        os.path.abspath(__file__))))
+    if not os.path.isdir(os.path.join(top, "src")) and "srcdir" in os.environ:
+        top = os.path.join(os.environ["srcdir"], "..", "..")
+    return top
+
+
+def main():
+    path = os.path.join(find_top(), TARGET)
+    try:
+        with open(path) as f:
+            lines = f.readlines()
+    except OSError as e:
+        print("check_query_authority: cannot read %s: %s" % (path, e))
+        return 1
+
+    errors = []
+
+    # The session table has no legitimate direct use here at all.
+    for n, line in enumerate(lines, 1):
+        if line.lstrip().startswith(("*", "/*", "//")):
+            continue
+        if re.search(r"\b%s\b" % SESSIONS, line):
+            errors.append("%s:%d: names %s directly; use %s()"
+                          % (TARGET, n, SESSIONS, ACCESSORS[2]))
+
+    # Capacity fields may be read, but only downstream of an accessor in
+    # the same query branch.  Branches are delimited by the key tests of
+    # the if/else-if chain in _query(), so split on those and require any
+    # chunk that reads capacity to have settled authority first.
+    branch = re.compile(r"(?:\}\s*else\s+)?if\s*\(\s*PMIx_Check_key\s*\(")
+    capacity = re.compile(r"->\s*(%s)\b" % "|".join(CAPACITY))
+
+    chunks = []
+    start = 0
+    for n, line in enumerate(lines):
+        if branch.search(line):
+            chunks.append((start, lines[start:n]))
+            start = n
+    chunks.append((start, lines[start:]))
+
+    for offset, chunk in chunks:
+        text = "".join(chunk)
+        hit = capacity.search(text)
+        if hit is None:
+            continue
+        if any(a in text for a in ACCESSORS):
+            continue
+        n = offset + text[:hit.start()].count("\n") + 1
+        errors.append("%s:%d: reads ->%s without first establishing "
+                      "authority; call one of %s and defer on "
+                      "PRTE_ERR_NOT_AUTHORITATIVE"
+                      % (TARGET, n, hit.group(1), ", ".join(ACCESSORS)))
+
+    if errors:
+        for e in errors:
+            print(e)
+        print("\n%d violation(s).  See the block comment above "
+              "query_complete() in %s." % (len(errors), TARGET))
+        return 1
+
+    print("check_query_authority: %s reaches master-only state only "
+          "through the accessors" % TARGET)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/unit/include/test_include.c
+++ b/test/unit/include/test_include.c
@@ -155,8 +155,8 @@ static int test_error_code_numbering(void)
      * must not itself be one. The check that it is not stale -- that the
      * offset just inside it is a real, named code -- needs prte_strerror()
      * and lives in test/unit/util; here we only pin the arithmetic. */
-    CHECK("the bound is below the last code", PRTE_ERR_MAX < PRTE_ERR_SLURM_UPDATE_FAILURE);
-    CHECK("the bound is one past the end", (PRTE_ERR_MAX + 1) == PRTE_ERR_SLURM_UPDATE_FAILURE);
+    CHECK("the bound is below the last code", PRTE_ERR_MAX < PRTE_ERR_NOT_AUTHORITATIVE);
+    CHECK("the bound is one past the end", (PRTE_ERR_MAX + 1) == PRTE_ERR_NOT_AUTHORITATIVE);
 
     /* PRTE_ERROR must NOT be PMIX_ERROR any more. They were both -1, which
      * made a PRRTE code handed to PMIx unconverted invisible in the one


### PR DESCRIPTION
### The problem

`_query()` in `src/prted/pmix/pmix_server_queries.c` is answered by whichever
daemon the client is connected to, and there is no relay in it — a
`pmix_server_query_fn` upcall thread-shifts into `_query` and that daemon
answers. Five of its arms read state that a prted does not have:

- `PMIX_NUM_SLOTS` — returns `node->slots`, or sums the pool
- `PMIX_QUERY_AVAILABLE_SLOTS` — sums `slots - slots_inuse`, filtering on
  `slots_max` and node state
- `PMIX_QUERY_ALLOCATION` — walks the pool emitting per-node info
- `PMIX_QUERY_ALLOC_IDS`, `PMIX_QUERY_ALLOC_PROPERTIES` — read `prte_sessions`

None of that is replicated. The nidmap ships node *identity* — names, aliases,
daemon vpids and pool slots — and has never shipped `slots`, `slots_max`,
`slots_inuse` or node `state`; every writer of those runs only on the master
(the `ras` components, the hostfile and `dash_host` parsers,
`plm_base_setup_virtual_machine()`), and `prte_job_pack` carries no per-node
capacity. `prte_sessions` on a prted holds the default session and nothing
more.

So a daemon answers these out of default-constructed zeros — and returns
`PMIX_SUCCESS`. The rank that lands on the master gets the truth, every other
rank gets nothing, and nothing anywhere says a word. The answer to a question
about the DVM depends on which daemon happened to be asked. Measured on a
four-node swarm, one rank per node:

```
                node1(master)  node2  node3  node4
before          SLOTS 8        SLOTS 0  SLOTS 0  SLOTS 0
after           SLOTS 8        SLOTS 8  SLOTS 8  SLOTS 8
```

The same `prun` from a tool connected to the HNP has always been right, which
is part of why this survived: it is only wrong for a client on a daemon.

### The approach

The obvious fix — a list of "keys that need the master" — is the one thing
that will not hold. Such a list is a snapshot of today's arms, and it goes
stale *silently*: a key someone forgets to add returns a plausible zero rather
than failing.

So the decision is made by the **read**, not by the key. Three accessors
(`prte_get_allocated_nodes()`, `prte_get_allocation_session()`,
`prte_get_allocation_sessions()`) are the only way into that state. They
succeed on the master — behavior there is unchanged — and return the new
`PRTE_ERR_NOT_AUTHORITATIVE` anywhere else. An arm that gets that back jumps
to a `defer:` label; at `done:` the deferred keys go to the master on
`PRTE_RML_TAG_QUERY`, and the reply merges into the results gathered locally
so the client sees one answer covering every key it asked for.

A key added tomorrow that reads capacity is relayed with no edit. One that
reads only what the nidmap and the launch message already deliver stays local
with no edit. `test/unit/check_query_authority.py` fails `make check` if the
file reaches that state any other way.

**Deferral is per key**, not per query, because the things a daemon must
answer for *itself* can arrive in the same `PMIx_Query_info` as a key only the
master can answer: `PMIX_HWLOC_XML_V1`/`_V2` export this node's topology, an
unqualified `PMIX_SERVER_URI` is this daemon's own URI, and
`PMIX_QUERY_LOCAL_PROC_TABLE` means the procs this daemon is hosting. Relaying
a whole query would answer those about the master.

The master answers with the same `_query()`, so there is one implementation.
The relay carries the original requestor, so the master defaults the query to
the right job. Transport is the tracker pattern `pmix_server_allocate.c`
already uses; a tag of its own rather than `PRTE_RML_TAG_SCHED`, which
demultiplexes on a command byte a query has no value for.

### Testing

- warning-free `--enable-debug` build
- `make check` — all pass, including the new scan, which I verified fails on
  both violation shapes (an ungated `->slots_max` read, and a direct
  `prte_sessions` reference)
- single-node DVM smoke test
- `contrib/dockerswarm` full suite: **764 passed, 0 failed, 3 skipped** (the
  skips are the pre-existing "no network device in these topologies" ones)
- the new multi-node case verified in **both** directions: with the authority
  check disabled, the swarm reproduces the table above exactly, so the test is
  not vacuous

### Not in this PR

Queries whose answer belongs to a *particular node or proc* need a different
destination — the daemon on that node, or hosting that proc — not the master.
Nothing reaches that gap today (the category-3 keys that exist are all
unqualified, and the two resource-usage arms are empty), but it is the natural
next thing someone will hit. Recorded as #2742.
