### PR TITLE
Pin the node-alias match at the hostfile level, and say why the local-host test is absent

### DIFF
--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -635,6 +635,17 @@ prte_node_t* prte_node_match(pmix_list_t *nodes, const char *name)
     return NULL;
 }
 
+/* Does not ask prte_check_host_is_local() about either name, though
+ * prte_quickmatch() and prte_node_match() below both do, and this used to as
+ * well. Every caller has already resolved local names before it gets here:
+ * hostfile_parse_line() and the dash-host parser rewrite any name answering
+ * to this host into prte_process_info.nodename as they read it, and
+ * prte_ras_base_node_insert() folds a locally-named node into the HNP's pool
+ * entry in a branch that never reaches the dedup loop calling this. So the
+ * check would find nothing - at the price of putting pmix_ifislocal(), which
+ * resolves addresses and appends to a process-global alias list, inside a
+ * loop that runs once per pool entry for every node inserted. Do not put it
+ * back; fix the caller that failed to normalize instead. */
 bool prte_nptr_match(prte_node_t *n1, prte_node_t *n2)
 {
     size_t i, m;

--- a/test/unit/util/test_util.c
+++ b/test/unit/util/test_util.c
@@ -57,6 +57,13 @@
  *    prte_util_get_ordered_host_list() walked the list through an item it
  *    had already released.
  *
+ *  - prte_util_filter_hostfile_nodes() stopped recognizing an allocated node
+ *    once its daemon reported a different hostname for it, because the node
+ *    matcher only looked at the second node's aliases when the first node had
+ *    aliases of its own -- and the node parsed out of the hostfile, which is
+ *    always passed first, never has any. A hostfile naming nodes by address
+ *    launched once and then failed to map.
+ *
  * What is deliberately NOT here: session_dir (creates directories under
  * the real tmpdir), stacktrace (installs signal handlers), daemon_init
  * (forks), and the parts of nidmap that need a populated DVM. Those belong
@@ -1068,6 +1075,54 @@ static int test_hostfile(void)
         }
     }
     PMIX_LIST_DESTRUCT(&nodes);
+
+    /*
+     * A hostfile has to keep matching a node after the daemons report in.
+     * prted_report_launch() replaces each node's name with the hostname its
+     * own daemon found and demotes the name the allocation used to an alias,
+     * so on the second and later passes the hostfile's name lives on the
+     * allocation node's ALIAS list while the node parsed out of the file has
+     * no aliases at all - and the parsed node is always the first argument to
+     * prte_nptr_match(). That is the shape that failed: the matcher only
+     * examined the second node's aliases when the first had aliases of its
+     * own, so a hostfile naming nodes by address launched once and then died
+     * with hostfile:extra-node-not-found. The predicate is pinned directly in
+     * test/unit/runtime, but only this reaches it the way the launch does.
+     *
+     * Address resolution is turned off across the case so the address is
+     * compared as a name rather than against whichever interfaces the machine
+     * running the test happens to own.
+     */
+    {
+        bool saved_resolve = prte_do_not_resolve;
+        char filterpath[256];
+
+        prte_do_not_resolve = true;
+        PMIX_CONSTRUCT(&nodes, pmix_list_t);
+        nd = PMIX_NEW(prte_node_t);
+        nd->name = strdup("node05");
+        PMIx_Argv_append_nosize(&nd->aliases, "10.0.0.5");
+        nd->slots = 4;
+        pmix_list_append(&nodes, &nd->super);
+        /* a second node the hostfile does not name, so the filter still has
+         * to discriminate and not simply keep whatever it was given */
+        nd = PMIX_NEW(prte_node_t);
+        nd->name = strdup("node06");
+        nd->slots = 4;
+        pmix_list_append(&nodes, &nd->super);
+
+        if (NULL != write_hostfile("10.0.0.5\n", filterpath, sizeof(filterpath))) {
+            rc = prte_util_filter_hostfile_nodes(&nodes, filterpath, true);
+            CHECK("a hostfile name matches an allocated node's alias", PRTE_SUCCESS == rc);
+            CHECK("...and the node is kept under the name its daemon reported",
+                  1 == pmix_list_get_size(&nodes) && NULL != find_node(&nodes, "node05"));
+            CHECK("...and the node it did not name is gone",
+                  NULL == find_node(&nodes, "node06"));
+            unlink(filterpath);
+        }
+        PMIX_LIST_DESTRUCT(&nodes);
+        prte_do_not_resolve = saved_resolve;
+    }
 
     unlink(path);
     return failures;


### PR DESCRIPTION
Two follow-ups to #2747, which fixed `prte_nptr_match()` so a node is
recognized through its aliases from either side.

## The regression test was one level too low

#2747 pins the predicate in `test/unit/runtime`, which is right, but nothing
exercised the matcher the way a launch does — and that is why the asymmetry
survived four years. The failure only appears once the shape is assembled:
`prted_report_launch()` replaces each node's name with the hostname its own
daemon found and demotes the name the allocation used to an alias, so from
the second pass onward the hostfile's name lives on the *allocation* node's
alias list while the node parsed out of the file has no aliases at all — and
the parsed node is always the first argument to `prte_nptr_match()`. A
hostfile naming nodes by address launched once and then died with
`hostfile:extra-node-not-found`.

The first commit drives `prte_util_filter_hostfile_nodes()` with exactly
that: an allocation holding `node05` carrying `10.0.0.5` as an alias,
filtered through a hostfile naming `10.0.0.5`. A second, unnamed node is on
the list so the filter still has to discriminate rather than hand back what
it was given. Address resolution is turned off across the case so the address
is compared as a name and not against whichever interfaces the machine
running the test happens to own.

Reverting the #2747 matcher fix fails this test; it passes with it.

## The missing local-host test looks like a bug and is not one

`prte_nptr_match()` is the only one of the three matchers in
`prte_globals.c` that does not ask `prte_check_host_is_local()` about the
names it is given. `prte_quickmatch()` and `prte_node_match()` both ask, and
this function did too until the node-resolution rework in 86b647e1b took it
out. Read cold, that is a standing invitation to put it back.

It should not go back. Every caller has already resolved local names by the
time it gets here:

- `hostfile_parse_line()` rewrites any name answering to this host into
  `prte_process_info.nodename` as it reads it (`hostfile.c:181`, `:222`) —
  and that is the single line parser behind all three hostfile entry points,
  so `prte_util_filter_hostfile_nodes()` never sees an unnormalized local
  name.
- The dash-host parser does the same (`dash_host.c:291`, `:522`).
- `prte_ras_base_node_insert()` folds a locally-named node into the HNP's
  pool entry in an `if` arm (`ras_base_node.c:158`) whose `else` holds the
  dedup loop that calls this — so a local name never reaches it.

`src/util/AGENTS.md` already states this as design. So the check would find
nothing, and it would cost a `pmix_ifislocal()` — which resolves addresses
and appends to a process-global alias list — once per pool entry for every
node inserted, in an O(pool x inserted) loop.

The second commit is comment-only: it records that, and records the remedy
for the case the check looks like it would have caught — a caller that failed
to normalize is the thing to fix.

## Testing

`make check` passes all 24 suites, warning-free `--enable-debug` build. The
offline mapper harness was not re-run for this branch: the only `src` change
is a comment, and that source ran 2449 pass / 0 fail while #2747 was being
reviewed.