### PR TITLE
Fail a launch we cannot register, and stop guessing at device distances

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -56,7 +56,7 @@ It is **not** a Docker Swarm in the orchestration sense — just ten plain
 | `dataserver.c` | A bare PMIx client for the publish/lookup service (`dataserver` in the install): publish/lookup/lookupwait/lookup2/unpublish. Drives `src/runtime/data_server`. See §13. |
 | `jobinfo.c` | A bare PMIx client for the **direct-modex** paths (`jobinfo` in the install): `publish`/`fetch`/`fetchkey`. Drives `src/prted/pmix/pmix_server_fence.c` from a daemon that hosts none of the target job's procs. |
 | `proctable.c` | A bare PMIx client for the **proc-table and server-URI queries** (`proctable` in the install): `procs`/`localprocs`/`serveruri`. Those are the only callers of `prte_pmix_convert_state()`, and the local-vs-global proc-table split has no meaning on one host. Drives `src/pmix`. |
-| `peerinfo.c` | A bare PMIx client in which every rank asks **every other rank of its own job** where it is (`peerinfo` in the install): rank, app rank, local/node rank, node id, hostname, cpuset, locality string. The only client here that reads a *peer's* reserved keys, and so the only one that reaches the daemon's derive-on-demand path — everything else either reads back what it put itself or asks about the job. Drives `derive_proc_data()` in `src/prted/pmix/pmix_server_fence.c`. See §20. |
+| `peerinfo.c` | A bare PMIx client in which every rank asks **every other rank of its own job** where it is (`peerinfo` in the install): rank, app rank, local/node rank, node id, hostname, cpuset, locality string — and device distances, the one key an off-node peer must be *refused*. The only client here that reads a *peer's* reserved keys, and so the only one that reaches the daemon's derive-on-demand path — everything else either reads back what it put itself or asks about the job. Drives `derive_proc_data()` in `src/prted/pmix/pmix_server_fence.c`. See §20. |
 | `groupcon.c` | A bare PMIx client that drives a **group construct/destruct** (`groupcon` in the install): every rank contributes a local cid, asks for a context id, constructs, reads every peer's contribution back, destructs. Drives grpcomm's `grp_release` on daemons that merely *received* the broadcast. See §15. |
 | `groupinv.c` | A bare PMIx client that forms a group by **invitation** and asks for a context id (`groupinv` in the install). The highest rank leads, so mapped by node the leader is never the HNP - which is the point: that method runs no collective, so its leader asks for the id through job control and only the HNP holds the pool, so the request has to be relayed. Drives `PRTE_PMIX_GROUP_CTXID` in `src/prted/pmix`. See §15. |
 | `envspawn.c` | A PMIx client that spawns a child job carrying one of every **envar directive** (`envspawn` in the install): SET/ADD/UNSET/PREPEND/APPEND, pinned to a named host, with the child reporting the environment it actually got into a file on its own node. Those directives have no command-line surface — they arrive only on a spawn request — and `odls` applies them on whichever daemon forks the process, so the child has to land somewhere the parent is not. Drives `prte_odls_base_process_envars`. |
@@ -1982,20 +1982,21 @@ prterun ... --prtemca pmix_server_verbose 2 --leave-session-attached \
 
 ## 20. Asking a peer where it is (`peerinfo`, `test_pmix`)
 
-A daemon does not have to publish, to its local PMIx server, everything it
-knows about every proc of a job. `prte_pmix_lazy_procdata` publishes only
-the procs that daemon hosts and derives the rest out of its own job object
-when PMIx brings it a request — see
+A daemon publishes, to its local PMIx server, everything it knows about
+every proc of a job — but there are things it does not know about a proc it
+does not host, above all the binding, which the launch message scatters. It
+answers those out of its own job object when PMIx brings it a request; see
 [`src/prted/pmix/AGENTS.md`](../../src/prted/pmix/AGENTS.md), *What a daemon
-publishes, and what it derives*.
+publishes, and what it derives*. (Publishing *only* the procs a daemon hosts
+was tried, measured and closed — `docs/todo.rst`.)
 
 **Nothing else in this harness asks one rank about another rank.** Every
 other client either puts its own data and reads it back, or asks about the
 job rather than about a peer, and both are answered out of the local
 server's cache without the daemon ever being consulted. So the derivation
-could be switched on, the whole suite run green, and the path never once
-have executed — which is exactly what happened the first time it was
-written, and why the change sat unproven.
+could run the whole suite green and never once have executed — which is
+exactly what happened the first time it was written, and why the change sat
+unproven.
 
 Read that as a hole in the coverage and not as a finding about workloads.
 PRRTE is not one MPI's runtime; several programming libraries build on it,
@@ -2031,6 +2032,28 @@ so the assertion is a string compare — what rank *r* was told about rank
   about — which is what catches a derivation that walked to the wrong
   entry and produced a whole line of plausible values.
 
+`peerinfo` also asks every peer for its **device distances**, on a `DIST`
+line of its own carrying the *status* rather than a value:
+
+```
+DIST <myrank> <targetrank> self|local|remote <status>
+```
+
+That key is the one a daemon must refuse for a proc it does not host. Only
+the HNP collects topologies; `prte_util_decode_nidmap()` hands every daemon
+its own for every node in its pool, "always default to homogeneous". So a
+daemon that answered would measure **its** hardware and label the result
+with somebody else's rank — plausible, and wrong, which is worse than a
+refusal. Every `remote` line must read `PMIX_ERR_NOT_SUPPORTED`.
+
+Nothing is asserted about a `local` peer, deliberately: the daemon
+published those distances at registration and the question never leaves the
+local PMIx server, so what comes back says only whether the machine has a
+device of the configured types (`prte_pmix_generate_distances`, default
+`fabric,gpu,network`) — a fact about the container, not about PRRTE. Judge
+the status in the harness rather than in the client, for the same reason:
+`peerinfo` reports, `run-tests.sh` decides.
+
 A consistent table still cannot tell the two implementations apart, so a
 second case watches the daemon say it did the work:
 
@@ -2040,14 +2063,36 @@ prterun --host node1:2,node2:2,node3:2,node4:2 -n 8 --map-by node \
     /opt/prte/prte/bin/peerinfo 2>&1 | grep -c "ANSWERED LOCALLY"
 ```
 
-It must be **one per remote proc per daemon** — 24 for that command (four
-daemons, six remote procs each), *not* one per lookup: PMIx caches the
-modex reply, so the second rank on a node asking about the same peer never
-reaches the daemon at all. A count equal to the number of lookups would
-mean the caching is not working; a count of zero means the path did not
-run and everything above it proved nothing. `--leave-session-attached` is
-required, and for the same reason it is in §19: a daemonized `prted` has no
-stderr to read, so without it only the master's traces come back.
+**The number to expect is "some", and the case asserts only that.** What is
+fixed is the count one level down: `DMODX REQ FOR` on a placement key is
+**one per remote proc per daemon** — 24 for that command (four daemons, six
+remote procs each), *not* one per lookup, because PMIx caches the modex
+reply and the second rank on a node asking about the same peer never
+reaches the daemon at all. How many of those 24 are *derived* is not fixed,
+because a modex reply for a specific rank carries **every** key for that
+rank, so whichever key happens to be asked first about a given peer brings
+the rest with it and is the only one the daemon ever sees. The cpuset
+cannot be derived — it was scattered — so a peer whose cpuset is asked for
+first costs a wire fetch, while one whose rank is asked for first is
+answered out of the job object. Measured on that command: 24 requests, 6
+`ANSWERED LOCALLY` and 18 `pmix.cpuset` fetches. A count of **zero** is the
+failure — it means the path did not run and everything above it proved
+nothing.
+
+The same capture is where the other half of the device-distance check
+lives: `DEVICE DISTANCES - NOT SUPPORTED` must appear, because a
+client-side `PMIX_ERR_NOT_SUPPORTED` alone cannot say *who* produced it.
+Those are counted separately from the 24 above, and unlike the 24 the
+figure is **not** stable — two runs of the identical command gave 36 and
+29. A refused request stores nothing, so each rank re-asks rather than
+reading a cache, and what varies is how many of those land close enough
+together for `dmodex_req()`'s "has anyone already requested data for this
+target" loop to park one behind another. Assert that it is non-zero, never
+that it is a particular number.
+
+`--leave-session-attached` is required, and for the same reason it is in
+§19: a daemonized `prted` has no stderr to read, so without it only the
+master's traces come back.
 
 ## 21. Client churn against the PMIx server (`pmixloop`, `test_pmix_cycling`, `test_pmix_server_teardown`)
 

--- a/contrib/dockerswarm/peerinfo.c
+++ b/contrib/dockerswarm/peerinfo.c
@@ -28,18 +28,18 @@
  * These are the keys PRRTE decided when it mapped the job - rank, app rank,
  * local and node rank, node id, hostname, cpuset, locality string.  Every
  * daemon used to publish all of them, for every proc in the job, to its
- * local PMIx server, which is a table that grows with the whole job on a
- * node that will only ever run its own slice of it.  A daemon can instead
- * publish only the procs it hosts and answer for the rest out of its own
- * job object when somebody asks, which is what prte_pmix_lazy_procdata
- * turns on.
+ * local PMIx server, and still does: publishing only the procs it hosts was
+ * tried and closed (docs/todo.rst).  What it cannot publish for a proc it
+ * does not host - the binding, which the launch message scatters - it
+ * answers out of its own job object when somebody asks, and this client is
+ * what asks.
  *
  * Nothing else in this harness ever asks one rank about another rank's
  * reserved keys.  Every other client here either puts its own data and
  * fetches it back, or asks about the job rather than about a peer, and
  * both of those are answered without the request ever reaching the daemon.
- * So the whole derive-on-demand path could be switched on, run the entire
- * suite green, and never once have executed.  This client is the shape of
+ * So the whole derive-on-demand path could run the entire suite green and
+ * never once have executed.  This client is the shape of
  * an MPI initialization - each rank asking where its peers are - and it is
  * the only thing here that drives a PMIx_Get for a reserved key of a proc
  * this daemon does not host.
@@ -48,6 +48,19 @@
  * one MPI's runtime, several programming libraries build on it, and what
  * any of them asks a peer for is not knowable from this tree - so read the
  * gap as missing coverage, not as evidence that these keys go unwanted.
+ *
+ * It also asks each peer for its device distances, and reports the status
+ * rather than the value.  That is the one reserved key a daemon must NOT
+ * answer for a proc it does not host - distances are measured against the
+ * topology of the node the proc runs on, and a daemon holds only its own -
+ * so an off-node peer has to come back refused rather than answered from
+ * the asking daemon's hardware.  The line is
+ *
+ *   DIST <myrank> <targetrank> self|local|remote <status>
+ *
+ * and the harness is what judges it, because what a LOCAL answer should
+ * contain is a property of the machine (whether it has a device of the
+ * configured types at all) rather than of PRRTE.
  *
  * Run it with --map-by node so the peers are genuinely elsewhere; on one
  * node every answer comes out of the local publication and the interesting
@@ -175,6 +188,25 @@ static void describe(pmix_proc_t *target, char *out, size_t sz)
     }
 }
 
+/* Report - not judge - what came back when we asked `target` for its
+ * device distances.  Deliberately not routed through fetch(): a refusal is
+ * the RIGHT answer for an off-node peer, so counting it as a lookup failure
+ * would invert the test, and the value is a data array that has nothing to
+ * compare against a peer's own account of itself. */
+static void distances(pmix_proc_t *target, const char *rel)
+{
+    pmix_status_t rc;
+    pmix_value_t *val = NULL;
+
+    rc = PMIx_Get(target, PMIX_DEVICE_DISTANCES, NULL, 0, &val);
+    printf("DIST %u %u %s %s\n", myproc.rank, target->rank, rel,
+           PMIx_Error_string(rc));
+    fflush(stdout);
+    if (NULL != val) {
+        PMIX_VALUE_RELEASE(val);
+    }
+}
+
 int main(int argc, char **argv)
 {
     pmix_status_t rc;
@@ -182,6 +214,7 @@ int main(int argc, char **argv)
     pmix_value_t *val = NULL;
     uint32_t jobsize = 0, r;
     char line[FIELD_MAX * 12];
+    char myhost[FIELD_MAX], peerhost[FIELD_MAX];
 
     (void) argc;
     (void) argv;
@@ -209,6 +242,12 @@ int main(int argc, char **argv)
     printf("SELF %u %s\n", myproc.rank, line);
     fflush(stdout);
 
+    /* which node I am on, so a peer can be called local or remote below.
+     * The refusal only applies to a proc this daemon does not host, and on
+     * a job that spans nodes both kinds are present. */
+    fetch(&myproc, PMIX_HOSTNAME, myhost, sizeof(myhost));
+    distances(&myproc, "self");
+
     for (r = 0; r < jobsize; r++) {
         if ((pmix_rank_t) r == myproc.rank) {
             continue;
@@ -227,6 +266,16 @@ int main(int argc, char **argv)
                    PMIX_RANK, line);
             fflush(stdout);
             ++nfail;
+        }
+        /* "unknown" rather than a guess when either hostname is absent:
+         * calling an unclassifiable peer local would quietly retire the
+         * off-node assertion, where an unknown leaves it with nothing to
+         * count and the case says so. */
+        fetch(&target, PMIX_HOSTNAME, peerhost, sizeof(peerhost));
+        if (0 == strcmp(myhost, "-") || 0 == strcmp(peerhost, "-")) {
+            distances(&target, "unknown");
+        } else {
+            distances(&target, (0 == strcmp(myhost, peerhost)) ? "local" : "remote");
         }
     }
 

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -2586,7 +2586,7 @@ peerinfo_mismatches() {
 }
 
 test_pmix() {
-    local out rc n hosts undef peers lazyout eagerout mism a b vrb
+    local out rc n hosts undef peers lazyout mism a vrb
 
     banner "pmix: the queried proc table carries a real state for every proc"
     # PMIX_QUERY_PROC_TABLE is the only caller of prte_pmix_convert_state(),
@@ -2800,11 +2800,13 @@ test_pmix() {
     # It matters because of what the daemon may legitimately not have
     # published.  Registering a PMIx entry for every proc in the job, on every
     # daemon, builds a table that grows with the whole job on a node that runs
-    # a fixed slice of it, so prte_pmix_lazy_procdata publishes only the procs
-    # this daemon hosts and derives the rest from its own job object when
-    # somebody asks.  The derivation is reached through the direct-modex
-    # up-call, which is a path no single-host run has: on one node every proc
-    # is local and there is nothing to derive.
+    # a fixed slice of it.  Publishing only the procs this daemon hosts was
+    # tried and closed (docs/todo.rst); what remains is the derivation, which
+    # answers out of this daemon's own job object for the keys it does hold
+    # and which the eager registration cannot publish -- above all the
+    # binding, which the launch message scatters.  The derivation is reached
+    # through the direct-modex up-call, which is a path no single-host run
+    # has: on one node every proc is local and there is nothing to derive.
     #
     # The assertion is a cross-check rather than a spot value, because the
     # interesting failure is not "no answer" but "a plausible wrong answer" --
@@ -2853,6 +2855,28 @@ test_pmix() {
             && ok "...including every peer's binding, which off-node had to be fetched" \
             || bad "$n of 56 peer lookups came back with a binding"
 
+        # ...and the one reserved key that must NOT be answered for a peer
+        # elsewhere.  Device distances are measured against the topology of
+        # the node the proc runs on, and a daemon holds only its own -- the
+        # HNP collects every node's, no daemon receives anybody else's.  So
+        # a daemon that answered would be handing back distances computed
+        # from ITS hardware and labelled with somebody else's rank, which is
+        # worse than a refusal because it is plausible.  The request is
+        # refused outright rather than sent on a round trip that cannot
+        # answer it.  Nothing is asserted about a peer on this same node:
+        # the daemon published those at registration and the question never
+        # leaves the local server, and whether any device of the configured
+        # types exists at all is a property of the machine.
+        n=$(echo "$lazyout" | tr -d '\r' | awk '$1 == "DIST" && $4 == "remote" {c++} END {print c+0}')
+        a=$(echo "$lazyout" | tr -d '\r' | awk '$1 == "DIST" && $4 == "remote" && $5 != "PMIX_ERR_NOT_SUPPORTED" {c++} END {print c+0}')
+        if [ "${n:-0}" -eq 0 ]; then
+            bad "no rank asked an off-node peer for its device distances -- the refusal went untested"
+        elif [ "${a:-0}" -eq 0 ]; then
+            ok "...and all $n requests for an off-node peer's device distances were refused as unsupported"
+        else
+            bad "$a of $n off-node device-distance requests were not refused: $(echo "$lazyout" | tr -d '\r' | awk '$1 == "DIST" && $4 == "remote" && $5 != "PMIX_ERR_NOT_SUPPORTED"' | head -3 | tr '\n' ' ')"
+        fi
+
         # Note what that comparison already is: a SELF line is what the
         # proc's OWN daemon published about it -- which a daemon does for
         # its own procs either way -- while the PEER lines about it are what
@@ -2861,17 +2885,14 @@ test_pmix() {
         # two separate runs would not be: a second job has a different
         # PMIX_GLOBAL_RANK offset, so the tables legitimately differ.
         #
-        # The same job with the derivation off is therefore a control on the
-        # client rather than a second reading: it must pass here too, or a
-        # failure above says nothing about the derivation.
-        eagerout=$(PRUN "$peers --prtemca prte_pmix_lazy_procdata 0 $PI" 2>&1)
-        mism=$(peerinfo_mismatches "$eagerout")
-        n=$(echo "$eagerout" | grep -c '^PEERFAIL')
-        if [ -z "$mism" ] && [ "$n" = 0 ]; then
-            ok "eager publication (prte_pmix_lazy_procdata 0) passes the same check"
-        else
-            bad "the check fails with the derivation off, so it is not testing the derivation: $(echo "$mism" | head -2 | tr '\n' ' ' | tail -c 400)"
-        fi
+        # There used to be a second reading here with the derivation
+        # switched off, as a control on the client.  The switch is gone --
+        # deriving what we can and asking the wire for the rest is what the
+        # daemon does, and the parameter only ever controlled the requesting
+        # side, so "off" meant "fetch the same answer over the wire".  The
+        # control that remains is the one below: the daemon has to say it
+        # derived something, or the compare above is passing on eagerly
+        # published data and proves nothing.
         RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     fi
     cleanup_swarm
@@ -2959,12 +2980,14 @@ test_pmix() {
         [ "$n" = 0 ] \
             && ok "...and none of the lookups failed" \
             || bad "$n lookups failed while the derivation was in use"
-        # ...and with it off, nothing may claim to have derived anything.
-        out=$(RUN "timeout -k 5 150 prterun --host node1:2,node2:2,node3:2,node4:2 \
-                     -n 8 --map-by node $vrb --prtemca prte_pmix_lazy_procdata 0 $PI" 2>&1)
-        echo "$out" | grep -q 'ANSWERED LOCALLY' \
-            && bad "the derivation ran even though prte_pmix_lazy_procdata was 0" \
-            || ok "prte_pmix_lazy_procdata 0 turns the derivation off completely"
+        # ...and the one key no daemon can derive is refused rather than
+        # sent on a round trip that cannot answer it.  Device distances are
+        # measured against the topology of the node the proc runs on, and a
+        # daemon holds only its own.
+        n=$(echo "$out" | grep -c 'DEVICE DISTANCES - NOT SUPPORTED')
+        [ "${n:-0}" -gt 0 ] \
+            && ok "...and $n requests for a remote proc's device distances were refused by the daemon" \
+            || bad "no daemon refused a device-distance request -- either peerinfo stopped asking or the refusal moved"
     fi
     cleanup_swarm
 }

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -122,14 +122,6 @@ job registered with a key silently missing.  What would settle it properly
 is not forty checks but an accumulator — one status the adds fold into,
 tested once — which is a change to the macro, not to this file.
 
-**``PRTE_JOB_NSPACE_REGISTERED`` is written and never read.**  Both
-registration paths in ``pmix_server_register_fns.c`` set it, and nothing in
-the tree consults it.  Either something should — the obvious candidate is
-the wildcard direct-modex arm of ``dmodex_req``, which re-registers a
-namespace it may already have registered — or the attribute should go, along
-with its entry in ``src/util/attr.h``.  Leaving it is the third option and
-is what the code does today.
-
 **A session control addressed to every session answers with no session id.**
 ``apply_to_all`` (``src/prted/pmix/pmix_server_session.c``) applies the
 operation to each session the requestor controls and then builds one answer

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -898,7 +898,8 @@ takes more off this traffic than aggregating it ever would have.
 **Lazy proc-data registration: the withholding half.**  The *deriving*
 half is in: ``dmodex_req`` answers a request for one of the placement keys
 out of ``jdata->procs[rank]`` rather than going to the hosting daemon
-(``prte_pmix_lazy_procdata``, on by default).  The *withholding* half is not,
+(unconditionally — the MCA parameter that used to gate it is gone, having
+only ever controlled the requesting side).  The *withholding* half is not,
 and not by omission from the design — the commit that landed the derivation
 does not touch ``pmix_server_register_fns.c`` at all.  That file's per-proc
 loop still emits a ``PMIX_PROC_INFO_ARRAY`` for **every** proc in the job on
@@ -919,8 +920,7 @@ anyone spends effort on the other half.  Measured with
 job where it is — at eight ranks over four nodes, with
 ``--prtemca prte_pmix_server_verbose 2``, the twenty-four peer lookups split
 six answered by the derivation and eighteen by a wire round trip to the
-hosting daemon; with ``prte_pmix_lazy_procdata 0`` it is zero and
-twenty-four.  Every one of the six is on the master, and every one is for
+hosting daemon.  Every one of the six is on the master, and every one is for
 ``PMIX_RANK``.  That is the only key PMIx never has: it consumes the rank
 entry as the array's identifier rather than storing it.  Everything else the
 eager registration publishes is found locally and never reaches the

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -122,15 +122,6 @@ job registered with a key silently missing.  What would settle it properly
 is not forty checks but an accumulator — one status the adds fold into,
 tested once — which is a change to the macro, not to this file.
 
-**A client registration that fails is logged and the launch continues.**
-``register_nspace()`` calls ``PMIx_server_register_client`` for each proc it
-is about to host and, on an error, logs it and carries on.  The proc's
-``PMIx_Init`` will then be refused by our own PMIx server, which the
-application sees as an obscure failure some way downstream rather than as
-the launch failure it is.  Failing the whole job on it would be the honest
-alternative and is not obviously right either — the observed failure modes
-are out-of-memory — so it is recorded rather than changed.
-
 **``PRTE_JOB_NSPACE_REGISTERED`` is written and never read.**  Both
 registration paths in ``pmix_server_register_fns.c`` set it, and nothing in
 the tree consults it.  Either something should — the obvious candidate is

--- a/src/mca/odls/AGENTS.md
+++ b/src/mca/odls/AGENTS.md
@@ -332,8 +332,21 @@ Runs **on every daemon** (including the HNP). This is the mirror image of
     progress thread*:
     `prte_pmix_server_register_nspace` thread-shifts before calling back.
     That is what makes the unlocked `pending` bookkeeping safe.
-- On any failure it activates `PRTE_JOB_STATE_NEVER_LAUNCHED` so the HNP
-  doesn't hang waiting for a daemon that silently died.
+- On any failure it calls `fail_local_procs()` and then activates
+  `PRTE_JOB_STATE_NEVER_LAUNCHED` so the HNP doesn't hang waiting for a
+  daemon that silently died. **The activation alone is not enough**, which
+  is why the two are always paired: what the prted errmgr sends the HNP is
+  the *state of this daemon's local children* of that job, so children left
+  in whatever state they were unpacked in read at the HNP as "nothing wrong
+  here" — and `failed_start()` only retires procs it finds already marked
+  `PRTE_PROC_STATE_FAILED_TO_START`, so without the marking they sit in
+  `prte_local_children` forever and this daemon's own termination accounting
+  waits on procs that do not exist. `fail_local_procs()` marks them, sets
+  `PRTE_PROC_FLAG_IOF_COMPLETE` and `PRTE_PROC_FLAG_WAITPID` (nothing was
+  forked and no stdio was ever opened, so both are complete by definition),
+  adds any that never reached `prte_local_children`, and resets
+  `num_local_procs` to match. It is a no-op on the master, which reports to
+  nobody and holds the authoritative job object.
 - **`jdata` at the `REPORT_ERROR` label must be the job we were told to
   launch, or NULL.** The prior-jobs loop that used to sit at the top of this
   function decoded *other* jobs, and reused `jdata` to do it — so a failure

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -443,6 +443,58 @@ static void ls_cbunc(pmix_status_t status, void *cbdata)
     prte_event_active(&cd->ev, PRTE_EV_WRITE, 1);
 }
 
+/* Fail every proc of this job that was ours to launch.
+ *
+ * Activating PRTE_JOB_STATE_NEVER_LAUNCHED is not enough on its own.  What
+ * the prted errmgr sends the HNP is the state of this daemon's local
+ * children of that job, and children left in whatever state they were
+ * unpacked in read at the HNP as "nothing wrong here" - the job then never
+ * completes and the tool that asked for it waits forever with nothing
+ * logged anywhere (that is what made #2616 present as a silent hang).  The
+ * same states are what this daemon's own failed_start() looks for when it
+ * retires the procs out of prte_local_children, so without them they sit
+ * there forever and the daemon's termination accounting waits on procs that
+ * do not exist.
+ *
+ * The master reports to nobody and already holds the authoritative job
+ * object, so this is for the daemons only.
+ */
+static void fail_local_procs(prte_job_t *jdata, int rc)
+{
+    prte_proc_t *pptr;
+    int32_t nlocal = 0;
+    int n;
+
+    if (PRTE_PROC_IS_MASTER || NULL == jdata || NULL == jdata->procs) {
+        return;
+    }
+
+    for (n = 0; n < jdata->procs->size; n++) {
+        pptr = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, n);
+        if (NULL == pptr || pptr->parent != PRTE_PROC_MY_NAME->rank) {
+            continue;
+        }
+        pptr->state = PRTE_PROC_STATE_FAILED_TO_START;
+        pptr->exit_code = rc;
+        /* nothing was forked and no stdio was ever opened for it, so the
+         * two things the lifecycle waits on are complete by definition */
+        PRTE_FLAG_SET(pptr, PRTE_PROC_FLAG_IOF_COMPLETE);
+        PRTE_FLAG_SET(pptr, PRTE_PROC_FLAG_WAITPID);
+        if (!PRTE_FLAG_TEST(pptr, PRTE_PROC_FLAG_LOCAL)) {
+            /* the report walks prte_local_children, so a proc we never
+             * got as far as adding would otherwise go unmentioned */
+            PMIX_RETAIN(pptr);
+            PRTE_FLAG_SET(pptr, PRTE_PROC_FLAG_LOCAL);
+            pmix_pointer_array_add(prte_local_children, pptr);
+        }
+        ++nlocal;
+    }
+    /* keep the count that the termination accounting compares against in
+     * step with the list we just completed - a caller that abandoned the
+     * loop which normally maintains it may have left it short */
+    jdata->num_local_procs = nlocal;
+}
+
 /* join point for the nspace registrations - once they have all
  * reported, proceed with the local support setup and launch.
  * Executes on the PRRTE progress thread */
@@ -459,6 +511,7 @@ static void job_reg_join(prte_odls_jcaddy_t *cd)
     if (PMIX_SUCCESS != cd->rstatus) {
         /* report an error back to the HNP so we don't just hang
          * while it waits to hear that our local procs launched */
+        fail_local_procs(cd->jdata, prte_pmix_convert_status(cd->rstatus));
         PRTE_ACTIVATE_JOB_STATE(cd->jdata, PRTE_JOB_STATE_NEVER_LAUNCHED);
         PMIX_RELEASE(cd);
         return;
@@ -475,6 +528,7 @@ static void job_reg_join(prte_odls_jcaddy_t *cd)
                                               ls_cbunc, cd);
         if (PMIX_SUCCESS != ret) {
             PMIX_ERROR_LOG(ret);
+            fail_local_procs(cd->jdata, prte_pmix_convert_status(ret));
             PRTE_ACTIVATE_JOB_STATE(cd->jdata, PRTE_JOB_STATE_NEVER_LAUNCHED);
             PMIX_RELEASE(cd);
             return;
@@ -1151,44 +1205,12 @@ REPORT_ERROR:
      * were told to launch) or that job - never one of the prior jobs
      * decoded above, which use their own variable. A NULL here is
      * survivable: the prted errmgr falls back to the daemon job. */
-    /* We have to report an error back to the HNP so we don't just hang.
-     * Activating the job state is not enough on its own: what the errmgr
-     * sends the HNP is the state of this daemon's local children of that
-     * job, and a child list we failed to build has none - or has them in
-     * whatever state they were unpacked in, which the HNP reads as "nothing
-     * wrong here". The job then never completes and the tool that asked for
-     * it waits forever with nothing logged anywhere (that is what made
-     * #2616 present as a silent hang). So first fail every proc that was
-     * ours to launch, which is what gives the HNP something to act on.
-     * The master reports to nobody and already holds the authoritative
-     * job object, so this is for the daemons only. */
-    if (!PRTE_PROC_IS_MASTER && NULL != jdata && NULL != jdata->procs) {
-        int32_t nlocal = 0;
-        for (n = 0; n < jdata->procs->size; n++) {
-            pptr = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, n);
-            if (NULL == pptr || pptr->parent != PRTE_PROC_MY_NAME->rank) {
-                continue;
-            }
-            pptr->state = PRTE_PROC_STATE_FAILED_TO_START;
-            pptr->exit_code = rc;
-            /* nothing was forked and no stdio was ever opened for it, so the
-             * two things the lifecycle waits on are complete by definition */
-            PRTE_FLAG_SET(pptr, PRTE_PROC_FLAG_IOF_COMPLETE);
-            PRTE_FLAG_SET(pptr, PRTE_PROC_FLAG_WAITPID);
-            if (!PRTE_FLAG_TEST(pptr, PRTE_PROC_FLAG_LOCAL)) {
-                /* the report walks prte_local_children, so a proc we never
-                 * got as far as adding would otherwise go unmentioned */
-                PMIX_RETAIN(pptr);
-                PRTE_FLAG_SET(pptr, PRTE_PROC_FLAG_LOCAL);
-                pmix_pointer_array_add(prte_local_children, pptr);
-            }
-            ++nlocal;
-        }
-        /* keep the count that the termination accounting compares against in
-         * step with the list we just completed - we abandoned the loop that
-         * normally maintains it */
-        jdata->num_local_procs = nlocal;
-    }
+    /* We have to report an error back to the HNP so we don't just hang:
+     * a child list we failed to build has no local children to report, or
+     * has them in whatever state they were unpacked in. Fail every proc
+     * that was ours to launch, which is what gives the HNP something to
+     * act on. */
+    fail_local_procs(jdata, rc);
     PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_NEVER_LAUNCHED);
     return rc;
 }

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -477,27 +477,50 @@ treatment.
 
 `prte_pmix_server_register_nspace()` hands its local PMIx server a
 `PMIX_PROC_INFO_ARRAY` for **every** proc of a job — rank, global rank,
-app rank, appnum, local and node rank, node id, hostname and, for the procs
-it hosts, cpuset and the locality string generated from it. Every daemon,
-for the whole job. That is a table proportional to the job on a node that
-will only ever run its own slice of it, and `prte_hostname_cutoff` — which
-drops one field of it above a thousand nodes — is the record of that wall
-having been met once already.
+app rank, appnum, local and node rank, node id, hostname, parent id and,
+for the procs it hosts, cpuset, the locality string generated from it, and
+the device distances. Every daemon, for the whole job. That is a table
+proportional to the job on a node that will only ever run its own slice of
+it, and `prte_hostname_cutoff` — which drops one field of it above a
+thousand nodes — is the record of that wall having been met once already.
 
-**Only the two location keys are withheld today, and for a different
-reason** (the cpuset scatter, below). `prte_pmix_lazy_procdata` — on by
-default — switches on the *deriving* half of the narrowing: when PMIx asks
-for one of the placement keys through the `direct_modex` upcall,
-`dmodex_req()` answers out of `jdata->procs[rank]` rather than going to the
-hosting daemon. The *withholding* half is **not** in: the per-proc loop
-here still emits an array for every proc of the job on every daemon, so the
-derivation almost never fires — everything the eager registration published
-is found locally first. Do not read the paragraphs below as a description
-of a daemon that publishes only its own procs; they describe the rules any
-such narrowing must keep to, and
-[`docs/todo.rst`](../../../docs/todo.rst) carries the measurement of what
-the derivation is worth as it stands and what the other half would cost.
-Four things about the derivation are load bearing:
+**What is withheld is withheld because this daemon does not have it, never
+to make the table smaller.** Three keys, on two grounds. The cpuset and the
+locality string come from the binding, which the launch message *scatters*,
+so a daemon holds one only for the procs it forks (below). The device
+distances are measured against the node's topology, and a daemon has only
+its own — `prte_util_decode_nidmap()` hands every node in its pool that one,
+"always default to homogeneous" — so computing them for a proc it does not
+host would measure its own hardware and label it as somebody else's.
+
+That last one is the same hazard *A daemon must not answer out of state it
+does not have* describes for the query arms, and it is worth knowing why the
+remedy differs. There, a key the daemon cannot answer is **relayed** to the
+master, which does hold the state. Here it is **refused**, even though the
+master likewise holds every node's real topology — because this is a
+`direct_modex` for one proc's data rather than a query, and an answer
+available only through the master would make the same `PMIx_Get` succeed or
+fail depending on which daemon the asker happens to be running under. A
+uniform `PMIX_ERR_NOT_SUPPORTED` is a better contract than one that is right
+on one node in the DVM.
+
+Everything else in the array is published for every proc on every daemon,
+and **that is deliberate**. Narrowing it — publishing only the procs a
+daemon hosts and deriving the rest — was tried, measured and closed; see
+[`docs/todo.rst`](../../../docs/todo.rst), which carries the reasoning and
+the numbers. The short version is that PMIx rebuilds most of the per-rank
+table from the node and proc maps whether PRRTE publishes the arrays or
+not, so the withholding removes a handful of keys and not the table. Do not
+read the paragraphs below as a description of a daemon that publishes only
+its own procs.
+
+The *deriving* half is unconditional and is what makes the three withheld
+keys answerable: when PMIx asks for a placement key through the
+`direct_modex` upcall, `dmodex_req()` answers out of `jdata->procs[rank]`
+rather than going to the hosting daemon. There is no MCA parameter for it
+— there was, and it controlled only the requesting side, which made "off"
+mean "ask the wire for the same answer". Four things about the derivation
+are load bearing:
 
 - **The key set is what PRRTE is the authority for, not what an app wants.**
   `derivable_key()` lists the placement and binding this DVM computed —
@@ -508,10 +531,22 @@ Four things about the derivation are load bearing:
 - **`derive_proc_data()` mirrors the per-proc section of
   `register_nspace()`.** A key added to one and not the other is a key
   that becomes a wire round trip (harmless, but a silent loss of the
-  point), or worse, one whose two spellings disagree. `PMIX_PARENT_ID` and
-  `PMIX_DEVICE_DISTANCES` are deliberately *not* derived: they are still
-  published by the daemon that hosts the proc, so a request for one falls
-  through to that daemon and is answered there.
+  point), or worse, one whose two spellings disagree. The two keys not in
+  the set are not in it for opposite reasons. `PMIX_PARENT_ID` needs no
+  derivation: every daemon publishes it for every proc, so a get for it is
+  answered locally and never reaches this path at all.
+  `PMIX_DEVICE_DISTANCES` *cannot* be derived — only the hosting daemon has
+  the topology to measure — so `dmodex_req()` refuses a request for a
+  remote proc's with `PMIX_ERR_NOT_SUPPORTED` rather than sending it on.
+  **Do not "fix" that by letting it fall through to the hosting daemon.**
+  That daemon publishes the key to its own PMIx server but cannot hand it
+  back: a direct modex reply carries only what the process itself PUT
+  (`PMIX_REMOTE` scope), so the asker pays a round trip to be told
+  `NOT_FOUND` — or parks until the proc commits something it may never
+  commit. `contrib/dockerswarm`'s `peerinfo` asks each of its peers for
+  the key and prints the status it got, so the refusal is asserted from
+  both ends: every off-node peer must come back `PMIX_ERR_NOT_SUPPORTED`,
+  and the daemon must be seen saying it refused.
 - **The answer is a packed blob of `pmix_kval_t`, not a bare success.**
   PMIx stores a modex reply itself, and for a specific rank it stores it
   under `PMIX_REMOTE` — which is where the re-satisfy after a reply then

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -558,9 +558,57 @@ in there with a *side effect* has to be idempotent, or it repeats at that
 rate. The process sets are the case: appending the registry entry again
 duplicated the pset in every query answer and took a reference on the job
 object that nothing would give back, so that append is now guarded by a
-lookup. Client registration is not, and does not need to be — the daemon
-that takes this second path hosts no procs of the job, so the loop that
-registers them does not run.
+lookup.
+
+### A daemon registers a namespace exactly once
+
+That is the invariant, and `dmodex_req()`'s wildcard arm is what enforces
+it. **Do not assume the caller that gets there hosts none of the job's
+procs.** PMIx sends the host a `PMIX_RANK_WILDCARD` `direct_modex` on two
+quite different grounds (`pmix_server_get.c`): it holds nothing at all for
+the namespace, *or* it holds the namespace but the **reserved** key asked
+for came back empty from its own store. Only the first is ours to fix. The
+second reaches the daemon that forked the asking client as readily as any
+other, because PRRTE does not publish every reserved job-level key — a
+`PMIx_Get` of `PMIX_NUM_SLOTS` from an ordinary app is enough, and on a
+one-node `prterun -n 2` it produced a *second* `register_nspace()` on the
+HNP with both of its own ranks coming back `PMIX_ERR_DUPLICATE_KEY`.
+
+Re-registering cannot help: it assembles and stores the identical data from
+the same job object, so a key that was not in it the first time is not in
+it now, and the client waits through the whole thing to be told
+`NOT_FOUND` anyway. So the arm answers `PMIX_ERR_NOT_FOUND` directly when
+the job is already registered, which is what `PRTE_JOB_NSPACE_REGISTERED`
+is for — the attribute that until now was written and never read.
+
+**It is set when the registration *completes*, not when we finish
+assembling it** (`_nspace_reg_done`, which is why the registration caddy
+holds a reference on the job). "Registered" has to mean *PMIx has our
+answer*; a request arriving mid-flight would otherwise be told `NOT_FOUND`
+about data that was seconds from landing. That window is instead the one
+place a namespace can still be registered twice, which is why the client
+loop keeps `PMIX_ERR_DUPLICATE_KEY` as a tolerated status — PMIx must
+refuse a second add of a rank (a duplicate entry in its rank list puts that
+list permanently past `nlocalprocs`, so `all_registered` is never set and
+every collective involving the namespace hangs) and reports it as a hard
+error.
+
+**None of this is the lazy-procdata derivation.** That answers a request for
+a *per-proc* placement key (`prte_pmix_server_derivable_key()` — rank,
+appnum, nodeid, hostname, cpuset, locality) out of the job object, and it is
+asked for with a *specific* rank, so it arrives at the proc-level arm below.
+It never comes through the wildcard arm, and the wildcard arm has nothing to
+derive.
+
+**A client we cannot register is a launch failure, not a log line.** Every
+other status from `PMIx_server_register_client` aborts the registration and
+returns an error. Forking a proc our own PMIx server will refuse at
+`PMIx_Init` only moves the failure to where nobody can read it — the
+application sees an obscure error some way downstream of a launch that
+appeared to succeed. Returning the error puts it where it belongs:
+`job_reg_join()` in `odls` fails this daemon's procs and activates
+`PRTE_JOB_STATE_NEVER_LAUNCHED`, and the tool's `PMIx_Spawn` returns
+`PMIX_ERR_JOB_FAILED_TO_LAUNCH`.
 
 ### A binding we were not sent is not a binding of "none"
 

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -539,20 +539,6 @@ void pmix_server_register_params(void)
                                       PMIX_MCA_BASE_VAR_TYPE_BOOL,
                                       &prte_pmix_server_globals.allow_client_clones);
 
-    /* Publish per-proc data only for the procs we host, and derive the rest on
-     * demand.  Every daemon registering a PMIx entry for every proc in the job
-     * is a table that grows with the job while the work on the node does not;
-     * the placement it describes is derivable here from the job object, so the
-     * direct-modex upcall can answer for a proc we do not host without any
-     * wire traffic.  See derive_proc_data() in pmix_server_fence.c. */
-    prte_pmix_server_globals.lazy_procdata = true;
-    (void) pmix_mca_base_var_register("prte", "pmix", NULL, "lazy_procdata",
-                                      "Publish per-proc data to the local PMIx server only "
-                                      "for procs this daemon hosts, deriving data for other "
-                                      "procs on demand",
-                                      PMIX_MCA_BASE_VAR_TYPE_BOOL,
-                                      &prte_pmix_server_globals.lazy_procdata);
-
     /* whether or not to drop a session-level tool rendezvous point */
     prte_pmix_server_globals.session_server = false;
     (void) pmix_mca_base_var_register("prte", "pmix", NULL, "session_server",

--- a/src/prted/pmix/pmix_server_fence.c
+++ b/src/prted/pmix/pmix_server_fence.c
@@ -274,6 +274,34 @@ static void dmodex_req(int sd, short args, void *cbdata)
         return;
     }
 
+    /* Device distances for a proc we do not host are not something this
+     * DVM can answer, and saying so is better than looking for them.
+     *
+     * They are computed against the topology of the node the proc runs on.
+     * PRRTE collects topologies at the HNP only - a daemon's node pool
+     * carries its own topology against every entry (prte_util_decode_nidmap,
+     * "always default to homogeneous") - so no daemon but the hosting one
+     * has the hardware to measure, and shipping every node's topology to
+     * every daemon to change that is a real cost for a question almost
+     * nobody asks about somebody else's process.
+     *
+     * NOT_SUPPORTED rather than NOT_FOUND: the key is not missing from a
+     * store that might yet fill, it is a question this runtime does not
+     * answer for a remote proc.  Without this the request would go out on
+     * the wire to the hosting daemon, which publishes the key to its own
+     * PMIx server but cannot hand it back - a direct modex reply carries
+     * only what the process itself PUT (PMIX_REMOTE scope) - so the asker
+     * would wait for a round trip and then be told NOT_FOUND anyway, or
+     * park until the proc commits something it may never commit. */
+    if (NULL != req->key && PMIx_Check_key(req->key, PMIX_DEVICE_DISTANCES)) {
+        pmix_output_verbose(2, prte_pmix_server_globals.output,
+                            "%s DMODX REQ FOR %s:%u DEVICE DISTANCES - NOT SUPPORTED",
+                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                            req->tproc.nspace, req->tproc.rank);
+        prc = PMIX_ERR_NOT_SUPPORTED;
+        goto callback;
+    }
+
     /* if they are asking about a specific proc, then fetch it */
     proct = (prte_proc_t *) pmix_pointer_array_get_item(jdata->procs, req->tproc.rank);
     if (NULL == proct) {
@@ -306,8 +334,7 @@ static void dmodex_req(int sd, short args, void *cbdata)
      * shrink - can still be said to have been placed where it was placed, and
      * that is an answer eager publication would have had in hand.  Requiring
      * a live daemon here would turn it into a failure. */
-    if (prte_pmix_server_globals.lazy_procdata && !refresh_cache &&
-        prte_pmix_server_derivable_key(req->key) &&
+    if (!refresh_cache && prte_pmix_server_derivable_key(req->key) &&
         /* ...but not a binding we do not hold.  The launch message scatters
          * the cpusets, so a NULL one on a proc we do not host means "never
          * sent", not "not bound", and answering either way would be a
@@ -429,11 +456,15 @@ callback:
 
 /* ---- deriving a remote proc's data instead of fetching it -------------
  *
- * With prte_pmix_server_globals.lazy_procdata set, register_nspace publishes
- * per-proc data only for the procs this daemon hosts.  Everything it would
- * have published about the others is still right here, in the job object the
- * launch message built, so a request for one of them is answered from local
- * memory rather than by asking the daemon that hosts it.
+ * A request for one of the placement keys is answered out of the job object
+ * the launch message built, rather than by asking the daemon that hosts the
+ * proc.  What reaches this path is what register_nspace could not publish -
+ * above all the binding, which the launch message scatters, so a daemon holds
+ * one only for the procs it forks.
+ *
+ * There is no switch for this.  Deriving what we can and asking the wire for
+ * the rest is simply what the daemon does; a knob would only offer a slower
+ * way to get the same answer.
  *
  * These are exactly the keys PRRTE is the *authority* for - the placement and
  * binding it decided when it mapped the job.  Anything else a proc holds was

--- a/src/prted/pmix/pmix_server_fence.c
+++ b/src/prted/pmix/pmix_server_fence.c
@@ -216,11 +216,33 @@ static void dmodex_req(int sd, short args, void *cbdata)
         return;
     }
     /* if this is a request for rank=WILDCARD, then they want the job-level data
-     * for this job. It was probably not stored locally because we aren't hosting
-     * any local procs. There is no need to request the data as we already have
+     * for this job.  There is no need to request the data as we already have
      * it - so just register the nspace so the local PMIx server gets it. The
-     * registration completes asynchronously */
+     * registration completes asynchronously.
+     *
+     * PMIx sends us this on two quite different grounds (pmix_server_get.c):
+     * it holds nothing at all for the namespace, or it holds the namespace
+     * but the RESERVED key asked for came back empty from its own store.
+     * Only the first is ours to fix.  If we have already registered this job
+     * with our PMIx server then it has everything we know, and assembling
+     * and registering the identical data a second time cannot produce a key
+     * that was not in it the first time - the client would wait through all
+     * of that to be told NOT_FOUND anyway.  Tell it now.
+     *
+     * A daemon registers a given namespace exactly once, and this is what
+     * makes that true: without the check, an ordinary PMIx_Get of a reserved
+     * job-level key PRRTE does not publish (PMIX_NUM_SLOTS, say) re-runs the
+     * whole registration - on the very daemon that forked the asking client,
+     * over procs it has already registered - once per such get. */
     if (PMIX_RANK_WILDCARD == req->tproc.rank) {
+        if (prte_get_attribute(&jdata->attributes, PRTE_JOB_NSPACE_REGISTERED,
+                               NULL, PMIX_BOOL)) {
+            pmix_output_verbose(2, prte_pmix_server_globals.output,
+                                "%s DMODX REQ FOR %s:WILDCARD - ALREADY REGISTERED",
+                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), req->tproc.nspace);
+            prc = PMIX_ERR_NOT_FOUND;
+            goto callback;
+        }
         /* ...but that registration is assembled from the job's map, and the
          * map is not always there.  It is created when the job is mapped and
          * released again the moment the job completes

--- a/src/prted/pmix/pmix_server_internal.h
+++ b/src/prted/pmix/pmix_server_internal.h
@@ -673,7 +673,6 @@ typedef struct {
      * them through the direct-modex upcall.  Registering every proc in the job
      * on every daemon costs a table that grows with the total process count on
      * a node that will run a fixed slice of it. */
-    bool lazy_procdata;
     pmix_list_t psets;
     pmix_list_t groups;
     /* assemblages formed by PMIx_Connect - see prte_pmix_server_connection_t.

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -68,6 +68,7 @@ typedef struct {
     pmix_op_cbfunc_t cbfunc;
     void *cbdata;
     pmix_status_t status;
+    prte_job_t *jdata;
 } prte_pmix_reg_caddy_t;
 static void regcon(prte_pmix_reg_caddy_t *p)
 {
@@ -76,11 +77,15 @@ static void regcon(prte_pmix_reg_caddy_t *p)
     p->cbfunc = NULL;
     p->cbdata = NULL;
     p->status = PMIX_SUCCESS;
+    p->jdata = NULL;
 }
 static void regdes(prte_pmix_reg_caddy_t *p)
 {
     if (NULL != p->pinfo) {
         PMIX_INFO_FREE(p->pinfo, p->ninfo);
+    }
+    if (NULL != p->jdata) {
+        PMIX_RELEASE(p->jdata);
     }
 }
 static PMIX_CLASS_INSTANCE(prte_pmix_reg_caddy_t, pmix_object_t, regcon, regdes);
@@ -94,6 +99,16 @@ static void _nspace_reg_done(int sd, short args, void *cbdata)
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
     PMIX_ACQUIRE_OBJECT(cd);
+
+    /* Mark the job registered only now that PMIx actually holds it.  This
+     * is what dmodex_req()'s wildcard arm reads to decide that a job-level
+     * key it is being asked for is one we do not have, rather than one we
+     * have not published yet - so it has to mean "PMIx has our answer",
+     * not "we have finished assembling it". */
+    if (PMIX_SUCCESS == cd->status && NULL != cd->jdata) {
+        prte_set_attribute(&cd->jdata->attributes, PRTE_JOB_NSPACE_REGISTERED,
+                           PRTE_ATTR_LOCAL, NULL, PMIX_BOOL);
+    }
 
     if (NULL != cd->cbfunc) {
         cd->cbfunc(cd->status, cd->cbdata);
@@ -147,10 +162,10 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
     uint32_t ui32, *ui32_ptr;
     pmix_data_array_t *devarray;
     uint32_t nodesize;
-    prte_job_t *parent = NULL;
     pmix_device_distance_t *distances;
     size_t ndist;
     pmix_topology_t topo;
+    prte_job_t *parent = NULL;
     pmix_data_array_t darray, lparray;
     bool flag, *fptr, newpset;
 
@@ -562,10 +577,10 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
             PMIX_INFO_LIST_ADD(ret, iarray, PMIX_PSET_NAME, tmp, PMIX_STRING);
             /* Have we already recorded this one?  This function is not
              * called once per job: the wildcard arm of dmodex_req() calls it
-             * again every time a client asks a daemon that hosts none of the
-             * job's procs for job-level data the local server does not hold,
-             * which is once per such get.  The info arrays below have to be
-             * rebuilt each time - that is what the caller wants - but the
+             * again for a job-level key the local server does not hold, on
+             * any daemon - including one hosting the job's procs - though
+             * only until that arm marks the job registered.  The info arrays
+             * below have to be rebuilt each time it does call us, but the
              * registry entry is a per-job fact, and appending it again both
              * duplicated the pset in every query answer and took a reference
              * on the job object that nothing would ever give back. */
@@ -840,10 +855,6 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
         PMIX_INFO_DESTRUCT(&devinfo[1]);
     }
 
-    /* mark the job as registered */
-    prte_set_attribute(&jdata->attributes, PRTE_JOB_NSPACE_REGISTERED, PRTE_ATTR_LOCAL, NULL,
-                       PMIX_BOOL);
-
     /* add the local procs, if they are defined */
     if (0 < (nmsize = pmix_list_get_size(&local_procs))) {
         pmix_proc_t *procs_tmp;
@@ -884,6 +895,10 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
     cd->ninfo = darray.size;
     cd->cbfunc = cbfunc;
     cd->cbdata = cbdata;
+    /* held so the completion can mark it registered - the callers that do
+     * not wait for us have no reason to keep the job alive for our sake */
+    PMIX_RETAIN(jdata);
+    cd->jdata = jdata;
     ret = PMIx_server_register_nspace(pproc.nspace, jdata->num_local_procs,
                                       cd->pinfo, cd->ninfo, regcbfunc, cd);
     if (PMIX_SUCCESS != ret) {
@@ -1275,11 +1290,6 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
     PMIX_INFO_LIST_RELEASE(ilist);
 
 
-    /* mark the job as registered */
-    prte_set_attribute(&jdata->attributes, PRTE_JOB_NSPACE_REGISTERED, PRTE_ATTR_LOCAL, NULL,
-                       PMIX_BOOL);
-
-
     /* register it */
     PMIX_INFO_LIST_CONVERT(ret, joblist, &darray);
     if (PMIX_SUCCESS != ret) {
@@ -1298,6 +1308,11 @@ int prte_pmix_server_register_tool(prte_pmix_server_req_t *cd,
     rcd->ninfo = darray.size;
     rcd->cbfunc = cbfunc;
     rcd->cbdata = cbdata;
+    /* marked registered by the completion, for the same reason as above:
+     * the flag has to mean PMIx holds this namespace, not that we finished
+     * describing it */
+    PMIX_RETAIN(jdata);
+    rcd->jdata = jdata;
     ret = PMIx_server_register_nspace(cd->target.nspace, 1,
                                       rcd->pinfo, rcd->ninfo,
                                       regcbfunc, rcd);

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -734,7 +734,26 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
                 }
                 PMIX_INFO_LIST_ADD(ret, pmap, PMIX_LOCALITY_STRING, tmp, PMIX_STRING);
                 free(tmp);
-                if (0 != prte_pmix_server_globals.generate_dist) {
+                /* Device distances, but only for a proc we host.
+                 *
+                 * These are computed against the topology of the node the
+                 * proc runs on, and a daemon does not have one for any node
+                 * but its own: PRRTE collects topologies at the HNP, and
+                 * prte_util_decode_nidmap() hands every node in a daemon's
+                 * pool a retained reference to that daemon's OWN topology,
+                 * "always default to homogeneous as that is the most common
+                 * scenario".  So computing this for a proc we do not host
+                 * measures our hardware and labels it as that proc's -
+                 * correct by accident on a homogeneous cluster and silently
+                 * wrong on any other.  (The HNP is the exception, holding
+                 * the real topology of every node, but answering there and
+                 * nowhere else is a worse contract than not answering.)
+                 *
+                 * A get for someone else's is refused with NOT_SUPPORTED by
+                 * dmodex_req(), rather than being left to fail as though the
+                 * data were merely missing. */
+                if (0 != prte_pmix_server_globals.generate_dist &&
+                    PRTE_PROC_MY_NAME->rank == node->daemon->name.rank) {
                     /* compute the device distances for this proc */
                     topo.topology = node->topology->topo;
                     devinfo[1].value.data.string = node->name;

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -263,16 +263,50 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
                         PMIX_LOAD_PROCID(&nm->name, pptr->name.nspace, pptr->name.rank);
                         pmix_list_append(&local_procs, &nm->super);
                         if (PMIX_CHECK_NSPACE(jdata->nspace, pptr->name.nspace)) {
-                            /* Go ahead and register this client.  The PMIx library
-                             * serializes registration requests, so this one is
-                             * ordered ahead of the register_nspace below however
-                             * long either takes - which is why neither has to be
-                             * waited for here, and why this one being fire-and-
-                             * forget does not race the namespace it belongs to. */
+                            /* Go ahead and register this client.  Handing it no
+                             * callback asks for the blocking form: PMIx runs the
+                             * registration on its own progress thread and returns
+                             * here when it is done, so the status below is the
+                             * registration's own and the rank is on record before
+                             * the register_nspace at the bottom tells PMIx how
+                             * many to expect. */
                             ret = PMIx_server_register_client(&pptr->name, uid, gid,
                                                               (void*)pptr, NULL, NULL);
+                            /* A rank we already hold is not a failure - it is
+                             * the state we wanted.  A daemon registers a given
+                             * namespace once (dmodex_req()'s wildcard arm is
+                             * what keeps that true), but "once" is not "once
+                             * successfully": the failure exit below abandons
+                             * this loop with the ranks ahead of it already
+                             * registered and the job never marked registered,
+                             * so a later wildcard get re-runs the whole
+                             * registration and meets every one of them again.
+                             * PMIx must refuse a second add of a rank - a
+                             * duplicate entry in its rank list puts that list
+                             * permanently past nlocalprocs, so all_registered
+                             * is never set and every collective involving the
+                             * namespace hangs - and reports it as a hard
+                             * error, so treating it as fatal here would fail a
+                             * registration that is in fact fine. */
+                            if (PMIX_ERR_DUPLICATE_KEY == ret) {
+                                ret = PMIX_SUCCESS;
+                            }
                             if (PMIX_SUCCESS != ret && PMIX_OPERATION_SUCCEEDED != ret) {
+                                /* Anything else means our own PMIx server will
+                                 * refuse this proc's PMIx_Init, so forking it
+                                 * would only move the failure to where nobody
+                                 * can read it: the application sees an obscure
+                                 * error some way downstream of a launch that
+                                 * appeared to succeed.  Fail the registration
+                                 * instead.  The launch path (job_reg_join, in
+                                 * odls) turns that into NEVER_LAUNCHED, which is
+                                 * what it is. */
                                 PMIX_ERROR_LOG(ret);
+                                PMIx_Argv_free(micro);
+                                micro = NULL;
+                                PMIX_INFO_LIST_RELEASE(info);
+                                rc = prte_pmix_convert_status(ret);
+                                goto errout;
                             }
                         }
                     }


### PR DESCRIPTION
Three defects found while investigating the `todo.rst` entry *"A client
registration that fails is logged and the launch continues"*. They are
separate commits and can be read independently.

### A client we cannot register was forked anyway

`register_nspace()` calls `PMIx_server_register_client` for each proc the
daemon is about to host and, on an error, logged it and carried on. The
proc was then forked into a PMIx server that will refuse its `PMIx_Init`,
so the user saw an obscure failure some way downstream of a launch that had
appeared to succeed.

Fixing that exposed a second gap on the path the error now takes: both
failure arms of `job_reg_join()` activated `PRTE_JOB_STATE_NEVER_LAUNCHED`
without first marking any proc as failed, so `failed_start()` retired
nothing and the HNP read the report as "nothing wrong here" — the job never
completed and the tool never returned. The proc-marking `REPORT_ERROR`
already did is now a function both arms call.

`PMIX_ERR_DUPLICATE_KEY` is tolerated rather than fatal, and it is
genuinely reachable: the new error exit abandons the loop with the ranks
ahead of it already registered.

### A namespace was re-registered once per unanswerable get

`PRTE_JOB_NSPACE_REGISTERED` was written by both registration paths and read
by nothing — its own `todo.rst` entry. Meanwhile `dmodex_req()`'s wildcard
arm re-ran the whole of `register_nspace()` every time PMIx surfaced a
job-level key its store could not answer, assembling and registering
identical data from the same job object. A key absent the first time was
absent again, and the client waited through all of it to be told
`NOT_FOUND` anyway.

The comment there claimed that arm is only reached by a daemon hosting none
of the job's procs. It is not: PMIx sends a wildcard `direct_modex` either
when it holds nothing for the namespace **or** when it holds the namespace
and a *reserved* key came back empty, and the second reaches the daemon that
forked the asking client. A `PMIx_Get` of `PMIX_NUM_SLOTS` from an ordinary
app is enough — on a one-node `prterun -n 2` it re-registered on the HNP
with both of its own ranks coming back `PMIX_ERR_DUPLICATE_KEY`.

The flag is now set when the registration *completes* rather than while it
is still being assembled, so that it means "PMIx has our answer" rather than
"we have finished describing it".

### Device distances for a remote proc were measured against the wrong node

They are computed against the topology of the node the proc runs on, and a
daemon has one only for its own: topologies are collected at the HNP, and
`prte_util_decode_nidmap()` hands every node in a daemon's pool a retained
reference to that daemon's own topology, defaulting to homogeneous. So a
daemon computing them for a proc it does not host measures its own hardware
and labels the answer with somebody else's rank — correct by accident on a
homogeneous cluster and silently wrong anywhere else.

They are now published only for the procs we host, and a request for anyone
else's is refused with `PMIX_ERR_NOT_SUPPORTED`. Falling through to the
hosting daemon would not help: it publishes the key to its own PMIx server
but cannot hand it back, because a direct modex reply carries only what the
process itself PUT.

The `prte_pmix_lazy_procdata` parameter goes with it. It gated only the
requesting side, so "off" meant fetching the same answer over the wire.

### Testing

`contrib/dockerswarm`'s `peerinfo` now asks each peer for the key and
reports the status, so the refusal is asserted from both ends. The path had
no coverage before this — nothing in the harness queried it, so the suite
was green either way.

- container build with `-Werror`: no warnings
- `make check`: 24 pass, 0 fail
- `peerinfo`, 8 ranks over 4 nodes: 48 remote lookups, all
  `PMIX_ERR_NOT_SUPPORTED`; 56/56 peer descriptions; 0 failures; no
  SELF/PEER mismatch
- daemon side: 6 `ANSWERED LOCALLY`, 29 device-distance refusals

Also corrected two figures in `contrib/dockerswarm/AGENTS.md` that the
measurements contradict: the derived-lookup count is 6, not 24 (24 is the
`DMODX REQ FOR` count one level down), and the refusal count is not stable
across runs, so the case asserts non-zero rather than a number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SK33fGo5qrFeRYmsHtVbb2
