### PR TITLE
Match a node through its aliases from either side

### DIFF
--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -644,19 +644,32 @@ bool prte_nptr_match(prte_node_t *n1, prte_node_t *n2)
         return true;
     }
 
+    /* each side's alias list has to be checked against the other's name
+     * independently of whether the far side has aliases at all. A node
+     * parsed out of a hostfile or a dash-host spec carries no aliases of
+     * its own, while the allocation's node has the name the user gave
+     * demoted to an alias the moment its daemon reports the hostname it
+     * found for itself - so nesting either test inside the other means a
+     * node named by an address, and reported by name, stops matching. */
     if (NULL != n1->aliases) {
         for (i = 0; NULL != n1->aliases[i]; i++) {
             if (0 == strcmp(n1->aliases[i], n2->name)) {
                 return true;
             }
-            if (NULL != n2->aliases) {
-                for (m = 0; NULL != n2->aliases[m]; m++) {
-                    if (0 == strcmp(n2->aliases[m], n1->name)) {
-                        return true;
-                    }
-                    if (0 == strcmp(n1->aliases[i], n2->aliases[m])) {
-                        return true;
-                    }
+        }
+    }
+    if (NULL != n2->aliases) {
+        for (m = 0; NULL != n2->aliases[m]; m++) {
+            if (0 == strcmp(n2->aliases[m], n1->name)) {
+                return true;
+            }
+        }
+    }
+    if (NULL != n1->aliases && NULL != n2->aliases) {
+        for (i = 0; NULL != n1->aliases[i]; i++) {
+            for (m = 0; NULL != n2->aliases[m]; m++) {
+                if (0 == strcmp(n1->aliases[i], n2->aliases[m])) {
+                    return true;
                 }
             }
         }

--- a/test/unit/runtime/test_runtime.c
+++ b/test/unit/runtime/test_runtime.c
@@ -452,6 +452,10 @@ static int test_node_matching(void)
     {
         prte_node_t *n3 = make_node("c01");
         CHECK("match: nptr_match through an alias", prte_nptr_match(n1, n3));
+        /* the hostfile and dash-host parsers always pass the node they
+         * parsed first, and that node never carries aliases of its own,
+         * so the aliased side has to be recognized from either position */
+        CHECK("match: nptr_match through an alias, reversed", prte_nptr_match(n3, n1));
         PMIX_RELEASE(n3);
     }
 


### PR DESCRIPTION
prte_nptr_match() nests the test of n2's aliases inside a check that n1 has aliases of its own, so n2's aliases are compared against n1's name only when n1 also carries an alias list - and when n1 has none, nothing about n2's aliases is examined at all.

That is the wrong way round for how the callers use it.  A node parsed out of a hostfile carries only the name the user typed and no aliases, and the parsed node is always passed first.  So a hostfile naming remote nodes by IP address fails on the second job phase of a multi-phase launch: the first pass matches by plain strcmp, before the daemons report, and then the daemon callback replaces each node's name with the gethostname value its daemon found and demotes the IP to an alias.  The second pass needs that alias, never looks at it, and the launch dies with hostfile:extra-node-not-found and PMIX_ERR_JOB_FAILED_TO_MAP.

This is also why --host works where --hostfile does not: dash_host matches through prte_node_match() and node_answers_to(), which checks the alias list unconditionally.  Two matchers in the same tree disagree.

Compare each side's aliases against the other's name on its own, and compare the two lists only when both exist.  The result is a strict superset of the current behavior.  Extend the node matching unit test to try the aliased node from the second position as well as the first.