### PR TITLE
Exercise the fence's early-arrival window, and ask the right question of a modex

### DIFF
--- a/contrib/dockerswarm/fencer.c
+++ b/contrib/dockerswarm/fencer.c
@@ -160,7 +160,7 @@ int main(int argc, char **argv)
         pmix_value_t *got = NULL;
         uint32_t universe = 0, r;
         int found = 0, missing = 0;
-        pmix_status_t rc2nd;
+        pmix_status_t rc1st, rc2nd;
 
         PMIX_LOAD_PROCID(&peer, me.nspace, PMIX_RANK_WILDCARD);
         if (PMIX_SUCCESS == PMIx_Get(&peer, PMIX_JOB_SIZE, NULL, 0, &got) &&
@@ -173,9 +173,22 @@ int main(int argc, char **argv)
                 continue;   /* only remote peers prove the collective ran */
             }
             PMIX_LOAD_PROCID(&peer, me.nspace, r);
-            snprintf(key, sizeof(key), "fencer.rank.%u", r);
-            got = NULL;
-            if (PMIX_SUCCESS == PMIx_Get(&peer, key, NULL, 0, &got) && NULL != got) {
+            /* PMIX_OPTIONAL here too, and for the reason spelled out at the
+             * second key below: without it this asks whether the runtime can
+             * find the value by any means - including fetching it from the
+             * owning daemon on demand - rather than whether the collective
+             * carried it.  A fence that delivered nothing at all would still
+             * satisfy an ordinary Get. */
+            {
+                pmix_info_t opt[1];
+                bool t = true;
+                PMIX_INFO_LOAD(&opt[0], PMIX_OPTIONAL, &t, PMIX_BOOL);
+                snprintf(key, sizeof(key), "fencer.rank.%u", r);
+                got = NULL;
+                rc1st = PMIx_Get(&peer, key, opt, 1, &got);
+                PMIX_INFO_DESTRUCT(&opt[0]);
+            }
+            if (PMIX_SUCCESS == rc1st && NULL != got) {
                 uint32_t v = 0;
                 PMIx_Value_get_number(got, &v, PMIX_UINT32);
                 if (v == r) {

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -4600,6 +4600,70 @@ test_grpcomm() {
     test_grpcomm_invite
     test_grpcomm_ft
     test_fence_straggler
+    test_fence_early_arrival
+}
+
+test_fence_early_arrival() {
+    local out n
+
+    banner "grpcomm: a contribution for the next round does not join this one"
+    # The other side of the round number, and the one a straggler test cannot
+    # reach.  A fence release is an xcast, and PRTE_RML_TAG_FENCE_RELEASE is
+    # not in the process_first set, so a daemon FORWARDS a release to its
+    # children before it processes the release itself.  In that gap a child is
+    # released, its clients open the next round, and its contribution arrives
+    # at a parent that still has the previous round open.
+    #
+    # Keyed by signature alone that contribution joins the round it is not
+    # part of: it lands in a bucket that is about to be discarded by the
+    # release, and the round it actually belonged to then waits for a
+    # contribution that has already been consumed.  The symptom is not wrong
+    # data, it is the SECOND fence never completing.
+    #
+    # The gap is microseconds wide in normal running, so widen it:
+    # grpcomm_release_delay_ms holds one daemon's own processing of the
+    # release back while its children get theirs on time.  radix 1 makes the
+    # tree a chain, so daemon 1 is an interior daemon with a real subtree
+    # below it rather than a leaf hanging off the HNP.
+    cleanup_swarm
+    if ! RUN "test -x $FENCER"; then
+        skp "fencer client not installed -- re-run ./build.sh"
+        return
+    fi
+    if ! prted_dvm_start_mca 'node1:1,node2:1,node3:1,node4:1' \
+            '--prtemca rml_base_radix 1 --prtemca grpcomm_release_delay_ms 5000 --prtemca grpcomm_release_delay_vpid 1'; then
+        bad "could not start a DVM for the fence early-arrival test"
+        cleanup_swarm
+        return
+    fi
+
+    out=$(PRUN "--host node1:1,node2:1,node3:1,node4:1 -n 4 --map-by node $FENCER collect --twice" 2>&1)
+
+    # The first fence has to have completed, or there was no release to run
+    # ahead of and nothing below tests anything.
+    n=$(echo "$out" | grep -c 'FENCER collect rank .* rc PMIX_SUCCESS')
+    [ "$n" = 4 ] \
+        && ok "the first fence completed despite the held-back release" \
+        || bad "$n of 4 ranks completed the first fence: $(echo "$out" | grep 'FENCER collect' | tr '\n' ' ' | tail -c 250)"
+
+    # ...and the assertion: the next round, whose contributions reached a
+    # daemon that had not caught up, still converges.
+    n=$(echo "$out" | grep -c 'FENCER second rank .* rc PMIX_SUCCESS')
+    [ "$n" = 4 ] \
+        && ok "...and the round that overtook it completed too" \
+        || bad "$n of 4 ranks completed the second fence: $(echo "$out" | grep 'FENCER second' | tr '\n' ' ' | tail -c 250)"
+
+    n=$(echo "$out" | grep -c 'peers-bad 0')
+    [ "$n" = 4 ] \
+        && ok "...with every peer's contribution intact" \
+        || bad "$n of 4 ranks got a complete modex: $(echo "$out" | grep 'peers-' | tr '\n' ' ' | tail -c 250)"
+
+    RUN 'pgrep -x prte' >/dev/null 2>&1 \
+        && ok "...and the DVM survived the overlap" \
+        || bad "the HNP died over the overlapping rounds"
+
+    RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    cleanup_swarm
 }
 
 test_fence_straggler() {

--- a/src/grpcomm/AGENTS.md
+++ b/src/grpcomm/AGENTS.md
@@ -658,15 +658,30 @@ That cost two full build-and-run cycles of false green here.  (It is also a
 neat demonstration that the on-demand path works: the fence had genuinely
 lost the key and the application never noticed.)
 
-**Still open: the early contribution.**  `PRTE_RML_TAG_FENCE_RELEASE` is not
-in `xcast`'s `process_first` set, so a daemon forwards a release to its
-children *before* processing it itself.  A child can therefore be released,
-start the next round, and have its contribution reach the parent while the
-parent is still in the previous one.  Dropping is safe there but adopting the
-higher number onto the live tracker is **not** — it relabels a tracker whose
-bucket holds the previous round's data.  Handling that properly means keying
-trackers by `(signature, generation)` rather than by signature alone, which is
-the same identity a lateral movement would need.
+**The early contribution, and why it is not a corner case.**
+`PRTE_RML_TAG_FENCE_RELEASE` is not in `xcast`'s `process_first` set, so a
+daemon forwards a release to its children *before* processing it itself.  A
+child can therefore be released, start the next round, and have its
+contribution reach the parent while the parent is still in the previous one.
+That is what `(signature, generation)` keying is for: the early contribution
+gets a tracker of its own instead of landing in a bucket the release is about
+to discard.
+
+Adopting the higher number onto the live tracker instead — which is what the
+first attempt did — is worse than dropping, because it relabels a tracker
+holding the previous round's data.  The symptom is not wrong data but a
+**hang**: the early contribution is consumed by the wrong round, and the round
+it belonged to then waits for something that has already arrived.  Measured,
+with the generation removed from the key: the second fence completes on 0 of 4
+ranks while the first still succeeds and the DVM survives.
+
+`grpcomm_release_delay_ms` (with `grpcomm_release_delay_vpid`) is what makes
+that reachable — it holds one daemon's own *processing* of a release back
+while the forward to its children goes on time, widening a window that is
+otherwise microseconds.  Drive it at `rml_base_radix 1` so the tree is a chain
+and the delayed daemon is genuinely interior; hanging it off the HNP as a leaf
+tests nothing.  See the *"a contribution for the next round does not join this
+one"* case in `contrib/dockerswarm`.
 
 **A release with no local callback still has data to free.** A daemon
 holding a tracker only because it relayed for its subtree has no `cbfunc`

--- a/src/grpcomm/grpcomm.c
+++ b/src/grpcomm/grpcomm.c
@@ -91,6 +91,8 @@ void prte_grpcomm_register(void)
      * can arrange that window: it is otherwise a timing accident.
      *
      * Compiled in always, on purpose.  See src/grpcomm/AGENTS.md. */
+    prte_grpcomm_globals.release_delay_ms = 0;
+    prte_grpcomm_globals.release_delay_vpid = -1;
     prte_grpcomm_globals.joined_late = false;
     prte_grpcomm_globals.joined_late_known = false;
 
@@ -102,6 +104,27 @@ void prte_grpcomm_register(void)
                                "0 (the default) sends immediately.",
                                PMIX_MCA_BASE_VAR_TYPE_INT,
                                &prte_grpcomm_globals.fence_delay_ms);
+
+    /* The other half of the pair: hold a daemon's own processing of a release
+     * back while its children get theirs on time.  That is the only way to
+     * reach the early-arrival window, where a contribution for the NEXT round
+     * lands on a daemon still finishing the previous one. */
+    prte_grpcomm_globals.release_delay_ms = 0;
+    pmix_mca_base_var_register("prte", "grpcomm", NULL, "release_delay_ms",
+                               "Hold this daemon's own processing of a fence "
+                               "release back by this many milliseconds. The "
+                               "forward to its children is not delayed. Fault "
+                               "injection; 0 (the default) processes at once.",
+                               PMIX_MCA_BASE_VAR_TYPE_INT,
+                               &prte_grpcomm_globals.release_delay_ms);
+
+    prte_grpcomm_globals.release_delay_vpid = -1;
+    pmix_mca_base_var_register("prte", "grpcomm", NULL, "release_delay_vpid",
+                               "Restrict grpcomm_release_delay_ms to the daemon "
+                               "with this vpid. -1 (the default) delays on "
+                               "every daemon that reads the parameter.",
+                               PMIX_MCA_BASE_VAR_TYPE_INT,
+                               &prte_grpcomm_globals.release_delay_vpid);
 
     /* -1 means "whichever daemon this is", which is what a per-node MCA file
      * wants; a vpid names one daemon in a DVM-wide setting, which is what a

--- a/src/grpcomm/grpcomm_fence.c
+++ b/src/grpcomm/grpcomm_fence.c
@@ -1368,9 +1368,85 @@ static void relcb(void *cbdata)
     }
 }
 
+static void fence_release_process(pmix_data_buffer_t *buffer);
+
+/* Fault injection: carry a release across the delay timer.  The buffer is a
+ * copy - the one the RML handed us goes back when that callback returns. */
+typedef struct {
+    prte_event_t ev;
+    pmix_data_buffer_t *buf;
+} release_delay_caddy_t;
+
+static void release_delay_fire(int sd, short args, void *cbdata)
+{
+    release_delay_caddy_t *dc = (release_delay_caddy_t *) cbdata;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
+                         "%s grpcomm:fence processing the held-back release",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+    fence_release_process(dc->buf);
+    PMIX_DATA_BUFFER_RELEASE(dc->buf);
+    free(dc);
+}
+
+static bool release_should_delay(void)
+{
+    if (0 >= prte_grpcomm_globals.release_delay_ms) {
+        return false;
+    }
+    if (0 > prte_grpcomm_globals.release_delay_vpid) {
+        return true;
+    }
+    return ((pmix_rank_t) prte_grpcomm_globals.release_delay_vpid
+            == PRTE_PROC_MY_NAME->rank);
+}
+
 void prte_grpcomm_fence_release(int status, pmix_proc_t *sender,
                                        pmix_data_buffer_t *buffer,
                                        prte_rml_tag_t tag, void *cbdata)
+{
+    PRTE_HIDE_UNUSED_PARAMS(status, sender, tag, cbdata);
+
+    if (release_should_delay()) {
+        /* Hold our own processing back while our children get theirs on time
+         * - xcast forwarded to them before handing this up, so they are
+         * already going.  Their clients will open the next round and their
+         * contributions will arrive here while this daemon still has the
+         * previous one open, which is the window the round number covers and
+         * which is otherwise microseconds wide. */
+        release_delay_caddy_t *dc = (release_delay_caddy_t *) calloc(1, sizeof(*dc));
+        struct timeval tv;
+        pmix_status_t prc;
+
+        if (NULL == dc) {
+            fence_release_process(buffer);
+            return;
+        }
+        PMIX_DATA_BUFFER_CREATE(dc->buf);
+        prc = PMIx_Data_copy_payload(dc->buf, buffer);
+        if (PMIX_SUCCESS != prc) {
+            PMIX_ERROR_LOG(prc);
+            PMIX_DATA_BUFFER_RELEASE(dc->buf);
+            free(dc);
+            fence_release_process(buffer);
+            return;
+        }
+        PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
+                             "%s grpcomm:fence holding its release back %d ms",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                             prte_grpcomm_globals.release_delay_ms));
+        tv.tv_sec = prte_grpcomm_globals.release_delay_ms / 1000;
+        tv.tv_usec = (prte_grpcomm_globals.release_delay_ms % 1000) * 1000;
+        prte_event_evtimer_set(prte_event_base, &dc->ev, release_delay_fire, dc);
+        PMIX_POST_OBJECT(dc);
+        prte_event_evtimer_add(&dc->ev, &tv);
+        return;
+    }
+    fence_release_process(buffer);
+}
+
+static void fence_release_process(pmix_data_buffer_t *buffer)
 {
     int32_t cnt;
     int rc, ret;
@@ -1378,7 +1454,6 @@ void prte_grpcomm_fence_release(int status, pmix_proc_t *sender,
     prte_grpcomm_fence_t *coll;
     pmix_byte_object_t bo;
     uint32_t gen;
-    PRTE_HIDE_UNUSED_PARAMS(status, sender, tag, cbdata);
 
     PMIX_OUTPUT_VERBOSE((5, prte_grpcomm_globals.output,
                          "%s grpcomm: fence release called with %d bytes",

--- a/src/grpcomm/grpcomm_internal.h
+++ b/src/grpcomm/grpcomm_internal.h
@@ -110,6 +110,20 @@ typedef struct {
     // delay_ms 0 costs one compare per fence.
     int fence_delay_ms;
     int fence_delay_vpid;
+    // Fault injection, the other half: hold this daemon's own *processing* of
+    // a fence release back, without holding up the forward to its children.
+    //
+    // That is the shape of the one window the round number has to cover and
+    // grpcomm_fence_delay_ms cannot reach. xcast forwards a release before
+    // processing it, so a child is released while its parent still has the
+    // previous round open; the child's clients start the next round and their
+    // contribution arrives at a parent that has not caught up. Delaying the
+    // parent's processing widens that gap from microseconds to whatever is
+    // asked for, which is what makes it testable at all.
+    //
+    // Ships for the same reason its sibling does.
+    int release_delay_ms;
+    int release_delay_vpid;
     // Did this daemon join a DVM that had already been running collectives?
     //
     // It decides what "I have no round number for this signature" means, and


### PR DESCRIPTION
Follow-on to #2746. Three changes: the knob that reaches the one window the round number covers but nothing could provoke, the case that drives it, and a correction to what the existing fence assertions were actually testing.

## The early-arrival window

A fence release is an `xcast`, and `PRTE_RML_TAG_FENCE_RELEASE` is not in the `process_first` set — so a daemon **forwards a release to its children before it processes the release itself**. In that gap a child is released, its clients open the next round, and its contribution arrives at a parent that still has the previous round open.

#2746 keyed trackers by `(signature, generation)` so that contribution gets a tracker of its own instead of landing in a bucket the release is about to discard. Nothing exercised it, because the gap is microseconds wide in normal running.

`grpcomm_release_delay_ms` (with `grpcomm_release_delay_vpid`) holds a daemon's own *processing* of a release back without delaying the forward — precisely the shape of the window, widened to whatever is asked for. Compiled in rather than hidden behind a debug build, for the same reason its sibling `grpcomm_fence_delay_ms` is: a hook that exists only under `PRTE_ENABLE_DEBUG` cannot reproduce a race on the build that shows it.

Two things have to be true for the case to test anything, and both are asserted or arranged rather than hoped for:

- the delayed daemon must be **interior**, with a subtree below it — a leaf hanging off the HNP has no children to run ahead of it. The case runs at `rml_base_radix 1` so the tree is a chain.
- the **first** fence must have completed, or there was no release to overtake. That is asserted before anything is asserted about the second.

**The failure it guards against is a hang, not bad data**, which is worth knowing when reading a red run. Keyed by signature alone, the early contribution is consumed by the round it does not belong to, and the round it does belong to then waits for something that has already arrived. Measured with the generation removed from the key: the second fence completes on **0 of 4** ranks, while the first still succeeds and the DVM survives.

## What the fence assertions were really asking

`fencer`'s readback used a plain `PMIx_Get`, and a plain `PMIx_Get` for a key the collective did not carry **falls through to a direct modex** and fetches it from the owning daemon. The value turns up, the check passes, and nothing has been learned about the fence — which is the one thing these cases exist to establish.

Not hypothetical: a fence deliberately broken to lose a contribution satisfied every one of these assertions, and only reported the loss once the Get was made `PMIX_OPTIONAL`. The second key already did this; the first now does too.

Running the suite with the change confirms the existing cases were sound — nothing went red, so they were being met by the collective all along rather than by the fall-through. Worth having established rather than assumed.

(It is also a tidy demonstration that the on-demand path works, which is recorded against Level 2 in the plan doc.)

## Verification

- CI-equivalent build reproduced locally first this time — gcc `-O3 -Werror`, `--enable-devel-check --enable-testbuild-launchers` — clean
- `--enable-debug` build clean, `make check` 24/24
- `contrib/dockerswarm` full suite **772 passed, 0 failed, 3 skipped**
- The new case verified in both directions: green with the generation in the tracker key, red without it