### PR TITLE
Tell a fence's two operations apart, and give it a round number

### DIFF
--- a/contrib/dockerswarm/fencer.c
+++ b/contrib/dockerswarm/fencer.c
@@ -11,6 +11,14 @@
  * A PMIx client that does exactly one fence, either as a modex or as a pure
  * barrier, so a test can drive the two apart.
  *
+ * With --timeout N the fence carries a PMIX_TIMEOUT, so the controller ends
+ * it whether or not every contribution arrived; with --twice a second fence
+ * over the same participants follows, and it is the second one that is
+ * verified.  Together with the grpcomm_fence_delay_ms fault-injection knob
+ * those two reproduce a post-release straggler: one daemon's contribution is
+ * still climbing the tree when the deadline ends the fence, and the next
+ * fence over those participants must not inherit it.
+ *
  * This exists because PMIX_COLLECT_DATA is the only thing that distinguishes
  * them, and it is what the "auto" fence-movement selection reads.  No other
  * harness client makes that distinction visible: a job running `hostname`
@@ -26,22 +34,47 @@
 
 #include <pmix.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 int main(int argc, char **argv)
 {
     pmix_proc_t me, wild;
-    pmix_info_t info[1];
+    pmix_info_t info[2];
+    size_t ninfo = 0;
     pmix_value_t val;
     pmix_status_t rc;
-    bool collect = false;
+    bool collect = false, twice = false;
+    int timeout = 0, a;
     char key[PMIX_MAX_KEYLEN + 1];
 
     if (2 > argc || (0 != strcmp(argv[1], "collect") && 0 != strcmp(argv[1], "barrier"))) {
-        fprintf(stderr, "usage: fencer collect|barrier\n");
+        fprintf(stderr, "usage: fencer collect|barrier [--timeout N] [--twice]\n");
         return 2;
     }
     collect = (0 == strcmp(argv[1], "collect"));
+    for (a = 2; a < argc; a++) {
+        if (0 == strcmp(argv[a], "--timeout") && a + 1 < argc) {
+            /* Put a deadline on the fence, so the controller ends it whether
+             * or not every contribution has arrived.  That is what makes a
+             * straggler reachable: pair it with grpcomm_fence_delay_ms on one
+             * daemon and its contribution is still on the wire when the
+             * release lands. */
+            timeout = atoi(argv[++a]);
+        } else if (0 == strcmp(argv[a], "--twice")) {
+            /* Fence AGAIN over the same participants after the first one
+             * ended.  This is the assertion that matters for the round
+             * discriminator: a straggler from the first fence arrives with no
+             * tracker to join, and if nothing recognizes which round it
+             * belongs to it builds one that this second fence then finds -
+             * inheriting a contribution count and a bucket it never gathered,
+             * and converging early on the previous round's data. */
+            twice = true;
+        } else {
+            fprintf(stderr, "usage: fencer collect|barrier [--timeout N] [--twice]\n");
+            return 2;
+        }
+    }
 
     if (PMIX_SUCCESS != (rc = PMIx_Init(&me, NULL, 0))) {
         fprintf(stderr, "FENCER init failed %s\n", PMIx_Error_string(rc));
@@ -66,13 +99,56 @@ int main(int argc, char **argv)
     PMIX_LOAD_PROCID(&wild, me.nspace, PMIX_RANK_WILDCARD);
     if (collect) {
         bool t = true;
-        PMIX_INFO_LOAD(&info[0], PMIX_COLLECT_DATA, &t, PMIX_BOOL);
-        rc = PMIx_Fence(&wild, 1, info, 1);
-    } else {
-        rc = PMIx_Fence(&wild, 1, NULL, 0);
+        PMIX_INFO_LOAD(&info[ninfo++], PMIX_COLLECT_DATA, &t, PMIX_BOOL);
     }
+    if (0 < timeout) {
+        PMIX_INFO_LOAD(&info[ninfo++], PMIX_TIMEOUT, &timeout, PMIX_INT);
+    }
+    rc = PMIx_Fence(&wild, 1, ninfo ? info : NULL, ninfo);
 
     printf("FENCER %s rank %u rc %s\n", argv[1], me.rank, PMIx_Error_string(rc));
+
+    /* The second fence.  Its result is reported separately and deliberately
+     * is NOT folded into the first one's: the first is expected to fail when
+     * a deadline ended it, and what is being asserted here is that the next
+     * fence over the same participants is unaffected by that. */
+    if (twice) {
+        pmix_status_t rc2;
+        uint32_t second = me.rank + 1000;
+
+        /* Publish something NEW before the second fence, and this is the
+         * whole point of the exercise rather than a detail.
+         *
+         * A straggler from the first round carries whatever that round's
+         * contribution held.  If both fences carried the same bytes, a second
+         * fence that wrongly counted the straggler in place of this round's
+         * real contribution would still end up with a complete and correct
+         * modex - the defect would happen and be invisible.  Giving the second
+         * round data the first one never had is what makes the difference
+         * observable: absorb the straggler and this key is missing. */
+        snprintf(key, sizeof(key), "fencer.second.%u", me.rank);
+        PMIX_VALUE_LOAD(&val, &second, PMIX_UINT32);
+        rc2 = PMIx_Put(PMIX_GLOBAL, key, &val);
+        if (PMIX_SUCCESS == rc2) {
+            rc2 = PMIx_Commit();
+        }
+        if (PMIX_SUCCESS != rc2) {
+            fprintf(stderr, "FENCER second put/commit failed %s\n",
+                    PMIx_Error_string(rc2));
+            PMIx_Finalize(NULL, 0);
+            return 1;
+        }
+
+        ninfo = 0;
+        if (collect) {
+            bool t = true;
+            PMIX_INFO_LOAD(&info[ninfo++], PMIX_COLLECT_DATA, &t, PMIX_BOOL);
+        }
+        rc2 = PMIx_Fence(&wild, 1, ninfo ? info : NULL, ninfo);
+        printf("FENCER second rank %u rc %s\n", me.rank, PMIx_Error_string(rc2));
+        /* verify against the SECOND fence, which is the one under test */
+        rc = rc2;
+    }
 
     /* After a collect fence every rank must be able to read every OTHER
      * rank's contribution, and that is the only assertion here that actually
@@ -84,6 +160,7 @@ int main(int argc, char **argv)
         pmix_value_t *got = NULL;
         uint32_t universe = 0, r;
         int found = 0, missing = 0;
+        pmix_status_t rc2nd;
 
         PMIX_LOAD_PROCID(&peer, me.nspace, PMIX_RANK_WILDCARD);
         if (PMIX_SUCCESS == PMIx_Get(&peer, PMIX_JOB_SIZE, NULL, 0, &got) &&
@@ -102,6 +179,39 @@ int main(int argc, char **argv)
                 uint32_t v = 0;
                 PMIx_Value_get_number(got, &v, PMIX_UINT32);
                 if (v == r) {
+                    found++;
+                } else {
+                    missing++;
+                }
+                PMIX_VALUE_RELEASE(got);
+            } else {
+                missing++;
+            }
+            if (!twice) {
+                continue;
+            }
+            /* The key that only the second round carried - see the note
+             * where it is published.
+             *
+             * PMIX_OPTIONAL, and that is essential rather than tidy: without
+             * it a PMIx_Get for a key the fence did not deliver falls through
+             * to a direct modex and fetches it from the owning daemon anyway.
+             * The value turns up either way and the check proves nothing.
+             * OPTIONAL says "answer from what this client already has", which
+             * is exactly the question - did the collective deliver it? */
+            {
+                pmix_info_t opt[1];
+                bool t = true;
+                PMIX_INFO_LOAD(&opt[0], PMIX_OPTIONAL, &t, PMIX_BOOL);
+                snprintf(key, sizeof(key), "fencer.second.%u", r);
+                got = NULL;
+                rc2nd = PMIx_Get(&peer, key, opt, 1, &got);
+                PMIX_INFO_DESTRUCT(&opt[0]);
+            }
+            if (PMIX_SUCCESS == rc2nd && NULL != got) {
+                uint32_t v = 0;
+                PMIx_Value_get_number(got, &v, PMIX_UINT32);
+                if (v == r + 1000) {
                     found++;
                 } else {
                     missing++;

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -4599,6 +4599,72 @@ test_grpcomm() {
 
     test_grpcomm_invite
     test_grpcomm_ft
+    test_fence_straggler
+}
+
+test_fence_straggler() {
+    local out n
+
+    banner "grpcomm: a straggler from an aborted fence is not the next round"
+    # A fence signature is only its participant list, so nothing about a
+    # contribution says which round it belongs to.  That costs nothing while a
+    # daemon converges only once everything it expects has arrived -- but
+    # abort_fence_op() ends a fence early, on a PMIX_TIMEOUT or a lost
+    # participant, and a contribution still climbing the tree then reaches a
+    # daemon whose tracker the release already retired.  Without a round
+    # number fence_recv() builds a fresh tracker for it, and the NEXT fence
+    # over those same participants finds that tracker, inherits its nreported
+    # and its bucket, and can converge early carrying the previous round's
+    # data.
+    #
+    # That window is a timing accident no test can arrange from outside, which
+    # is why grpcomm_fence_delay_ms exists and why it is compiled in rather
+    # than hidden behind a debug build.  Daemon vpid 2 holds its contribution
+    # for 8s; the fence carries a 3s deadline, so the controller ends it
+    # without that daemon; the held contribution then lands at ~8s, by which
+    # time the SECOND fence is in flight -- exactly on top of the tracker it
+    # must not join.
+    cleanup_swarm
+    if ! RUN "test -x $FENCER"; then
+        skp "fencer client not installed -- re-run ./build.sh"
+        return
+    fi
+    if ! prted_dvm_start_mca 'node1:1,node2:1,node3:1,node4:1' \
+            '--prtemca grpcomm_fence_delay_ms 8000 --prtemca grpcomm_fence_delay_vpid 2'; then
+        bad "could not start a DVM for the fence straggler test"
+        cleanup_swarm
+        return
+    fi
+
+    out=$(PRUN "--host node1:1,node2:1,node3:1,node4:1 -n 4 --map-by node $FENCER collect --timeout 3 --twice" 2>&1)
+
+    # First: the window has to have actually opened.  If the first fence
+    # SUCCEEDED then nothing was aborted, no contribution was left in flight,
+    # and everything below would pass without testing anything at all.
+    n=$(echo "$out" | grep -c 'FENCER collect rank .* rc PMIX_ERR_TIMEOUT')
+    [ "$n" = 4 ] \
+        && ok "the deadline ended the first fence without the held-back daemon" \
+        || bad "$n of 4 ranks saw the first fence time out -- the straggler window never opened: $(echo "$out" | grep 'FENCER collect' | tr '\n' ' ' | tail -c 250)"
+
+    # ...and now the assertion this exists for.
+    n=$(echo "$out" | grep -c 'FENCER second rank .* rc PMIX_SUCCESS')
+    [ "$n" = 4 ] \
+        && ok "...and the next fence over the same participants completed" \
+        || bad "$n of 4 ranks completed the second fence: $(echo "$out" | grep 'FENCER second' | tr '\n' ' ' | tail -c 250)"
+
+    # Converging is not enough: a fence that inherited the previous round's
+    # bucket converges too, and answers with data it never gathered.
+    n=$(echo "$out" | grep -c 'peers-bad 0')
+    [ "$n" = 4 ] \
+        && ok "...carrying every peer's contribution, not the aborted round's" \
+        || bad "$n of 4 ranks got a complete modex from the second fence: $(echo "$out" | grep 'peers-' | tr '\n' ' ' | tail -c 250)"
+
+    RUN 'pgrep -x prte' >/dev/null 2>&1 \
+        && ok "...and the DVM survived the aborted fence" \
+        || bad "the HNP died over the aborted fence"
+
+    RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    cleanup_swarm
 }
 
 # A group formed by INVITATION, asking for a context id.

--- a/docs/plans/scalable_collectives/scalable-collectives.rst
+++ b/docs/plans/scalable_collectives/scalable-collectives.rst
@@ -1315,6 +1315,25 @@ when the movements were written are true now:
   ``MCA_BTL_FLAGS_SINGLE_ADD_PROCS``, and remote procs materialise on first
   use.  Exactly one non-optional reserved key names an off-node proc, and
   PMIx derives it and its neighbours from the node and proc maps.
+* **The direct-modex path has now been seen repairing an incomplete fence,
+  accidentally and under controlled conditions.**  While building the fence
+  straggler regression test (2026-08-31), a deliberately broken second fence
+  failed to deliver one daemon's contribution to the other three.  With an
+  ordinary ``PMIx_Get`` every rank read every peer's key back and reported a
+  complete modex; with ``PMIX_OPTIONAL`` on the same Get, in the same build
+  and the same workload, three of four ranks reported the key missing.  The
+  fence had genuinely lost it, and the on-demand resolution fetched it
+  correctly without the application noticing.
+
+  That is a narrow demonstration - four ranks, one key, the owning daemon
+  alive and its data committed - and it says nothing about cost.  But it is
+  direct evidence for the thing Level 2 depends on: that a fence which does
+  not deliver everything is *recoverable* rather than fatal, which is exactly
+  the failure class ``answer_from_job()`` closed.  It also means any test
+  asserting that a collective delivered something must use ``PMIX_OPTIONAL``,
+  or it is testing the runtime's ability to find the data by any means rather
+  than the collective's.
+
 * The crossover has been measured, and it favours on-demand once the per-rank
   contribution is kilobytes rather than tens of bytes — and the win grows with
   ``N``, because collecting is ``O(N)`` a daemon while resolving is
@@ -1882,10 +1901,30 @@ Revised after the sweep, which moved two items and deleted one.
    the enabling step for the two-radix release and for any exchange schedule
    that comes later.
 #. **Land the fence sequence number standalone**, on tree-only code, and
-   settle its elastic-join rule (see below).  The retire-before-deliver half
-   is already merged as ``0d9dde1c8a``.  Cheap, reviewable in isolation, and it
-   takes the defect that killed the movements off the critical path of
-   anything that comes later.
+   settle its elastic-join rule (see below).  **DONE.**  Each daemon now keeps,
+   per signature, the number of the next fence over it — one past the last
+   generation released here — stamps every contribution with it, and drops a
+   contribution stamped below what it expects.  The screen runs *before*
+   ``get_tracker()``: building a tracker for a straggler and then discarding
+   the message would leave exactly the wreck the mechanism exists to prevent.
+   The retire-before-deliver half was already merged as ``0d9dde1c8a``.
+
+   **The elastic-join rule is settled, and deriving the count locally is not
+   enough.**  A daemon added by a grow has released none of the earlier rounds;
+   if it stamped 0, every daemon that had been present would drop its
+   contribution as ancient and the fence would hang — the very failure the
+   number exists to prevent.  So a daemon with no entry stamps a distinct
+   ``UNKNOWN`` rather than 0, which is silence rather than a claim about a
+   round and is accepted into whatever round is current; and the release
+   carries the generation it ends, which the recipient **adopts** rather than
+   increments.  That is what puts a joiner in step after its first fence
+   instead of leaving it permanently one behind, and it is why the number is
+   carried in both directions and checked on arrival — the robustness this
+   document already noted in Slurm's ``kvs_seq``.
+
+   The memo is bounded.  Evicting an entry is a graceful loss: that signature
+   returns to the pre-generation behaviour, where a straggler and a new round
+   are indistinguishable.
 #. **Hold the radix and the pipelined release.**  Both target the byte term,
    which does not dominate until ~140 KB of total modex, and the radix half is
    now measured as neutral-to-harmful.  Chunking ``xcast`` is still right for

--- a/docs/plans/scalable_collectives/scalable-collectives.rst
+++ b/docs/plans/scalable_collectives/scalable-collectives.rst
@@ -1847,12 +1847,23 @@ What to do, and in what order
 Revised after the sweep, which moved two items and deleted one.
 
 #. **Make the commit a true delta, and give shmem3 delta segments with
-   search-back.**  One piece of work in openpmix, against openpmix#4087: the
-   delta commit is the trigger condition the ``shmem3`` comment already names
-   for needing search-back, and it is what flattens the transfer as well as
-   the storage.  It turns a run of repeated modex fences from ``O(K^2)`` into
-   ``O(K)`` — 2.1x at eight fences, 3.5x at twenty.  It does **not** reduce
-   the cost of a single collecting fence; see the caveat above.
+   search-back.**  **DONE**, and in openpmix rather than here, as this entry
+   predicted: ``c784d9b81`` contributes only what changed to a collecting
+   fence, ``bd52187a9`` screens the contribution's flag byte and names the
+   delta marker, and the shmem3 generation chain followed (``7790e0f08``,
+   ``c3c56a394``).  Key deletion arrived with it (``21bdfcdb1``,
+   ``0062e188c``), and the design is written up on that side (``111fac636``,
+   openpmix#4162).
+
+   It turns a run of repeated modex fences from ``O(K^2)`` into ``O(K)``
+   — 2.1x at eight fences, 3.5x at twenty.  It does **not** reduce the cost
+   of a single collecting fence; see the caveat above.
+
+   One consequence lands back on this side, and it is why the item below is
+   worded the way it is: **a zero-byte contribution to an allgather is now
+   ordinary**.  A participant with nothing new to say contributes nothing at
+   all, so any rule that read the operation off the payload would now misread
+   the common case rather than a corner one.
 #. **Make the first fence cheaper**, which is a separate lever and reaches the
    case a single-collective job actually pays.  ``shmem3`` builds its
    in-segment hash at ~35 ns a byte against ``hash``'s ~14 for the same data;
@@ -1863,10 +1874,13 @@ Revised after the sweep, which moved two items and deleted one.
    is a one-parameter change that cuts the fence cost 4.3x at 32 daemons.  It
    is not free — it gives up the cheap post-fence ``PMIx_Get`` that ``shmem3``
    is buying — so it is a knob to characterise, not a default to change.
-#. **Decide the COLLECT_DATA-as-commit-barrier question.**  The only item
-   that attacks the dominant term for jobs below roughly a thousand ranks, and
-   the only one with an order-of-magnitude story rather than a constant-factor
-   one.  It is a policy call, not a measurement.
+#. **Decide the COLLECT_DATA-as-commit-barrier question.**  **DECIDED, and in
+   the negative** — see "The directive names the operation" below.
+   ``COLLECT_DATA`` means collect: a fence that asked for the data delivers
+   it, and the certification reading is not taken.  What the decision produced
+   instead is that the two operations are now told apart in the code, which is
+   the enabling step for the two-radix release and for any exchange schedule
+   that comes later.
 #. **Land the fence sequence number standalone**, on tree-only code, and
    settle its elastic-join rule (see below).  The retire-before-deliver half
    is already merged as ``0d9dde1c8a``.  Cheap, reviewable in isolation, and it
@@ -1882,6 +1896,71 @@ Revised after the sweep, which moved two items and deleted one.
    ``alpha`` and ``beta`` constants that a single-host container swarm cannot
    supply — now demonstrated rather than asserted — and 2847 lines have
    already been spent on that bet once.
+
+The directive names the operation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``COLLECT_DATA`` question above was settled in 2026-08 and settled
+plainly: **the directive names the operation, and nothing else may.**
+``PMIX_COLLECT_DATA`` false or absent is a **barrier**; true is an
+**allgather**, and it stays an allgather even when some participants
+contribute zero bytes.
+
+That closes the certification reading this document put on the table.  A fence
+that asked for the data delivers the data; PRRTE does not reinterpret the
+directive into a commit barrier and leave ``PMIx_Get`` to fetch on demand.
+The lazy-delivery idea is not refuted by anything measured — it remains the
+only lever with an order-of-magnitude story — but it changes what a
+long-standing interface promises, and that is not a trade to make silently in
+the runtime underneath it.
+
+**Why the payload can never be the discriminator**, which is the part worth
+carrying forward.  The operation must be the same at every participant or the
+collective cannot converge: a fence has no originator, so every daemon has to
+reach the same answer independently, and a daemon that decided "barrier" while
+its peer decided "allgather" is the hang that withdrew the lateral movements.
+``PMIX_COLLECT_DATA`` is safe because it is a property of the *call* — every
+participant passes the same value, and PMIx has already forced the local
+participants of each daemon to agree before the upcall, refusing the fence
+locally with ``PMIX_COLLECT_INVALID`` if they do not.  The payload is a
+property of what the local procs happened to publish, and varies by daemon.
+Since the delta commit landed it varies all the way to nothing, so the naive
+rule would not merely be fragile, it would misfire on the second fence of
+every ordinary job.
+
+**What it bought immediately.**  A barrier now has no data path at all.  PMIx
+builds a blob for one — a lone ``PMIX_COLLECT_NO`` flag byte, compressed and
+wrapped — and PRRTE used to roll one of those up the tree from every daemon
+and broadcast the concatenation of all of them back down to everybody.  At ten
+thousand daemons that is ten thousand little blobs gathered and re-broadcast
+to say, collectively, nothing.  They are now dropped where they are built and
+nothing crosses the wire; PMIx in turn skips its store outright, which a
+present-but-empty payload does not let it do.
+
+**And it re-opens the two-radix release as a buildable thing.**  The 16x that
+"Separating the barrier from the modex" costed out needs the rollup and the
+release to run at different radices, and the release to be selected per
+operation.  Nothing could select per operation while the code could not tell
+the operations apart.  Now it can, on the tracker, from the first contribution
+onward.
+
+**One check became load-bearing in the process.**  PMIx compares a
+collect-flag byte per contribution inside ``store_modex`` and raises
+``collection-mismatch`` when servers disagree.  A barrier no longer puts
+anything on the wire for that comparison to see, so PRRTE has to catch the
+disagreement itself — it does, at the rollup, with a ``show_help`` and a
+sticky ``PMIX_ERR_INVALID_ARG`` that the release carries back to every
+participant.  Note that this is a *better* place to catch it than PMIx's: the
+rollup sees the disagreement while the fence is still in flight, rather than
+after a bucket has been assembled from contributions that meant different
+things.
+
+**Deliberately not done: a separate barrier entry point.**  It was considered.
+The two operations share the signature, the tracker, the rollup, the recovery
+restart, the epoch stamping, the timeout guard and the fault handler; the only
+difference is whether a payload rides along, which is three gates.  Splitting
+would fork several hundred lines of subtle recovery machinery to avoid them,
+and that machinery is exactly the part where a second copy would rot.
 
 Verification
 ------------

--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -175,39 +175,6 @@ with that blast radius has to be asked for by the run that wants it.  An
 older ``prte.conf`` carrying the keys still parses: they are unknown keys
 now, and unknown keys are ignored.
 
-**A fence cannot tell a post-release straggler from the next round.**  A
-fence signature is only its participant list, so nothing on the
-``PRTE_RML_TAG_FENCE`` wire says which *round* a contribution belongs to.
-That is invisible in the normal flow — a daemon converges only once every
-contribution it expects has arrived, so nothing can arrive afterwards — but
-the controller also ends a fence early, on a ``PMIX_TIMEOUT`` and on a
-participant lost to a failed daemon (``abort_fence_op()``,
-``src/grpcomm/grpcomm_fence.c``).  A contribution still climbing the tree
-then lands on a daemon that has already retired its tracker, and
-``fence_recv()`` builds a fresh one for it.  The next fence over the same
-participants finds that tracker, inherits its ``nreported`` and its bucket,
-and can converge early carrying the previous round's data.
-
-The group collective solves the same problem with ``completed_group_ops``, a
-bounded memo of released operations that ``grp_recv`` consults, and that fix
-**cannot** be copied here.  A group is keyed by ``groupID`` plus operation
-and ``group()`` forgets the memo entry when a local client starts one; a
-daemon relaying a fence for its subtree has no local client, so the memo
-would never be forgotten there and the *next* fence's legitimate
-contribution would be dropped — a hang in place of a wrong answer.  On a
-pure relay the two are genuinely indistinguishable without a round
-discriminator on the wire, and a fence has no originator to assign one: this
-is the same "every participant must reach the same answer independently"
-problem that the withdrawn lateral fence ran into
-(``src/grpcomm/AGENTS.md``).
-
-What would work is a per-signature release count: each daemon counts the
-releases it has seen for a signature, stamps its contributions with that
-count, and drops a contribution stamped below its own — the recovery epoch's
-mechanism, scoped to a signature and driven by releases rather than by
-failures.  That is a wire change plus a memo that holds a counter, and it
-needs the dockerswarm harness to validate, so it has not been attempted.
-
 **A connected job's teardown costs one DVM-wide broadcast per process.**
 `PMIx_Connect` obliges the host to tell an assemblage about every member
 that leaves without disconnecting first, and PRRTE keeps that promise in

--- a/src/grpcomm/AGENTS.md
+++ b/src/grpcomm/AGENTS.md
@@ -600,15 +600,35 @@ The rules, and each earns its place:
   expect is dropped there, deliberately ahead of building anything: creating
   a tracker and then discarding the message would leave exactly the wreck the
   mechanism exists to prevent.
-- **`PRTE_GRPCOMM_FENCE_GEN_UNKNOWN` is silence, not round zero**, and it is
-  the load-bearing case.  A daemon grown into the DVM after the job started
-  has released none of the earlier rounds; if it stamped 0 every daemon that
-  had been present would drop its contribution as ancient and the fence would
-  hang — precisely what the generation exists to prevent.  So it says nothing,
-  is accepted into the current round, and adopts the true number from the
-  release.  Deriving the count locally is *not* sufficient on its own, which
-  is why it is checked on arrival rather than only counted; Slurm's `kvs_seq`
-  carries it in both directions for the same reason.
+- **The counter has to bootstrap, and that means round 0 must be a real
+  round.**  A daemon present since the DVM started takes "no entry for this
+  signature" as round 0 and stamps 0.  Without that nothing ever establishes
+  a first round: every contribution is stamped "unknown", nothing is ever
+  recognized as stale, and the mechanism is **inert** — which is exactly what
+  the first version of this did, and it passed every unit test while doing
+  nothing, because the tests drove the counter directly instead of through
+  the path that has to start it.
+
+- **`PRTE_GRPCOMM_FENCE_GEN_UNKNOWN` is for a daemon a grow added, and only
+  for one.**  It has released none of the earlier rounds, so it cannot claim
+  0 — every daemon that has been present is past it and would drop a 0 as
+  ancient, hanging the fence.  It says it does not know instead, which a
+  receiver takes into whatever round is current.  Safe because a joiner has
+  no earlier round over that signature to have straggled from, so its first
+  contribution cannot be one: the window is **one contribution per signature
+  per joiner**, and after its first release it holds a real number.
+
+- **Which of the two a daemon is, it is told rather than derives**
+  (`prte_grpcomm_fence_note_join()`), on the first wireup it receives, and
+  never revised afterwards — a later wireup describes a DVM it is already
+  part of.  What travels is a **flag, not a count**, and that is the whole
+  reason it works: a count would be stale on arrival, because the master goes
+  on answering fences over other signatures while the grow completes and
+  there is no moment at which a number handed over is still true.  A flag is
+  true exactly as long as it is true.  Deriving the count locally is not
+  sufficient on its own either, which is why it is checked on arrival rather
+  than only counted; Slurm's `kvs_seq` carries it in both directions for the
+  same reason.
 - **The memo is bounded** (`PRTE_GRPCOMM_FENCE_MEMO_MAX`).  Eviction is a
   graceful loss: that signature returns to the pre-generation behaviour, where
   a straggler and a new round are indistinguishable.  It does not corrupt
@@ -618,6 +638,35 @@ The rules, and each earns its place:
 The other half of this was already in place: `0d9dde1c8a` retires the tracker
 *before* delivering, at both sites, because a client may fence again over the
 same participants the moment the callback returns.
+
+**Reproducing the race.**  The window is a timing accident no test can
+arrange from outside, so `grpcomm_fence_delay_ms` (with
+`grpcomm_fence_delay_vpid`) holds one daemon's own contribution back.  Paired
+with a `PMIX_TIMEOUT` on the fence, the controller ends the round without
+that daemon and the held contribution lands afterwards — the straggler.  The
+knob is **compiled in always**, deliberately: a race hook that exists only
+under `PRTE_ENABLE_DEBUG` cannot reproduce a race on the build that shows it.
+`contrib/dockerswarm`'s *"a straggler from an aborted fence is not the next
+round"* case drives it, and it has been watched failing with the drop removed
+— a regression test for a race that has never been red proves nothing.
+
+**A test that asserts a collective *delivered* something must use
+`PMIX_OPTIONAL` on the readback.**  Without it a `PMIx_Get` for a key the
+fence did not carry falls through to a direct modex and fetches it from the
+owning daemon anyway; the value turns up and the assertion proves nothing.
+That cost two full build-and-run cycles of false green here.  (It is also a
+neat demonstration that the on-demand path works: the fence had genuinely
+lost the key and the application never noticed.)
+
+**Still open: the early contribution.**  `PRTE_RML_TAG_FENCE_RELEASE` is not
+in `xcast`'s `process_first` set, so a daemon forwards a release to its
+children *before* processing it itself.  A child can therefore be released,
+start the next round, and have its contribution reach the parent while the
+parent is still in the previous one.  Dropping is safe there but adopting the
+higher number onto the live tracker is **not** — it relabels a tracker whose
+bucket holds the previous round's data.  Handling that properly means keying
+trackers by `(signature, generation)` rather than by signature alone, which is
+the same identity a lateral movement would need.
 
 **A release with no local callback still has data to free.** A daemon
 holding a tracker only because it relayed for its subtree has no `cbfunc`

--- a/src/grpcomm/AGENTS.md
+++ b/src/grpcomm/AGENTS.md
@@ -566,33 +566,58 @@ gathers the *local* contributions, then deletes it the instant the request
 is handed to the host — deliberately, so a late host answer cannot reach a
 tracker it already released.
 
-**A contribution can outlive the release that ended its fence, and nothing
-here can tell that from the next round.**  A fence signature is only its
-participant list — no round, no sequence number, nothing on the wire that
-distinguishes one fence over a set of procs from the next.  In the normal
-flow that costs nothing, because a daemon converges only when everything it
-expects has arrived, so nothing *can* arrive afterwards.  But
-`abort_fence_op()` ends a fence early — on a `PMIX_TIMEOUT`, and on a
-participant lost to a failed daemon — and a contribution still climbing the
-tree then reaches a daemon whose tracker the release already retired.
-`fence_recv()` builds a new tracker for it, and the next fence over those
-same participants *finds* that tracker, inherits its `nreported` and its
-bucket, and can converge early carrying the previous round's data.
+**A contribution can outlive the release that ended its fence, and a
+generation on the wire is what tells that from the next round.**  A fence
+signature is only its participant list, so nothing about a contribution says
+which round it belongs to.  In the normal flow that costs nothing, because a
+daemon converges only when everything it expects has arrived, so nothing
+*can* arrive afterwards.  But `abort_fence_op()` ends a fence early — on a
+`PMIX_TIMEOUT`, and on a participant lost to a failed daemon — and a
+contribution still climbing the tree then reaches a daemon whose tracker the
+release already retired.  Without a round number `fence_recv()` builds a new
+tracker for it, and the next fence over those same participants *finds* that
+tracker, inherits its `nreported` and its bucket, and converges early
+carrying the previous round's data.
 
-**Do not fix this by copying `completed_group_ops`.**  The group memo works
-because a group is keyed by `groupID` + operation and `group()` drops the
-memo entry when a local client starts one.  A daemon relaying a fence for
-its subtree has no local client and would never drop the entry, so the next
-fence's legitimate contribution would be discarded — a hang, which is worse
-than the wrong answer it was meant to prevent.  On a pure relay a straggler
-and a new round are genuinely the same message, and a fence has no
-originator to stamp a round id: this is the same "every participant must
-reach the same answer independently" problem the withdrawn lateral fence
-ran into.  What would work is a per-signature *release count* — each daemon
-counts releases seen for a signature, stamps contributions with it, drops
-anything stamped lower — which is the recovery epoch's mechanism scoped to a
-signature.  That is a wire change and needs the dockerswarm harness; see
-[`docs/todo.rst`](../../docs/todo.rst).
+**It is a counter, not a memo, and that is why `completed_group_ops` could
+not be copied.**  The group memo works because a group is keyed by `groupID`
++ operation and `group()` drops the entry when a local client starts one.  A
+daemon relaying a fence for its subtree has no local client and would never
+drop it, so the next fence's legitimate contribution would be discarded — a
+hang, worse than the wrong answer it was meant to prevent.  What works is a
+per-signature *release count*: `prte_grpcomm_globals.fence_generations` holds
+one `prte_grpcomm_fence_memo_t` per signature giving the number of the **next**
+fence over it, one past the last released here.
+
+The rules, and each earns its place:
+
+- **The count is driven by releases**, and `prte_grpcomm_fence_gen_record()`
+  **adopts** the released generation rather than incrementing.
+- **Every contribution is stamped** with its tracker's generation, and the
+  **release carries one too** — up *and* down, so a daemon can learn a number
+  it never counted.
+- **`fence_recv()` screens before `get_tracker()`.**  A stamp below what we
+  expect is dropped there, deliberately ahead of building anything: creating
+  a tracker and then discarding the message would leave exactly the wreck the
+  mechanism exists to prevent.
+- **`PRTE_GRPCOMM_FENCE_GEN_UNKNOWN` is silence, not round zero**, and it is
+  the load-bearing case.  A daemon grown into the DVM after the job started
+  has released none of the earlier rounds; if it stamped 0 every daemon that
+  had been present would drop its contribution as ancient and the fence would
+  hang — precisely what the generation exists to prevent.  So it says nothing,
+  is accepted into the current round, and adopts the true number from the
+  release.  Deriving the count locally is *not* sufficient on its own, which
+  is why it is checked on arrival rather than only counted; Slurm's `kvs_seq`
+  carries it in both directions for the same reason.
+- **The memo is bounded** (`PRTE_GRPCOMM_FENCE_MEMO_MAX`).  Eviction is a
+  graceful loss: that signature returns to the pre-generation behaviour, where
+  a straggler and a new round are indistinguishable.  It does not corrupt
+  anything, and an entry only has to outlive its own fence's in-flight
+  messages.
+
+The other half of this was already in place: `0d9dde1c8a` retires the tracker
+*before* delivering, at both sites, because a client may fence again over the
+same participants the moment the callback returns.
 
 **A release with no local callback still has data to free.** A daemon
 holding a tracker only because it relayed for its subtree has no `cbfunc`

--- a/src/grpcomm/AGENTS.md
+++ b/src/grpcomm/AGENTS.md
@@ -510,18 +510,24 @@ is the hook the elastic DVM-shrink path uses.
 thread-shifts to the static `fence()` handler.
 
 1. **`fence` handler.** Computes the signature, gets-or-creates the
-   tracker, packs signature + info + payload, and **sends it to itself** on
+   tracker, names the operation from the directives, packs signature +
+   operation + info + payload, and **sends it to itself** on
    `PRTE_RML_TAG_FENCE` — funnelling the local contribution through the
-   same receive path everything else uses.
+   same receive path everything else uses.  A barrier packs no payload.
 2. **`fence_recv`.** Checks the epoch, unpacks the signature, finds the
-   tracker, merges info (`PMIX_TIMEOUT` takes the max; a non-success
-   `PMIX_LOCAL_COLLECTIVE_STATUS` is sticky), copies the payload into
-   `coll->bucket`, bumps `nreported`. At `nreported == nexpected`:
+   tracker, merges the operation (see *Two operations* below), merges info
+   (`PMIX_TIMEOUT` takes the max; a non-success `PMIX_LOCAL_COLLECTIVE_STATUS`
+   is sticky), copies the payload into `coll->bucket` **if this is an
+   allgather**, bumps `nreported` either way. At `nreported == nexpected`:
    - **HNP:** broadcast the result via `prte_grpcomm_release_bcast`.
    - **non-HNP:** forward the bucket up to `PRTE_PROC_MY_PARENT`.
 3. **`fence_release`.** Finds the tracker (missing tracker == "I had no
    local participants", not an error) and fires `coll->cbfunc` to hand the
    gathered data back to the PMIx server. Removes and releases the tracker.
+   A barrier is handed a NULL payload rather than an empty one, which is what
+   tells PMIx to skip its store outright. The release message itself does not
+   carry the operation and does not need to: a daemon only reaches this path
+   by holding a tracker, and a tracker knows which collective it is.
 
 **`create_dmns()`'s answer is a pair, and NULL means two different
 things.** A signature naming the daemon job is "every daemon in the DVM",
@@ -611,12 +617,62 @@ ends it with `PMIX_ERR_LOST_CONNECTION`. Note the difference from a group
 construct, which *can* complete on survivors when asked: a fence has no
 equivalent of `PMIX_GROUP_FT_COLLECTIVE`.
 
+### Two operations, one movement
+
+**`PMIX_COLLECT_DATA` names the operation, and nothing else may.** False or
+absent is a **barrier**; true is an **allgather**. `prte_grpcomm_fence_op_from_info()`
+reads it out of the info array PMIx hands to the upcall, `fence()` records it
+on the tracker, and every contribution carries it as a byte of its own ahead
+of the info array — `fence_op_pack()` / `fence_op_unpack()`.
+
+**Do not derive it from the payload.** The bytes vary from daemon to daemon
+while the operation must not: a participant with nothing to publish is fully a
+participant in an allgather, and since PMIx learned to contribute only what
+changed, a zero-byte contribution is the ordinary case for any fence after the
+first rather than a degenerate one. Deriving the operation from the payload
+would have daemons disagree about which collective they are in, and a fence
+has no originator to settle it — the same failure that withdrew the lateral
+movements. The directive is safe precisely because it is a property of the
+*call*: every participant passes the same value, and PMIx has already forced
+the local participants to agree before the upcall (disagreement there becomes
+`PMIX_COLLECT_INVALID` and the fence is refused locally).
+
+**What the operation gates is the payload, in three places** — the
+contribution `fence()` packs, the bucket `tree_gather_answer()` sends up or
+broadcasts, and the unload `fence_release()` performs. It gates *nothing*
+about participation: `nreported`, `reported_slots` and `self_reported` are
+counted, never weighed, so an empty contribution advances the rollup exactly
+as far as a large one. That is the invariant that lets an allgather stay an
+allgather when a participant has nothing to add, and any future exchange
+schedule will depend on it.
+
+**A barrier has no data path at all.** PMIx still builds a blob for one — a
+lone `PMIX_COLLECT_NO` flag byte, compressed and wrapped — but it never leaves
+the node: rolling one of those up from every daemon and broadcasting the
+concatenation back to all of them spends the whole round trip on bytes that
+say only "there is nothing here". The receiving side wants it no more than we
+do, because PMIx skips its store outright when the host returns no data, where
+a present-but-empty payload makes it walk the blobs to find that out.
+
+**A disagreement is reported, not resolved.** `prte_grpcomm_fence_op_merge()`
+adopts on the first answer and requires agreement after that; a mismatch emits
+`help-prte-grpcomm.txt`'s `fence-op-mismatch` and makes `coll->status` sticky
+at `PMIX_ERR_INVALID_ARG` — the status PMIx itself answers for the local form
+of the same user error — which the rollup carries to the controller and the
+release carries back out to every participant. The contribution is still
+counted: convergence is what delivers the failure, so refusing to count it
+would hang instead. **This check is load-bearing rather than belt-and-braces.**
+PMIx compares a collect-flag byte per contribution inside `store_modex` and
+raises `collection-mismatch`, but a barrier no longer puts anything on the wire
+for it to compare, so PRRTE is now the only thing that can see the two answers
+together.
+
 ### One movement: rollup and release
 
 A fence rolls its contributions **up the routing tree** to the controller,
-which broadcasts the gathered result back down. Barrier and modex travel the
-same way; nothing reads `PMIX_COLLECT_DATA` to decide, and no movement id is
-on the wire.
+which broadcasts the gathered result back down. Both operations travel that
+way — the operation decides what rides along, not where it goes — and no
+movement id is on the wire.
 
 The seam that a different movement would use is still visible in the shape of
 the code — `tree_gather_converged()` / `_contribute()` / `_answer()` are

--- a/src/grpcomm/Makefile.am
+++ b/src/grpcomm/Makefile.am
@@ -20,6 +20,9 @@
 # $HEADER$
 #
 
+EXTRA_DIST += \
+    grpcomm/help-prte-grpcomm.txt
+
 headers += \
     grpcomm/grpcomm.h \
     grpcomm/grpcomm_internal.h

--- a/src/grpcomm/grpcomm.c
+++ b/src/grpcomm/grpcomm.c
@@ -83,6 +83,36 @@ void prte_grpcomm_register(void)
                                "grpcomm_base_verbose 1.",
                                PMIX_MCA_BASE_VAR_TYPE_BOOL,
                                &prte_grpcomm_globals.enable_timing);
+
+    /* Fault injection for the fence's round discriminator.  Holding one
+     * daemon's contribution back, while a PMIX_TIMEOUT ends the fence without
+     * it, is what puts a contribution on the wire for a round that is already
+     * over - the straggler the generation exists to recognize.  Nothing else
+     * can arrange that window: it is otherwise a timing accident.
+     *
+     * Compiled in always, on purpose.  See src/grpcomm/AGENTS.md. */
+    prte_grpcomm_globals.joined_late = false;
+    prte_grpcomm_globals.joined_late_known = false;
+
+    prte_grpcomm_globals.fence_delay_ms = 0;
+    pmix_mca_base_var_register("prte", "grpcomm", NULL, "fence_delay_ms",
+                               "Hold this daemon's own fence contribution back "
+                               "by this many milliseconds before sending it. "
+                               "Fault injection for the fence's round handling; "
+                               "0 (the default) sends immediately.",
+                               PMIX_MCA_BASE_VAR_TYPE_INT,
+                               &prte_grpcomm_globals.fence_delay_ms);
+
+    /* -1 means "whichever daemon this is", which is what a per-node MCA file
+     * wants; a vpid names one daemon in a DVM-wide setting, which is what a
+     * test driving the whole DVM from one command line wants. */
+    prte_grpcomm_globals.fence_delay_vpid = -1;
+    pmix_mca_base_var_register("prte", "grpcomm", NULL, "fence_delay_vpid",
+                               "Restrict grpcomm_fence_delay_ms to the daemon "
+                               "with this vpid. -1 (the default) delays on "
+                               "every daemon that reads the parameter.",
+                               PMIX_MCA_BASE_VAR_TYPE_INT,
+                               &prte_grpcomm_globals.fence_delay_vpid);
 }
 
 /**

--- a/src/grpcomm/grpcomm.c
+++ b/src/grpcomm/grpcomm.c
@@ -44,7 +44,8 @@ prte_grpcomm_globals_t prte_grpcomm_globals = {
     .output = -1,
     .context_id = UINT32_MAX,
     .fence_ops = PMIX_LIST_STATIC_INIT(prte_grpcomm_globals.fence_ops),
-    .group_ops = PMIX_LIST_STATIC_INIT(prte_grpcomm_globals.group_ops)
+    .group_ops = PMIX_LIST_STATIC_INIT(prte_grpcomm_globals.group_ops),
+    .fence_generations = PMIX_LIST_STATIC_INIT(prte_grpcomm_globals.fence_generations)
 };
 
 prte_grpcomm_release_bcast_fn_t prte_grpcomm_release_bcast = prte_grpcomm_xcast;
@@ -95,6 +96,7 @@ int prte_grpcomm_init(void)
     PMIX_CONSTRUCT(&prte_grpcomm_globals.fence_ops, pmix_list_t);
     PMIX_CONSTRUCT(&prte_grpcomm_globals.group_ops, pmix_list_t);
     PMIX_CONSTRUCT(&prte_grpcomm_globals.completed_group_ops, pmix_list_t);
+    PMIX_CONSTRUCT(&prte_grpcomm_globals.fence_generations, pmix_list_t);
 
     /* xcast receives */
     PRTE_RML_RECV(PRTE_NAME_WILDCARD, PRTE_RML_TAG_XCAST,
@@ -127,6 +129,7 @@ void prte_grpcomm_finalize(void)
     PMIX_LIST_DESTRUCT(&prte_grpcomm_globals.fence_ops);
     PMIX_LIST_DESTRUCT(&prte_grpcomm_globals.group_ops);
     PMIX_LIST_DESTRUCT(&prte_grpcomm_globals.completed_group_ops);
+    PMIX_LIST_DESTRUCT(&prte_grpcomm_globals.fence_generations);
 
     PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_XCAST);
     PRTE_RML_CANCEL(PRTE_NAME_WILDCARD, PRTE_RML_TAG_XCAST_ACK);

--- a/src/grpcomm/grpcomm_classes.c
+++ b/src/grpcomm/grpcomm_classes.c
@@ -107,11 +107,27 @@ PMIX_CLASS_INSTANCE(prte_grpcomm_group_signature_t,
                     pmix_object_t,
                     sgcon, sgdes);
 
+static void mcon(prte_grpcomm_fence_memo_t *p)
+{
+    p->sig = NULL;
+    p->next_generation = 0;
+}
+static void mdes(prte_grpcomm_fence_memo_t *p)
+{
+    if (NULL != p->sig) {
+        PMIX_RELEASE(p->sig);
+    }
+}
+PMIX_CLASS_INSTANCE(prte_grpcomm_fence_memo_t,
+                    pmix_list_item_t,
+                    mcon, mdes);
+
 static void ccon(prte_grpcomm_fence_t *p)
 {
     p->sig = NULL;
     p->status = PMIX_SUCCESS;
     p->op = PRTE_GRPCOMM_FENCE_OP_UNKNOWN;
+    p->generation = PRTE_GRPCOMM_FENCE_GEN_UNKNOWN;
     PMIX_DATA_BUFFER_CONSTRUCT(&p->bucket);
     p->dmns = NULL;
     p->ndmns = 0;

--- a/src/grpcomm/grpcomm_classes.c
+++ b/src/grpcomm/grpcomm_classes.c
@@ -111,6 +111,7 @@ static void ccon(prte_grpcomm_fence_t *p)
 {
     p->sig = NULL;
     p->status = PMIX_SUCCESS;
+    p->op = PRTE_GRPCOMM_FENCE_OP_UNKNOWN;
     PMIX_DATA_BUFFER_CONSTRUCT(&p->bucket);
     p->dmns = NULL;
     p->ndmns = 0;

--- a/src/grpcomm/grpcomm_classes.c
+++ b/src/grpcomm/grpcomm_classes.c
@@ -128,6 +128,7 @@ static void ccon(prte_grpcomm_fence_t *p)
     p->status = PMIX_SUCCESS;
     p->op = PRTE_GRPCOMM_FENCE_OP_UNKNOWN;
     p->generation = PRTE_GRPCOMM_FENCE_GEN_UNKNOWN;
+    p->step = 0;
     PMIX_DATA_BUFFER_CONSTRUCT(&p->bucket);
     p->dmns = NULL;
     p->ndmns = 0;

--- a/src/grpcomm/grpcomm_fence.c
+++ b/src/grpcomm/grpcomm_fence.c
@@ -41,7 +41,9 @@
 
 /* internal functions */
 static void fence(int sd, short args, void *cbdata);
-static prte_grpcomm_fence_t* get_tracker(prte_grpcomm_fence_signature_t *sig, bool create);
+static prte_grpcomm_fence_t* get_tracker(prte_grpcomm_fence_signature_t *sig,
+                                         uint32_t generation, uint32_t step,
+                                         bool create);
 static int create_dmns(prte_grpcomm_fence_signature_t *sig,
                        pmix_rank_t **dmns, size_t *ndmns);
 static int fence_sig_pack(pmix_data_buffer_t *bkt,
@@ -699,7 +701,8 @@ static void fence(int sd, short args, void *cbdata)
     /* retrieve an existing tracker, create it if not
      * already found. The fence module is responsible
      * for releasing it upon completion of the collective */
-    coll = get_tracker(&sig, true);
+    coll = get_tracker(&sig, prte_grpcomm_fence_gen_next(&sig),
+                       PRTE_GRPCOMM_FENCE_STEP_ROLLUP, true);
     if (NULL == coll) {
         st = PMIX_ERR_NOT_FOUND;
         goto done;
@@ -984,28 +987,31 @@ void prte_grpcomm_fence_recv(int status, pmix_proc_t *sender,
         return;
     }
 
-    /* check for the tracker and create it if not found */
-    if (NULL == (coll = get_tracker(sig, true))) {
+    /* Which round this contribution belongs to, and so which tracker it joins.
+     *
+     * A sender that named a round gets that round - including one AHEAD of
+     * where we are.  That happens routinely rather than exceptionally: xcast
+     * hands a release to our children before we process it ourselves, so a
+     * child can be released, open the next round, and reach us while we are
+     * still finishing the previous one.  Its contribution gets a tracker of
+     * its own and accumulates there until our own release arrives and we
+     * catch up.  Folding it into the round we are still in - which is what
+     * adopting the higher number onto the live tracker would do - would put
+     * the next round's data in a bucket holding this round's.
+     *
+     * A sender that named no round is a daemon a grow added, which has not
+     * learned this signature's numbering yet.  It joins whatever round we
+     * think is current, which is the right answer for a joiner and cannot be
+     * a straggler: it has no earlier round here to have straggled from. */
+    if (PRTE_GRPCOMM_FENCE_GEN_UNKNOWN == gen) {
+        gen = prte_grpcomm_fence_gen_next(sig);
+    }
+    if (NULL == (coll = get_tracker(sig, gen, PRTE_GRPCOMM_FENCE_STEP_ROLLUP, true))) {
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
         PMIX_RELEASE(sig);
         return;
     }
     PMIX_RELEASE(sig);
-
-    /* Settle the tracker's round against what just arrived.
-     *
-     * UNKNOWN on either side is silence rather than a claim: a daemon with no
-     * memo entry for these participants has never released a fence over them,
-     * which is the ordinary state of one grown into the DVM after the job
-     * started.  It cannot stamp 0 - that names a round long since released,
-     * and its contribution would be dropped by every daemon that had been
-     * present for it.  Adopting a higher generation is the same move
-     * fence_recv makes for a recovery epoch it has not caught up with. */
-    if (PRTE_GRPCOMM_FENCE_GEN_UNKNOWN != gen &&
-        (PRTE_GRPCOMM_FENCE_GEN_UNKNOWN == coll->generation ||
-         coll->generation < gen)) {
-        coll->generation = gen;
-    }
 
     if (!prte_grpcomm_fence_op_merge(coll, op)) {
         /* The participants asked for different collectives.  Report it and
@@ -1403,10 +1409,28 @@ void prte_grpcomm_fence_release(int status, pmix_proc_t *sender,
     }
     prte_grpcomm_fence_gen_record(sig, gen);
 
-    /* check for the tracker - it is not an error if not
-     * found as that just means we are not involved
-     * in the collective */
-    if (NULL == (coll = get_tracker(sig, false))) {
+    /* Find the round this release ends.  Not an error if there is none - that
+     * just means we had no participants in it.
+     *
+     * The fallback is for a daemon a grow added.  It did not know this
+     * signature's numbering when it opened its tracker, so that tracker is
+     * filed under UNKNOWN rather than under the round the rest of the DVM
+     * calls this one; the release is the first thing that tells it, so adopt
+     * the number onto it here.  There can only be the one such tracker per
+     * signature: the next round opens with a real number, because recording
+     * this release above gave us one. */
+    coll = get_tracker(sig, gen, PRTE_GRPCOMM_FENCE_STEP_ROLLUP, false);
+    if (NULL == coll) {
+        coll = get_tracker(sig, PRTE_GRPCOMM_FENCE_GEN_UNKNOWN,
+                           PRTE_GRPCOMM_FENCE_STEP_ROLLUP, false);
+        if (NULL != coll) {
+            PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
+                                 "%s grpcomm:fence learning that its round is %u",
+                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (unsigned) gen));
+            coll->generation = gen;
+        }
+    }
+    if (NULL == coll) {
         PMIX_RELEASE(sig);
         return;
     }
@@ -1462,21 +1486,37 @@ void prte_grpcomm_fence_release(int status, pmix_proc_t *sender,
     PMIX_RELEASE(sig);
 }
 
-static prte_grpcomm_fence_t* get_tracker(prte_grpcomm_fence_signature_t *sig, bool create)
+/* Does this tracker have the identity we are looking for?
+ *
+ * All three parts, and the reason each is here is in the tracker's own
+ * definition. Note that the generation is compared exactly, including when
+ * it is UNKNOWN: a daemon that has not learned a signature's numbering keeps
+ * its work on an UNKNOWN tracker and adopts a real number when a release
+ * tells it one - see the note in fence_release(). */
+static bool tracker_matches(prte_grpcomm_fence_t *coll,
+                            prte_grpcomm_fence_signature_t *sig,
+                            uint32_t generation, uint32_t step)
+{
+    if (coll->generation != generation || coll->step != step) {
+        return false;
+    }
+    return fence_sig_same(sig, coll->sig);
+}
+
+static prte_grpcomm_fence_t* get_tracker(prte_grpcomm_fence_signature_t *sig,
+                                         uint32_t generation, uint32_t step,
+                                         bool create)
 {
     prte_grpcomm_fence_t *coll;
     int rc;
 
     /* search the existing tracker list to see if this already exists */
     PMIX_LIST_FOREACH(coll, &prte_grpcomm_globals.fence_ops, prte_grpcomm_fence_t) {
-        if (sig->sz == coll->sig->sz) {
-            // must match proc signature
-            if (0 == memcmp(sig->signature, coll->sig->signature, sig->sz * sizeof(pmix_proc_t))) {
-                PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
-                                     "%s grpcomm:base:returning existing collective",
-                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
-                return coll;
-            }
+        if (tracker_matches(coll, sig, generation, step)) {
+            PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
+                                 "%s grpcomm:base:returning existing collective",
+                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+            return coll;
         }
     }
     /* if we get here, then this is a new collective - so create
@@ -1496,11 +1536,11 @@ static prte_grpcomm_fence_t* get_tracker(prte_grpcomm_fence_signature_t *sig, bo
         PMIX_PROC_CREATE(coll->sig->signature, coll->sig->sz);
         memcpy(coll->sig->signature, sig->signature, coll->sig->sz * sizeof(pmix_proc_t));
     }
-    /* Which round this is.  The memo answers UNKNOWN if we have never
-     * released a fence over these participants, and that is not the same as
-     * zero: it means we have no claim to make, and the first contribution to
-     * name a generation will settle it. */
-    coll->generation = prte_grpcomm_fence_gen_next(coll->sig);
+    /* the identity we were asked for - the caller resolved it, because only
+     * the caller knows whether it is opening a round of its own or joining
+     * one somebody else named */
+    coll->generation = generation;
+    coll->step = step;
     pmix_list_append(&prte_grpcomm_globals.fence_ops, &coll->super);
 
     /* now get the daemons involved */
@@ -1525,9 +1565,11 @@ static prte_grpcomm_fence_t* get_tracker(prte_grpcomm_fence_signature_t *sig, bo
  * build a tracker and inspect what the rollup was sized to expect, which is
  * where a fence goes wrong long before any message moves. */
 prte_grpcomm_fence_t *prte_grpcomm_fence_get_tracker(prte_grpcomm_fence_signature_t *sig,
+                                                            uint32_t generation,
+                                                            uint32_t step,
                                                             bool create)
 {
-    return get_tracker(sig, create);
+    return get_tracker(sig, generation, step, create);
 }
 
 static int create_dmns(prte_grpcomm_fence_signature_t *sig,

--- a/src/grpcomm/grpcomm_fence.c
+++ b/src/grpcomm/grpcomm_fence.c
@@ -911,8 +911,14 @@ void prte_grpcomm_fence_recv(int status, pmix_proc_t *sender,
     pmix_info_t *info = NULL;
     prte_grpcomm_fence_signature_t *sig = NULL;
     prte_grpcomm_fence_t *coll;
-    prte_grpcomm_fence_op_t op;
-    uint32_t gen;
+    /* Both are filled by their unpack below, which writes nothing on failure
+     * and whose failure returns from here - so neither is ever read unset.
+     * Initialized anyway, and to the value that means "nothing was said"
+     * rather than to a round or an operation this contribution did not name:
+     * a compiler that cannot see across the unpack has to assume they might
+     * be read, and if one ever were, silence is the only safe answer. */
+    prte_grpcomm_fence_op_t op = PRTE_GRPCOMM_FENCE_OP_UNKNOWN;
+    uint32_t gen = PRTE_GRPCOMM_FENCE_GEN_UNKNOWN;
     PRTE_HIDE_UNUSED_PARAMS(status, tag, cbdata);
 
     PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,

--- a/src/grpcomm/grpcomm_fence.c
+++ b/src/grpcomm/grpcomm_fence.c
@@ -49,6 +49,8 @@ static int fence_sig_pack(pmix_data_buffer_t *bkt,
 static int fence_sig_unpack(pmix_data_buffer_t *buffer,
                             prte_grpcomm_fence_signature_t **sig);
 static void check_complete(prte_grpcomm_fence_t *coll);
+static int fence_op_pack(pmix_data_buffer_t *bkt, prte_grpcomm_fence_op_t op);
+static int fence_op_unpack(pmix_data_buffer_t *buffer, prte_grpcomm_fence_op_t *op);
 static void relcb(void *cbdata);
 static void abort_fence_op(prte_grpcomm_fence_t *coll, pmix_status_t st);
 static int pack_epoch_frame(pmix_data_buffer_t *framed, pmix_data_buffer_t *body);
@@ -59,6 +61,83 @@ static bool tree_gather_converged(prte_grpcomm_fence_t *coll);
 static int  tree_gather_contribute(prte_grpcomm_fence_t *coll,
                                    pmix_data_buffer_t *payload);
 static void tree_gather_answer(prte_grpcomm_fence_t *coll);
+
+/* PMIX_COLLECT_DATA is the whole of the classification, and its absence is a
+ * barrier: a caller that named no directive asked to synchronize and nothing
+ * more.  PMIx resolves the flag across a daemon's *local* participants before
+ * it ever reaches us - disagreement there becomes PMIX_COLLECT_INVALID and the
+ * fence is refused locally - so what arrives here is one answer per daemon,
+ * and this is where the DVM-wide agreement gets tested. */
+prte_grpcomm_fence_op_t prte_grpcomm_fence_op_from_info(const pmix_info_t info[],
+                                                        size_t ninfo)
+{
+    size_t n;
+
+    for (n = 0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_COLLECT_DATA)) {
+            if (PMIX_INFO_TRUE(&info[n])) {
+                return PRTE_GRPCOMM_FENCE_OP_ALLGATHER;
+            }
+            return PRTE_GRPCOMM_FENCE_OP_BARRIER;
+        }
+    }
+    return PRTE_GRPCOMM_FENCE_OP_BARRIER;
+}
+
+bool prte_grpcomm_fence_op_merge(prte_grpcomm_fence_t *coll,
+                                 prte_grpcomm_fence_op_t incoming)
+{
+    /* an arrival that names no operation tells us nothing, so it cannot
+     * disagree with anything either */
+    if (PRTE_GRPCOMM_FENCE_OP_UNKNOWN == incoming) {
+        return true;
+    }
+    if (PRTE_GRPCOMM_FENCE_OP_UNKNOWN == coll->op) {
+        coll->op = incoming;
+        return true;
+    }
+    return (coll->op == incoming);
+}
+
+/* The operation rides every contribution as a byte of its own rather than as
+ * one more optional directive, because unlike the timeout and the collective
+ * status it is not optional: every contribution has an operation, and a reader
+ * that has to cope with its absence cannot tell "barrier" from "nobody said". */
+static int fence_op_pack(pmix_data_buffer_t *bkt, prte_grpcomm_fence_op_t op)
+{
+    uint8_t val = (uint8_t) op;
+    pmix_status_t rc;
+
+    rc = PMIx_Data_pack(NULL, bkt, &val, 1, PMIX_UINT8);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return prte_pmix_convert_status(rc);
+    }
+    return PRTE_SUCCESS;
+}
+
+static int fence_op_unpack(pmix_data_buffer_t *buffer, prte_grpcomm_fence_op_t *op)
+{
+    uint8_t val;
+    int32_t cnt = 1;
+    pmix_status_t rc;
+
+    rc = PMIx_Data_unpack(NULL, buffer, &val, &cnt, PMIX_UINT8);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return prte_pmix_convert_status(rc);
+    }
+    /* screen it before it is compared: a value no release ever assigned would
+     * otherwise agree with nothing and disagree with nothing, and be taken for
+     * a mismatch by every daemon that saw it - which reports a user error for
+     * what is a corrupt message */
+    if (PRTE_GRPCOMM_FENCE_OP_BARRIER != (prte_grpcomm_fence_op_t) val &&
+        PRTE_GRPCOMM_FENCE_OP_ALLGATHER != (prte_grpcomm_fence_op_t) val) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+    *op = (prte_grpcomm_fence_op_t) val;
+    return PRTE_SUCCESS;
+}
 
 /* Work out how many contributions this daemon has to collect for a fence:
  * one per child subtree holding a participant, plus our own if we are one.
@@ -373,6 +452,18 @@ static void fence(int sd, short args, void *cbdata)
     coll->cbfunc = cd->cbfunc;
     coll->cbdata = cd->cbdata;
 
+    /* Name the operation from the directives our own participants gave, and
+     * fold it in the same way an arriving contribution's would be - this
+     * daemon is a participant like any other, and if it is the second one to
+     * reach a tracker its answer has to agree with the first. */
+    if (!prte_grpcomm_fence_op_merge(coll,
+                                     prte_grpcomm_fence_op_from_info(cd->info, cd->ninfo))) {
+        prte_show_help("help-prte-grpcomm.txt", "fence-op-mismatch", true,
+                       prte_process_info.nodename);
+        if (PMIX_SUCCESS == coll->status) {
+            coll->status = PMIX_ERR_INVALID_ARG;
+        }
+    }
 
     PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
                          "%s grpcomm: fence",
@@ -382,6 +473,15 @@ static void fence(int sd, short args, void *cbdata)
     PMIX_DATA_BUFFER_CREATE(relay);
     /* pack the signature */
     rc = fence_sig_pack(relay, coll->sig);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(relay);
+        st = prte_pmix_convert_rc(rc);
+        goto done;
+    }
+
+    /* say which operation this contribution belongs to */
+    rc = fence_op_pack(relay, coll->op);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(relay);
@@ -407,18 +507,35 @@ static void fence(int sd, short args, void *cbdata)
         }
     }
 
-    /* pass along the payload */
-    PMIX_DATA_BUFFER_CONSTRUCT(&bkt);
-    bo.bytes = cd->data;
-    bo.size = cd->ndata;
-    PMIx_Data_embed(&bkt, &bo);
-    rc = PMIx_Data_copy_payload(relay, &bkt);
-    PMIX_DATA_BUFFER_DESTRUCT(&bkt);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_DATA_BUFFER_RELEASE(relay);
-        st = rc;
-        goto done;
+    /* Pass along the payload - for an allgather, and only for one.
+     *
+     * A barrier has no data path at all: PMIx still hands us a blob for one
+     * (a lone PMIX_COLLECT_NO flag byte, compressed and wrapped), and rolling
+     * one of those up from every daemon and broadcasting the concatenation
+     * back to all of them is the entire round trip spent on bytes that say
+     * only "there is nothing here".  The receiving side wants it no more than
+     * we do - PMIx skips its store outright when the host returns no data,
+     * where a present-but-empty payload makes it walk the blobs to find that
+     * out.
+     *
+     * An allgather packs its payload unconditionally, including when this
+     * daemon has nothing to say.  A participant with an empty contribution is
+     * still a participant: it is counted in nexpected, it must report, and
+     * with PMIx contributing only what changed an empty block is the ordinary
+     * case for any fence after the first rather than a degenerate one. */
+    if (PRTE_GRPCOMM_FENCE_OP_ALLGATHER == coll->op) {
+        PMIX_DATA_BUFFER_CONSTRUCT(&bkt);
+        bo.bytes = cd->data;
+        bo.size = cd->ndata;
+        PMIx_Data_embed(&bkt, &bo);
+        rc = PMIx_Data_copy_payload(relay, &bkt);
+        PMIX_DATA_BUFFER_DESTRUCT(&bkt);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(relay);
+            st = rc;
+            goto done;
+        }
     }
 
     /* Keep our own contribution so a fault can replay it: recovery resets
@@ -499,6 +616,7 @@ void prte_grpcomm_fence_recv(int status, pmix_proc_t *sender,
     pmix_info_t *info = NULL;
     prte_grpcomm_fence_signature_t *sig = NULL;
     prte_grpcomm_fence_t *coll;
+    prte_grpcomm_fence_op_t op;
     PRTE_HIDE_UNUSED_PARAMS(status, tag, cbdata);
 
     PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
@@ -569,6 +687,28 @@ void prte_grpcomm_fence_recv(int status, pmix_proc_t *sender,
         }
     }
 
+    /* which operation this contribution belongs to, and whether it agrees
+     * with everything else this tracker has heard */
+    rc = fence_op_unpack(buffer, &op);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        return;
+    }
+    if (!prte_grpcomm_fence_op_merge(coll, op)) {
+        /* The participants asked for different collectives.  Report it and
+         * carry on: the contribution still has to be counted or the fence
+         * never converges, and it is convergence that carries the failure
+         * back out to every participant through the release.  This is the
+         * same treatment a non-success PMIX_LOCAL_COLLECTIVE_STATUS gets, and
+         * the status is deliberately the one PMIx answers for the local form
+         * of the same disagreement. */
+        prte_show_help("help-prte-grpcomm.txt", "fence-op-mismatch", true,
+                       prte_process_info.nodename);
+        if (PMIX_SUCCESS == coll->status) {
+            coll->status = PMIX_ERR_INVALID_ARG;
+        }
+    }
+
     // unpack the info structs
     cnt = 1;
     rc = PMIx_Data_unpack(NULL, buffer, &ninfo, &cnt, PMIX_SIZE);
@@ -631,12 +771,20 @@ void prte_grpcomm_fence_recv(int status, pmix_proc_t *sender,
     }
 
     /* Absorb the payload - the remainder of the message after the info
-     * structs - into the bucket. */
-    rc = tree_gather_contribute(coll, buffer);
-    if (PRTE_SUCCESS != rc) {
-        PRTE_ERROR_LOG(rc);
-        PMIX_INFO_FREE(info, ninfo);
-        return;
+     * structs - into the bucket.  A barrier put none there, and asking for it
+     * anyway would be asking a fully-consumed buffer for its remainder.
+     *
+     * Note what is *not* conditional: the accounting below.  Participation is
+     * counted, never weighed, so a contribution of zero bytes advances the
+     * rollup exactly as far as a large one does.  That is what lets an
+     * allgather stay an allgather when a participant has nothing to add. */
+    if (PRTE_GRPCOMM_FENCE_OP_ALLGATHER == coll->op) {
+        rc = tree_gather_contribute(coll, buffer);
+        if (PRTE_SUCCESS != rc) {
+            PRTE_ERROR_LOG(rc);
+            PMIX_INFO_FREE(info, ninfo);
+            return;
+        }
     }
     PMIX_INFO_FREE(info, ninfo);
 
@@ -743,11 +891,19 @@ static void tree_gather_answer(prte_grpcomm_fence_t *coll)
             PMIX_DATA_BUFFER_RELEASE(reply);
             return;
         }
-        rc = PMIx_Data_copy_payload(reply, &coll->bucket);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_DATA_BUFFER_RELEASE(reply);
-            return;
+        /* A barrier's release is the signature and the status: there is
+         * nothing gathered to hand back, and saying so by sending nothing is
+         * what lets every daemon's release path skip the unload and PMIx skip
+         * its store.  The operation is not on this message because it does
+         * not need to be - a daemon only reaches its release path by holding
+         * a tracker, and a tracker knows which collective it is. */
+        if (PRTE_GRPCOMM_FENCE_OP_BARRIER != coll->op) {
+            rc = PMIx_Data_copy_payload(reply, &coll->bucket);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_DATA_BUFFER_RELEASE(reply);
+                return;
+            }
         }
         /* xcast copies the payload, so the buffer is still ours to free */
         (void) prte_grpcomm_release_bcast(PRTE_RML_TAG_FENCE_RELEASE, reply);
@@ -762,6 +918,16 @@ static void tree_gather_answer(prte_grpcomm_fence_t *coll)
 
     PMIX_DATA_BUFFER_CREATE(reply);
     rc = fence_sig_pack(reply, coll->sig);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(reply);
+        return;
+    }
+
+    /* the aggregate travels as a contribution like any other, so it names its
+     * operation like any other - this is the merged answer for our whole
+     * subtree, which is what our parent has to agree with */
+    rc = fence_op_pack(reply, coll->op);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(reply);
@@ -803,11 +969,13 @@ static void tree_gather_answer(prte_grpcomm_fence_t *coll)
         }
     }
 
-    rc = PMIx_Data_copy_payload(reply, &coll->bucket);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        PMIX_DATA_BUFFER_RELEASE(reply);
-        return;
+    if (PRTE_GRPCOMM_FENCE_OP_BARRIER != coll->op) {
+        rc = PMIx_Data_copy_payload(reply, &coll->bucket);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(reply);
+            return;
+        }
     }
 
     /* stamp it with the epoch it belongs to, so a parent that has already
@@ -875,13 +1043,25 @@ void prte_grpcomm_fence_release(int status, pmix_proc_t *sender,
         return;
     }
 
-    /* unload the buffer. An aborted fence carries no gathered data, so an
+    /* Unload the buffer. An aborted fence carries no gathered data, so an
      * empty or unreadable payload is expected there - do not let that
-     * overwrite the status the controller sent, which is the whole message. */
+     * overwrite the status the controller sent, which is the whole message.
+     *
+     * A barrier is not asked at all.  Its release legitimately carries nothing
+     * on the success path too, so an unload that objected to an empty buffer
+     * would turn every barrier into a failure; and there is nothing to gain by
+     * asking, because handing PMIx a NULL payload is what tells it to skip the
+     * store rather than walk a bucket to discover it is empty.  The test is
+     * written so that only a positively-known barrier is skipped: a tracker
+     * still at UNKNOWN never heard a contribution, which is a released fence
+     * this daemon merely relayed for, and taking the old path there costs
+     * nothing. */
     PMIX_BYTE_OBJECT_CONSTRUCT(&bo);
-    rc = PMIx_Data_unload(buffer, &bo);
-    if (PMIX_SUCCESS != rc && PMIX_SUCCESS == ret) {
-        ret = rc;
+    if (PRTE_GRPCOMM_FENCE_OP_BARRIER != coll->op) {
+        rc = PMIx_Data_unload(buffer, &bo);
+        if (PMIX_SUCCESS != rc && PMIX_SUCCESS == ret) {
+            ret = rc;
+        }
     }
 
     /* Retire the tracker BEFORE delivering, not after. This fence is over the

--- a/src/grpcomm/grpcomm_fence.c
+++ b/src/grpcomm/grpcomm_fence.c
@@ -51,6 +51,8 @@ static int fence_sig_unpack(pmix_data_buffer_t *buffer,
 static void check_complete(prte_grpcomm_fence_t *coll);
 static int fence_op_pack(pmix_data_buffer_t *bkt, prte_grpcomm_fence_op_t op);
 static int fence_op_unpack(pmix_data_buffer_t *buffer, prte_grpcomm_fence_op_t *op);
+static bool fence_sig_same(prte_grpcomm_fence_signature_t *a,
+                           prte_grpcomm_fence_signature_t *b);
 static void relcb(void *cbdata);
 static void abort_fence_op(prte_grpcomm_fence_t *coll, pmix_status_t st);
 static int pack_epoch_frame(pmix_data_buffer_t *framed, pmix_data_buffer_t *body);
@@ -97,6 +99,179 @@ bool prte_grpcomm_fence_op_merge(prte_grpcomm_fence_t *coll,
         return true;
     }
     return (coll->op == incoming);
+}
+
+/* Two signatures name the same collective when they name the same procs in
+ * the same order. This is the comparison get_tracker() has always made
+ * inline; the generation memo needs the same one, so it is named once. */
+static bool fence_sig_same(prte_grpcomm_fence_signature_t *a,
+                           prte_grpcomm_fence_signature_t *b)
+{
+    if (a->sz != b->sz) {
+        return false;
+    }
+    if (0 == a->sz) {
+        return true;
+    }
+    if (NULL == a->signature || NULL == b->signature) {
+        return (a->signature == b->signature);
+    }
+    return (0 == memcmp(a->signature, b->signature, a->sz * sizeof(pmix_proc_t)));
+}
+
+/* ------------------------------------------------------------------ *
+ * Telling one round over a signature from the next.
+ *
+ * A fence signature is only its participant list, so nothing about a
+ * contribution says which round it belongs to.  In the ordinary flow that
+ * costs nothing, because a daemon converges only once everything it expects
+ * has arrived and so nothing *can* arrive afterwards.  But abort_fence_op()
+ * ends a fence early - on a PMIX_TIMEOUT, and on a participant lost with a
+ * failed daemon - and a contribution still climbing the tree then reaches a
+ * daemon whose tracker the release already retired.  Without a round number
+ * fence_recv() builds a fresh tracker for it, and the *next* fence over those
+ * same participants finds that tracker, inherits its nreported and its
+ * bucket, and can converge early carrying the previous round's data.
+ *
+ * The group collective solves its version of this with a memo of released
+ * operations, and that cannot be copied here: a group is forgotten when a
+ * local client starts another of the same name, and a daemon relaying a fence
+ * for its subtree has no local client, so the entry would never be forgotten
+ * there and the next fence's legitimate contribution would be dropped - a
+ * hang in place of a wrong answer.  So this is a counter rather than a memo,
+ * and what it counts is releases.
+ * ------------------------------------------------------------------ */
+
+static prte_grpcomm_fence_memo_t *fence_gen_find(prte_grpcomm_fence_signature_t *sig)
+{
+    prte_grpcomm_fence_memo_t *memo;
+
+    PMIX_LIST_FOREACH(memo, &prte_grpcomm_globals.fence_generations,
+                      prte_grpcomm_fence_memo_t) {
+        if (fence_sig_same(sig, memo->sig)) {
+            return memo;
+        }
+    }
+    return NULL;
+}
+
+uint32_t prte_grpcomm_fence_gen_next(prte_grpcomm_fence_signature_t *sig)
+{
+    prte_grpcomm_fence_memo_t *memo = fence_gen_find(sig);
+
+    if (NULL == memo) {
+        return PRTE_GRPCOMM_FENCE_GEN_UNKNOWN;
+    }
+    return memo->next_generation;
+}
+
+bool prte_grpcomm_fence_gen_is_stale(prte_grpcomm_fence_signature_t *sig, uint32_t gen)
+{
+    uint32_t next;
+
+    /* a contribution that names no round makes no claim to be from an old
+     * one either - see the UNKNOWN commentary in fence_recv() */
+    if (PRTE_GRPCOMM_FENCE_GEN_UNKNOWN == gen) {
+        return false;
+    }
+    next = prte_grpcomm_fence_gen_next(sig);
+    if (PRTE_GRPCOMM_FENCE_GEN_UNKNOWN == next) {
+        return false;
+    }
+    return (gen < next);
+}
+
+void prte_grpcomm_fence_gen_record(prte_grpcomm_fence_signature_t *sig, uint32_t gen)
+{
+    prte_grpcomm_fence_memo_t *memo;
+
+    if (PRTE_GRPCOMM_FENCE_GEN_UNKNOWN == gen) {
+        return;
+    }
+
+    memo = fence_gen_find(sig);
+    if (NULL != memo) {
+        /* Adopt rather than increment.  A daemon grown into the DVM after k
+         * fences have run has counted none of them, and incrementing would
+         * leave it one behind for ever; taking the released generation from
+         * the wire puts it in step after its first fence instead.  The test
+         * is written so a release that arrives out of order cannot walk the
+         * counter backwards. */
+        if (memo->next_generation < gen + 1) {
+            memo->next_generation = gen + 1;
+        }
+        return;
+    }
+
+    /* Bounded, and evicting the oldest is safe in the way that matters: an
+     * entry only has to outlive the messages still in flight for its own
+     * fence.  Losing one early does not corrupt anything - it returns that
+     * signature to the behaviour this whole mechanism replaced, where a
+     * straggler is indistinguishable from the next round. */
+    while (PRTE_GRPCOMM_FENCE_MEMO_MAX <=
+           pmix_list_get_size(&prte_grpcomm_globals.fence_generations)) {
+        memo = (prte_grpcomm_fence_memo_t *)
+            pmix_list_remove_first(&prte_grpcomm_globals.fence_generations);
+        /* answers NULL for an empty list, and the loop bound is the only
+         * thing claiming this one is not - screen it rather than hand a NULL
+         * to the reference count */
+        if (NULL == memo) {
+            break;
+        }
+        PMIX_RELEASE(memo);
+    }
+
+    memo = PMIX_NEW(prte_grpcomm_fence_memo_t);
+    if (NULL == memo) {
+        return;
+    }
+    memo->sig = PMIX_NEW(prte_grpcomm_fence_signature_t);
+    if (NULL == memo->sig) {
+        PMIX_RELEASE(memo);
+        return;
+    }
+    memo->sig->sz = sig->sz;
+    if (0 < sig->sz) {
+        PMIX_PROC_CREATE(memo->sig->signature, sig->sz);
+        if (NULL == memo->sig->signature) {
+            PMIX_RELEASE(memo);
+            return;
+        }
+        memcpy(memo->sig->signature, sig->signature, sig->sz * sizeof(pmix_proc_t));
+    }
+    memo->next_generation = gen + 1;
+    pmix_list_append(&prte_grpcomm_globals.fence_generations, &memo->super);
+}
+
+/* The generation rides the wire beside the operation, and is checked on
+ * arrival rather than only derived locally.  Deriving alone is not enough:
+ * every participant does take part in every fence over a set, so counting
+ * retirements agrees across daemons that have been present throughout - but a
+ * daemon added by an elastic grow has counted none of them, and would
+ * originate 0 while everyone else is at k. */
+static int fence_gen_pack(pmix_data_buffer_t *bkt, uint32_t gen)
+{
+    pmix_status_t rc;
+
+    rc = PMIx_Data_pack(NULL, bkt, &gen, 1, PMIX_UINT32);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return prte_pmix_convert_status(rc);
+    }
+    return PRTE_SUCCESS;
+}
+
+static int fence_gen_unpack(pmix_data_buffer_t *buffer, uint32_t *gen)
+{
+    int32_t cnt = 1;
+    pmix_status_t rc;
+
+    rc = PMIx_Data_unpack(NULL, buffer, gen, &cnt, PMIX_UINT32);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return prte_pmix_convert_status(rc);
+    }
+    return PRTE_SUCCESS;
 }
 
 /* The operation rides every contribution as a byte of its own rather than as
@@ -251,6 +426,15 @@ static void abort_fence_op(prte_grpcomm_fence_t *coll, pmix_status_t st)
     prc = PMIx_Data_pack(NULL, reply, &st, 1, PMIX_INT32);
     if (PMIX_SUCCESS != prc) {
         PMIX_ERROR_LOG(prc);
+        PMIX_DATA_BUFFER_RELEASE(reply);
+        return;
+    }
+    /* An abort is a release like any other and has to say which round it
+     * ends - it is in fact the release that makes stragglers possible at
+     * all, since it is what ends a fence with contributions still climbing. */
+    rc = fence_gen_pack(reply, coll->generation);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(reply);
         return;
     }
@@ -489,6 +673,15 @@ static void fence(int sd, short args, void *cbdata)
         goto done;
     }
 
+    /* ...and which round of it */
+    rc = fence_gen_pack(relay, coll->generation);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(relay);
+        st = prte_pmix_convert_rc(rc);
+        goto done;
+    }
+
     // pack the info structs
     rc = PMIx_Data_pack(NULL, relay, &cd->ninfo, 1, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
@@ -617,6 +810,7 @@ void prte_grpcomm_fence_recv(int status, pmix_proc_t *sender,
     prte_grpcomm_fence_signature_t *sig = NULL;
     prte_grpcomm_fence_t *coll;
     prte_grpcomm_fence_op_t op;
+    uint32_t gen;
     PRTE_HIDE_UNUSED_PARAMS(status, tag, cbdata);
 
     PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
@@ -656,6 +850,41 @@ void prte_grpcomm_fence_recv(int status, pmix_proc_t *sender,
         return;
     }
 
+    /* Which operation and which round this contribution belongs to.  Both are
+     * read before the tracker is looked up, because whether we want a tracker
+     * at all depends on the round. */
+    rc = fence_op_unpack(buffer, &op);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_RELEASE(sig);
+        return;
+    }
+    rc = fence_gen_unpack(buffer, &gen);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_RELEASE(sig);
+        return;
+    }
+
+    /* A contribution from a round we have already released.  This is the
+     * straggler abort_fence_op() makes possible: its fence was ended early,
+     * the release retired our tracker, and this was still climbing the tree.
+     *
+     * Dropping it here, before get_tracker(), is the whole point.  Creating a
+     * tracker for it and then discarding the message would leave exactly the
+     * wreck this mechanism exists to prevent - a tracker carrying a stale
+     * contribution that the *next* fence over these participants would find,
+     * inherit, and converge early on. */
+    if (prte_grpcomm_fence_gen_is_stale(sig, gen)) {
+        PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
+                             "%s grpcomm fence dropping a contribution from "
+                             "generation %u (now at %u)",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (unsigned) gen,
+                             (unsigned) prte_grpcomm_fence_gen_next(sig)));
+        PMIX_RELEASE(sig);
+        return;
+    }
+
     /* check for the tracker and create it if not found */
     if (NULL == (coll = get_tracker(sig, true))) {
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
@@ -663,6 +892,36 @@ void prte_grpcomm_fence_recv(int status, pmix_proc_t *sender,
         return;
     }
     PMIX_RELEASE(sig);
+
+    /* Settle the tracker's round against what just arrived.
+     *
+     * UNKNOWN on either side is silence rather than a claim: a daemon with no
+     * memo entry for these participants has never released a fence over them,
+     * which is the ordinary state of one grown into the DVM after the job
+     * started.  It cannot stamp 0 - that names a round long since released,
+     * and its contribution would be dropped by every daemon that had been
+     * present for it.  Adopting a higher generation is the same move
+     * fence_recv makes for a recovery epoch it has not caught up with. */
+    if (PRTE_GRPCOMM_FENCE_GEN_UNKNOWN != gen &&
+        (PRTE_GRPCOMM_FENCE_GEN_UNKNOWN == coll->generation ||
+         coll->generation < gen)) {
+        coll->generation = gen;
+    }
+
+    if (!prte_grpcomm_fence_op_merge(coll, op)) {
+        /* The participants asked for different collectives.  Report it and
+         * carry on: the contribution still has to be counted or the fence
+         * never converges, and it is convergence that carries the failure
+         * back out to every participant through the release.  This is the
+         * same treatment a non-success PMIX_LOCAL_COLLECTIVE_STATUS gets, and
+         * the status is deliberately the one PMIx answers for the local form
+         * of the same disagreement. */
+        prte_show_help("help-prte-grpcomm.txt", "fence-op-mismatch", true,
+                       prte_process_info.nodename);
+        if (PMIX_SUCCESS == coll->status) {
+            coll->status = PMIX_ERR_INVALID_ARG;
+        }
+    }
 
     /* Identify which child subtree this came from, and drop it whole if that
      * subtree has already been heard from - see the matching note in the group
@@ -684,28 +943,6 @@ void prte_grpcomm_fence_recv(int status, pmix_proc_t *sender,
         }
         if (pmix_bitmap_is_set_bit(&coll->reported_slots, slot)) {
             return;
-        }
-    }
-
-    /* which operation this contribution belongs to, and whether it agrees
-     * with everything else this tracker has heard */
-    rc = fence_op_unpack(buffer, &op);
-    if (PRTE_SUCCESS != rc) {
-        PRTE_ERROR_LOG(rc);
-        return;
-    }
-    if (!prte_grpcomm_fence_op_merge(coll, op)) {
-        /* The participants asked for different collectives.  Report it and
-         * carry on: the contribution still has to be counted or the fence
-         * never converges, and it is convergence that carries the failure
-         * back out to every participant through the release.  This is the
-         * same treatment a non-success PMIX_LOCAL_COLLECTIVE_STATUS gets, and
-         * the status is deliberately the one PMIx answers for the local form
-         * of the same disagreement. */
-        prte_show_help("help-prte-grpcomm.txt", "fence-op-mismatch", true,
-                       prte_process_info.nodename);
-        if (PMIX_SUCCESS == coll->status) {
-            coll->status = PMIX_ERR_INVALID_ARG;
         }
     }
 
@@ -891,6 +1128,16 @@ static void tree_gather_answer(prte_grpcomm_fence_t *coll)
             PMIX_DATA_BUFFER_RELEASE(reply);
             return;
         }
+        /* Which round is being ended.  Carrying it down as well as up is what
+         * lets a daemon that has not been present for every fence over these
+         * participants - one grown into the DVM - adopt the true number
+         * instead of counting from its own arrival. */
+        rc = fence_gen_pack(reply, coll->generation);
+        if (PRTE_SUCCESS != rc) {
+            PRTE_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(reply);
+            return;
+        }
         /* A barrier's release is the signature and the status: there is
          * nothing gathered to hand back, and saying so by sending nothing is
          * what lets every daemon's release path skip the unload and PMIx skip
@@ -928,6 +1175,12 @@ static void tree_gather_answer(prte_grpcomm_fence_t *coll)
      * operation like any other - this is the merged answer for our whole
      * subtree, which is what our parent has to agree with */
     rc = fence_op_pack(reply, coll->op);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(reply);
+        return;
+    }
+    rc = fence_gen_pack(reply, coll->generation);
     if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(reply);
@@ -1013,6 +1266,7 @@ void prte_grpcomm_fence_release(int status, pmix_proc_t *sender,
     prte_grpcomm_fence_signature_t *sig = NULL;
     prte_grpcomm_fence_t *coll;
     pmix_byte_object_t bo;
+    uint32_t gen;
     PRTE_HIDE_UNUSED_PARAMS(status, sender, tag, cbdata);
 
     PMIX_OUTPUT_VERBOSE((5, prte_grpcomm_globals.output,
@@ -1034,6 +1288,21 @@ void prte_grpcomm_fence_release(int status, pmix_proc_t *sender,
         PMIX_RELEASE(sig);
         return;
     }
+
+    /* Which round this release ends, and remember it.
+     *
+     * This happens whether or not we hold a tracker.  A daemon with no
+     * participants of its own still needs the count, because it may relay for
+     * a subtree in a later round and has to be able to recognize a straggler
+     * from this one.  It is also what a daemon grown into the DVM adopts
+     * instead of counting rounds from its own arrival. */
+    rc = fence_gen_unpack(buffer, &gen);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_RELEASE(sig);
+        return;
+    }
+    prte_grpcomm_fence_gen_record(sig, gen);
 
     /* check for the tracker - it is not an error if not
      * found as that just means we are not involved
@@ -1128,6 +1397,11 @@ static prte_grpcomm_fence_t* get_tracker(prte_grpcomm_fence_signature_t *sig, bo
         PMIX_PROC_CREATE(coll->sig->signature, coll->sig->sz);
         memcpy(coll->sig->signature, sig->signature, coll->sig->sz * sizeof(pmix_proc_t));
     }
+    /* Which round this is.  The memo answers UNKNOWN if we have never
+     * released a fence over these participants, and that is not the same as
+     * zero: it means we have no claim to make, and the first contribution to
+     * name a generation will settle it. */
+    coll->generation = prte_grpcomm_fence_gen_next(coll->sig);
     pmix_list_append(&prte_grpcomm_globals.fence_ops, &coll->super);
 
     /* now get the daemons involved */

--- a/src/grpcomm/grpcomm_fence.c
+++ b/src/grpcomm/grpcomm_fence.c
@@ -155,12 +155,41 @@ static prte_grpcomm_fence_memo_t *fence_gen_find(prte_grpcomm_fence_signature_t 
     return NULL;
 }
 
+void prte_grpcomm_fence_note_join(bool late)
+{
+    /* The first wireup settles it.  A later one describes a DVM this daemon
+     * is already part of and says nothing about how it got here. */
+    if (prte_grpcomm_globals.joined_late_known) {
+        return;
+    }
+    prte_grpcomm_globals.joined_late = late;
+    prte_grpcomm_globals.joined_late_known = true;
+}
+
+uint32_t prte_grpcomm_fence_gen_baseline(void)
+{
+    /* A daemon added to a running DVM cannot claim round 0: every daemon that
+     * has been present is past it, and would drop a 0 as ancient.  It says it
+     * does not know instead, which a receiver takes into whatever round is
+     * current - safe precisely because a joiner has no earlier round over
+     * this signature to have straggled from, so its first contribution cannot
+     * be one.  One contribution per signature, then it has a real number. */
+    if (prte_grpcomm_globals.joined_late) {
+        return PRTE_GRPCOMM_FENCE_GEN_UNKNOWN;
+    }
+    /* ...and a daemon that has been here since the start says 0, which is
+     * what bootstraps the counter. Without this nothing ever establishes a
+     * first round, every contribution is stamped UNKNOWN for ever, and the
+     * whole mechanism is inert. */
+    return 0;
+}
+
 uint32_t prte_grpcomm_fence_gen_next(prte_grpcomm_fence_signature_t *sig)
 {
     prte_grpcomm_fence_memo_t *memo = fence_gen_find(sig);
 
     if (NULL == memo) {
-        return PRTE_GRPCOMM_FENCE_GEN_UNKNOWN;
+        return prte_grpcomm_fence_gen_baseline();
     }
     return memo->next_generation;
 }
@@ -598,6 +627,47 @@ void prte_grpcomm_fence_fault_handler(const prte_rml_recovery_status_t* status)
     }
 }
 
+/* Fault injection: carry a held-back contribution across the delay timer.
+ * Plain storage rather than a reference-counted object - it lives from the
+ * moment the timer is armed until it fires, exactly once, and nothing else
+ * ever looks at it. Zeroed on allocation because the embedded event must
+ * start clean. */
+typedef struct {
+    prte_event_t ev;
+    pmix_data_buffer_t *framed;
+} fence_delay_caddy_t;
+
+static void fence_delay_fire(int sd, short args, void *cbdata)
+{
+    fence_delay_caddy_t *dc = (fence_delay_caddy_t *) cbdata;
+    int rc;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
+                         "%s grpcomm:fence releasing the held-back contribution",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+    PRTE_RML_SEND(rc, PRTE_PROC_MY_NAME->rank, dc->framed, PRTE_RML_TAG_FENCE);
+    if (PRTE_SUCCESS != rc) {
+        PRTE_ERROR_LOG(rc);
+        PMIX_DATA_BUFFER_RELEASE(dc->framed);
+    }
+    free(dc);
+}
+
+/* Should this daemon hold its contribution back?  Only when a delay was asked
+ * for and either no vpid was named or this is the one named. */
+static bool fence_should_delay(void)
+{
+    if (0 >= prte_grpcomm_globals.fence_delay_ms) {
+        return false;
+    }
+    if (0 > prte_grpcomm_globals.fence_delay_vpid) {
+        return true;
+    }
+    return ((pmix_rank_t) prte_grpcomm_globals.fence_delay_vpid
+            == PRTE_PROC_MY_NAME->rank);
+}
+
 static void fence(int sd, short args, void *cbdata)
 {
     prte_pmix_fence_caddy_t *cd = (prte_pmix_fence_caddy_t *) cbdata;
@@ -609,6 +679,7 @@ static void fence(int sd, short args, void *cbdata)
     pmix_status_t st = PMIX_SUCCESS;
     pmix_data_buffer_t *relay, *framed, bkt;
     pmix_byte_object_t bo;
+    struct timeval tv;
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
     PMIX_ACQUIRE_OBJECT(cd);
@@ -763,12 +834,40 @@ static void fence(int sd, short args, void *cbdata)
                          "%s grpcomm:fence sending to ourself",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
 
-    PRTE_RML_SEND(rc, PRTE_PROC_MY_NAME->rank, framed,
-                  PRTE_RML_TAG_FENCE);
-    if (PRTE_SUCCESS != rc) {
-        PRTE_ERROR_LOG(rc);
-        PMIX_DATA_BUFFER_RELEASE(framed);
-        st = prte_pmix_convert_rc(rc);
+    if (fence_should_delay()) {
+        /* Hold it back, so that a fence ended without it - by a PMIX_TIMEOUT,
+         * or by losing a participant - has this contribution still on the
+         * wire when its release lands. That is the straggler the generation
+         * has to recognize, and it is otherwise unreachable from a test.
+         *
+         * The entry point already answered PRTE_SUCCESS, so nothing upstream
+         * is waiting on this send; if the fence is aborted meanwhile our own
+         * participants are completed by the release, exactly as they would be
+         * for a contribution genuinely lost in the network. */
+        fence_delay_caddy_t *dc = (fence_delay_caddy_t *) calloc(1, sizeof(*dc));
+        if (NULL == dc) {
+            PMIX_DATA_BUFFER_RELEASE(framed);
+            st = PMIX_ERR_NOMEM;
+            goto done;
+        }
+        dc->framed = framed;
+        PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
+                             "%s grpcomm:fence holding its contribution back %d ms",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                             prte_grpcomm_globals.fence_delay_ms));
+        tv.tv_sec = prte_grpcomm_globals.fence_delay_ms / 1000;
+        tv.tv_usec = (prte_grpcomm_globals.fence_delay_ms % 1000) * 1000;
+        prte_event_evtimer_set(prte_event_base, &dc->ev, fence_delay_fire, dc);
+        PMIX_POST_OBJECT(dc);
+        prte_event_evtimer_add(&dc->ev, &tv);
+    } else {
+        PRTE_RML_SEND(rc, PRTE_PROC_MY_NAME->rank, framed,
+                      PRTE_RML_TAG_FENCE);
+        if (PRTE_SUCCESS != rc) {
+            PRTE_ERROR_LOG(rc);
+            PMIX_DATA_BUFFER_RELEASE(framed);
+            st = prte_pmix_convert_rc(rc);
+        }
     }
 
 done:

--- a/src/grpcomm/grpcomm_internal.h
+++ b/src/grpcomm/grpcomm_internal.h
@@ -69,6 +69,17 @@ typedef struct {
     // as the first contribution to a brand-new operation and build a tracker
     // that nothing will ever complete or delete.
     pmix_list_t completed_group_ops;
+    // How many fences over each signature this daemon has released - list of
+    // prte_grpcomm_fence_memo_t, capped at PRTE_GRPCOMM_FENCE_MEMO_MAX. This
+    // is what tells a straggler from the next round: a fence signature is
+    // only its participant list, so without a per-round number on the wire a
+    // contribution that outlived the release which ended its fence is
+    // indistinguishable from the first contribution to the next fence over
+    // the same procs. Unlike completed_group_ops this is a counter rather
+    // than a memo of "already done", because a fence has no local client
+    // whose arrival could forget the entry - see the commentary in
+    // grpcomm_fence.c.
+    pmix_list_t fence_generations;
     // The collective recovery epoch for this daemon. A daemon failure
     // invalidates every in-flight rollup, because how many contributions each
     // daemon expects is derived from the routing tree. Recovery is a
@@ -86,6 +97,13 @@ typedef struct {
 } prte_grpcomm_globals_t;
 
 #define PRTE_GRPCOMM_GROUP_MEMO_MAX 64
+#define PRTE_GRPCOMM_FENCE_MEMO_MAX 64
+
+/* "No round number is known here." Distinct from generation 0, which is a
+ * real round: a daemon that has never taken part in a fence over a signature
+ * must be able to say so, because 0 would be read as a round already long
+ * released and its contribution dropped. */
+#define PRTE_GRPCOMM_FENCE_GEN_UNKNOWN UINT32_MAX
 
 typedef struct {
     pmix_list_item_t super;
@@ -139,6 +157,18 @@ typedef struct {
     size_t sz;
 } prte_grpcomm_fence_signature_t;
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_grpcomm_fence_signature_t);
+
+/* What this daemon remembers about a signature once its fence is over: the
+ * number of the NEXT fence over those participants, which is one past the
+ * last generation released here. It has to outlive the tracker, because the
+ * whole point is to recognize something that arrives after the tracker is
+ * gone. */
+typedef struct {
+    pmix_list_item_t super;
+    prte_grpcomm_fence_signature_t *sig;
+    uint32_t next_generation;
+} prte_grpcomm_fence_memo_t;
+PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_grpcomm_fence_memo_t);
 
 typedef struct {
     pmix_object_t super;
@@ -196,6 +226,11 @@ typedef struct {
     // rather than re-derived, so that a participant that disagrees can be
     // caught saying so instead of quietly running the other collective.
     prte_grpcomm_fence_op_t op;
+    // Which round over this signature this tracker is. Seeded from the memo
+    // when the tracker is built, adopted from the first contribution to name
+    // one when the memo had nothing to say, and stamped on everything this
+    // daemon sends for the fence. PRTE_GRPCOMM_FENCE_GEN_UNKNOWN until known.
+    uint32_t generation;
     /* collection bucket */
     pmix_data_buffer_t bucket;
     /* participating daemons */
@@ -382,6 +417,25 @@ prte_grpcomm_fence_op_t prte_grpcomm_fence_op_from_info(const pmix_info_t info[]
 PRTE_EXPORT
 bool prte_grpcomm_fence_op_merge(prte_grpcomm_fence_t *coll,
                                  prte_grpcomm_fence_op_t incoming);
+
+/* The number of the next fence over this signature - one past the last
+ * generation released here - or PRTE_GRPCOMM_FENCE_GEN_UNKNOWN if this daemon
+ * has never released one. Exported so the unit test can drive it. */
+PRTE_EXPORT
+uint32_t prte_grpcomm_fence_gen_next(prte_grpcomm_fence_signature_t *sig);
+
+/* Record that generation `gen` over this signature has been released here, so
+ * the next one is gen+1. Adopts rather than increments, which is what puts a
+ * daemon that joined the DVM late - and so counted none of the earlier rounds
+ * - in step with everyone else after its first fence. Exported for the test. */
+PRTE_EXPORT
+void prte_grpcomm_fence_gen_record(prte_grpcomm_fence_signature_t *sig, uint32_t gen);
+
+/* Is a contribution stamped `gen` one this daemon has already released?  Only
+ * a stamp strictly below what we are expecting is stale; UNKNOWN never is,
+ * because it carries no claim about a round at all.  Exported for the test. */
+PRTE_EXPORT
+bool prte_grpcomm_fence_gen_is_stale(prte_grpcomm_fence_signature_t *sig, uint32_t gen);
 
 /* group functions */
 PRTE_EXPORT extern

--- a/src/grpcomm/grpcomm_internal.h
+++ b/src/grpcomm/grpcomm_internal.h
@@ -94,6 +94,42 @@ typedef struct {
     // and the clock reads it needs sit directly in the broadcast path.
     // Set with the grpcomm_enable_timing MCA parameter.
     bool enable_timing;
+    // Fault injection: hold this daemon's own fence contribution back by
+    // delay_ms before sending it, on the daemon whose vpid is delay_vpid.
+    //
+    // This exists to make a race reachable that no test can otherwise
+    // provoke: abort_fence_op() ends a fence while contributions are still
+    // climbing the tree, and what arrives afterwards must be recognized as
+    // belonging to a round that is over rather than absorbed into the next
+    // one. Without a way to hold a contribution back, the window is a timing
+    // accident nobody can arrange.
+    //
+    // It ships, and is deliberately not compiled out of an optimized build:
+    // a race hook that only exists under PRTE_ENABLE_DEBUG cannot be used to
+    // reproduce a race on the build that shows it. Off unless asked for -
+    // delay_ms 0 costs one compare per fence.
+    int fence_delay_ms;
+    int fence_delay_vpid;
+    // Did this daemon join a DVM that had already been running collectives?
+    //
+    // It decides what "I have no round number for this signature" means, and
+    // the two readings are opposites. For a daemon present from the start it
+    // means round 0 has not happened yet, so it stamps 0 and the counter
+    // bootstraps. For one added by a grow it means the round is genuinely
+    // unknown - every daemon that has been present is at some k, and a 0 from
+    // this one would be read as ancient and dropped, hanging the fence.
+    //
+    // Told, not derived, because only the master can tell the two apart; and
+    // told as a *flag* rather than as a count, because a count would be stale
+    // by the time it arrived - the master goes on answering fences while the
+    // grow completes. A flag cannot go stale: it stays true exactly as long
+    // as it is true, and stops mattering the moment this daemon sees its
+    // first release for a signature and learns that signature's real number.
+    //
+    // Set from the first wireup this daemon receives and never revised: a
+    // later wireup describes a DVM this daemon is already part of.
+    bool joined_late;
+    bool joined_late_known;
 } prte_grpcomm_globals_t;
 
 #define PRTE_GRPCOMM_GROUP_MEMO_MAX 64
@@ -423,6 +459,18 @@ bool prte_grpcomm_fence_op_merge(prte_grpcomm_fence_t *coll,
  * has never released one. Exported so the unit test can drive it. */
 PRTE_EXPORT
 uint32_t prte_grpcomm_fence_gen_next(prte_grpcomm_fence_signature_t *sig);
+
+/* What this daemon stamps on a contribution for a signature it has no entry
+ * for: round 0 if it has been here since the start, UNKNOWN if it joined a
+ * DVM that was already running collectives. Exported so the unit test can
+ * drive both readings. */
+PRTE_EXPORT
+uint32_t prte_grpcomm_fence_gen_baseline(void);
+
+/* Record whether this daemon joined an already-running DVM. Called once, from
+ * the first wireup; later calls are ignored. Exported for the unit test. */
+PRTE_EXPORT
+void prte_grpcomm_fence_note_join(bool late);
 
 /* Record that generation `gen` over this signature has been released here, so
  * the next one is gen+1. Adopts rather than increments, which is what puts a

--- a/src/grpcomm/grpcomm_internal.h
+++ b/src/grpcomm/grpcomm_internal.h
@@ -141,6 +141,12 @@ typedef struct {
  * released and its contribution dropped. */
 #define PRTE_GRPCOMM_FENCE_GEN_UNKNOWN UINT32_MAX
 
+/* The step a tree rollup runs at.  A rollup has exactly one - every
+ * participant contributes once and one release ends it - so this is the only
+ * value in use today.  A dissemination exchange numbers its steps from here
+ * and stamps them on the wire; see the tracker identity commentary below. */
+#define PRTE_GRPCOMM_FENCE_STEP_ROLLUP 0
+
 typedef struct {
     pmix_list_item_t super;
     char *groupID;
@@ -262,11 +268,28 @@ typedef struct {
     // rather than re-derived, so that a participant that disagrees can be
     // caught saying so instead of quietly running the other collective.
     prte_grpcomm_fence_op_t op;
-    // Which round over this signature this tracker is. Seeded from the memo
-    // when the tracker is built, adopted from the first contribution to name
-    // one when the memo had nothing to say, and stamped on everything this
-    // daemon sends for the fence. PRTE_GRPCOMM_FENCE_GEN_UNKNOWN until known.
+    // ---- the tracker's identity ----
+    //
+    // A tracker is identified by its signature AND its generation, not by the
+    // signature alone. Two rounds over the same participants can legitimately
+    // be live on one daemon at the same time: xcast forwards a release to a
+    // daemon's children before that daemon processes it, so a child can be
+    // released, start the next round, and have its contribution arrive while
+    // its parent is still in the previous one. Keyed by signature alone that
+    // contribution joins the wrong collective; keyed by both it gets a
+    // tracker of its own and each round accumulates separately.
+    //
+    // `step` is the third level, and is 0 everywhere today. A tree rollup has
+    // no steps - one contribution per participant, one release - so the pair
+    // is enough for it. A dissemination exchange (Bruck, recursive doubling,
+    // a ring) has log2(N) or N-1 *steps within one collective*, each carrying
+    // a different block, and a message from step i is not interchangeable
+    // with one from step j even at the same generation. Whoever adds such a
+    // movement stamps the step on the wire beside the generation and keys its
+    // trackers on all three; nothing else here has to change to accommodate
+    // it, which is the reason the field is here rather than added later.
     uint32_t generation;
+    uint32_t step;
     /* collection bucket */
     pmix_data_buffer_t bucket;
     /* participating daemons */
@@ -433,6 +456,8 @@ void prte_grpcomm_fence_fault_handler(const prte_rml_recovery_status_t* status);
  * list - if that cannot be done. Exported so the unit test can drive it. */
 PRTE_EXPORT
 prte_grpcomm_fence_t *prte_grpcomm_fence_get_tracker(prte_grpcomm_fence_signature_t *sig,
+                                                            uint32_t generation,
+                                                            uint32_t step,
                                                             bool create);
 
 /* Which operation this fence's directives ask for.  Only PMIX_COLLECT_DATA is

--- a/src/grpcomm/grpcomm_internal.h
+++ b/src/grpcomm/grpcomm_internal.h
@@ -164,6 +164,27 @@ typedef struct {
 } prte_grpcomm_group_signature_t;
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_grpcomm_group_signature_t);
 
+/* Which of the two operations a fence is running.
+ *
+ * PMIX_COLLECT_DATA names it, and nothing else may: the directive is a
+ * property of the *call*, so every participant passes the same value, while
+ * the payload is a property of what the local procs happened to publish and
+ * differs from daemon to daemon.  Deriving the operation from the bytes would
+ * therefore have daemons disagree about which collective they are in, and a
+ * fence has no originator to settle it - which is the failure class that
+ * withdrew the lateral movements (see docs/plans/scalable_collectives/).
+ *
+ * That distinction stopped being academic when PMIx learned to contribute
+ * only what changed: a participant with nothing new to say contributes zero
+ * bytes to an allgather it is fully a member of.
+ *
+ * UNKNOWN is "no contribution has said yet", not a third operation. */
+typedef enum {
+    PRTE_GRPCOMM_FENCE_OP_UNKNOWN = 0,
+    PRTE_GRPCOMM_FENCE_OP_BARRIER,
+    PRTE_GRPCOMM_FENCE_OP_ALLGATHER
+} prte_grpcomm_fence_op_t;
+
 /* Internal component object for tracking ongoing
  * allgather operations */
 typedef struct {
@@ -171,6 +192,10 @@ typedef struct {
     /* collective's signature */
     prte_grpcomm_fence_signature_t *sig;
     pmix_status_t status;
+    // Which operation this is. Carried on the wire by every contribution
+    // rather than re-derived, so that a participant that disagrees can be
+    // caught saying so instead of quietly running the other collective.
+    prte_grpcomm_fence_op_t op;
     /* collection bucket */
     pmix_data_buffer_t bucket;
     /* participating daemons */
@@ -338,6 +363,25 @@ void prte_grpcomm_fence_fault_handler(const prte_rml_recovery_status_t* status);
 PRTE_EXPORT
 prte_grpcomm_fence_t *prte_grpcomm_fence_get_tracker(prte_grpcomm_fence_signature_t *sig,
                                                             bool create);
+
+/* Which operation this fence's directives ask for.  Only PMIX_COLLECT_DATA is
+ * consulted: true is an allgather, false is a barrier, and so is its absence -
+ * a caller that said nothing asked for synchronization and nothing else.
+ * Never answers UNKNOWN.  Exported so the unit test can drive it. */
+PRTE_EXPORT
+prte_grpcomm_fence_op_t prte_grpcomm_fence_op_from_info(const pmix_info_t info[],
+                                                        size_t ninfo);
+
+/* Fold an arriving contribution's operation into the tracker's, adopting it if
+ * the tracker has not heard one yet.  Returns false if the two disagree, which
+ * means the participants asked for different collectives - a user error the
+ * fence cannot resolve, and one that has to be caught here because it is
+ * otherwise invisible: a barrier now puts nothing on the wire for PMIx's own
+ * per-blob collect-flag check to compare.  Exported so the unit test can drive
+ * it; the caller is what reports the disagreement. */
+PRTE_EXPORT
+bool prte_grpcomm_fence_op_merge(prte_grpcomm_fence_t *coll,
+                                 prte_grpcomm_fence_op_t incoming);
 
 /* group functions */
 PRTE_EXPORT extern

--- a/src/grpcomm/grpcomm_xcast.c
+++ b/src/grpcomm/grpcomm_xcast.c
@@ -1058,6 +1058,20 @@ static void process_wireup(pmix_data_buffer_t *msg){
      * after (see the epoch member of prte_rml_recovery_status_t).  Adopting is
      * by highest value seen, so a daemon already at or past this one is
      * unaffected and no in-flight notice can be undone by a late wireup. */
+    /* Whether we joined a DVM that was already running collectives - see the
+     * matching note where this is packed, and prte_grpcomm_fence_gen_baseline().
+     * Only the first wireup is honoured, so a daemon already in the DVM keeps
+     * the answer it was given when it arrived. */
+    bool grown = false;
+    int gcnt = 1;
+    ret = PMIx_Data_unpack(NULL, msg, &grown, &gcnt, PMIX_BOOL);
+    if(PMIX_SUCCESS != ret){
+       PMIX_ERROR_LOG(ret);
+       PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
+       return;
+    }
+    prte_grpcomm_fence_note_join(grown);
+
     uint32_t epoch = 0;
     int ecnt = 1;
     ret = PMIx_Data_unpack(NULL, msg, &epoch, &ecnt, PMIX_UINT32);

--- a/src/grpcomm/help-prte-grpcomm.txt
+++ b/src/grpcomm/help-prte-grpcomm.txt
@@ -1,0 +1,28 @@
+# -*- text -*-
+#
+# Copyright (c) 2026      Nanook Consulting  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# This is the US/English help file for PRTE's DVM-wide collectives.
+#
+[fence-op-mismatch]
+
+Participants in a fence asked for different operations. A fence is a
+barrier when PMIX_COLLECT_DATA is false or absent, and an allgather when
+it is true, and every participant must ask for the same one:
+
+   Node reporting the disagreement: %s
+
+This is an error in the application or in the library calling
+PMIx_Fence: the directive is part of the collective's definition, so
+passing different values from different participants asks the runtime
+for two collectives at once. The fence has been failed rather than
+completed with a result that only some participants would recognize.
+
+Note that a participant contributing no data is NOT this error. An
+allgather over participants that happen to have nothing to publish is
+still an allgather, and is expected — only the directive decides.

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -262,6 +262,11 @@ static void init_complete(int sd, short args, void *cbdata)
     PMIX_RELEASE(caddy);
 }
 
+/* Whether any DVM-ready broadcast has gone out yet.  The first one describes
+ * a DVM starting up; every later one follows a grow, and the daemons reading
+ * it for the first time are the ones the grow added. */
+static bool first_vm_ready = true;
+
 static void vm_ready(int fd, short args, void *cbdata)
 {
     prte_state_caddy_t *caddy = (prte_state_caddy_t *) cbdata;
@@ -271,6 +276,7 @@ static void vm_ready(int fd, short args, void *cbdata)
     prte_proc_t *dmn;
     int32_t v;
     uint32_t epoch;
+    bool grown;
     pmix_value_t *val, *sval;
     pmix_status_t ret;
     PRTE_HIDE_UNUSED_PARAMS(fd, args);
@@ -332,6 +338,39 @@ static void vm_ready(int fd, short args, void *cbdata)
              * notice still in flight will also reach the new daemon, which is
              * routable by now, and the epoch is adopted by highest value seen
              * so the two orders agree. */
+            /* ...and whether the daemons reading this for the FIRST time
+             * joined a DVM that was already running collectives.
+             *
+             * A fence's round number is per-signature and is bootstrapped
+             * locally: a daemon with no record for a signature takes it as
+             * round 0.  That is right for a daemon present from the start and
+             * wrong for one a grow added, which would stamp 0 while every
+             * other participant is at some k and have its contribution
+             * dropped as ancient - hanging the fence.
+             *
+             * What travels is a flag rather than a count, and deliberately: a
+             * count would be stale on arrival, because this master goes on
+             * answering fences over other signatures while the grow completes,
+             * and there is no moment at which a number handed over here is
+             * still true.  The flag is always true when it is true.  It says
+             * only "you do not know your round numbers, so ask rather than
+             * assume", and a joiner stops needing it the moment it sees its
+             * first release for a signature.
+             *
+             * Broadcast to everyone, like the epoch, and harmless there: the
+             * receiver keeps the first answer it is given, so a daemon that
+             * has been through a wireup already is unaffected by this one. */
+            grown = !first_vm_ready;
+            first_vm_ready = false;
+            rc = PMIx_Data_pack(NULL, &buf, &grown, 1, PMIX_BOOL);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_DATA_BUFFER_DESTRUCT(&buf);
+                PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
+                PMIX_RELEASE(caddy);
+                return;
+            }
+
             epoch = prte_grpcomm_current_epoch();
             rc = PMIx_Data_pack(NULL, &buf, &epoch, 1, PMIX_UINT32);
             if (PMIX_SUCCESS != rc) {

--- a/test/unit/grpcomm/test_grpcomm.c
+++ b/test/unit/grpcomm/test_grpcomm.c
@@ -166,6 +166,10 @@ static int test_classes(void)
     prte_grpcomm_fence_t *fc = PMIX_NEW(prte_grpcomm_fence_t);
     CHECK("fence trk sig NULL", NULL == fc->sig);
     CHECK("fence trk status SUCCESS", PMIX_SUCCESS == fc->status);
+    /* a fresh tracker has not been told which collective it is in - and
+     * UNKNOWN has to be distinct from "barrier", or the first contribution
+     * to arrive would find its operation already decided for it */
+    CHECK("fence trk op UNKNOWN", PRTE_GRPCOMM_FENCE_OP_UNKNOWN == fc->op);
     CHECK("fence trk dmns NULL", NULL == fc->dmns);
     CHECK("fence trk ndmns 0", 0 == fc->ndmns);
     CHECK("fence trk nexpected 0", 0 == fc->nexpected);
@@ -848,6 +852,113 @@ static int test_recovery_epoch(void)
     return failures;
 }
 
+/*
+ * Which operation a fence runs is named by PMIX_COLLECT_DATA and by nothing
+ * else.  Both halves of that are pinned here: the classifier, which reads the
+ * directive out of a caller's info array, and the merge, which is how a daemon
+ * decides whether an arriving contribution agrees with what it already knows.
+ *
+ * Note what the classifier's signature does not take: a payload.  A fence's
+ * operation cannot be inferred from whether a participant contributed bytes,
+ * because the bytes vary from daemon to daemon while the operation must not -
+ * a participant with nothing to publish is fully a participant in an
+ * allgather, and since PMIx learned to contribute only what changed that is
+ * the ordinary case rather than a corner one.  Deriving the operation from the
+ * payload would have daemons disagree about which collective they are running,
+ * and a fence has no originator to settle it.
+ */
+static int test_fence_operation(void)
+{
+    int failures = 0;
+#if PRTE_TEST_GRPCOMM_INTERNALS
+    pmix_info_t info[2];
+    prte_grpcomm_fence_t *coll;
+    bool flag;
+    int tmo = 30;
+
+    /* No directives at all.  The caller asked to synchronize and said nothing
+     * else, and that is a barrier - the absence of the flag has to mean the
+     * same as the flag being false, because a caller wanting a plain barrier
+     * has no reason to pass anything. */
+    CHECK("op: no directives is a barrier",
+          PRTE_GRPCOMM_FENCE_OP_BARRIER == prte_grpcomm_fence_op_from_info(NULL, 0));
+
+    flag = true;
+    PMIX_INFO_LOAD(&info[0], PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
+    CHECK("op: collect true is an allgather",
+          PRTE_GRPCOMM_FENCE_OP_ALLGATHER == prte_grpcomm_fence_op_from_info(info, 1));
+    PMIX_INFO_DESTRUCT(&info[0]);
+
+    flag = false;
+    PMIX_INFO_LOAD(&info[0], PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
+    CHECK("op: collect false is a barrier",
+          PRTE_GRPCOMM_FENCE_OP_BARRIER == prte_grpcomm_fence_op_from_info(info, 1));
+    PMIX_INFO_DESTRUCT(&info[0]);
+
+    /* Present with no value.  PMIx's convention is that the bare presence of
+     * an attribute means true, and this has to read it the same way PMIx's own
+     * fence does or a caller that set the flag that way would silently be
+     * given a barrier and then find its data missing. */
+    PMIX_INFO_LOAD(&info[0], PMIX_COLLECT_DATA, NULL, PMIX_BOOL);
+    CHECK("op: a valueless collect flag is still true",
+          PRTE_GRPCOMM_FENCE_OP_ALLGATHER == prte_grpcomm_fence_op_from_info(info, 1));
+    PMIX_INFO_DESTRUCT(&info[0]);
+
+    /* An unrelated directive names no operation and must not be mistaken for
+     * one; and the flag is still found when it is not the first entry. */
+    PMIX_INFO_LOAD(&info[0], PMIX_TIMEOUT, &tmo, PMIX_INT);
+    CHECK("op: an unrelated directive leaves it a barrier",
+          PRTE_GRPCOMM_FENCE_OP_BARRIER == prte_grpcomm_fence_op_from_info(info, 1));
+    flag = true;
+    PMIX_INFO_LOAD(&info[1], PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
+    CHECK("op: the flag is found past the first entry",
+          PRTE_GRPCOMM_FENCE_OP_ALLGATHER == prte_grpcomm_fence_op_from_info(info, 2));
+    PMIX_INFO_DESTRUCT(&info[0]);
+    PMIX_INFO_DESTRUCT(&info[1]);
+
+    /* The merge.  A tracker that has heard nothing adopts; one that has heard
+     * something requires agreement. */
+    coll = PMIX_NEW(prte_grpcomm_fence_t);
+    CHECK("merge: an unknown tracker adopts",
+          prte_grpcomm_fence_op_merge(coll, PRTE_GRPCOMM_FENCE_OP_ALLGATHER));
+    CHECK("merge: and records what it adopted",
+          PRTE_GRPCOMM_FENCE_OP_ALLGATHER == coll->op);
+    CHECK("merge: the same answer again agrees",
+          prte_grpcomm_fence_op_merge(coll, PRTE_GRPCOMM_FENCE_OP_ALLGATHER));
+    /* An arrival that names no operation tells us nothing, so it cannot
+     * disagree with anything either - it must not be read as a barrier. */
+    CHECK("merge: an unknown arrival cannot disagree",
+          prte_grpcomm_fence_op_merge(coll, PRTE_GRPCOMM_FENCE_OP_UNKNOWN));
+    CHECK("merge: and does not disturb what was recorded",
+          PRTE_GRPCOMM_FENCE_OP_ALLGATHER == coll->op);
+    /* The disagreement this whole mechanism exists to catch.  It has to be
+     * caught here because it is otherwise invisible: a barrier now puts
+     * nothing on the wire, so PMIx's own per-blob collect-flag comparison
+     * never sees the two answers together. */
+    CHECK("merge: the opposite operation disagrees",
+          !prte_grpcomm_fence_op_merge(coll, PRTE_GRPCOMM_FENCE_OP_BARRIER));
+    CHECK("merge: and a disagreement changes nothing",
+          PRTE_GRPCOMM_FENCE_OP_ALLGATHER == coll->op);
+    PMIX_RELEASE(coll);
+
+    /* the same, adopting the other way round, so neither operation is
+     * privileged by the order the tests happen to run in */
+    coll = PMIX_NEW(prte_grpcomm_fence_t);
+    CHECK("merge: an unknown tracker adopts a barrier too",
+          prte_grpcomm_fence_op_merge(coll, PRTE_GRPCOMM_FENCE_OP_BARRIER));
+    CHECK("merge: barrier recorded",
+          PRTE_GRPCOMM_FENCE_OP_BARRIER == coll->op);
+    CHECK("merge: an allgather against a barrier disagrees",
+          !prte_grpcomm_fence_op_merge(coll, PRTE_GRPCOMM_FENCE_OP_ALLGATHER));
+    PMIX_RELEASE(coll);
+#endif
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_fence_operation\n");
+    }
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0;
@@ -876,6 +987,7 @@ int main(void)
     failures += test_member_departed();
 #endif
     failures += test_group_directives();
+    failures += test_fence_operation();
     failures += test_fence_tracker();
     failures += test_fence_fault_handler();
     failures += test_recovery_epoch();

--- a/test/unit/grpcomm/test_grpcomm.c
+++ b/test/unit/grpcomm/test_grpcomm.c
@@ -959,6 +959,116 @@ static int test_fence_operation(void)
     return failures;
 }
 
+#if PRTE_TEST_GRPCOMM_INTERNALS
+/* Build a throwaway signature naming one proc, so the tests below have
+ * distinct collectives to talk about without a job to resolve them against. */
+static void gen_sig(prte_grpcomm_fence_signature_t *sig, const char *nspace,
+                    pmix_rank_t rank)
+{
+    PMIX_CONSTRUCT(sig, prte_grpcomm_fence_signature_t);
+    sig->sz = 1;
+    PMIX_PROC_CREATE(sig->signature, 1);
+    PMIX_LOAD_PROCID(&sig->signature[0], nspace, rank);
+}
+#endif
+
+/*
+ * Telling one round over a signature from the next.
+ *
+ * A fence signature is only its participant list, so a contribution that
+ * outlived the release ending its fence is otherwise indistinguishable from
+ * the first contribution to the next fence over the same procs - and the
+ * second one converges early on the first one's data.  What makes that
+ * reachable is abort_fence_op(), which ends a fence while contributions are
+ * still climbing the tree.
+ *
+ * The counter is driven by releases, and UNKNOWN is load-bearing: it is the
+ * state of a daemon grown into the DVM after the job started, which has
+ * released none of the earlier rounds.  It must not be confused with round 0,
+ * which every other daemon has long since retired.
+ */
+static int test_fence_generation(void)
+{
+    int failures = 0;
+#if PRTE_TEST_GRPCOMM_INTERNALS
+    prte_grpcomm_fence_signature_t a, b;
+    size_t i;
+
+    PMIX_CONSTRUCT(&prte_grpcomm_globals.fence_generations, pmix_list_t);
+    gen_sig(&a, "gen-nspace-a", PMIX_RANK_WILDCARD);
+    gen_sig(&b, "gen-nspace-b", PMIX_RANK_WILDCARD);
+
+    /* Nothing released yet.  The answer is "no claim", not zero - a daemon
+     * that has never taken part cannot assert that round 0 is behind it. */
+    CHECK("gen: an unseen signature is UNKNOWN",
+          PRTE_GRPCOMM_FENCE_GEN_UNKNOWN == prte_grpcomm_fence_gen_next(&a));
+    CHECK("gen: and nothing is stale against it",
+          !prte_grpcomm_fence_gen_is_stale(&a, 0));
+    CHECK("gen: ...including a high generation",
+          !prte_grpcomm_fence_gen_is_stale(&a, 7));
+
+    /* An UNKNOWN stamp is silence, never staleness.  This is what a
+     * newly-grown daemon sends, and dropping it would hang the fence it is
+     * legitimately joining. */
+    prte_grpcomm_fence_gen_record(&a, 4);
+    CHECK("gen: an UNKNOWN stamp is never stale",
+          !prte_grpcomm_fence_gen_is_stale(&a, PRTE_GRPCOMM_FENCE_GEN_UNKNOWN));
+
+    /* Recording a release moves us to the next round. */
+    CHECK("gen: releasing 4 puts the next fence at 5",
+          5 == prte_grpcomm_fence_gen_next(&a));
+    CHECK("gen: round 4 is now stale", prte_grpcomm_fence_gen_is_stale(&a, 4));
+    CHECK("gen: as is anything below it",
+          prte_grpcomm_fence_gen_is_stale(&a, 0));
+    CHECK("gen: but the round we are on is not",
+          !prte_grpcomm_fence_gen_is_stale(&a, 5));
+    CHECK("gen: nor is one ahead of us",
+          !prte_grpcomm_fence_gen_is_stale(&a, 6));
+
+    /* Adopt, do not increment.  A daemon that missed rounds must be able to
+     * jump straight to the true number rather than count from its arrival. */
+    prte_grpcomm_fence_gen_record(&a, 20);
+    CHECK("gen: a release adopts its generation rather than incrementing",
+          21 == prte_grpcomm_fence_gen_next(&a));
+
+    /* ...and a release that arrives out of order cannot walk it backwards,
+     * which would un-stale contributions already correctly dropped. */
+    prte_grpcomm_fence_gen_record(&a, 6);
+    CHECK("gen: an out-of-order release does not move it back",
+          21 == prte_grpcomm_fence_gen_next(&a));
+
+    /* Signatures are independent - a fence over other procs is another
+     * collective entirely, and must not inherit this one's count. */
+    CHECK("gen: a different signature is untouched",
+          PRTE_GRPCOMM_FENCE_GEN_UNKNOWN == prte_grpcomm_fence_gen_next(&b));
+
+    /* The memo is bounded.  Eviction is a graceful loss - that signature
+     * returns to the old behaviour - but the list must not grow without end
+     * on a long-lived DVM that fences over many different proc sets. */
+    for (i = 0; i < PRTE_GRPCOMM_FENCE_MEMO_MAX + 8; i++) {
+        prte_grpcomm_fence_signature_t t;
+        char ns[PMIX_MAX_NSLEN + 1];
+        snprintf(ns, sizeof(ns), "gen-fill-%zu", i);
+        gen_sig(&t, ns, PMIX_RANK_WILDCARD);
+        prte_grpcomm_fence_gen_record(&t, 0);
+        PMIX_DESTRUCT(&t);
+    }
+    CHECK("gen: the memo stays bounded",
+          PRTE_GRPCOMM_FENCE_MEMO_MAX >=
+              pmix_list_get_size(&prte_grpcomm_globals.fence_generations));
+
+    PMIX_DESTRUCT(&a);
+    PMIX_DESTRUCT(&b);
+    PMIX_LIST_DESTRUCT(&prte_grpcomm_globals.fence_generations);
+    PMIX_CONSTRUCT(&prte_grpcomm_globals.fence_generations, pmix_list_t);
+#endif
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_fence_generation\n");
+    }
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0;
@@ -988,6 +1098,7 @@ int main(void)
 #endif
     failures += test_group_directives();
     failures += test_fence_operation();
+    failures += test_fence_generation();
     failures += test_fence_tracker();
     failures += test_fence_fault_handler();
     failures += test_recovery_epoch();

--- a/test/unit/grpcomm/test_grpcomm.c
+++ b/test/unit/grpcomm/test_grpcomm.c
@@ -998,14 +998,39 @@ static int test_fence_generation(void)
     gen_sig(&a, "gen-nspace-a", PMIX_RANK_WILDCARD);
     gen_sig(&b, "gen-nspace-b", PMIX_RANK_WILDCARD);
 
-    /* Nothing released yet.  The answer is "no claim", not zero - a daemon
-     * that has never taken part cannot assert that round 0 is behind it. */
-    CHECK("gen: an unseen signature is UNKNOWN",
-          PRTE_GRPCOMM_FENCE_GEN_UNKNOWN == prte_grpcomm_fence_gen_next(&a));
-    CHECK("gen: and nothing is stale against it",
+    /* Nothing released yet, on a daemon that has been here since the start.
+     * The answer is round 0, and that is what bootstraps the counter: if an
+     * unseen signature answered "no claim" instead, no first round would ever
+     * be established, every contribution would be stamped UNKNOWN for ever,
+     * and the whole mechanism would be inert. */
+    prte_grpcomm_fence_note_join(false);
+    CHECK("gen: an original daemon starts an unseen signature at 0",
+          0 == prte_grpcomm_fence_gen_next(&a));
+    CHECK("gen: round 0 is not stale before it has been released",
           !prte_grpcomm_fence_gen_is_stale(&a, 0));
-    CHECK("gen: ...including a high generation",
+    CHECK("gen: ...nor is a later one",
           !prte_grpcomm_fence_gen_is_stale(&a, 7));
+
+    /* ...and the same question on a daemon a grow added answers differently.
+     * It cannot claim 0 - every daemon that has been present is past it and
+     * would drop a 0 as ancient, hanging the fence - so it says it does not
+     * know, which a receiver takes into whatever round is current. */
+    prte_grpcomm_globals.joined_late_known = false;
+    prte_grpcomm_fence_note_join(true);
+    CHECK("gen: a daemon that joined late answers UNKNOWN instead",
+          PRTE_GRPCOMM_FENCE_GEN_UNKNOWN == prte_grpcomm_fence_gen_baseline());
+    CHECK("gen: ...and that is what an unseen signature gives it",
+          PRTE_GRPCOMM_FENCE_GEN_UNKNOWN == prte_grpcomm_fence_gen_next(&b));
+
+    /* The flag is settled by the FIRST wireup and never revised - a later one
+     * describes a DVM this daemon is already part of. */
+    prte_grpcomm_fence_note_join(false);
+    CHECK("gen: a later wireup does not revise how we joined",
+          PRTE_GRPCOMM_FENCE_GEN_UNKNOWN == prte_grpcomm_fence_gen_baseline());
+
+    /* back to an original daemon for the rest */
+    prte_grpcomm_globals.joined_late_known = false;
+    prte_grpcomm_fence_note_join(false);
 
     /* An UNKNOWN stamp is silence, never staleness.  This is what a
      * newly-grown daemon sends, and dropping it would hang the fence it is
@@ -1039,8 +1064,10 @@ static int test_fence_generation(void)
 
     /* Signatures are independent - a fence over other procs is another
      * collective entirely, and must not inherit this one's count. */
+    /* ...and it moved only for the signature it was recorded against. b is
+     * still at its baseline rather than having inherited a's count. */
     CHECK("gen: a different signature is untouched",
-          PRTE_GRPCOMM_FENCE_GEN_UNKNOWN == prte_grpcomm_fence_gen_next(&b));
+          0 == prte_grpcomm_fence_gen_next(&b));
 
     /* The memo is bounded.  Eviction is a graceful loss - that signature
      * returns to the old behaviour - but the list must not grow without end

--- a/test/unit/grpcomm/test_grpcomm.c
+++ b/test/unit/grpcomm/test_grpcomm.c
@@ -485,7 +485,7 @@ static int test_fence_tracker(void)
     sig.sz = 1;
     PMIX_PROC_CREATE(sig.signature, 1);
     PMIX_LOAD_PROCID(&sig.signature[0], PRTE_PROC_MY_NAME->nspace, PMIX_RANK_WILDCARD);
-    coll = prte_grpcomm_fence_get_tracker(&sig, true);
+    coll = prte_grpcomm_fence_get_tracker(&sig, 0, PRTE_GRPCOMM_FENCE_STEP_ROLLUP, true);
     CHECK("tracker: a daemon-job fence resolves", NULL != coll);
     if (NULL != coll) {
         CHECK("tracker: every daemon means all of them, with no array",
@@ -493,21 +493,41 @@ static int test_fence_tracker(void)
         CHECK("tracker: expects our children plus ourselves",
               (size_t) prte_rml_base.n_children + 1 == coll->nexpected);
     }
-    /* the same signature must find that tracker rather than build a second */
-    again = prte_grpcomm_fence_get_tracker(&sig, true);
-    CHECK("tracker: the same signature returns the same tracker", again == coll);
+    /* the same signature AND round must find that tracker, not build a second */
+    again = prte_grpcomm_fence_get_tracker(&sig, 0, PRTE_GRPCOMM_FENCE_STEP_ROLLUP, true);
+    CHECK("tracker: the same identity returns the same tracker", again == coll);
     CHECK("tracker: and does not add another",
           1 == pmix_list_get_size(&prte_grpcomm_globals.fence_ops));
+
+    /* ...but the NEXT round over those same participants is a different
+     * collective and gets a tracker of its own.  Both are live at once on
+     * purpose: xcast hands a release to a daemon's children before that
+     * daemon processes it, so a child can open round 1 and reach us while we
+     * are still finishing round 0.  Keyed by signature alone the two would
+     * be the same tracker and the new round's data would land in the old
+     * round's bucket. */
+    again = prte_grpcomm_fence_get_tracker(&sig, 1, PRTE_GRPCOMM_FENCE_STEP_ROLLUP, true);
+    CHECK("tracker: a later round is a different collective", again != coll);
+    CHECK("tracker: ...and both are live at once",
+          2 == pmix_list_get_size(&prte_grpcomm_globals.fence_ops));
+    CHECK("tracker: ...each knowing which round it is",
+          NULL != again && 1 == again->generation && 0 == coll->generation);
+
+    /* the step is the third level of identity, and is where a dissemination
+     * exchange would separate the blocks of one collective from each other */
+    again = prte_grpcomm_fence_get_tracker(&sig, 0, PRTE_GRPCOMM_FENCE_STEP_ROLLUP + 1, true);
+    CHECK("tracker: a different step is a different collective too",
+          again != coll && 3 == pmix_list_get_size(&prte_grpcomm_globals.fence_ops));
     PMIX_DESTRUCT(&sig);
 
     /* a signature naming nobody is refused rather than read as the "all
      * daemons" case above, which is what an empty nspace would otherwise
      * match */
     PMIX_CONSTRUCT(&sig, prte_grpcomm_fence_signature_t);
-    coll = prte_grpcomm_fence_get_tracker(&sig, true);
+    coll = prte_grpcomm_fence_get_tracker(&sig, 0, PRTE_GRPCOMM_FENCE_STEP_ROLLUP, true);
     CHECK("tracker: an empty signature is refused", NULL == coll);
     CHECK("tracker: and builds nothing",
-          1 == pmix_list_get_size(&prte_grpcomm_globals.fence_ops));
+          3 == pmix_list_get_size(&prte_grpcomm_globals.fence_ops));
     PMIX_DESTRUCT(&sig);
 
     /* a signature we cannot resolve at all - no such job, and nothing has
@@ -516,12 +536,12 @@ static int test_fence_tracker(void)
     sig.sz = 1;
     PMIX_PROC_CREATE(sig.signature, 1);
     PMIX_LOAD_PROCID(&sig.signature[0], "fence-nosuchjob", 0);
-    coll = prte_grpcomm_fence_get_tracker(&sig, true);
+    coll = prte_grpcomm_fence_get_tracker(&sig, 0, PRTE_GRPCOMM_FENCE_STEP_ROLLUP, true);
     CHECK("tracker: an unresolvable signature yields no tracker", NULL == coll);
     CHECK("tracker: and leaves no wreckage on the list",
-          1 == pmix_list_get_size(&prte_grpcomm_globals.fence_ops));
+          3 == pmix_list_get_size(&prte_grpcomm_globals.fence_ops));
     /* ...so asking again is a fresh attempt, not a hand-back of the wreck */
-    coll = prte_grpcomm_fence_get_tracker(&sig, false);
+    coll = prte_grpcomm_fence_get_tracker(&sig, 0, PRTE_GRPCOMM_FENCE_STEP_ROLLUP, false);
     CHECK("tracker: nothing to find on a second look", NULL == coll);
     PMIX_DESTRUCT(&sig);
 


### PR DESCRIPTION
Two related changes to the DVM fence, plus the machinery to prove the second one works.

## The fence has two operations, and now says so

`PMIX_COLLECT_DATA` reached the fence upcall and was never read, so a barrier and a modex took the same path and carried the same payload. That is now the discriminator: false or absent is a **barrier**, true is an **allgather**, and it stays an allgather even when some participants contribute nothing.

The directive has to decide this and the payload must never, because every participant must reach the same answer independently or the collective hangs. `PMIX_COLLECT_DATA` is a property of the *call* — every participant passes the same value, and PMIx has already refused the fence locally if a daemon's own participants disagreed. The payload is a property of what the local procs happened to publish, and since PMIx learned to contribute only what changed it differs all the way down to nothing. Reading the operation off the bytes would misfire on the second fence of an ordinary job.

A barrier now has no data path. PMIx builds a blob even for one — a lone `PMIX_COLLECT_NO` flag byte, compressed and wrapped — and every daemon used to roll one of those up the tree so the controller could broadcast the concatenation back down. Nothing crosses the wire for a barrier now, and PMIx skips its store outright rather than walking a bucket to find it empty.

One check moves as a result: PMIx compares a collect flag per contribution inside `store_modex`, but a barrier no longer puts anything on the wire for that comparison to see. A disagreement is caught at the rollup instead, with a `show_help` and a sticky `PMIX_ERR_INVALID_ARG` that the release carries back to every participant.

## A fence now knows which round it is

A fence signature is only its participant list, so nothing said which round a contribution belonged to. `abort_fence_op()` ends a fence early — on a `PMIX_TIMEOUT`, or on a participant lost with a failed daemon — and a contribution still climbing the tree then reached a daemon whose tracker the release had already retired. The next fence over those participants found that tracker, inherited its `nreported` and its bucket, and could converge early carrying the previous round's data.

Each daemon now keeps, per signature, the number of the next fence over it. Contributions are stamped; a stamp below what the receiver expects is dropped, and the screen runs *before* `get_tracker()` because building a tracker for a straggler and then discarding the message leaves exactly the wreck this prevents.

**Bootstrapping it needs round 0 to be a real round**, and the elastic case makes that awkward. A daemon present since the DVM started reads "no entry" as round 0 and stamps 0. A daemon a grow added has released none of the earlier rounds and cannot claim 0 — every daemon that has been present would read that as ancient and drop it, hanging the fence — so it stamps "unknown" and resolves from its first release. Only the master can tell the two apart, so it says which, in the wireup that already carries the collective recovery epoch. What travels is a **flag rather than a count**: a count would be stale on arrival, because the master goes on answering fences over other signatures while the grow completes.

**Trackers are keyed by `(signature, generation)`**, not by signature alone. `PRTE_RML_TAG_FENCE_RELEASE` is not in xcast's `process_first` set, so a daemon forwards a release to its children before processing it — a child can be released, open the next round, and reach its parent while the parent is still finishing the previous one. That contribution now gets a tracker of its own instead of contaminating the live one.

The identity carries a third part, `step`, zero everywhere today. A rollup has one step; a dissemination exchange (Bruck, recursive doubling, a ring) has several within one collective, each carrying a different block. The field is there so adding such a movement is a matter of stamping the step beside the generation rather than revisiting what a tracker is. Nothing puts a step on the wire yet, deliberately.

## Proving it

The window is a timing accident no test can arrange from outside, so `grpcomm_fence_delay_ms` holds one daemon's contribution back. It is compiled in rather than hidden behind a debug build, because a hook that exists only under `PRTE_ENABLE_DEBUG` cannot reproduce a race on the build that shows it.

Paired with a deadline on the fence, the controller ends the round without that daemon and the held contribution lands while the next fence is in flight. `fencer` grows `--timeout` and `--twice`; the dockerswarm case asserts the deadline really did end the first fence before asserting anything about the second, since otherwise there was no straggler and everything below would pass vacuously.

Two details decide whether that case tests anything, and both were learned by watching it pass when it should not have. The two fences must carry **different data**, or a fence that wrongly counted the straggler still ends up with a correct modex. And the readback must be **`PMIX_OPTIONAL`**, or a `PMIx_Get` for a key the fence never delivered falls through to a direct modex and fetches it anyway. The case has been watched failing with the staleness check removed.

That second point produced an incidental result worth recording, and it is in the plan doc: a fence deliberately broken to lose a contribution was repaired by the direct modex without the application noticing. Narrow, and it says nothing about cost, but it is a direct observation of the property the "stop collecting" option depends on.

## Verification

- `--enable-debug` build clean, zero warnings
- `make check` 24/24, including cases pinning that two rounds over one signature are separate collectives and both live at once
- `contrib/dockerswarm` full suite **768 passed, 0 failed, 3 skipped**
- Live DVM: six consecutive collecting fences over one signature, zero bad verifies

## Still open

`fence_recv` drops a stale contribution and separates an early one, but nothing yet exercises the early-arrival path directly — provoking it needs a knob that delays a child's *release processing* rather than its contribution. Noted in `src/grpcomm/AGENTS.md`.