### PR TITLE
Design: a low-radix release beside the high-radix rollup

### DIFF
--- a/contrib/dockerswarm/fencer.c
+++ b/contrib/dockerswarm/fencer.c
@@ -160,7 +160,7 @@ int main(int argc, char **argv)
         pmix_value_t *got = NULL;
         uint32_t universe = 0, r;
         int found = 0, missing = 0;
-        pmix_status_t rc2nd;
+        pmix_status_t rc1st, rc2nd;
 
         PMIX_LOAD_PROCID(&peer, me.nspace, PMIX_RANK_WILDCARD);
         if (PMIX_SUCCESS == PMIx_Get(&peer, PMIX_JOB_SIZE, NULL, 0, &got) &&
@@ -173,9 +173,22 @@ int main(int argc, char **argv)
                 continue;   /* only remote peers prove the collective ran */
             }
             PMIX_LOAD_PROCID(&peer, me.nspace, r);
-            snprintf(key, sizeof(key), "fencer.rank.%u", r);
-            got = NULL;
-            if (PMIX_SUCCESS == PMIx_Get(&peer, key, NULL, 0, &got) && NULL != got) {
+            /* PMIX_OPTIONAL here too, and for the reason spelled out at the
+             * second key below: without it this asks whether the runtime can
+             * find the value by any means - including fetching it from the
+             * owning daemon on demand - rather than whether the collective
+             * carried it.  A fence that delivered nothing at all would still
+             * satisfy an ordinary Get. */
+            {
+                pmix_info_t opt[1];
+                bool t = true;
+                PMIX_INFO_LOAD(&opt[0], PMIX_OPTIONAL, &t, PMIX_BOOL);
+                snprintf(key, sizeof(key), "fencer.rank.%u", r);
+                got = NULL;
+                rc1st = PMIx_Get(&peer, key, opt, 1, &got);
+                PMIX_INFO_DESTRUCT(&opt[0]);
+            }
+            if (PMIX_SUCCESS == rc1st && NULL != got) {
                 uint32_t v = 0;
                 PMIx_Value_get_number(got, &v, PMIX_UINT32);
                 if (v == r) {

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -4600,6 +4600,70 @@ test_grpcomm() {
     test_grpcomm_invite
     test_grpcomm_ft
     test_fence_straggler
+    test_fence_early_arrival
+}
+
+test_fence_early_arrival() {
+    local out n
+
+    banner "grpcomm: a contribution for the next round does not join this one"
+    # The other side of the round number, and the one a straggler test cannot
+    # reach.  A fence release is an xcast, and PRTE_RML_TAG_FENCE_RELEASE is
+    # not in the process_first set, so a daemon FORWARDS a release to its
+    # children before it processes the release itself.  In that gap a child is
+    # released, its clients open the next round, and its contribution arrives
+    # at a parent that still has the previous round open.
+    #
+    # Keyed by signature alone that contribution joins the round it is not
+    # part of: it lands in a bucket that is about to be discarded by the
+    # release, and the round it actually belonged to then waits for a
+    # contribution that has already been consumed.  The symptom is not wrong
+    # data, it is the SECOND fence never completing.
+    #
+    # The gap is microseconds wide in normal running, so widen it:
+    # grpcomm_release_delay_ms holds one daemon's own processing of the
+    # release back while its children get theirs on time.  radix 1 makes the
+    # tree a chain, so daemon 1 is an interior daemon with a real subtree
+    # below it rather than a leaf hanging off the HNP.
+    cleanup_swarm
+    if ! RUN "test -x $FENCER"; then
+        skp "fencer client not installed -- re-run ./build.sh"
+        return
+    fi
+    if ! prted_dvm_start_mca 'node1:1,node2:1,node3:1,node4:1' \
+            '--prtemca rml_base_radix 1 --prtemca grpcomm_release_delay_ms 5000 --prtemca grpcomm_release_delay_vpid 1'; then
+        bad "could not start a DVM for the fence early-arrival test"
+        cleanup_swarm
+        return
+    fi
+
+    out=$(PRUN "--host node1:1,node2:1,node3:1,node4:1 -n 4 --map-by node $FENCER collect --twice" 2>&1)
+
+    # The first fence has to have completed, or there was no release to run
+    # ahead of and nothing below tests anything.
+    n=$(echo "$out" | grep -c 'FENCER collect rank .* rc PMIX_SUCCESS')
+    [ "$n" = 4 ] \
+        && ok "the first fence completed despite the held-back release" \
+        || bad "$n of 4 ranks completed the first fence: $(echo "$out" | grep 'FENCER collect' | tr '\n' ' ' | tail -c 250)"
+
+    # ...and the assertion: the next round, whose contributions reached a
+    # daemon that had not caught up, still converges.
+    n=$(echo "$out" | grep -c 'FENCER second rank .* rc PMIX_SUCCESS')
+    [ "$n" = 4 ] \
+        && ok "...and the round that overtook it completed too" \
+        || bad "$n of 4 ranks completed the second fence: $(echo "$out" | grep 'FENCER second' | tr '\n' ' ' | tail -c 250)"
+
+    n=$(echo "$out" | grep -c 'peers-bad 0')
+    [ "$n" = 4 ] \
+        && ok "...with every peer's contribution intact" \
+        || bad "$n of 4 ranks got a complete modex: $(echo "$out" | grep 'peers-' | tr '\n' ' ' | tail -c 250)"
+
+    RUN 'pgrep -x prte' >/dev/null 2>&1 \
+        && ok "...and the DVM survived the overlap" \
+        || bad "the HNP died over the overlapping rounds"
+
+    RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    cleanup_swarm
 }
 
 test_fence_straggler() {

--- a/docs/plans/scalable_collectives/index.rst
+++ b/docs/plans/scalable_collectives/index.rst
@@ -9,3 +9,4 @@ the lateral-movement experiment built, measured, and why it was withdrawn.
    :maxdepth: 2
 
    scalable-collectives.rst
+   two-radix-release.rst

--- a/docs/plans/scalable_collectives/two-radix-release.rst
+++ b/docs/plans/scalable_collectives/two-radix-release.rst
@@ -1,0 +1,239 @@
+Two trees: a low-radix release beside the high-radix rollup
+===========================================================
+
+Status
+------
+
+Design, not yet implemented.  It is the first of the alternative collection
+topologies that ``grpcomm`` will offer behind an MCA parameter, with the
+existing single tree remaining the default because it is the one we know
+works.  We will not have data to pick a winner before release, so the others
+ship for evaluation rather than as a recommendation.
+
+Why this one first
+------------------
+
+Of everything the withdrawn lateral work explored, this is the largest gain
+per unit of new risk, and the arithmetic is already recorded under
+"Separating the barrier from the modex".
+
+**The gather and the broadcast are asymmetric, and that is the whole
+opportunity.**  A broadcasting daemon receives one copy of ``D`` and sends
+``r`` copies, so its egress is ``r*D``.  A gathering daemon receives ``r``
+messages and sends **one** aggregate, so fanout costs it nothing at all.
+Every axis therefore favours a *high* radix for the rollup — smaller
+per-node egress, fewer hops, ``d`` times fewer total byte-hops — and only the
+release wants a low one.  Writing the cost of the pair as
+``(1 + r_release) * D/B``:
+
+====================================  ==============  ==========
+configuration                         cost            vs today
+====================================  ==============  ==========
+radix 64 both (today)                 ``65 * D/B``      1x
+gather 64, release 3                  ``4 * D/B``     **16x**
+Bruck allgather                       ``1 * D/B``       65x
+====================================  ==============  ==========
+
+So a two-radix tree captures 16x of an available 65x **with no exchange
+schedule**.  Its ceiling is the gather's own ``D/B``, irreducible because the
+controller must receive the entire modex; that is why gather-then-broadcast
+can never reach an allgather, and why Bruck remains worth another 4x on top.
+
+**And the transport already exists.**  A radix-3 release edge is a *sibling*
+edge in a radix-64 routing tree, so this needs direct sends to non-children —
+which is Piece 1, and Piece 1 survived the tree-only reset.
+``prte_rml_send_buffer_direct_nb``, ``PRTE_RML_SEND_DIRECT``,
+``prte_rml_base.lateral_links`` and ``prte_rml_is_lateral_only`` are all on
+master and currently unused.
+
+The decision that shapes everything else
+----------------------------------------
+
+**Each tree carries its own reliable-message recovery.**  There are two trees
+in the system with two dedicated purposes — rollup and fan-out — and neither
+can account for the other's coverage.
+
+This is not a detail of implementation, it is the thing that makes the design
+tractable, and the reason is visible in what an ``op_t`` already holds
+(``src/grpcomm/grpcomm_xcast.c``):
+
+* ``nexpected`` is "# children at time of (re)start" — a statement about one
+  topology's shape.
+* ``ack_id_up`` / ``ack_id_down`` "track which acks are valid by order of
+  faults reported from HNP" — an ordering over one topology's repairs.
+* ``replay_pending_parent`` exists because "our completion information for
+  older ops is invalid when our subtree grows" — a promotion in one tree.
+
+You cannot account for coverage of a message that traversed tree *B* by
+rolling up acks on tree *A*.  A release whose reliability is accounted on the
+wrong topology is worse than one with no reliability at all, because it
+reports success it has not established.
+
+Shape
+-----
+
+**Parameterize the existing op machinery by topology; do not copy it.**  The
+reliability logic — hold the payload until completion is confirmed, count
+child acks, replay on repair — is correct and hard-won, and it is the same
+logic for both trees.  What differs is only *which tree* it asks for children
+and *which* repairs it reacts to.  So an op gains a topology, and:
+
+* ``forward_op`` asks that topology for its children rather than
+  ``prte_rml_base`` directly.
+* acks roll up that topology.
+* ``nexpected`` is that topology's child count.
+* a repair in that topology triggers that topology's replay.
+
+**The op id must stop being one global space.**  It is documented today as
+"HNP's assigned collective ID, globally unique", and two topologies
+allocating from it will alias.  Either the topology becomes part of the key
+or each gets its own counter; the key is cleaner, and matches the direction
+the fence has already taken with ``(signature, generation, step)``.
+
+**Each topology needs its own RML tag and receive path.**  This is not
+optional tidiness.  A daemon receiving a release on a sibling edge is not in
+any of this daemon's routing subtrees, and any handler that screens on
+``prte_rml_get_subtree_index()`` will discard it — which is exactly what the
+deleted ``PRTE_RML_TAG_XCAST_BULK`` and ``_FENCE_EXCHANGE`` existed to avoid.
+
+Deriving the second tree
+------------------------
+
+Every daemon must compute the same low-radix tree independently, from the
+same inputs — the daemon set and the release radix — exactly as the routing
+tree is derived today.  No exchange, no agreement protocol, no state to keep
+in step.  That matters beyond convenience: it is the same "every participant
+must reach the same answer independently" rule that a fence lives under,
+because a fence has no originator to settle a disagreement.
+
+The failed-daemon set is an input, and it must be **the same input on every
+daemon**.  The withdrawn work learned this the expensive way and it is
+recorded under Piece 2: deriving a participant list from the failed set makes
+daemons disagree in the window around a fault, and the collective deadlocks.
+The release tree is derived from the daemon set and repaired on the recovery
+epoch, which every daemon already adopts in step.
+
+Fault model
+-----------
+
+A daemon that dies is a relay in *both* trees, and each has to repair
+independently.
+
+* In the **rollup** tree nothing changes: the routing tree repairs as it does
+  today, and the fence's existing recovery restart re-offers contributions.
+* In the **release** tree the dead daemon orphans its low-radix subtree.  That
+  subtree's members must be re-parented by the same deterministic derivation —
+  they recompute the tree from the surviving daemon set and reach the same
+  answer — and the release replayed to them, which is what the op's held
+  payload is for.
+
+Note the asymmetry that makes this tractable: a release is idempotent at the
+receiver.  A daemon that receives the same release twice retires a tracker
+that is already gone, which ``fence_release`` already treats as "not
+involved" rather than an error.  Replaying too much is safe; replaying too
+little hangs.  Prefer the former.
+
+What is *not* covered by the fence's existing fault handler: it ends a fence
+that lost a **participant**, and knows nothing about losing a **relay on a
+second topology**.  That is this design's own responsibility.
+
+Selection
+---------
+
+One MCA parameter naming the release topology, defaulting to the current
+behaviour.  The rollup is not selectable — every axis favours a high radix
+for it, so there is nothing to choose.
+
+A second parameter gives the release radix, so the 16x above can be explored
+rather than asserted; the cost model says 3 but the model's constants are the
+ones we do not have.
+
+**The topology must be stamped on the wire and checked, not merely
+configured.**  A release is a broadcast and does have an originator, so
+unlike the fence's movement id this could in principle instruct rather than
+detect — but a daemon configured differently from its peers is a real
+deployment error, and the failure it produces without a check is a hang.
+Mismatch should produce a named ``show_help``, as the withdrawn movement id
+did.
+
+Verification
+------------
+
+* **Unit** — the low-radix tree derivation: same answer on every daemon for
+  the same inputs, including non-power-of-two daemon counts and the vpid
+  holes an elastic shrink leaves.
+* **Multi-node** — a large modex over a DVM with the release at a low radix,
+  every daemon holding identical bytes; and the fault case, where a relay in
+  the release tree dies mid-release and its orphaned subtree is still
+  released.  ``contrib/dockerswarm``'s ``grpcomm_release_delay_ms`` can widen
+  the window a fault has to land in.
+* **A/B** — the same sweep with the release topology set both ways.  Expect
+  it to show nothing on the container swarm: the fence is fixed-cost
+  dominated below roughly 140 KB of total modex, and a real job's modex is
+  far under that.  That is not a reason to skip the measurement, but it is a
+  reason not to read a null result as a verdict.
+
+Open questions
+--------------
+
+#. **Does the release still reach every daemon, or only participants?**
+   **Answered: every daemon, and not merely because it is simpler.**
+
+   To be clear about what the alternative was, since it is easy to misread:
+   a participants-only release is still a *relayed tree*, not a message to
+   each participant.  Only the node set differs — daemons hosting
+   participants rather than every daemon — so the traffic is ``(P-1)*D``
+   against ``(N-1)*D``.  For a job-wide fence ``P`` is ``N`` and there is no
+   difference at all; the saving exists only for a **subset** fence on a
+   large DVM, where today the payload reaches daemons with no stake in it.
+
+   What rules it out is the round number.  ``fence_release`` records the
+   generation *before* it looks for a tracker, deliberately, so **every**
+   daemon records **every** signature's round whether it participated or
+   not.  That is what makes the bootstrap rule safe: a daemon present since
+   the DVM started may stamp 0 for a signature it has no entry for, because
+   a DVM-wide release means "no entry" really does imply "round 0 has not
+   happened yet".
+
+   Send the release only to participants and that implication fails.  A
+   daemon outside the set records nothing; the job later grows onto it, so
+   it acquires participants; it has no entry and it is *not* ``joined_late``,
+   having been here since the start; so it stamps 0 while every other
+   participant is at ``k``, and its contribution is dropped as ancient.  A
+   hang — precisely the failure the joiner flag exists to prevent, reached
+   through a different door.  And unlike a joiner, this daemon cannot detect
+   its own situation: "I have been a participant throughout" is not
+   something it can know locally.
+
+   If the subset saving is ever wanted, the way to have both is to split the
+   release: a small DVM-wide notice that round ``k`` of signature ``S`` is
+   done, and the *payload* over participants only.  The notice is O(1)
+   against the payload's ``D``, so the saving survives and the invariant
+   holds.  Not worth building until a subset-fence workload asks for it.
+#. **Where does the release radix come from at scale?**  A fixed 3 is the
+   cost model's answer for a large DVM and is plainly wrong for a small one,
+   where the extra depth buys nothing.  A rule of thumb wants data we do not
+   have.
+#. **Does the group collective's release want the same treatment?**
+   **Answered: it gets the mechanism for free, and should keep the tree's
+   radix.**
+
+   There is nothing to consolidate — the consolidation already happened when
+   ``grpcomm`` came out of MCA.  ``prte_grpcomm_release_bcast`` is a single
+   seam that every release goes through: two sites in the fence (the normal
+   release and ``abort_fence_op``'s) and two in the group.  Implementing the
+   low-radix release inside that seam means both operations get it, and the
+   two cannot drift apart into different methods for the same job.
+
+   What should stay per-operation is the **radix**, not the mechanism.  A
+   group release is small, and a low radix only pays where the ``r*M*beta``
+   term is real; where it is nil, a low radix buys nothing and costs depth —
+   the same reason the operations table says a barrier and a tiny broadcast
+   both want a *high* radix.  Since the seam already takes a tag, selecting
+   on it is free, and it is the lesson Piece 5 recorded: the launch message
+   was given a tag of its own precisely so the choice could be made by
+   operation rather than by a byte threshold.
+
+   So: one mechanism, chosen by tag.  ``PRTE_RML_TAG_FENCE_RELEASE`` takes
+   the low radix when it is enabled; ``PRTE_RML_TAG_GROUP_RELEASE`` keeps the
+   tree unless someone measures a reason to change it.

--- a/src/grpcomm/AGENTS.md
+++ b/src/grpcomm/AGENTS.md
@@ -658,15 +658,30 @@ That cost two full build-and-run cycles of false green here.  (It is also a
 neat demonstration that the on-demand path works: the fence had genuinely
 lost the key and the application never noticed.)
 
-**Still open: the early contribution.**  `PRTE_RML_TAG_FENCE_RELEASE` is not
-in `xcast`'s `process_first` set, so a daemon forwards a release to its
-children *before* processing it itself.  A child can therefore be released,
-start the next round, and have its contribution reach the parent while the
-parent is still in the previous one.  Dropping is safe there but adopting the
-higher number onto the live tracker is **not** — it relabels a tracker whose
-bucket holds the previous round's data.  Handling that properly means keying
-trackers by `(signature, generation)` rather than by signature alone, which is
-the same identity a lateral movement would need.
+**The early contribution, and why it is not a corner case.**
+`PRTE_RML_TAG_FENCE_RELEASE` is not in `xcast`'s `process_first` set, so a
+daemon forwards a release to its children *before* processing it itself.  A
+child can therefore be released, start the next round, and have its
+contribution reach the parent while the parent is still in the previous one.
+That is what `(signature, generation)` keying is for: the early contribution
+gets a tracker of its own instead of landing in a bucket the release is about
+to discard.
+
+Adopting the higher number onto the live tracker instead — which is what the
+first attempt did — is worse than dropping, because it relabels a tracker
+holding the previous round's data.  The symptom is not wrong data but a
+**hang**: the early contribution is consumed by the wrong round, and the round
+it belonged to then waits for something that has already arrived.  Measured,
+with the generation removed from the key: the second fence completes on 0 of 4
+ranks while the first still succeeds and the DVM survives.
+
+`grpcomm_release_delay_ms` (with `grpcomm_release_delay_vpid`) is what makes
+that reachable — it holds one daemon's own *processing* of a release back
+while the forward to its children goes on time, widening a window that is
+otherwise microseconds.  Drive it at `rml_base_radix 1` so the tree is a chain
+and the delayed daemon is genuinely interior; hanging it off the HNP as a leaf
+tests nothing.  See the *"a contribution for the next round does not join this
+one"* case in `contrib/dockerswarm`.
 
 **A release with no local callback still has data to free.** A daemon
 holding a tracker only because it relayed for its subtree has no `cbfunc`

--- a/src/grpcomm/grpcomm.c
+++ b/src/grpcomm/grpcomm.c
@@ -91,6 +91,8 @@ void prte_grpcomm_register(void)
      * can arrange that window: it is otherwise a timing accident.
      *
      * Compiled in always, on purpose.  See src/grpcomm/AGENTS.md. */
+    prte_grpcomm_globals.release_delay_ms = 0;
+    prte_grpcomm_globals.release_delay_vpid = -1;
     prte_grpcomm_globals.joined_late = false;
     prte_grpcomm_globals.joined_late_known = false;
 
@@ -102,6 +104,27 @@ void prte_grpcomm_register(void)
                                "0 (the default) sends immediately.",
                                PMIX_MCA_BASE_VAR_TYPE_INT,
                                &prte_grpcomm_globals.fence_delay_ms);
+
+    /* The other half of the pair: hold a daemon's own processing of a release
+     * back while its children get theirs on time.  That is the only way to
+     * reach the early-arrival window, where a contribution for the NEXT round
+     * lands on a daemon still finishing the previous one. */
+    prte_grpcomm_globals.release_delay_ms = 0;
+    pmix_mca_base_var_register("prte", "grpcomm", NULL, "release_delay_ms",
+                               "Hold this daemon's own processing of a fence "
+                               "release back by this many milliseconds. The "
+                               "forward to its children is not delayed. Fault "
+                               "injection; 0 (the default) processes at once.",
+                               PMIX_MCA_BASE_VAR_TYPE_INT,
+                               &prte_grpcomm_globals.release_delay_ms);
+
+    prte_grpcomm_globals.release_delay_vpid = -1;
+    pmix_mca_base_var_register("prte", "grpcomm", NULL, "release_delay_vpid",
+                               "Restrict grpcomm_release_delay_ms to the daemon "
+                               "with this vpid. -1 (the default) delays on "
+                               "every daemon that reads the parameter.",
+                               PMIX_MCA_BASE_VAR_TYPE_INT,
+                               &prte_grpcomm_globals.release_delay_vpid);
 
     /* -1 means "whichever daemon this is", which is what a per-node MCA file
      * wants; a vpid names one daemon in a DVM-wide setting, which is what a

--- a/src/grpcomm/grpcomm_fence.c
+++ b/src/grpcomm/grpcomm_fence.c
@@ -1368,9 +1368,85 @@ static void relcb(void *cbdata)
     }
 }
 
+static void fence_release_process(pmix_data_buffer_t *buffer);
+
+/* Fault injection: carry a release across the delay timer.  The buffer is a
+ * copy - the one the RML handed us goes back when that callback returns. */
+typedef struct {
+    prte_event_t ev;
+    pmix_data_buffer_t *buf;
+} release_delay_caddy_t;
+
+static void release_delay_fire(int sd, short args, void *cbdata)
+{
+    release_delay_caddy_t *dc = (release_delay_caddy_t *) cbdata;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
+                         "%s grpcomm:fence processing the held-back release",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+    fence_release_process(dc->buf);
+    PMIX_DATA_BUFFER_RELEASE(dc->buf);
+    free(dc);
+}
+
+static bool release_should_delay(void)
+{
+    if (0 >= prte_grpcomm_globals.release_delay_ms) {
+        return false;
+    }
+    if (0 > prte_grpcomm_globals.release_delay_vpid) {
+        return true;
+    }
+    return ((pmix_rank_t) prte_grpcomm_globals.release_delay_vpid
+            == PRTE_PROC_MY_NAME->rank);
+}
+
 void prte_grpcomm_fence_release(int status, pmix_proc_t *sender,
                                        pmix_data_buffer_t *buffer,
                                        prte_rml_tag_t tag, void *cbdata)
+{
+    PRTE_HIDE_UNUSED_PARAMS(status, sender, tag, cbdata);
+
+    if (release_should_delay()) {
+        /* Hold our own processing back while our children get theirs on time
+         * - xcast forwarded to them before handing this up, so they are
+         * already going.  Their clients will open the next round and their
+         * contributions will arrive here while this daemon still has the
+         * previous one open, which is the window the round number covers and
+         * which is otherwise microseconds wide. */
+        release_delay_caddy_t *dc = (release_delay_caddy_t *) calloc(1, sizeof(*dc));
+        struct timeval tv;
+        pmix_status_t prc;
+
+        if (NULL == dc) {
+            fence_release_process(buffer);
+            return;
+        }
+        PMIX_DATA_BUFFER_CREATE(dc->buf);
+        prc = PMIx_Data_copy_payload(dc->buf, buffer);
+        if (PMIX_SUCCESS != prc) {
+            PMIX_ERROR_LOG(prc);
+            PMIX_DATA_BUFFER_RELEASE(dc->buf);
+            free(dc);
+            fence_release_process(buffer);
+            return;
+        }
+        PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
+                             "%s grpcomm:fence holding its release back %d ms",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                             prte_grpcomm_globals.release_delay_ms));
+        tv.tv_sec = prte_grpcomm_globals.release_delay_ms / 1000;
+        tv.tv_usec = (prte_grpcomm_globals.release_delay_ms % 1000) * 1000;
+        prte_event_evtimer_set(prte_event_base, &dc->ev, release_delay_fire, dc);
+        PMIX_POST_OBJECT(dc);
+        prte_event_evtimer_add(&dc->ev, &tv);
+        return;
+    }
+    fence_release_process(buffer);
+}
+
+static void fence_release_process(pmix_data_buffer_t *buffer)
 {
     int32_t cnt;
     int rc, ret;
@@ -1378,7 +1454,6 @@ void prte_grpcomm_fence_release(int status, pmix_proc_t *sender,
     prte_grpcomm_fence_t *coll;
     pmix_byte_object_t bo;
     uint32_t gen;
-    PRTE_HIDE_UNUSED_PARAMS(status, sender, tag, cbdata);
 
     PMIX_OUTPUT_VERBOSE((5, prte_grpcomm_globals.output,
                          "%s grpcomm: fence release called with %d bytes",

--- a/src/grpcomm/grpcomm_internal.h
+++ b/src/grpcomm/grpcomm_internal.h
@@ -110,6 +110,20 @@ typedef struct {
     // delay_ms 0 costs one compare per fence.
     int fence_delay_ms;
     int fence_delay_vpid;
+    // Fault injection, the other half: hold this daemon's own *processing* of
+    // a fence release back, without holding up the forward to its children.
+    //
+    // That is the shape of the one window the round number has to cover and
+    // grpcomm_fence_delay_ms cannot reach. xcast forwards a release before
+    // processing it, so a child is released while its parent still has the
+    // previous round open; the child's clients start the next round and their
+    // contribution arrives at a parent that has not caught up. Delaying the
+    // parent's processing widens that gap from microseconds to whatever is
+    // asked for, which is what makes it testable at all.
+    //
+    // Ships for the same reason its sibling does.
+    int release_delay_ms;
+    int release_delay_vpid;
     // Did this daemon join a DVM that had already been running collectives?
     //
     // It decides what "I have no round number for this signature" means, and


### PR DESCRIPTION
Design only — no code. The first of the alternative collection topologies `grpcomm` will offer behind an MCA parameter, written up before implementation so the decisions are reviewable on their own.

**The tree stays the default.** We will not have data to pick a winner before release, so the alternatives ship for evaluation rather than as a recommendation.

## Why this one first

The gather and the broadcast are asymmetric: a broadcasting daemon receives one copy of `D` and sends `r`, while a gathering daemon receives `r` messages and sends **one** aggregate — so fanout costs it nothing. Every axis favours a high radix for the rollup and only the release wants a low one. Splitting them captures **16x of an available 65x with no exchange schedule**, against Bruck's 65x with a whole new fault model.

And the transport is already here: a low-radix release edge is a *sibling* edge, which is what Piece 1's direct sends provide — and Piece 1 survived the tree-only reset, unused.

## The decision the design is built around

**Each tree carries its own reliable-message recovery.** Two trees, two dedicated purposes, and neither can account for the other's coverage. The reason is visible in what an `op_t` already holds: `nexpected` is a statement about one topology's shape, `ack_id_up`/`ack_id_down` order one topology's repairs, and `replay_pending_parent` exists because a promotion invalidates completion information for a subtree that grew.

A release whose reliability is accounted on the wrong topology is worse than one with none, because it reports a success it has not established.

## What follows, recorded so it is not rediscovered

- **Parameterize the op machinery by topology; do not copy it.** The hold-payload / count-acks / replay-on-repair logic is identical for both trees — only "which tree do I ask for children" and "which repairs do I react to" differ. Two copies would rot independently.
- **The op id must stop being a single global space.** It is documented as "globally unique"; two topologies allocating from it will alias.
- **Each topology needs its own tag and receive path.** A sibling-edge arrival is in nobody's routing subtree, and any handler screening on `prte_rml_get_subtree_index()` discards it — which is what the deleted `PRTE_RML_TAG_XCAST_BULK` existed to avoid.
- **The second tree is derived, never agreed** — same inputs, same answer, no protocol. And the failed-daemon set must be an input every daemon holds in step, because deriving from it mid-fault is what deadlocked the withdrawn exchange.
- **Replaying a release too often is safe; replaying too little hangs.** A duplicate retires a tracker already gone, which `fence_release` treats as "not involved". The fault path should prefer the former.

## Two questions answered in the writing

**The release stays DVM-wide** — and not merely because it is simpler. `fence_release` records the generation *before* the tracker lookup, so every daemon records every signature's round whether it participated or not. That is what makes the round-number bootstrap safe. Send it only to participants and a daemon outside the set records nothing; the job later grows onto it; it has no entry and is not `joined_late`; so it stamps 0 while everyone else is at *k* and is dropped as ancient. A hang — the failure the joiner flag prevents, through a different door — and one the daemon cannot detect locally.

(If the subset-fence saving is ever wanted, the way to have both is an O(1) DVM-wide "round *k* is done" notice plus the payload over participants only. Recorded, not built.)

**The group release gets the mechanism for free and should keep the tree's radix.** There is nothing to consolidate — `prte_grpcomm_release_bcast` is already a single seam every release goes through, so implementing this inside it means fence and group cannot drift into different methods. What stays per-operation is the radix: a group release is small, and a low radix only pays where the `r*M*beta` term is real. Selection by tag, which is the lesson Piece 5 recorded.

## Expect the swarm to show nothing

The fence is fixed-cost dominated below roughly 140 KB of total modex, and a real job's is far under that. That is a reason not to read a null result as a verdict, not a reason to skip the measurement.

## Remaining unknown

The release radix itself. The cost model says 3, but its constants — `alpha` as a progress-thread hop, `beta` on real per-node uplinks — are exactly what a single-host container swarm cannot supply. The parameter ships tunable and the default is a judgement call.