### PR TITLE
Give a fence release a tree of its own, and its own recovery

### DIFF
--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -4601,6 +4601,7 @@ test_grpcomm() {
     test_grpcomm_ft
     test_fence_straggler
     test_fence_early_arrival
+    test_low_radix_release
 }
 
 test_fence_early_arrival() {
@@ -4663,6 +4664,73 @@ test_fence_early_arrival() {
         || bad "the HNP died over the overlapping rounds"
 
     RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    cleanup_swarm
+}
+
+test_low_radix_release() {
+    local out n hosts
+
+    banner "grpcomm: a fence release can travel a tree of its own"
+    # The rollup and the release want opposite radices.  A gathering daemon
+    # receives r messages and sends ONE aggregate, so fanout costs it nothing;
+    # a broadcasting daemon receives one copy and sends r, so fanout is the
+    # whole cost.  grpcomm_low_radix_release sends a fence's release down the
+    # tree rml_base_radix2 describes rather than the routing tree.
+    #
+    # The two radices are deliberately far apart here: routing radix 64 over
+    # eight daemons is one hop from the HNP to everybody, while release radix
+    # 2 is three levels deep.  That is what makes the case worth running - the
+    # release then arrives from a daemon that is NOT the receiver's routing
+    # parent, which the parent check screened on until it learned to ask which
+    # tree a message travelled, and daemons in the middle relay on a tree they
+    # relay on for nothing else.
+    #
+    # Run in the foreground rather than against a daemonized DVM, because the
+    # last assertion reads the HNP's verbose output and a --daemonize'd DVM
+    # detaches it.
+    #
+    # Note what this does NOT establish: anything about speed.  These
+    # containers share one host and have no per-node uplinks for a radix to
+    # contend on, so the entire point of the low radix is invisible here.
+    # What it establishes is that the release arrives, intact, over the other
+    # tree.
+    hosts=node1:1,node2:1,node3:1,node4:1,node5:1,node6:1,node7:1,node8:1
+    cleanup_swarm
+    if ! RUN "test -x $FENCER"; then
+        skp "fencer client not installed -- re-run ./build.sh"
+        return
+    fi
+
+    out=$(RUN "timeout -k 5 180 prterun --prtemca grpcomm_low_radix_release 1 \
+                   --prtemca rml_base_radix2 2 --prtemca rml_base_radix 64 \
+                   --prtemca grpcomm_base_verbose 1 \
+                   --host $hosts -n 8 --map-by node $FENCER collect --twice" 2>&1)
+
+    n=$(echo "$out" | grep -c 'FENCER collect rank .* rc PMIX_SUCCESS')
+    [ "$n" = 8 ] \
+        && ok "all 8 ranks completed a modex fence released on the other tree" \
+        || bad "$n of 8 ranks completed the fence: $(echo "$out" | grep FENCER | tr '\n' ' ' | tail -c 250)"
+
+    n=$(echo "$out" | grep -c 'FENCER second rank .* rc PMIX_SUCCESS')
+    [ "$n" = 8 ] \
+        && ok "...and a second one over the same participants" \
+        || bad "$n of 8 ranks completed the second fence"
+
+    n=$(echo "$out" | grep -c 'peers-bad 0')
+    [ "$n" = 8 ] \
+        && ok "...with every peer's contribution delivered" \
+        || bad "$n of 8 ranks got a complete modex: $(echo "$out" | grep 'peers-' | tr '\n' ' ' | tail -c 250)"
+
+    # The assertion without which every one above passes vacuously: the
+    # release has to have gone down the other tree.  All of them succeed just
+    # as well when the knob is quietly ignored, which is exactly what happened
+    # the first time this was wired up - the selector was never installed, and
+    # three green runs said nothing at all.
+    n=$(echo "$out" | grep -c 'on tree 1')
+    [ "$n" -ge 1 ] \
+        && ok "...and the release travelled the release tree, not the routing one" \
+        || bad "no broadcast used the release tree - the knob was ignored"
+
     cleanup_swarm
 }
 

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -4602,6 +4602,7 @@ test_grpcomm() {
     test_fence_straggler
     test_fence_early_arrival
     test_low_radix_release
+    test_low_radix_release_fault
 }
 
 test_fence_early_arrival() {
@@ -4731,6 +4732,107 @@ test_low_radix_release() {
         && ok "...and the release travelled the release tree, not the routing one" \
         || bad "no broadcast used the release tree - the knob was ignored"
 
+    cleanup_swarm
+}
+
+test_low_radix_release_fault() {
+    local out n t0 t1 el
+
+    banner "grpcomm: a release tree repairs itself when a relay dies"
+    # Two trees in the DVM, each for one direction of a collective, and each
+    # therefore needing its own recovery.  The routing tree's is reported to
+    # us by the RML -- who was promoted, which children changed, what the
+    # previous set was -- and none of that describes the release tree, which
+    # is derived rather than repaired: after a death every daemon simply
+    # computes a different answer from a live set they all hold in step.
+    #
+    # Applying the routing tree's facts to a release-tree operation is not a
+    # near miss, it is the wrong tree in every particular.  Here the routing
+    # radix is 64, so a non-master daemon has NO routing children at all --
+    # and the old handler read that as "my subtree is empty, this operation is
+    # complete" and retired a release that had not been forwarded anywhere.
+    #
+    # The shape: release radix 2 over eight daemons is 0->{1,2}, 1->{3,4},
+    # 2->{5,6}, 3->{7}.  Daemon 1 is told to hold its forward, so daemons 3, 4
+    # and 7 do not have the release; then daemon 1 is killed, taking the held
+    # copy with it.  The only way those three are ever released is the repair.
+    # Daemon 1 hosts no process, so what dies is a relay and nothing else --
+    # the fence itself is not "affected" and must simply carry on.
+    cleanup_swarm
+    if ! RUN "test -x $FENCER"; then
+        skp "fencer client not installed -- re-run ./build.sh"
+        return
+    fi
+
+    if ! prted_dvm_start_mca \
+            'node1:1,node2:1,node3:1,node4:1,node5:1,node6:1,node7:1,node8:1' \
+            '--prtemca grpcomm_low_radix_release 1 --prtemca rml_base_radix2 2 --prtemca rml_base_radix 64 --prtemca grpcomm_xcast_delay_ms 12000 --prtemca grpcomm_xcast_delay_vpid 1'; then
+        bad "could not start the DVM for the release-tree fault test"
+        cleanup_swarm
+        return
+    fi
+
+    # The canary, and the assertion without which everything below passes
+    # vacuously: prove the hold is armed and aimed at daemon 1 before killing
+    # anything.  A parameter that never reached the daemons, or a delay that
+    # is not on the path a release takes, makes every later assertion pass
+    # while testing nothing at all -- which is exactly how the first version
+    # of the low-radix case spent three green runs.  With daemon 1 holding for
+    # 12s the fence cannot finish sooner, so the wall clock says whether it is
+    # really holding.
+    t0=$(date +%s)
+    out=$(RUN "timeout -k 5 120 prun --dvm-uri file:$PRTED_URI \
+                   --host node1:1,node3:1,node4:1,node5:1,node6:1,node7:1,node8:1 \
+                   -n 7 --map-by node $FENCER collect" 2>&1)
+    t1=$(date +%s)
+    el=$((t1 - t0))
+    n=$(echo "$out" | grep -c 'FENCER collect rank .* rc PMIX_SUCCESS')
+    [ "$n" = 7 ] && [ "$el" -ge 10 ] \
+        && ok "the forward hold is live: 7 ranks released, after ${el}s" \
+        || bad "hold not in effect ($n of 7 ranks, ${el}s) -- every assertion below would be vacuous"
+
+    # Now the fault.  Kill daemon 1 while it is sitting on the release.
+    PRUN_BG /tmp/lrr-fault.out \
+        "--host node1:1,node3:1,node4:1,node5:1,node6:1,node7:1,node8:1 \
+         -n 7 --map-by node --rtos recoverable $FENCER collect"
+    sleep 4
+    if ! ON 2 'pgrep -x prted' >/dev/null 2>&1; then
+        bad "node2 has no daemon to kill"
+    else
+        ON 2 'pkill -9 -x prted' >/dev/null 2>&1
+        n=0
+        while [ "$n" -lt 90 ]; do
+            RUN 'pgrep -x prun' >/dev/null 2>&1 || break
+            sleep 1; n=$((n+1))
+        done
+        out=$(RUN 'tr -d "\000" < /tmp/lrr-fault.out' 2>&1)
+
+        n=$(echo "$out" | grep -c 'FENCER collect rank .* rc PMIX_SUCCESS')
+        [ "$n" = 7 ] \
+            && ok "every rank was released after the relay holding it died" \
+            || bad "$n of 7 ranks were released: $(echo "$out" | grep FENCER | tr '\n' ' ' | tail -c 300)"
+
+        # ...and with the payload intact.  A repair that delivered *a*
+        # release rather than the one that was in flight would still let the
+        # fence return; what says it was the right one is the modex.
+        n=$(echo "$out" | grep -c 'peers-bad 0')
+        [ "$n" = 7 ] \
+            && ok "...with every peer's contribution still delivered" \
+            || bad "$n of 7 ranks got a complete modex after the repair"
+    fi
+
+    # The DVM has to have survived it: the repair runs on every daemon, and
+    # one that mis-repairs takes its own broadcast ordering with it, which
+    # shows up on the NEXT collective rather than this one.
+    out=$(RUN "timeout -k 5 60 prun --dvm-uri file:$PRTED_URI \
+                   --host node1:1,node3:1,node4:1 -n 3 --map-by node \
+                   $FENCER collect" 2>&1)
+    n=$(echo "$out" | grep -c 'FENCER collect rank .* rc PMIX_SUCCESS')
+    [ "$n" = 3 ] \
+        && ok "...and a later fence over the survivors still completes" \
+        || bad "the DVM could not run a fence after the repair: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+
+    RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
     cleanup_swarm
 }
 
@@ -6755,6 +6857,17 @@ test_linux() {
         # anything yourself.
         echo "     Recreate them: ${SWARM_ENV}docker compose up -d --force-recreate" >&2
         echo "     (from contrib/dockerswarm, so the pinned project name applies)" >&2
+        return
+    fi
+
+    # Run only the named phases, for iterating on one of them.  Everything
+    # above this line is preflight and still runs: the checks that say the
+    # install is the one you built, and the sweep that says the swarm is
+    # clean, are exactly the ones whose absence makes a subset run lie.
+    if [ -n "${TEST_ONLY:-}" ]; then
+        for only_fn in $TEST_ONLY; do
+            "$only_fn"
+        done
         return
     fi
 

--- a/docs/plans/scalable_collectives/two-radix-release.rst
+++ b/docs/plans/scalable_collectives/two-radix-release.rst
@@ -137,12 +137,102 @@ What is *not* covered by the fence's existing fault handler: it ends a fence
 that lost a **participant**, and knows nothing about losing a **relay on a
 second topology**.  That is this design's own responsibility.
 
+What the implementation actually needed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The sketch above is right about the shape and wrong about the cost.  Four
+things had to change, and only the first was anticipated.  Each was found by
+killing a relay under a held release on the container harness, and each was
+measured rather than reasoned about — the count of daemons released went 4,
+then 5, then 7.
+
+**The derived tree did not agree with itself.**  Naming a parent by walking up
+past dead ancestors, while computing children by replacing a dead child in
+place, are two different promotion rules.  At eight daemons, radix 2, with
+daemon 1 dead, the promotion puts daemon 4 in slot 1 — so daemon 3's parent is
+4, while a walk-up says 0, and 0's children say 4.  Daemon 3 is in no tree at
+all.  Both halves now derive from the position the daemon actually occupies.
+``test_release_tree`` in ``test/unit/rml`` brute-forces every failure subset
+for radices 2 to 4 and requires the relation to be one tree rooted at 0
+covering exactly the living daemons; it is the cheapest guard here by a wide
+margin, and it catches this in milliseconds.
+
+**"Is the sender my parent?" is not answerable during a repair.**  Both the
+forward and the ack-request paths screened on the sender being this daemon's
+parent in the tree the message travelled.  That is sound on the routing tree,
+because the repair notice travels that same tree — a daemon has processed the
+notice that gave it a new parent before anything that parent relays afterwards
+can arrive.  A derived tree has no such ordering: every daemon recomputes
+independently when the notice reaches it, so a repaired parent replays to a
+child that has not heard, and the child discards the one message that would
+have released it.  The screen is now asked only of the routing tree.
+
+**An ack must answer whoever asked**, not whoever the answering daemon
+currently calls its parent, for the same reason.  Answering the wrong daemon
+costs nothing — it holds no operation under that ack id — while failing to
+answer the right one hangs the broadcast.
+
+**Nobody defers.**  The routing tree makes a promoted daemon wait for its own
+parent to replay before replaying onward, to preserve operation ordering.
+Copying that here strands subtrees: a daemon deferring to a parent that has
+already replayed waits for a second replay that is never coming.  It is also
+unnecessary — an operation a child is missing is by definition still in
+flight, so some daemon is replaying it in the same pass, in order, because the
+root cannot retire one until every daemon has acked.
+
+**A forward must be read under the view it was computed in.**  This is the one
+that does not follow from the tree being derived, and it is the subtlest.  A
+daemon promoted into a dead relay's slot still reads itself as a leaf until the
+news reaches it, so it answers the repair by retiring the operation as
+complete, having forwarded it nowhere — and the subtree the repair existed to
+reach is stranded with nobody holding the payload.  Every forward therefore
+carries ``prte_rml_tree_version()``, a monotone count of the departures and
+returns the sender has learned of, and a receiver that is behind it **and**
+was addressed by a daemon it does not call its parent takes the payload,
+delivers it locally, and parks the operation without deriving anything until
+the notice lands.
+
+Both conditions are load-bearing.  The version has to be monotone, which is
+why it counts events learned rather than the size of the failed set — a
+revival clears a bit, so a popcount would go *down*, and a daemon that had
+processed the revival would read every peer that had not as being ahead of
+it.  But monotone is not agreed: a daemon grown into a DVM is seeded from the
+departed set it was launched with, and daemons process a revival at different
+moments, so counts legitimately differ.  The "not my parent" test is the
+concrete local evidence that the two views actually disagree, and it is what
+keeps ordinary traffic — which always arrives from a daemon's parent — from
+ever being parked.
+
+Any further topology added here — Bruck above all — inherits all five.  They
+are properties of *deriving* a tree rather than being told one, not properties
+of this particular tree.
+
 Selection
 ---------
 
 One MCA parameter naming the release topology, defaulting to the current
 behaviour.  The rollup is not selectable — every axis favours a high radix
 for it, so there is nothing to choose.
+
+As implemented, the two are separate and only the first is a switch:
+
+``grpcomm_low_radix_release`` (bool, default **false**)
+   Whether a fence's release leaves the routing tree at all.  False is the
+   whole of the old behaviour: every release travels the routing tree, and
+   nothing in the derived-tree path runs.  This is the parameter that
+   collapses it all back.
+
+``rml_base_radix2`` (int, default **rml_base_radix**)
+   The shape of the release tree.  It selects nothing on its own — with the
+   switch off it is not consulted at all.
+
+That default is a trap and PRRTE now says so.  At equal radices the release
+tree *is* the routing tree — same parent and same children for every rank and
+every failure pattern, which ``test_release_tree_matches_routing`` pins — so
+turning the switch on and leaving the radix alone gets the identical fanout
+carried through more machinery, which can only be slower.  The
+``release-radix-noop`` help topic is emitted once by the master for that
+combination, and the run continues.
 
 A second parameter gives the release radix, so the 16x above can be explored
 rather than asserted; the cost model says 3 but the model's constants are the
@@ -155,6 +245,76 @@ detect — but a daemon configured differently from its peers is a real
 deployment error, and the failure it produces without a check is a hang.
 Mismatch should produce a named ``show_help``, as the withdrawn movement id
 did.
+
+First measurement, and what it does not settle
+----------------------------------------------
+
+Taken on ``contrib/dockerswarm``, ten daemons, routing radix 64 (so the
+release on the routing tree is one hop to all nine peers) against release
+radix 2 (depth 4, three hops).  ``grpcomm_enable_timing`` stamps an absolute
+microsecond when the originator starts a broadcast and when each daemon has
+the payload; coverage is the span between the two, so this measures the
+broadcast alone rather than an end-to-end fence — whose run-to-run spread on
+this harness is larger than the whole effect.  Payload from
+``scaletest --entropy``, since the default fill is a ramp that deflate
+squashes 250:1.  Medians over 10 releases per cell:
+
+.. list-table::
+   :header-rows: 1
+
+   * - release payload (on the wire)
+     - routing tree (radix 64)
+     - release tree (radix 2)
+   * - 33 B (a barrier's release)
+     - 408 us
+     - 854 us
+   * - 10.5 KB
+     - 1810 us
+     - 1770 us
+   * - 166 KB
+     - 4579 us
+     - 6326 us
+   * - 658 KB
+     - 9949 us
+     - 11406 us
+
+**The low radix loses here, and the reason is the harness rather than the
+idea.**  Every "node" is a container on one host, so the nine copies the flat
+tree makes the HNP send do not contend for anything — there is no per-node
+uplink, and they go at loopback speed.  The ``r*M*beta`` term the low radix
+exists to reduce is therefore close to free, while the extra hops are real:
+the 33-byte row is the cost of depth with no payload at all, and three extra
+hops cost ~450 us, or ~150 us a hop.
+
+So this is not evidence against the design.  It is a measurement of an
+environment in which the quantity being optimized is approximately zero, and
+it is the reading the harness section of ``contrib/dockerswarm/AGENTS.md``
+warns to expect.  What it does establish:
+
+* the mechanism works and is measurable — the release really does travel the
+  other tree, and the instrument resolves it;
+* the depth penalty is real and is roughly linear in hops;
+* nothing here justifies changing the default, which stays the routing tree.
+
+What would settle it is a machine where a daemon's outbound bandwidth is
+shared and finite — a real cluster with one NIC a node.  There the flat
+tree's nine copies serialize on that NIC while the low radix's extra hops are
+paid against a much larger transfer term.  ``contrib/scaling/cluster-sweep.sh``
+is the harness for that; until it has been run, the parameter ships off by
+default and this table is the only data.
+
+One caveat for whoever runs it next: the release is store-and-forward, so a
+deeper tree pays depth times the *transfer* time, not merely depth times a
+latency.  The crossover is therefore not simply "payload big enough" — it
+needs the per-copy bandwidth at the root to be the binding constraint, which
+is the thing this harness cannot arrange.
+
+A note on reading the instrument: a fence issues **two** releases per
+iteration and they are wildly different sizes — the allgather's carries the
+modex, the barrier's is 33 bytes — and both go out on the same tag.  A median
+taken over all tag-31 releases is therefore dominated by the 33-byte ones and
+says almost nothing about payload.  Pair each release with the size on the
+originator's own census line before averaging anything.
 
 Verification
 ------------

--- a/src/grpcomm/AGENTS.md
+++ b/src/grpcomm/AGENTS.md
@@ -458,6 +458,91 @@ The in-file comments are the real spec — read them. The load-bearing ideas:
   assuming its *newly-acquired* subtree finished ops it completed before
   promotion.
 
+### Turning the release onto its own tree takes TWO parameters
+
+`grpcomm_low_radix_release` (bool, **default false**) is the switch: it alone
+decides whether a fence's release leaves the routing tree. Off, every release
+goes down the routing tree and none of the derived-tree code below runs.
+
+`rml_base_radix2` (int, **defaults to `rml_base_radix`**) only gives the
+release tree its shape, and is not consulted at all while the switch is off.
+
+Setting the switch and leaving the radix alone does nothing useful, and it is
+the obvious mistake: at equal radices the release tree *is* the routing tree,
+identical parent and children for every rank and every failure pattern
+(`test_release_tree_matches_routing` in `test/unit/rml`). The master emits the
+`release-radix-noop` help topic for that combination and carries on. Note
+which way round the two want to be: the rollup wants a **wide** tree (a
+gathering daemon receives r messages and sends one aggregate, so width is
+free) and the release wants a **narrow** one (a broadcasting daemon receives
+one and sends r, so width is the whole cost).
+
+### A derived tree repairs by different rules, and they are not optional
+
+An op may travel a tree other than the routing one — today a fence release
+under `grpcomm_low_radix_release`, tomorrow anything else added to
+`prte_grpcomm_topology_t`. Such a tree is **derived**: every daemon computes
+it from the daemon count, the failed set and `rml_base_radix2`, all of which
+they hold in step, so there is no protocol and nothing to keep synchronized.
+That is what makes it cheap. It also means **none of the routing tree's
+recovery inputs describe it** — `status->promoted`, `->children_changed`,
+`->prev_children` and `prte_rml_base.n_children` are all facts about the
+routing tree, and applying them to an op travelling another one is not a near
+miss but the wrong tree in every particular. With `rml_base_radix 64` a
+non-master daemon has *no* routing children at all, and the handler read that
+as "my subtree is empty, this op is complete" and retired a release it had
+forwarded nowhere.
+
+`release_tree_fault()` is the separate path, and five rules hold it up. All
+five are properties of deriving a tree rather than being told one, so anything
+added here inherits them:
+
+- **Both halves of the derivation must agree.** `prte_rml_release_tree()`
+  computes a parent *and* children, and they have to describe the same tree
+  for every failure pattern. Walking up past dead ancestors to name a parent
+  while replacing a dead child in place is two different promotion rules and
+  orphans daemons outright. `test_release_tree` (`test/unit/rml`) brute-forces
+  every failure subset and requires one tree rooted at 0 covering exactly the
+  living daemons — run it before believing any change here.
+- **Do not screen a forward on "is the sender my parent".** That screen is
+  sound on the routing tree, whose repair notice travels the routing tree, so
+  a daemon has processed the notice that gave it a new parent before anything
+  that parent relays can arrive. A derived tree has no such ordering: a
+  repaired parent replays to a child that has not heard yet. Both the forward
+  and the ack-request screens are therefore asked only of
+  `PRTE_GRPCOMM_TOPO_ROUTING`.
+- **Ack whoever asked** (`send_ack_to`, `op->upstream`), not whoever this
+  daemon's own derivation currently calls its parent. Answering the wrong
+  daemon costs nothing; failing to answer the right one hangs the broadcast.
+- **Nobody defers.** `replay_pending_parent` is a routing-tree device; here a
+  daemon deferring to a parent that has already replayed waits for a second
+  replay that never comes, and strands its subtree. It is also unnecessary: an
+  op a child is missing is still in flight, hence held and replayed by someone
+  in the same pass, in op order.
+- **A forward must be read under the view it was computed in.** Every forward
+  carries `prte_rml_tree_version()` — a monotone count of the departures and
+  returns the sender has learned of. A receiver that is behind it **and** was
+  addressed by a daemon it does not call its parent parks the op
+  (`awaiting_news`): it takes the payload and delivers it locally, which does
+  not depend on the tree, but derives nothing until the notice lands. Without
+  this, a daemon promoted into a dead relay's slot still reads itself as a
+  leaf, retires the op as complete with zero children, and strands everything
+  beneath it. Both conditions are required — the version is a count of events
+  learned rather than an agreed number, and daemons legitimately hold
+  different ones for a while (a grown daemon is seeded from the departed set
+  it was launched with), so the "not my parent" test is what keeps ordinary
+  traffic from ever being parked.
+
+`grpcomm_xcast_delay_ms` / `_vpid` is the instrument: it holds one daemon's
+*forward* on a non-routing tree, so a broadcast that is otherwise over in
+microseconds can have a daemon killed underneath it on purpose. Its two
+siblings (`grpcomm_fence_delay_ms`, `grpcomm_release_delay_ms`) both act after
+the forward has gone and cannot reach this path at all. It ships compiled in,
+for the same reason they do. `contrib/dockerswarm`'s
+"a release tree repairs itself when a relay dies" is the case, and its first
+assertion is a canary on the hold being live — without it every assertion
+below passes vacuously.
+
 ### The forward is shared, and that changes what a send completion means
 
 `tree_whole_forward()` packs the forward **once** and hands the same

--- a/src/grpcomm/grpcomm.c
+++ b/src/grpcomm/grpcomm.c
@@ -38,6 +38,8 @@
 #include "src/mca/base/pmix_base.h"
 #include "src/util/pmix_output.h"
 
+#include "src/util/prte_show_help.h"
+
 #include "grpcomm_internal.h"
 
 prte_grpcomm_globals_t prte_grpcomm_globals = {
@@ -138,6 +140,30 @@ void prte_grpcomm_register(void)
                                PMIX_MCA_BASE_VAR_TYPE_INT,
                                &prte_grpcomm_globals.fence_delay_vpid);
 
+    /* And the third: hold the forward itself back, so an operation is still
+     * travelling its tree when a daemon is killed underneath it.  Its two
+     * siblings both act after the forward has gone, which cannot reach the
+     * fault path at all - on eight daemons a release is over in microseconds.
+     *
+     * Non-routing trees only.  Stalling the routing tree would hold up the
+     * daemon command channel rather than injecting a fault. */
+    prte_grpcomm_globals.xcast_delay_ms = 0;
+    pmix_mca_base_var_register("prte", "grpcomm", NULL, "xcast_delay_ms",
+                               "Fault injection: hold a daemon's forward of a "
+                               "broadcast on a non-routing tree back by this "
+                               "many milliseconds, so the operation stays in "
+                               "flight long enough for a daemon loss to be "
+                               "aimed at it (0 = off)",
+                               PMIX_MCA_BASE_VAR_TYPE_INT,
+                               &prte_grpcomm_globals.xcast_delay_ms);
+
+    prte_grpcomm_globals.xcast_delay_vpid = -1;
+    pmix_mca_base_var_register("prte", "grpcomm", NULL, "xcast_delay_vpid",
+                               "Restrict grpcomm_xcast_delay_ms to the daemon "
+                               "with this vpid (-1 = every daemon)",
+                               PMIX_MCA_BASE_VAR_TYPE_INT,
+                               &prte_grpcomm_globals.xcast_delay_vpid);
+
     /* Send a fence's release down the low-radix tree instead of the routing
      * tree.  Off by default, and that is the point of shipping it at all: we
      * will not have data to choose a winner before release, so the tree we
@@ -157,6 +183,23 @@ void prte_grpcomm_register(void)
  */
 int prte_grpcomm_init(void)
 {
+    /* A release tree at the routing tree's own radix IS the routing tree -
+     * same parent, same children, for every rank and every failure pattern
+     * (test_release_tree_matches_routing pins it).  rml_base_radix2 defaults
+     * to rml_base_radix, so turning the release onto its own tree and setting
+     * nothing else is the easy mistake, and it is a silent one: the fence
+     * still works, it just does the identical fanout through the derived-tree
+     * path.  Say so rather than let somebody measure it and conclude the idea
+     * does not help.
+     *
+     * The master alone, because every daemon reads the same two parameters
+     * and would otherwise say it once each. */
+    if (PRTE_PROC_IS_MASTER && prte_grpcomm_globals.low_radix_release
+        && prte_rml_base.radix2 == prte_rml_base.radix) {
+        prte_show_help("help-prte-grpcomm.txt", "release-radix-noop", true,
+                       prte_rml_base.radix, prte_rml_base.radix2);
+    }
+
     /* setup the trackers */
     PMIX_CONSTRUCT(&prte_grpcomm_globals.xcast_ops,
                    prte_grpcomm_xcast_t);

--- a/src/grpcomm/grpcomm.c
+++ b/src/grpcomm/grpcomm.c
@@ -48,7 +48,8 @@ prte_grpcomm_globals_t prte_grpcomm_globals = {
     .fence_generations = PMIX_LIST_STATIC_INIT(prte_grpcomm_globals.fence_generations)
 };
 
-prte_grpcomm_release_bcast_fn_t prte_grpcomm_release_bcast = prte_grpcomm_xcast;
+prte_grpcomm_release_bcast_fn_t prte_grpcomm_release_bcast =
+    prte_grpcomm_release_bcast_select;
 
 /* File scope, not a local: the MCA layer keeps the pointer it is handed and
  * writes through it whenever the variable is set, so a stack slot would be
@@ -136,6 +137,19 @@ void prte_grpcomm_register(void)
                                "every daemon that reads the parameter.",
                                PMIX_MCA_BASE_VAR_TYPE_INT,
                                &prte_grpcomm_globals.fence_delay_vpid);
+
+    /* Send a fence's release down the low-radix tree instead of the routing
+     * tree.  Off by default, and that is the point of shipping it at all: we
+     * will not have data to choose a winner before release, so the tree we
+     * know works stays the default and this exists to be evaluated against
+     * it.  The radix it uses is rml_base_radix2. */
+    prte_grpcomm_globals.low_radix_release = false;
+    pmix_mca_base_var_register("prte", "grpcomm", NULL, "low_radix_release",
+                               "Fan a fence's release out over the low-radix "
+                               "release tree (rml_base_radix2) rather than the "
+                               "routing tree. Off by default.",
+                               PMIX_MCA_BASE_VAR_TYPE_BOOL,
+                               &prte_grpcomm_globals.low_radix_release);
 }
 
 /**

--- a/src/grpcomm/grpcomm_internal.h
+++ b/src/grpcomm/grpcomm_internal.h
@@ -24,6 +24,43 @@
 
 BEGIN_C_DECLS
 
+/* Which tree a broadcast travels.
+ *
+ * There is more than one: the routing tree, at a high radix, which everything
+ * has always used; and the release tree, at a low one, which a collective's
+ * fan-out will use because the two want opposite radices - fanout is free on
+ * the way up a rollup and is the entire cost on the way down a release. See
+ * docs/plans/scalable_collectives/two-radix-release.rst.
+ *
+ * The topology is part of a broadcast's identity, not a routing hint. Two
+ * trees cannot share reliability accounting: a completion count is a
+ * statement about one tree's shape, and acks rolled up tree A say nothing
+ * about coverage of a message that travelled tree B. So each topology gets
+ * its own op-id sequence, its own completion state, and its own idea of who
+ * its parent and children are - and a message names which it belongs to.
+ *
+ * Keep PRTE_GRPCOMM_TOPO_ROUTING at zero: it is the value a zeroed structure
+ * or an unstamped message lands on, and it is the one that has always been
+ * meant. */
+typedef enum {
+    PRTE_GRPCOMM_TOPO_ROUTING = 0,
+    PRTE_GRPCOMM_TOPO_RELEASE,
+    PRTE_GRPCOMM_TOPO_COUNT
+} prte_grpcomm_topology_t;
+
+/* The per-tree reliability state.  One of these per topology: the sequence is
+ * what orders ops within a tree, and two trees ordering against one counter
+ * would have each raising out-of-order on the other's traffic. */
+typedef struct {
+    // ID of the last known completed (in our subtree) operation
+    size_t op_id_completed;
+    // op_id_completed when we were last promoted
+    // (our subtree grew, so we can't assume completion in our new subtree)
+    size_t op_id_completed_at_promotion;
+    // ID of the last known initiated operation
+    size_t op_id_inited;
+} prte_grpcomm_tree_state_t;
+
 /* Tracks ongoing xcast operations to ensure all messages are delivered exactly
  * once to all daemons even in the presence of daemon failures */
 typedef struct {
@@ -33,13 +70,8 @@ typedef struct {
     // FIFO of completion callbacks for master-originated broadcasts awaiting
     // relay back to the master (see grpcomm_xcast.c)
     pmix_list_t pending_completions;
-    // ID of the last known completed (in our subtree) operation
-    size_t op_id_completed;
-    // op_id_completed when we were last promoted
-    // (our subtree grew, so we can't assume completion in our new subtree)
-    size_t op_id_completed_at_promotion;
-    // ID of the last known initiated operation
-    size_t op_id_inited;
+    // reliability state, one set per tree
+    prte_grpcomm_tree_state_t tree[PRTE_GRPCOMM_TOPO_COUNT];
 } prte_grpcomm_xcast_t;
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_grpcomm_xcast_t);
 

--- a/src/grpcomm/grpcomm_internal.h
+++ b/src/grpcomm/grpcomm_internal.h
@@ -156,6 +156,26 @@ typedef struct {
     // Ships for the same reason its sibling does.
     int release_delay_ms;
     int release_delay_vpid;
+    // Fault injection, the third: hold this daemon's *forward* of a broadcast
+    // back, so the op stays in flight on the tree for as long as is asked
+    // for.
+    //
+    // Its two siblings both act on a release that has already been forwarded,
+    // which is the right shape for the round-number window and the wrong one
+    // for the fault path: repairing a tree only means anything while an op is
+    // still travelling it, and on eight daemons a release is over in
+    // microseconds. Widening that to seconds is what makes it possible to
+    // kill a daemon in the middle of a broadcast on purpose rather than by
+    // luck.
+    //
+    // Deliberately confined to the trees that are NOT the routing tree. The
+    // routing tree carries the daemon command channel - the halt, the wireup,
+    // the launch - and a knob that stalls those does not inject a fault, it
+    // wedges the DVM, which is a different experiment and a worse one.
+    //
+    // Ships for the same reason its siblings do.
+    int xcast_delay_ms;
+    int xcast_delay_vpid;
     // Did this daemon join a DVM that had already been running collectives?
     //
     // It decides what "I have no round number for this signature" means, and
@@ -249,6 +269,9 @@ int prte_grpcomm_xcast_topo(prte_rml_tag_t tag, pmix_data_buffer_t *msg,
  * for the same job. */
 typedef int (*prte_grpcomm_release_bcast_fn_t)(prte_rml_tag_t tag, pmix_data_buffer_t *msg);
 PRTE_EXPORT extern prte_grpcomm_release_bcast_fn_t prte_grpcomm_release_bcast;
+/* Which tree a release for this tag travels - the decision alone, so it can
+ * be asserted without a DVM to send over. */
+PRTE_EXPORT prte_grpcomm_topology_t prte_grpcomm_release_topology(prte_rml_tag_t tag);
 PRTE_EXPORT int prte_grpcomm_release_bcast_select(prte_rml_tag_t tag,
                                                   pmix_data_buffer_t *msg);
 

--- a/src/grpcomm/grpcomm_internal.h
+++ b/src/grpcomm/grpcomm_internal.h
@@ -176,6 +176,11 @@ typedef struct {
     // later wireup describes a DVM this daemon is already part of.
     bool joined_late;
     bool joined_late_known;
+    // Send a fence's release down the low-radix tree rather than the routing
+    // tree. Off by default: the tree we have is the one we know works, and
+    // there is no measurement yet that says which is better on hardware where
+    // the cost model's constants mean what it assumes.
+    bool low_radix_release;
 } prte_grpcomm_globals_t;
 
 #define PRTE_GRPCOMM_GROUP_MEMO_MAX 64
@@ -230,8 +235,22 @@ PRTE_EXPORT extern prte_grpcomm_globals_t prte_grpcomm_globals;
  * the result, with nothing to release - and because it is the only way the
  * unit test can see the release a controller would emit without standing up
  * an RML.  Production code sets this once, at startup, and never again. */
+/* Broadcast on a named tree. prte_grpcomm_xcast_nb is this with the routing
+ * tree, which is what almost every caller wants. */
+PRTE_EXPORT
+int prte_grpcomm_xcast_topo(prte_rml_tag_t tag, pmix_data_buffer_t *msg,
+                            prte_grpcomm_topology_t topology,
+                            prte_grpcomm_xcast_complete_fn_t cbfunc,
+                            void *cbdata);
+
+/* The one seam every collective's release goes through - two sites in the
+ * fence, two in the group. Putting the tree choice here rather than at each
+ * of them is what stops the two collectives drifting into different methods
+ * for the same job. */
 typedef int (*prte_grpcomm_release_bcast_fn_t)(prte_rml_tag_t tag, pmix_data_buffer_t *msg);
 PRTE_EXPORT extern prte_grpcomm_release_bcast_fn_t prte_grpcomm_release_bcast;
+PRTE_EXPORT int prte_grpcomm_release_bcast_select(prte_rml_tag_t tag,
+                                                  pmix_data_buffer_t *msg);
 
 
 /* Define collective signatures so we don't need to

--- a/src/grpcomm/grpcomm_xcast.c
+++ b/src/grpcomm/grpcomm_xcast.c
@@ -67,10 +67,37 @@ typedef struct {
 } pending_completion_t;
 PMIX_CLASS_INSTANCE(pending_completion_t, pmix_list_item_t, NULL, NULL);
 
-/* internal signature used to uniquely track a particular xcast */
+/* An op's identity folded into a single pointer-sized value, and back.
+ *
+ * PRTE_RML_SEND_CB carries one void* to its completion callback, and the
+ * identity it has to carry is now a pair: an op id is unique only within its
+ * topology, so the id alone would find the wrong op - or the right id in the
+ * wrong tree - as soon as both trees are in use. Folding is safe because an
+ * op id is a counter that will not approach the top three bits of a pointer
+ * in any run that could also exhaust memory. */
+#define SIG_TO_CBDATA(sig) \
+    ((void *)(intptr_t)(((sig).op_id * PRTE_GRPCOMM_TOPO_COUNT) + (sig).topology))
+#define SIG_FROM_CBDATA(sig, cbd)                                             \
+    do {                                                                      \
+        size_t _v = (size_t)(intptr_t)(cbd);                                  \
+        (sig).topology =                                                      \
+            (prte_grpcomm_topology_t)(_v % PRTE_GRPCOMM_TOPO_COUNT);          \
+        (sig).op_id = _v / PRTE_GRPCOMM_TOPO_COUNT;                           \
+    } while(0)
+
+/* internal signature used to uniquely track a particular xcast
+ *
+ * The op id is unique within its topology, not across all of them - two trees
+ * numbering from one counter would each raise out-of-order on the other's
+ * traffic. So the topology is part of the identity rather than a property of
+ * the op, and it travels with the signature. */
 typedef struct {
-    size_t op_id;    // HNP's assigned collective ID, globally unique
+    prte_grpcomm_topology_t topology;
+    size_t op_id;    // controller's assigned ID, unique within the topology
 } signature_t;
+
+/* the reliability state of the tree a signature names */
+#define TREE_OF(sig) (XCAST.tree[(sig).topology])
 
 /* internal component object for tracking ongoing operations */
 typedef struct {
@@ -138,6 +165,12 @@ static void finish_op(op_t *op);
 static void drive_completions(void);
 // Give up on this op's exchange and get the payload the tree way
 static void tree_whole_forward(op_t *op);
+/* Who this daemon relays to, and who relays to it, in a given tree - see the
+ * definitions for why the two trees answer differently. */
+static void topo_children(prte_grpcomm_topology_t topo, pmix_rank_t **children,
+                          size_t *n, bool *owned);
+static size_t topo_n_children(prte_grpcomm_topology_t topo);
+static pmix_rank_t topo_parent(prte_grpcomm_topology_t topo);
 
 
 // Pack the xcast message forwarded to our children.  Takes no destination:
@@ -298,10 +331,6 @@ void prte_grpcomm_xcast_recv(
     prte_rml_tag_t tag, void *cbdata
 ) {
     PRTE_HIDE_UNUSED_PARAMS(status,tag,cbdata);
-    if(!PRTE_PROC_IS_MASTER && sender->rank != PRTE_PROC_MY_PARENT->rank){
-        // Ignore messages from old parents
-        return;
-    }
     PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
                          "%s grpcomm:xcast:recv: with %d bytes",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
@@ -309,6 +338,16 @@ void prte_grpcomm_xcast_recv(
 
     signature_t sig;
     if(PMIX_SUCCESS != unpack_sig(buffer, &sig)) return;
+
+    /* Ignore messages from old parents - but "parent" is a question about the
+     * tree this broadcast is travelling, which is why the signature has to be
+     * read first. A release arriving over the low-radix tree comes from that
+     * tree's parent, and on a routing tree of a different radix that daemon is
+     * a sibling or a cousin rather than a parent. Screening on the routing
+     * parent would discard every one of them. */
+    if(!PRTE_PROC_IS_MASTER && sender->rank != topo_parent(sig.topology)){
+        return;
+    }
 
     /* An op-id of zero is an originator relaying to the controller rather than
      * a forward down the tree; the controller stamps the real id below. The
@@ -329,7 +368,7 @@ void prte_grpcomm_xcast_recv(
     // it is excluded. This is safe because a daemon that has *ever* participated
     // has op_id_inited > 0, so a genuine ordering violation mid-stream is still
     // caught.
-    bool late_joiner = !PRTE_PROC_IS_MASTER && (0 == XCAST.op_id_inited);
+    bool late_joiner = !PRTE_PROC_IS_MASTER && (0 == TREE_OF(sig).op_id_inited);
 
     if(PRTE_PROC_IS_MASTER){
         if(sig.op_id){
@@ -337,20 +376,20 @@ void prte_grpcomm_xcast_recv(
             PRTE_ERROR_LOG( PRTE_ERR_DUPLICATE_MSG );
             return;
         }
-        sig.op_id = ++XCAST.op_id_inited;
+        sig.op_id = ++TREE_OF(sig).op_id_inited;
     }
     if(!sig.op_id){
         PRTE_ERROR_LOG( PRTE_ERR_NOT_INITIALIZED );
         return;
     }
-    if(sig.op_id > XCAST.op_id_inited){
-        XCAST.op_id_inited = sig.op_id;
+    if(sig.op_id > TREE_OF(sig).op_id_inited){
+        TREE_OF(sig).op_id_inited = sig.op_id;
     }
     if(late_joiner && sig.op_id > 1){
         // Catch up to just below this op: ops 1..op_id-1 are taken as complete,
         // and this op is processed in order as our first.
-        XCAST.op_id_completed = sig.op_id - 1;
-        XCAST.op_id_completed_at_promotion = sig.op_id - 1;
+        TREE_OF(sig).op_id_completed = sig.op_id - 1;
+        TREE_OF(sig).op_id_completed_at_promotion = sig.op_id - 1;
     }
 
     // If we marked our subtree as completed, but then were promoted, our
@@ -358,12 +397,12 @@ void prte_grpcomm_xcast_recv(
     // But ops complete in order, so if we have completed anything since our
     // promotion, we know our new subtree has also completed all the older ops
     bool assume_incomplete =
-        sig.op_id <= XCAST.op_id_completed_at_promotion
-        && XCAST.op_id_completed == XCAST.op_id_completed_at_promotion;
+        sig.op_id <= TREE_OF(sig).op_id_completed_at_promotion
+        && TREE_OF(sig).op_id_completed == TREE_OF(sig).op_id_completed_at_promotion;
 
     // If we're certain our subtree has already completed this, we can just ack
     bool complete = !assume_incomplete &&
-        sig.op_id <= XCAST.op_id_completed;
+        sig.op_id <= TREE_OF(sig).op_id_completed;
 
     pmix_rank_t ack_id;
     if(PMIX_SUCCESS != unpack_ack_id(buffer, &ack_id)) return;
@@ -474,14 +513,15 @@ void prte_grpcomm_xcast_ack(
     op_t* op = find_op(&sig);
 
     if(is_request){
-        if(sender->rank != PRTE_PROC_MY_PARENT->rank){
-            // Old message
+        if(sender->rank != topo_parent(sig.topology)){
+            // Old message, or one from a daemon that is our parent in some
+            // other tree than the one this op travels
             return;
         }
         if(NULL != op){
             // We'll send with the new id once we're done
             op->ack_id_up = ack_id;
-        } else if(sig.op_id <= XCAST.op_id_completed){
+        } else if(sig.op_id <= TREE_OF(sig).op_id_completed){
             // We've finished this one, ack now
             send_ack(&sig, ack_id);
         } else {
@@ -508,8 +548,13 @@ void prte_grpcomm_xcast_fault_handler(
     if(status->scope != PRTE_RML_FAULT_SCOPE_LOCAL) return;
 
     if(status->promoted){
-        XCAST.op_id_completed_at_promotion =
-            XCAST.op_id_completed;
+        /* A promotion grows our subtree in EVERY tree we relay on, so the
+         * completion information we hold is stale in each of them - this is
+         * per-daemon news, not per-op. */
+        for(int t = 0; t < PRTE_GRPCOMM_TOPO_COUNT; t++){
+            XCAST.tree[t].op_id_completed_at_promotion =
+                XCAST.tree[t].op_id_completed;
+        }
     }
     if(status->parent_changed || status->promoted || status->demoted){
         // Avoid confusing new parent by accidentally acking with
@@ -660,7 +705,7 @@ static void send_ack_msg(
          * failure there is our lifeline, which is the fault machinery's
          * business and not this op's. */
         PRTE_RML_SEND_CB(ret, dest, msg, PRTE_RML_TAG_XCAST_ACK,
-                         forward_lost, (void*)(intptr_t) sig->op_id);
+                         forward_lost, SIG_TO_CBDATA(*sig));
     } else {
         PRTE_RML_SEND(ret, dest, msg, PRTE_RML_TAG_XCAST_ACK);
     }
@@ -673,8 +718,13 @@ static void send_ack_msg(
 }
 
 static void send_ack(signature_t* sig, pmix_rank_t ack_id){
+    /* Up the tree this op travelled, not up the routing tree. An ack is a
+     * statement about coverage of one topology, and it is only meaningful to
+     * the daemon that is waiting on it in that same topology. */
+    pmix_rank_t up = topo_parent(sig->topology);
     if(PRTE_PROC_IS_MASTER) return;
-    send_ack_msg(sig, ack_id, false, PRTE_PROC_MY_PARENT->rank);
+    if(PMIX_RANK_INVALID == up) return;
+    send_ack_msg(sig, ack_id, false, up);
 }
 
 static void request_ack(pmix_rank_t from, signature_t* sig, pmix_rank_t ack_id){
@@ -708,11 +758,11 @@ static void drive_completions(void){
 static void finish_op(op_t* op) {
     send_ack(&op->sig, op->ack_id_up);
     pmix_list_remove_item(&XCAST.ops, &op->super);
-    if(op->sig.op_id > XCAST.op_id_completed_at_promotion){
-        if(op->sig.op_id != XCAST.op_id_completed+1){
+    if(op->sig.op_id > TREE_OF(op->sig).op_id_completed_at_promotion){
+        if(op->sig.op_id != TREE_OF(op->sig).op_id_completed+1){
             PRTE_ERROR_LOG( PRTE_ERR_OUT_OF_ORDER_MSG );
         } else {
-            XCAST.op_id_completed++;
+            TREE_OF(op->sig).op_id_completed++;
         }
     }
     process_msg(op); // If not already processed, process before releasing
@@ -749,6 +799,11 @@ static void finish_op(op_t* op) {
     }
 
 static int pack_sig(pmix_data_buffer_t* buffer, signature_t* sig){
+    /* The topology leads, because the op id that follows is only meaningful
+     * within it - the reader has to know which tree's sequence it is reading
+     * before the number means anything. */
+    uint8_t topo = (uint8_t) sig->topology;
+    DIRECT_XCAST_PACK(buffer, &topo,          PMIX_UINT8);
     DIRECT_XCAST_PACK(buffer, &sig->op_id,    PMIX_SIZE);
     return PMIX_SUCCESS;
 }
@@ -768,6 +823,16 @@ static int pack_bool(pmix_data_buffer_t* buffer, bool* boolean){
 }
 
 static int unpack_sig(pmix_data_buffer_t* buffer, signature_t* sig){
+    uint8_t topo = 0;
+    DIRECT_XCAST_UNPACK(buffer, &topo, PMIX_UINT8);
+    /* Screen it before it indexes anything: this value selects an array
+     * element and a tree to walk, and a value no release ever assigned would
+     * do both out of bounds. */
+    if(PRTE_GRPCOMM_TOPO_COUNT <= topo){
+        PRTE_ERROR_LOG( PRTE_ERR_BAD_PARAM );
+        return PRTE_ERR_BAD_PARAM;
+    }
+    sig->topology = (prte_grpcomm_topology_t) topo;
     DIRECT_XCAST_UNPACK(buffer, &sig->op_id, PMIX_SIZE);
     return PMIX_SUCCESS;
 }
@@ -815,7 +880,7 @@ static op_t* insert_forwarded_op(signature_t* sig) {
     op_t* op = PMIX_NEW(op_t);
     op->sig = *sig;
 
-    if(sig->op_id == XCAST.op_id_inited){
+    if(sig->op_id == TREE_OF(*sig).op_id_inited){
         pmix_list_append(&XCAST.ops, &op->super);
     } else {
         op_t* next_op = NULL;
@@ -856,28 +921,100 @@ static op_t* insert_forwarded_op(signature_t* sig) {
  * That is why pack_forward_msg takes no destination.  If a forward ever does
  * need to differ per child, this is the loop that has to go back to packing
  * inside it - the sharing is not an optimization the RML can make on its own. */
-static void tree_whole_forward(op_t* op){
-    pmix_rank_t* children = (pmix_rank_t*) prte_rml_base.children.array;
-    prte_rml_payload_t* payload;
-    size_t i;
-    bool any = false;
+/* Who this daemon relays to, and who relays to it, in a given tree.
+ *
+ * The routing tree's answer is already computed and cached - it is consulted
+ * on every message and repaired incrementally, so it has to be. The release
+ * tree's is derived on demand: it is consulted once per broadcast, and
+ * recomputing is cheaper than keeping a second cache correct across every
+ * repair. Both answers come from state every daemon holds in step, so no two
+ * daemons can disagree about either shape.
+ *
+ * The caller frees *children when it was allocated, which topo_children says
+ * by setting *owned. The routing tree hands back its cached array. */
+static void topo_children(prte_grpcomm_topology_t topo, pmix_rank_t **children,
+                          size_t *n, bool *owned)
+{
+    *owned = false;
+    if (PRTE_GRPCOMM_TOPO_RELEASE == topo) {
+        pmix_rank_t parent;
+        if (PRTE_SUCCESS != prte_rml_release_tree(PRTE_PROC_MY_NAME->rank,
+                                                  &parent, children, n)) {
+            *children = NULL;
+            *n = 0;
+            return;
+        }
+        *owned = (NULL != *children);
+        return;
+    }
+    *children = (pmix_rank_t *) prte_rml_base.children.array;
+    *n = prte_rml_base.children.size;
+}
 
-    for (i = 0; i < prte_rml_base.children.size; i++) {
+/* How many children this daemon actually has in a tree - the count a
+ * completion is measured against, and a statement about that tree alone. */
+static size_t topo_n_children(prte_grpcomm_topology_t topo)
+{
+    pmix_rank_t *children;
+    size_t i, n, live = 0;
+    bool owned;
+
+    if (PRTE_GRPCOMM_TOPO_ROUTING == topo) {
+        return (size_t) prte_rml_base.n_children;
+    }
+    topo_children(topo, &children, &n, &owned);
+    for (i = 0; i < n; i++) {
+        if (PMIX_RANK_INVALID != children[i]) {
+            live++;
+        }
+    }
+    if (owned) { free(children); }
+    return live;
+}
+
+static pmix_rank_t topo_parent(prte_grpcomm_topology_t topo)
+{
+    if (PRTE_GRPCOMM_TOPO_RELEASE == topo) {
+        pmix_rank_t parent = PMIX_RANK_INVALID, *kids = NULL;
+        size_t n = 0;
+        if (PRTE_SUCCESS != prte_rml_release_tree(PRTE_PROC_MY_NAME->rank,
+                                                  &parent, &kids, &n)) {
+            return PMIX_RANK_INVALID;
+        }
+        if (NULL != kids) {
+            free(kids);
+        }
+        return parent;
+    }
+    return PRTE_PROC_MY_PARENT->rank;
+}
+
+static void tree_whole_forward(op_t* op){
+    pmix_rank_t* children;
+    prte_rml_payload_t* payload;
+    size_t i, nchildren;
+    bool any = false, owned = false;
+
+    topo_children(op->sig.topology, &children, &nchildren, &owned);
+
+    for (i = 0; i < nchildren; i++) {
         if (PMIX_RANK_INVALID != children[i]) {
             any = true;
             break;
         }
     }
     if (!any) {
+        if (owned) { free(children); }
         return;
     }
 
     payload = build_forward_payload(op);
     if (NULL == payload) {
+        if (owned) { free(children); }
         return;
     }
 
-    for (i = 0; i < prte_rml_base.children.size; i++) {
+    for (i = 0; i < nchildren; i++) {
         if (PMIX_RANK_INVALID == children[i]) {
             continue;
         }
@@ -887,6 +1024,7 @@ static void tree_whole_forward(op_t* op){
     /* every child that accepted the payload holds its own reference now; drop
      * ours, so the buffer dies with the last send rather than with this loop */
     PMIX_RELEASE(payload);
+    if (owned) { free(children); }
 }
 
 static void forward_op(op_t* op){
@@ -906,7 +1044,7 @@ static void forward_op(op_t* op){
     /* A daemon reports its subtree complete once it holds the payload and
      * all its children have reported. */
     op->replay_pending_parent = false;
-    op->nexpected = prte_rml_base.n_children;
+    op->nexpected = topo_n_children(op->sig.topology);
     op->nreported = 0;
 
     tree_whole_forward(op);
@@ -943,7 +1081,7 @@ static void forward_lost(int status, pmix_proc_t *peer,
     signature_t sig;
     op_t *op;
 
-    sig.op_id = (size_t) (intptr_t) cbdata;
+    SIG_FROM_CBDATA(sig, cbdata);
 
     /* keep the RML's own reporting: what a failed send means for the *daemon*
      * is the errmgr's call, and unchanged.  We only decide what it means for
@@ -1010,7 +1148,7 @@ static void forward_payload_to(op_t* op, prte_rml_payload_t* payload,
      * the op on precisely the paths that matter, so the callback has to be
      * able to look the op up and find it gone. */
     PRTE_RML_SEND_PAYLOAD_CB(rc, dest, payload, PRTE_RML_TAG_XCAST,
-                             forward_lost, (void *) (intptr_t) op->sig.op_id);
+                             forward_lost, SIG_TO_CBDATA(op->sig));
     if (PMIX_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
         PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);
@@ -1192,7 +1330,13 @@ static void process_msg(op_t* op){
 
 static void op_con(op_t* p)
 {
+    /* Every field, because PMIX_NEW mallocs without zeroing - a member left
+     * out here is heap garbage that gets packed onto the wire. The topology
+     * was exactly that until the swarm refused the first broadcast of the
+     * run: TOPO_ROUTING is zero, but nothing was setting it to zero. */
     p->sig.op_id = 0;
+    p->sig.topology = PRTE_GRPCOMM_TOPO_ROUTING;
+
 
     p->processed = false;
     p->replay_pending_parent = false;
@@ -1223,9 +1367,11 @@ static void xcast_con(prte_grpcomm_xcast_t* p)
 {
     PMIX_CONSTRUCT(&p->ops, pmix_list_t);
     PMIX_CONSTRUCT(&p->pending_completions, pmix_list_t);
-    p->op_id_completed = 0;
-    p->op_id_completed_at_promotion = 0;
-    p->op_id_inited = 0;
+    for(int t = 0; t < PRTE_GRPCOMM_TOPO_COUNT; t++){
+        p->tree[t].op_id_completed = 0;
+        p->tree[t].op_id_completed_at_promotion = 0;
+        p->tree[t].op_id_inited = 0;
+    }
 }
 static void xcast_des(prte_grpcomm_xcast_t* p)
 {

--- a/src/grpcomm/grpcomm_xcast.c
+++ b/src/grpcomm/grpcomm_xcast.c
@@ -193,15 +193,47 @@ int prte_grpcomm_xcast(prte_rml_tag_t tag, pmix_data_buffer_t *msg){
     return prte_grpcomm_xcast_nb(tag, msg, NULL, NULL);
 }
 
+/* Which tree a collective's release travels.
+ *
+ * Chosen by tag, not by size, and that is deliberate: the operations differ
+ * in what they carry, and a byte threshold cannot express that while a tag
+ * can. A fence release is the whole modex, which is what makes the release
+ * fanout dominate a collecting fence; a group release is small, and a low
+ * radix buys nothing where the r*M*beta term is nil and costs depth. So the
+ * fence's release is the one that moves when the low-radix tree is turned on
+ * and the group's is not, until somebody measures a reason otherwise.
+ *
+ * This is the single seam every release goes through, which is why the choice
+ * lives here rather than at each of the four call sites. */
+int prte_grpcomm_release_bcast_select(prte_rml_tag_t tag,
+                                      pmix_data_buffer_t *msg)
+{
+    if (prte_grpcomm_globals.low_radix_release &&
+        PRTE_RML_TAG_FENCE_RELEASE == tag) {
+        return prte_grpcomm_xcast_topo(tag, msg, PRTE_GRPCOMM_TOPO_RELEASE,
+                                       NULL, NULL);
+    }
+    return prte_grpcomm_xcast(tag, msg);
+}
+
 int prte_grpcomm_xcast_nb(prte_rml_tag_t tag, pmix_data_buffer_t *msg,
                                  prte_grpcomm_xcast_complete_fn_t cbfunc,
                                  void *cbdata){
+    return prte_grpcomm_xcast_topo(tag, msg, PRTE_GRPCOMM_TOPO_ROUTING,
+                                   cbfunc, cbdata);
+}
+
+int prte_grpcomm_xcast_topo(prte_rml_tag_t tag, pmix_data_buffer_t *msg,
+                            prte_grpcomm_topology_t topology,
+                            prte_grpcomm_xcast_complete_fn_t cbfunc,
+                            void *cbdata){
     PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
-                         "%s grpcomm:xcast: with %d bytes",
+                         "%s grpcomm:xcast: with %d bytes on tree %d",
                          PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
-                         (int) msg->bytes_used));
+                         (int) msg->bytes_used, (int) topology));
 
     op_t* op = PMIX_NEW(op_t);
+    op->sig.topology = topology;
     op->msg_tag = tag;
     /* stash the completion callback on the initiating op.  It is not fired from
      * this op (which is discarded after begin_xcast relays it); begin_xcast

--- a/src/grpcomm/grpcomm_xcast.c
+++ b/src/grpcomm/grpcomm_xcast.c
@@ -110,6 +110,15 @@ typedef struct {
     // replay it to our children. This is because our completion information
     // for older ops is invalid when our subtree grows
     bool replay_pending_parent;
+    /* Who last spoke to us about this op - the daemon that forwarded it, or
+     * that re-polled us for an ack.  It is who we answer, in preference to
+     * whoever our own derivation currently calls our parent: see send_ack_to. */
+    pmix_rank_t upstream;
+    /* Held because the daemon that forwarded it had seen departures we had
+     * not, so our own derivation of this tree is behind the one it was sent
+     * under.  Cleared when the news arrives - see the parking commentary in
+     * prte_grpcomm_xcast_recv. */
+    bool awaiting_news;
     // # children at time of (re)start
     size_t nexpected;
     // # children confirmed completed
@@ -155,7 +164,7 @@ static void forward_lost(int status, pmix_proc_t *peer,
 // Locally process the message being broadcast, if not already done
 static void process_msg(op_t *op);
 // Ack that myself and my full subtree have received this message
-static void send_ack(signature_t* sig, pmix_rank_t ack_id);
+static void send_ack_to(signature_t* sig, pmix_rank_t ack_id, pmix_rank_t up);
 // Request an ack after a failure without resending full user message
 static void request_ack(pmix_rank_t from, signature_t* sig, pmix_rank_t ack_id);
 // Remove local tracking and ack to parent
@@ -205,15 +214,21 @@ int prte_grpcomm_xcast(prte_rml_tag_t tag, pmix_data_buffer_t *msg){
  *
  * This is the single seam every release goes through, which is why the choice
  * lives here rather than at each of the four call sites. */
-int prte_grpcomm_release_bcast_select(prte_rml_tag_t tag,
-                                      pmix_data_buffer_t *msg)
+prte_grpcomm_topology_t prte_grpcomm_release_topology(prte_rml_tag_t tag)
 {
     if (prte_grpcomm_globals.low_radix_release &&
         PRTE_RML_TAG_FENCE_RELEASE == tag) {
-        return prte_grpcomm_xcast_topo(tag, msg, PRTE_GRPCOMM_TOPO_RELEASE,
-                                       NULL, NULL);
+        return PRTE_GRPCOMM_TOPO_RELEASE;
     }
-    return prte_grpcomm_xcast(tag, msg);
+    return PRTE_GRPCOMM_TOPO_ROUTING;
+}
+
+int prte_grpcomm_release_bcast_select(prte_rml_tag_t tag,
+                                      pmix_data_buffer_t *msg)
+{
+    return prte_grpcomm_xcast_topo(tag, msg,
+                                   prte_grpcomm_release_topology(tag),
+                                   NULL, NULL);
 }
 
 int prte_grpcomm_xcast_nb(prte_rml_tag_t tag, pmix_data_buffer_t *msg,
@@ -369,7 +384,15 @@ void prte_grpcomm_xcast_recv(
                          (int) buffer->bytes_used));
 
     signature_t sig;
+    uint32_t sender_version;
     if(PMIX_SUCCESS != unpack_sig(buffer, &sig)) return;
+    {
+        int32_t cnt = 1;
+        if (PMIX_SUCCESS != PMIx_Data_unpack(NULL, buffer, &sender_version,
+                                             &cnt, PMIX_UINT32)) {
+            return;
+        }
+    }
 
     /* Ignore messages from old parents - but "parent" is a question about the
      * tree this broadcast is travelling, which is why the signature has to be
@@ -377,7 +400,30 @@ void prte_grpcomm_xcast_recv(
      * tree's parent, and on a routing tree of a different radix that daemon is
      * a sibling or a cousin rather than a parent. Screening on the routing
      * parent would discard every one of them. */
-    if(!PRTE_PROC_IS_MASTER && sender->rank != topo_parent(sig.topology)){
+    if (!PRTE_PROC_IS_MASTER &&
+        PRTE_GRPCOMM_TOPO_ROUTING == sig.topology &&
+        sender->rank != topo_parent(sig.topology)) {
+        /* An old parent's forward, on the tree where "old" is a question this
+         * daemon can answer.  The repair notice travels this tree, so by the
+         * time a new parent relays anything we have already processed the
+         * notice that made it our parent - the screen can only ever be
+         * rejecting a genuinely superseded message.
+         *
+         * On a derived tree that reasoning does not hold and the screen is
+         * actively wrong: every daemon recomputes its own shape when the
+         * notice reaches it, and a daemon that has repaired can replay to a
+         * child that has not.  The child then reads a forward from its new
+         * parent as coming from a stranger and discards it, and since the
+         * whole point of the replay is to reach daemons whose relay died, it
+         * discards the one message that would have released it.  That was
+         * exactly the failure: a fence released on the low-radix tree hung
+         * three daemons behind a killed relay, each of them having received
+         * and silently dropped the repair.
+         *
+         * Accepting it costs nothing.  A duplicate forward is already
+         * idempotent - op_id decides, and an op we hold or have completed is
+         * recognized either way - and the ack goes back to the sender rather
+         * than to our own idea of a parent. */
         return;
     }
 
@@ -409,6 +455,32 @@ void prte_grpcomm_xcast_recv(
             return;
         }
         sig.op_id = ++TREE_OF(sig).op_id_inited;
+        /* Absolute microseconds, so a broadcast's coverage can be measured
+         * across daemons rather than only at one.  Every daemon prints the
+         * same stamp when it processes the payload (process_msg), and the
+         * span from this line to the last of those is how long the broadcast
+         * took to reach the whole DVM - which is the quantity a change to the
+         * fanout tree is about, and the one an end-to-end fence cannot
+         * resolve because the rollup's noise is larger than the effect.
+         *
+         * It is only comparable where the clocks are: fine on a container
+         * swarm sharing one kernel, meaningless across a real cluster without
+         * a synchronized clock. */
+        if (prte_grpcomm_globals.enable_timing) {
+            struct timeval tnow;
+            gettimeofday(&tnow, NULL);
+            /* No payload tag here on purpose: `tag` at this point is the
+             * tag the xcast message ARRIVED on (PRTE_RML_TAG_XCAST), not the
+             * one the payload will be delivered at - that is inside the
+             * message and is not unpacked until below.  The processed lines
+             * carry the real one, and (tree, op_id) pairs the two. */
+            pmix_output(0, "%s grpcomm:xcast:timing started op_id %lu "
+                        "tree %d at %ld.%06ld",
+                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                        (unsigned long) sig.op_id,
+                        (int) sig.topology, (long) tnow.tv_sec,
+                        (long) tnow.tv_usec);
+        }
     }
     if(!sig.op_id){
         PRTE_ERROR_LOG( PRTE_ERR_NOT_INITIALIZED );
@@ -440,7 +512,7 @@ void prte_grpcomm_xcast_recv(
     if(PMIX_SUCCESS != unpack_ack_id(buffer, &ack_id)) return;
 
     if(complete) {
-        send_ack(&sig, ack_id);
+        send_ack_to(&sig, ack_id, sender->rank);
         return;
     }
 
@@ -470,6 +542,69 @@ void prte_grpcomm_xcast_recv(
     }
 
     op->ack_id_up = ack_id;
+    op->upstream = sender->rank;
+
+    /* Park a forward that was derived from news we have not heard.
+     *
+     * On a derived tree the shape is a function of the live set, so a daemon
+     * that has recorded more departures than we have computed this forward
+     * from a set ours does not yet include - and everything we would do with
+     * it next depends on our own derivation.  Above all the child count: a
+     * daemon that has just been promoted into a dead relay's slot still reads
+     * itself as a leaf until the news reaches it, so it would answer the
+     * repair by retiring the operation as complete, having forwarded it
+     * nowhere.  The subtree the repair existed to reach is then stranded with
+     * nobody holding the payload, which is exactly how this failed: five of
+     * seven daemons released, and the two below the promoted one waiting for
+     * a broadcast that had already been declared delivered.
+     *
+     * So take the payload and deliver it locally - that part does not depend
+     * on the tree at all, and it is what releases this daemon's own clients -
+     * but do not derive anything until the news arrives.  nexpected is left
+     * at its constructed SIZE_MAX, so the operation cannot satisfy op_ready()
+     * and retire while parked; release_tree_fault() picks it up when the
+     * departure notice lands, and forwards it under the shape both ends then
+     * agree on.
+     *
+     * Two things have to be true before we hold anything, and the second is
+     * what keeps this from being a hazard of its own.  The sender must be
+     * ahead of us, and the forward must have come from a daemon our own
+     * derivation does not call our parent - concrete local evidence that the
+     * two views disagree, rather than an inference from a number.  In the
+     * ordinary case a forward always arrives from our parent, so ordinary
+     * traffic can never be parked however the versions happen to sit; and the
+     * case this exists for always fails that test, because a daemon promoted
+     * into a dead relay's slot is by definition being addressed by a daemon
+     * that is not its parent yet.
+     *
+     * That matters because the version is a count of events learned, not an
+     * agreed number.  It is monotone, which is all the comparison needs, but
+     * daemons can legitimately hold different counts for a while - a grown
+     * daemon is seeded from the departed set it was launched with, and a
+     * revival moves the count on the daemons that have processed it first.
+     * Requiring the second signal means such a skew costs nothing.
+     *
+     * The routing tree is exempt because it does not have the problem: its
+     * repair notice travels the routing tree itself, so a daemon has always
+     * processed the notice that gave it a new parent before anything that
+     * parent relays afterwards can arrive. */
+    if (PRTE_GRPCOMM_TOPO_ROUTING != sig.topology &&
+        sender_version > prte_rml_tree_version() &&
+        sender->rank != topo_parent(sig.topology)) {
+        PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
+                             "%s grpcomm:xcast holding op_id %lu on tree %d: "
+                             "%s is at tree version %u, we are at %u",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                             (unsigned long) sig.op_id, (int) sig.topology,
+                             PRTE_NAME_PRINT(sender),
+                             (unsigned) sender_version,
+                             (unsigned) prte_rml_tree_version()));
+        op->awaiting_news = true;
+        process_msg(op);
+        return;
+    }
+    op->awaiting_news = false;
+
     if(assume_incomplete){
         op->processed = true;
         op->replay_pending_parent = true;
@@ -545,17 +680,23 @@ void prte_grpcomm_xcast_ack(
     op_t* op = find_op(&sig);
 
     if(is_request){
-        if(sender->rank != topo_parent(sig.topology)){
+        if (PRTE_GRPCOMM_TOPO_ROUTING == sig.topology &&
+            sender->rank != topo_parent(sig.topology)) {
             // Old message, or one from a daemon that is our parent in some
-            // other tree than the one this op travels
+            // other tree than the one this op travels. Only asked of the
+            // routing tree, for the reason given at the same screen in
+            // prte_grpcomm_xcast_recv: on a derived tree the two ends repair
+            // independently, so "not my parent" may only mean "I have not
+            // heard yet", and refusing the poll strands the op.
             return;
         }
         if(NULL != op){
-            // We'll send with the new id once we're done
+            // We'll send with the new id once we're done, to whoever asked
             op->ack_id_up = ack_id;
+            op->upstream = sender->rank;
         } else if(sig.op_id <= TREE_OF(sig).op_id_completed){
             // We've finished this one, ack now
-            send_ack(&sig, ack_id);
+            send_ack_to(&sig, ack_id, sender->rank);
         } else {
             // We haven't seen this xcast before
             PRTE_ERROR_LOG( PRTE_ERR_OUT_OF_ORDER_MSG );
@@ -572,6 +713,79 @@ void prte_grpcomm_xcast_ack(
     }
 }
 
+/* Repair an op travelling a tree other than the routing one.
+ *
+ * The routing tree is repaired incrementally and the RML hands us a
+ * description of what moved - who was promoted, which children changed, what
+ * the previous set was.  None of that describes a derived tree, which is not
+ * repaired at all: after a death every daemon simply computes a different
+ * answer from a live set they all hold in step.  There is no "previous
+ * children" to diff against, and inventing one would mean caching a second
+ * tree only so that a fault could compare it.
+ *
+ * So do not diff.  Every daemon still holding this op forwards it to whoever
+ * its children are now, and the asymmetry the design turns on does the rest:
+ * a duplicate is harmless - the op id decides, so a daemon that holds this op
+ * or has already completed it recognizes it either way - while a release that
+ * never arrives hangs a fence for good.  Replaying too much costs a message on
+ * a path that has just lost a daemon; replaying too little costs the job.
+ *
+ * Note that nobody waits.  The routing tree makes a *promoted* daemon defer
+ * its replay until its own parent has replayed, because its subtree may have
+ * grown to include daemons that never saw this op, and sending them op N+1
+ * before op N breaks the ordering finish_op enforces.  Here that deferral is
+ * both unnecessary and harmful.  Unnecessary because an op a child is missing
+ * is by definition still in flight - the root cannot retire one until every
+ * daemon has acked it - so it is held by some daemon that is replaying it in
+ * this same pass, and the list is walked in op order.  Harmful because a
+ * daemon deferring to a parent that has already replayed waits for a second
+ * replay that is never coming, and strands its whole subtree.  That was
+ * measured rather than reasoned: relaxing only the parent screen took the
+ * count from four daemons released to five - the one that received the replay
+ * directly - and left the two below it waiting on it. */
+static void release_tree_fault(op_t* op)
+{
+    size_t n = topo_n_children(op->sig.topology);
+
+    PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
+                         "%s grpcomm:xcast repairing %sop_id %lu on tree %d: "
+                         "%d children now, parent %s",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                         op->awaiting_news ? "held " : "",
+                         (unsigned long) op->sig.op_id,
+                         (int) op->sig.topology, (int) n,
+                         PRTE_VPID_PRINT(topo_parent(op->sig.topology))));
+
+    /* Note what is deliberately NOT done here: the ack id we hold is not
+     * invalidated.  The block above does that for the routing tree, so that a
+     * new parent is not answered under a round it never opened - but it is
+     * only safe where somebody is going to ask again, and the empty-subtree
+     * case below answers immediately and then retires the op.  An ack under
+     * the last id we were actually given is at worst ignored; one under
+     * PMIX_RANK_INVALID is ignored for certain, and there is no second
+     * chance.  Every op that survives this call is about to be forwarded, and
+     * the forward it draws in reply carries a fresh id with it. */
+    if (0 == n) {
+        /* nothing below us on this tree any more - our subtree is complete
+         * by virtue of being empty, which is what the routing path does with
+         * the same discovery */
+        finish_op(op);
+        return;
+    }
+
+    op->nexpected = n;
+    op->nreported = 0;
+    /* we cannot tell a surviving child's ack from a dead one's, so nothing
+     * counted before this point can be trusted - start a fresh round */
+    op->ack_id_down++;
+    op->replay_pending_parent = false;
+    /* the news we were held for */
+    op->awaiting_news = false;
+
+    tree_whole_forward(op);
+}
+
+
 void prte_grpcomm_xcast_fault_handler(
     const prte_rml_recovery_status_t* status
 ) {
@@ -579,14 +793,29 @@ void prte_grpcomm_xcast_fault_handler(
     // is how we get the global scope notifications in the first place
     if(status->scope != PRTE_RML_FAULT_SCOPE_LOCAL) return;
 
-    if(status->promoted){
-        /* A promotion grows our subtree in EVERY tree we relay on, so the
-         * completion information we hold is stale in each of them - this is
-         * per-daemon news, not per-op. */
-        for(int t = 0; t < PRTE_GRPCOMM_TOPO_COUNT; t++){
-            XCAST.tree[t].op_id_completed_at_promotion =
-                XCAST.tree[t].op_id_completed;
+    /* Our subtree may have grown, and what we hold about it is then stale:
+     * an op we completed and released was completed by the daemons that were
+     * below us *then*, which says nothing about one that has just arrived.
+     * Marking the completions as suspect is what makes a later replay of such
+     * an op get re-inserted and forwarded on (assume_incomplete, in the recv
+     * path) rather than answered with a bare ack that ends the cascade one
+     * daemon short of the one still waiting.
+     *
+     * On the routing tree we are told when that happened: the RML repairs it
+     * incrementally and reports the promotion.  On a derived tree nobody
+     * reports anything - every daemon simply recomputes a different answer
+     * from the new live set - so there is no promotion to be told about, and
+     * the honest reading of any death is that our subtree there may have
+     * grown.  Do not be tempted to narrow this by comparing child sets: the
+     * daemon that needs the replay is not our child but somewhere below one,
+     * and our own children may be identical while the tree beneath them is
+     * not. */
+    for (int t = 0; t < PRTE_GRPCOMM_TOPO_COUNT; t++) {
+        if (PRTE_GRPCOMM_TOPO_ROUTING == t && !status->promoted) {
+            continue;
         }
+        XCAST.tree[t].op_id_completed_at_promotion =
+            XCAST.tree[t].op_id_completed;
     }
     if(status->parent_changed || status->promoted || status->demoted){
         // Avoid confusing new parent by accidentally acking with
@@ -596,6 +825,24 @@ void prte_grpcomm_xcast_fault_handler(
             op->ack_id_up = PMIX_RANK_INVALID;
         }
     }
+    /* Every tree this daemon relays on has just changed shape, not only the
+     * routing one - the release tree is derived from the live daemon set, so
+     * a death reshapes it too, and the ops travelling it need the same
+     * treatment on their own terms.  They cannot take the branch below: it
+     * reads the routing tree's child count, diffs against the routing tree's
+     * previous children, and forwards to them.  Applied to an op that is not
+     * travelling the routing tree, every one of those is the wrong tree. */
+    {
+        op_t* op;
+        op_t* next_op;
+        PMIX_LIST_FOREACH_SAFE(op, next_op, &XCAST.ops, op_t){
+            if (PRTE_GRPCOMM_TOPO_ROUTING == op->sig.topology) {
+                continue;
+            }
+            release_tree_fault(op);
+        }
+    }
+
     if(status->children_changed || status->promoted || status->demoted){
         const pmix_rank_t* prev_children =
             (const pmix_rank_t*) status->prev_children.array;
@@ -605,6 +852,9 @@ void prte_grpcomm_xcast_fault_handler(
         op_t* op;
         op_t* next_op;
         PMIX_LIST_FOREACH_SAFE(op, next_op, &XCAST.ops, op_t){
+            if (PRTE_GRPCOMM_TOPO_ROUTING != op->sig.topology) {
+                continue;
+            }
             if(0 == prte_rml_base.n_children){
                 /* Under tree_whole both tests are constants - every op holds
                  * its payload and nothing can be blocked - so this is the
@@ -749,15 +999,27 @@ static void send_ack_msg(
     }
 }
 
-static void send_ack(signature_t* sig, pmix_rank_t ack_id){
-    /* Up the tree this op travelled, not up the routing tree. An ack is a
-     * statement about coverage of one topology, and it is only meaningful to
-     * the daemon that is waiting on it in that same topology. */
-    pmix_rank_t up = topo_parent(sig->topology);
+/* Answer whoever asked.
+ *
+ * An ack is a reply to a particular forward or poll, so the daemon waiting for
+ * it is the one that sent that message - not whoever our own derivation calls
+ * our parent right now.  On the routing tree the two are the same, because the
+ * tree is repaired by a notice travelling that same tree and a daemon's view
+ * therefore changes before anything it relays afterwards can arrive.  A
+ * derived tree has no such ordering: every daemon recomputes it independently
+ * when the death notice reaches it, so a repaired parent can replay to a child
+ * that has not yet heard, and the two disagree for as long as that takes.
+ *
+ * Answering the sender needs neither side to be up to date.  Answering the
+ * wrong daemon costs nothing - it holds no op under that ack id and drops the
+ * message - while failing to answer the right one hangs the broadcast, so
+ * where the two rules differ this is the safe direction. */
+static void send_ack_to(signature_t* sig, pmix_rank_t ack_id, pmix_rank_t up){
     if(PRTE_PROC_IS_MASTER) return;
     if(PMIX_RANK_INVALID == up) return;
     send_ack_msg(sig, ack_id, false, up);
 }
+
 
 static void request_ack(pmix_rank_t from, signature_t* sig, pmix_rank_t ack_id){
     send_ack_msg(sig, ack_id, true, from);
@@ -788,7 +1050,9 @@ static void drive_completions(void){
 
 
 static void finish_op(op_t* op) {
-    send_ack(&op->sig, op->ack_id_up);
+    send_ack_to(&op->sig, op->ack_id_up,
+                PMIX_RANK_INVALID != op->upstream
+                    ? op->upstream : topo_parent(op->sig.topology));
     pmix_list_remove_item(&XCAST.ops, &op->super);
     if(op->sig.op_id > TREE_OF(op->sig).op_id_completed_at_promotion){
         if(op->sig.op_id != TREE_OF(op->sig).op_id_completed+1){
@@ -887,14 +1151,22 @@ static int unpack_bool(pmix_data_buffer_t* buffer, bool* boolean){
  * receiver tells it from a forward by the op-id, which is zero here and
  * assigned by the controller. */
 static int pack_relay_msg(pmix_data_buffer_t* buffer, op_t* op){
+    uint32_t version = prte_rml_tree_version();
     int rc = pack_sig(buffer, &op->sig);
+    if (PMIX_SUCCESS == rc) {
+        rc = PMIx_Data_pack(NULL, buffer, &version, 1, PMIX_UINT32);
+    }
     if(PMIX_SUCCESS == rc) rc = pack_ack_id(buffer, &op->ack_id_down);
     if(PMIX_SUCCESS == rc) rc = pack_msg(buffer, op);
     return rc;
 }
 
 static int pack_forward_msg(pmix_data_buffer_t* buffer, op_t* op){
+    uint32_t version = prte_rml_tree_version();
     int rc = pack_sig(buffer, &op->sig);
+    if (PMIX_SUCCESS == rc) {
+        rc = PMIx_Data_pack(NULL, buffer, &version, 1, PMIX_UINT32);
+    }
     if(PMIX_SUCCESS == rc) rc = pack_ack_id(buffer, &op->ack_id_down);
     if(PMIX_SUCCESS == rc) rc = pack_msg(buffer, op);
     return rc;
@@ -1059,6 +1331,57 @@ static void tree_whole_forward(op_t* op){
     if (owned) { free(children); }
 }
 
+/* Fault injection: hold a forward back so the op is still travelling its tree
+ * when a daemon is killed underneath it.  See grpcomm_internal.h for why this
+ * exists and why it refuses the routing tree. */
+typedef struct {
+    pmix_event_t ev;
+    op_t *op;
+} xcast_delay_caddy_t;
+
+static bool forward_should_delay(prte_grpcomm_topology_t topo)
+{
+    if (0 >= prte_grpcomm_globals.xcast_delay_ms) {
+        return false;
+    }
+    if (PRTE_GRPCOMM_TOPO_ROUTING == topo) {
+        return false;
+    }
+    if (0 > prte_grpcomm_globals.xcast_delay_vpid) {
+        return true;
+    }
+    return ((pmix_rank_t) prte_grpcomm_globals.xcast_delay_vpid
+            == PRTE_PROC_MY_NAME->rank);
+}
+
+static void forward_delay_fire(int sd, short args, void *cbdata)
+{
+    xcast_delay_caddy_t *dc = (xcast_delay_caddy_t *) cbdata;
+    op_t *op;
+    bool live = false;
+    PRTE_HIDE_UNUSED_PARAMS(sd, args);
+
+    /* The op may have retired while we sat on it - the fault handler retires
+     * one whose subtree has emptied - and forwarding a payload out of a
+     * retired op would put a broadcast on the tree that nothing is waiting
+     * for.  We hold a reference, so the object is ours to read either way;
+     * what has to be checked is whether it is still the live op. */
+    PMIX_LIST_FOREACH(op, &XCAST.ops, op_t){
+        if (op == dc->op) {
+            live = true;
+            break;
+        }
+    }
+    if (live) {
+        PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
+                             "%s grpcomm:xcast forwarding the held-back op",
+                             PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+        tree_whole_forward(dc->op);
+    }
+    PMIX_RELEASE(dc->op);
+    free(dc);
+}
+
 static void forward_op(op_t* op){
     /* The daemon job object can be gone by the time a broadcast is being
      * forwarded - teardown retires it while the last xcasts (the halt, the
@@ -1078,6 +1401,29 @@ static void forward_op(op_t* op){
     op->replay_pending_parent = false;
     op->nexpected = topo_n_children(op->sig.topology);
     op->nreported = 0;
+
+    if (forward_should_delay(op->sig.topology)) {
+        xcast_delay_caddy_t *dc = (xcast_delay_caddy_t *) calloc(1, sizeof(*dc));
+        struct timeval tv;
+
+        if (NULL != dc) {
+            /* nexpected is already set, so the op cannot retire while we hold
+             * the payload: it is waiting on children that have not been sent
+             * to yet, which is exactly the state being manufactured */
+            PMIX_RETAIN(op);
+            dc->op = op;
+            PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
+                                 "%s grpcomm:xcast holding its forward back %d ms",
+                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                 prte_grpcomm_globals.xcast_delay_ms));
+            tv.tv_sec = prte_grpcomm_globals.xcast_delay_ms / 1000;
+            tv.tv_usec = (prte_grpcomm_globals.xcast_delay_ms % 1000) * 1000;
+            prte_event_evtimer_set(prte_event_base, &dc->ev, forward_delay_fire, dc);
+            PMIX_POST_OBJECT(dc);
+            prte_event_evtimer_add(&dc->ev, &tv);
+            return;
+        }
+    }
 
     tree_whole_forward(op);
 }
@@ -1314,6 +1660,21 @@ static void process_msg(op_t* op){
     if(op->processed) return;
     op->processed = true;
 
+    /* The other end of the coverage measurement started in
+     * prte_grpcomm_xcast_recv - this is the moment this daemon actually has
+     * the payload, which for a fence release is the moment its clients are
+     * about to be let go. */
+    if (prte_grpcomm_globals.enable_timing) {
+        struct timeval tnow;
+        gettimeofday(&tnow, NULL);
+        pmix_output(0, "%s grpcomm:xcast:timing processed op_id %lu tag %u "
+                    "tree %d at %ld.%06ld",
+                    PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                    (unsigned long) op->sig.op_id, (unsigned) op->msg_tag,
+                    (int) op->sig.topology, (long) tnow.tv_sec,
+                    (long) tnow.tv_usec);
+    }
+
     pmix_data_buffer_t *msg = PMIx_Data_buffer_create();
     if(op->msg_compressed){
         pmix_byte_object_t decomp_msg = PMIX_BYTE_OBJECT_STATIC_INIT;
@@ -1372,6 +1733,8 @@ static void op_con(op_t* p)
 
     p->processed = false;
     p->replay_pending_parent = false;
+    p->upstream = PMIX_RANK_INVALID;
+    p->awaiting_news = false;
 
     p->nreported = 0;
     /* "not yet computed" - forward_op() sets the real count. Deliberately the

--- a/src/grpcomm/help-prte-grpcomm.txt
+++ b/src/grpcomm/help-prte-grpcomm.txt
@@ -26,3 +26,29 @@ completed with a result that only some participants would recognize.
 Note that a participant contributing no data is NOT this error. An
 allgather over participants that happen to have nothing to publish is
 still an allgather, and is expected — only the directive decides.
+#
+[release-radix-noop]
+
+The low-radix fence release was requested, but the release tree it would
+use has the same radix as the routing tree, so it describes exactly the
+same tree:
+
+   Routing radix (rml_base_radix): %d
+   Release radix (rml_base_radix2): %d
+
+grpcomm_low_radix_release moves a fence's release off the routing tree
+and onto a tree of its own, so that the rollup and the fanout can be
+given the radices each of them wants: a gathering daemon receives r
+messages and sends one aggregate, so a wide tree costs it nothing, while
+a broadcasting daemon receives one copy and sends r, so the width is the
+whole cost. The point of the second tree is therefore to be NARROWER
+than the first.
+
+At equal radices it is not narrower, it is identical - every daemon
+relays to the same children it already had. The release will still be
+correct, but it buys nothing and is carried through more machinery than
+the routing tree needs, so it can only be slower.
+
+Set rml_base_radix2 to the radix you actually want for the release, or
+turn grpcomm_low_radix_release off. The runtime is continuing with the
+settings as given.

--- a/src/rml/radix.h
+++ b/src/rml/radix.h
@@ -40,6 +40,11 @@ typedef prte_rml_routed_tree_node_t radix_node_t;
 /* Obtain a radix node configured for this rank */
 static radix_node_t radix_node(const pmix_rank_t rank);
 
+/* As radix_node, but in a tree of the given radix rather than the routing
+ * tree's.  There is more than one radix tree over the daemons - see the radix
+ * member of prte_rml_routed_tree_node_t. */
+static radix_node_t radix_node_in(const pmix_rank_t rank, const pmix_rank_t radix);
+
 /**
  * Raise the node's rank up the tree, to represent its parent
  *
@@ -124,7 +129,7 @@ static bool radix_node_is_valid(const radix_node_t* node){
     if(node->depth > prte_rml_base.n_dmns) return false;
     if(node->width == 0) return false;
     if(node->count == 0) return false;
-    if(node->count/prte_rml_base.radix > prte_rml_base.n_dmns) return false;
+    if(node->count/node->radix > prte_rml_base.n_dmns) return false;
     if(node->count < node->width) return false;
 
     pmix_rank_t layer_offset = node->count - node->width;
@@ -133,14 +138,14 @@ static bool radix_node_is_valid(const radix_node_t* node){
     if(node->rank != exp_rank) return false;
 
     pmix_rank_t exp_count =
-        (node->width*prte_rml_base.radix-1)/(prte_rml_base.radix-1);
+        (node->width*node->radix-1)/(node->radix-1);
     if(node->count != exp_count) return false;
 
     pmix_rank_t depth = node->depth;
     pmix_rank_t width = node->width;
-    while(width >= (pmix_rank_t) prte_rml_base.radix && depth > 0){
-        if(width % prte_rml_base.radix != 0) return false;
-        width = width / prte_rml_base.radix;
+    while(width >= (pmix_rank_t) node->radix && depth > 0){
+        if(width % node->radix != 0) return false;
+        width = width / node->radix;
         depth--;
     }
     if(depth != 0 || width != 1) return false;
@@ -164,7 +169,7 @@ static inline void radix_update_rank(radix_node_t* node){
 /* Helper: increment depth and update width/count without changing rank */
 static inline void radix_incr_depth(radix_node_t* node){
     if(node->depth > prte_rml_base.n_dmns+1 ||
-        node->width/prte_rml_base.radix > prte_rml_base.n_dmns
+        node->width/node->radix > prte_rml_base.n_dmns
     ) {
         // Avoid overflows leading to undefined behaviour
         node->depth = PMIX_RANK_INVALID;
@@ -172,7 +177,7 @@ static inline void radix_incr_depth(radix_node_t* node){
         node->count = PMIX_RANK_INVALID;
     }
     node->depth++;
-    node->width *= prte_rml_base.radix;
+    node->width *= node->radix;
     node->count += node->width;
 }
 /* Helper: decrement depth and update width/count without changing rank */
@@ -185,14 +190,23 @@ static inline void radix_decr_depth(radix_node_t* node){
     }
     node->depth--;
     node->count -= node->width;
-    node->width /= prte_rml_base.radix;
+    node->width /= node->radix;
 }
 
 __prte_attribute_unused__
-static radix_node_t radix_node(const pmix_rank_t rank){
-    radix_node_t node = {.base = rank};
+/* Build a node in a tree of the given radix.  Every other operation here
+ * derives from an existing node and copies it, so the radix travels with the
+ * node and this is the only place a tree is chosen. */
+static radix_node_t radix_node_in(const pmix_rank_t rank, const pmix_rank_t radix){
+    radix_node_t node = {.base = rank, .radix = radix};
     radix_to_base(&node);
     return node;
+}
+
+/* ...and in the routing tree, which is what almost every caller wants. */
+__prte_attribute_unused__
+static radix_node_t radix_node(const pmix_rank_t rank){
+    return radix_node_in(rank, (pmix_rank_t) prte_rml_base.radix);
 }
 
 static void radix_to_parent(radix_node_t* node){
@@ -211,7 +225,7 @@ __prte_attribute_unused__
 static radix_node_t radix_child(const radix_node_t* node, pmix_rank_t idx){
     radix_node_t child = *node;
     radix_incr_depth(&child);
-    if(idx >= (pmix_rank_t) prte_rml_base.radix) child.rank = PMIX_RANK_INVALID;
+    if(idx >= (pmix_rank_t) node->radix) child.rank = PMIX_RANK_INVALID;
     if(node->rank >= prte_rml_base.n_dmns){
         child.base = PMIX_RANK_INVALID;
     } else {
@@ -227,7 +241,7 @@ static radix_node_t radix_right_sibling(const radix_node_t* node){
     if(node->rank >= prte_rml_base.n_dmns){
         sibling.base = PMIX_RANK_INVALID;
     } else {
-        sibling.base = node->rank + node->width/prte_rml_base.radix;
+        sibling.base = node->rank + node->width/node->radix;
         if(sibling.base >= node->count) sibling.base = PMIX_RANK_INVALID;
     }
     radix_update_rank(&sibling);
@@ -235,9 +249,9 @@ static radix_node_t radix_right_sibling(const radix_node_t* node){
 }
 
 static void radix_to_depth(radix_node_t* node, const pmix_rank_t depth){
-    double width = pow(prte_rml_base.radix, depth);
-    double count = (width*prte_rml_base.radix-1)/(prte_rml_base.radix-1);
-    if(count/prte_rml_base.radix > prte_rml_base.n_dmns){
+    double width = pow(node->radix, depth);
+    double count = (width*node->radix-1)/(node->radix-1);
+    if(count/node->radix > prte_rml_base.n_dmns){
         node->rank  = PMIX_RANK_INVALID;
         node->depth = PMIX_RANK_INVALID;
         node->width = PMIX_RANK_INVALID;
@@ -266,10 +280,10 @@ static void radix_to_base(radix_node_t* node){
         return;
     }
 
-    double radix = prte_rml_base.radix;
+    double radix = node->radix;
     node->depth = log(node->base*(radix-1) + 1) / log(radix);
-    node->width = pow(prte_rml_base.radix, node->depth);
-    node->count = (node->width*prte_rml_base.radix-1)/(prte_rml_base.radix-1);
+    node->width = pow(node->radix, node->depth);
+    node->count = (node->width*node->radix-1)/(node->radix-1);
 
     // Floating point logic and integer truncation could mean we're slightly off
     // with our chosen depth
@@ -290,7 +304,7 @@ static void radix_to_next(radix_node_t* node){
         // child slot fell exactly on the boundary (e.g. rank 0 with the default
         // radix 64 in a 64-daemon DVM), which made radix_to_next_living give up
         // and silently drop every rank in that subtree from the repaired tree.
-        pmix_rank_t child = node->rank + node->width*prte_rml_base.radix;
+        pmix_rank_t child = node->rank + node->width*node->radix;
         while(child >= prte_rml_base.n_dmns) child -= node->width;
         radix_incr_depth(node);
         node->rank = child;
@@ -341,7 +355,7 @@ static pmix_rank_t radix_subtree_index(
     if(n == node->rank || !radix_subtree_contains(node, n)){
         return PMIX_RANK_INVALID;
     }
-    pmix_rank_t child_width = node->width*prte_rml_base.radix;
+    pmix_rank_t child_width = node->width*node->radix;
     // Return simplified from:
     // child_rank = (n - node->count)%child_width + node->count
     // child_index = ( child_rank - node->count ) / node->width

--- a/src/rml/rml.c
+++ b/src/rml/rml.c
@@ -236,6 +236,17 @@ void prte_rml_load_dead_dmns(const char *spec)
             continue;
         }
         for (r = first; r <= last; r++) {
+            if (!pmix_bitmap_is_set_bit(&prte_rml_base.dead_dmns, (int) r)) {
+                /* Start this daemon's derived-tree version in step with the
+                 * DVM it is joining.  A daemon grown into a DVM that has
+                 * already lost members has learned of those departures right
+                 * here and nowhere else, and leaving it at zero would make it
+                 * read every peer as being ahead of it - so every forward it
+                 * received on a derived tree would be parked, waiting for
+                 * news it had already been given, until the next daemon
+                 * happened to die. */
+                prte_rml_base.tree_version++;
+            }
             pmix_bitmap_set_bit(&prte_rml_base.dead_dmns, (int) r);
         }
     }

--- a/src/rml/rml.c
+++ b/src/rml/rml.c
@@ -288,6 +288,30 @@ void prte_rml_register(void)
         prte_rml_base.radix = 2;
     }
 
+    /* The radix of the second tree - the low one a release fans out over,
+     * beside the high one the rollup gathers on.  They want opposite values:
+     * a gathering daemon sends one aggregate however many children it has,
+     * while a broadcasting one sends a copy per child, so fanout is free
+     * going up and is the whole cost coming down.  See
+     * docs/plans/scalable_collectives/two-radix-release.rst.
+     *
+     * Defaulting it to the routing radix means the second tree is the same
+     * shape as the first until someone asks otherwise, which is what keeps
+     * the default behaviour exactly what it is today. */
+    prte_rml_base.radix2 = prte_rml_base.radix;
+    (void) pmix_mca_base_var_register("prte", "rml", "base", "radix2",
+                                      "Radix of the tree used to fan a "
+                                      "collective's release out (minimum 2). "
+                                      "Defaults to the routing tree's radix.",
+                                      PMIX_MCA_BASE_VAR_TYPE_INT,
+                                      &prte_rml_base.radix2);
+    /* Same clamp and the same reason: the tree math divides by (radix - 1). */
+    if (2 > prte_rml_base.radix2) {
+        pmix_output(0, "PRRTE: release tree radix %d is invalid (minimum is 2)"
+                       " - using 2", prte_rml_base.radix2);
+        prte_rml_base.radix2 = 2;
+    }
+
     /* The ranks that had already departed the DVM when we were launched. Only
      * a launcher sets this, on the prted command line: a daemon started into a
      * DVM that has lost ranks has to know which they are BEFORE it computes its

--- a/src/rml/rml.h
+++ b/src/rml/rml.h
@@ -304,6 +304,12 @@ typedef struct {
     pmix_list_t posted_recvs;
     pmix_list_t unmatched_msgs;
     int radix;
+    // Radix of the tree a collective's release fans out over. Separate from
+    // `radix` above because the two trees want opposite values - fanout is
+    // free on the way up and is the entire cost on the way down - and
+    // defaulting to `radix` keeps today's behaviour until someone asks for
+    // something else.
+    int radix2;
     bool static_ports;
 
     // # daemons before failures
@@ -465,6 +471,15 @@ PRTE_EXPORT int prte_rml_route_lost(pmix_rank_t route);
 PRTE_EXPORT pmix_rank_t prte_rml_get_route(pmix_rank_t target);
 PRTE_EXPORT int prte_rml_get_subtree_index(pmix_rank_t target);
 PRTE_EXPORT bool prte_rml_is_node_up(pmix_rank_t node);
+
+/* This daemon's parent and children in the RELEASE tree - the low-radix tree
+ * (prte_rml_base.radix2) a collective fans its release out over, as distinct
+ * from the routing tree its rollup gathers on. Derived, never agreed: every
+ * daemon computes the same shape from inputs they already hold in step.
+ * Answers PRTE_ERR_NOT_FOUND for a rank outside the DVM. The caller frees
+ * the children array. */
+PRTE_EXPORT int prte_rml_release_tree(pmix_rank_t me, pmix_rank_t *parent,
+                                      pmix_rank_t **children, size_t *nchildren);
 
 #define PRTE_RML_ACTIVATE_MESSAGE(m)                                           \
     do {                                                                       \

--- a/src/rml/rml.h
+++ b/src/rml/rml.h
@@ -358,6 +358,10 @@ typedef struct {
     // rank is a stale incarnation and is dropped. Grown on demand as ranks
     // appear; see prte_rml_epoch_ok / prte_rml_record_epoch.
     uint64_t *peer_epochs;
+    // Monotone count of departures and returns this daemon has learned of -
+    // the version of every tree derived from the live set. See
+    // prte_rml_tree_version().
+    uint32_t tree_version;
     size_t peer_epochs_size;
 
     // Track all ancestors up to HNP, to simplify fault handling
@@ -404,6 +408,23 @@ PRTE_EXPORT extern uint64_t prte_rml_boot_epoch;
  * that). prte_rml_record_epoch force-sets the authoritative epoch for a rank
  * (used by the revival path and the HNP's return validation);
  * prte_rml_get_epoch reads it (0 if unknown). */
+/* How many daemon departures and returns this process has learned of.
+ *
+ * A version number for every tree derived from the live set, and the only
+ * thing anything asks of it is "has the other end seen news I have not".  It
+ * therefore has to be **monotone**, which is why it counts events learned
+ * rather than the size of the failed set: a revival clears a bit, so a
+ * popcount of failed_dmns goes down, and a daemon that had processed the
+ * revival would read every peer that had not as being ahead of it - and wait
+ * for news that had already arrived.
+ *
+ * It counts ranks rather than notices, so a daemon told of three departures
+ * at once lands on the same number as one that learned them singly.  It is
+ * not a total order - two daemons can reach the same count having learned
+ * about different daemons - and is not meant to be; see the parking
+ * commentary in prte_grpcomm_xcast_recv for what is and is not concluded
+ * from it. */
+PRTE_EXPORT uint32_t prte_rml_tree_version(void);
 PRTE_EXPORT bool prte_rml_epoch_ok(pmix_rank_t rank, uint64_t epoch);
 PRTE_EXPORT void prte_rml_record_epoch(pmix_rank_t rank, uint64_t epoch);
 PRTE_EXPORT uint64_t prte_rml_get_epoch(pmix_rank_t rank);

--- a/src/rml/rml_types.h
+++ b/src/rml/rml_types.h
@@ -372,7 +372,7 @@ typedef struct {
 } prte_rml_recv_request_t;
 PRTE_EXPORT PMIX_CLASS_DECLARATION(prte_rml_recv_request_t);
 
-/* struct for traversing the routing tree - used internally */
+/* struct for traversing a radix tree - used internally */
 typedef struct {
     pmix_rank_t rank;
     pmix_rank_t depth; // depth of this rank in tree
@@ -381,6 +381,14 @@ typedef struct {
     pmix_rank_t base;  // rank the node was originally constructed as
                        //   note: used for going back down the tree after going
                        //   up, not necessarily related to failures
+    // Which tree this node belongs to, carried rather than read from a
+    // global. There is more than one radix tree over the daemons now - the
+    // routing tree the rollup gathers on, and the low-radix tree a release
+    // fans out over - and they want opposite radices. A node that knows its
+    // own means both can be walked in the same breath, with no mode to switch
+    // and nothing to get wrong if a walk of one is interleaved with a walk of
+    // the other.
+    pmix_rank_t radix;
 } prte_rml_routed_tree_node_t;
 
 /* Outcome of reconciling a peer's report of THIS daemon's ancestor list

--- a/src/rml/routed_radix.c
+++ b/src/rml/routed_radix.c
@@ -207,6 +207,86 @@ static void handle_promotion(void){
     }
 }
 
+/* This daemon's place in the *release* tree - the low-radix one a collective
+ * fans its release out over, beside the routing tree the rollup gathers on.
+ *
+ * It is the same radix machinery at a different radix, deliberately.  Sharing
+ * it means the release tree inherits the promotion the routing tree already
+ * does: a dead node is replaced by the next living one in its subtree, so a
+ * failure moves the edges below it and leaves the rest of the tree alone.
+ * The alternative - renumbering over the live daemons - is simpler to write
+ * and much worse to run: on 64 daemons at radix 3, losing an early daemon
+ * moves 43 edges rather than 3, and every moved edge is a lateral connection
+ * to open at exactly the moment the DVM is recovering.
+ *
+ * Nothing here is agreed between daemons.  Every daemon derives the same tree
+ * from the daemon count, the failed set and the radix, all of which they
+ * already hold in step, so there is no protocol and no window in which two
+ * daemons hold different shapes.  That is the same rule a fence lives under,
+ * and for the same reason: there is no originator to settle a disagreement.
+ *
+ * The caller frees `children`. */
+int prte_rml_release_tree(pmix_rank_t me, pmix_rank_t *parent,
+                          pmix_rank_t **children, size_t *nchildren)
+{
+    radix_node_t node, iter, up;
+    pmix_rank_t *kids;
+    size_t n = 0;
+
+    *parent = PMIX_RANK_INVALID;
+    *children = NULL;
+    *nchildren = 0;
+
+    if (2 > prte_rml_base.radix2) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+    if (me >= prte_rml_base.n_dmns) {
+        return PRTE_ERR_NOT_FOUND;
+    }
+
+    node = radix_node_in(me, (pmix_rank_t) prte_rml_base.radix2);
+
+    /* Walk up past any ancestor that has failed.  The root has no parent, and
+     * that is the only daemon allowed to be without one. */
+    if (0 != me) {
+        up = radix_parent(&node);
+        while (PMIX_RANK_INVALID != up.rank && !radix_is_living(&up)) {
+            if (0 == up.rank) {
+                break;
+            }
+            up = radix_parent(&up);
+        }
+        *parent = up.rank;
+    }
+
+    kids = (pmix_rank_t *) malloc((size_t) prte_rml_base.radix2 * sizeof(pmix_rank_t));
+    if (NULL == kids) {
+        return PRTE_ERR_OUT_OF_RESOURCE;
+    }
+
+    /* ...and take each child, or the next living node beneath it if that
+     * child has failed - the promotion the routing tree performs, at this
+     * tree's radix. */
+    RADIX_CHILD_FOREACH(node, iter) {
+        radix_node_t c = iter;
+        if (!radix_is_living(&c)) {
+            c = radix_rooted_get_next_living(&iter, &iter);
+        }
+        if (PMIX_RANK_INVALID == c.rank || c.rank >= prte_rml_base.n_dmns) {
+            continue;
+        }
+        kids[n++] = c.rank;
+    }
+
+    if (0 == n) {
+        free(kids);
+        kids = NULL;
+    }
+    *children = kids;
+    *nchildren = n;
+    return PRTE_SUCCESS;
+}
+
 // Replace failed children after promotion or failures
 static void update_descendants(void){
     pmix_rank_t* children = (pmix_rank_t*)prte_rml_base.children.array;

--- a/src/rml/routed_radix.c
+++ b/src/rml/routed_radix.c
@@ -226,10 +226,15 @@ static void handle_promotion(void){
  * and for the same reason: there is no originator to settle a disagreement.
  *
  * The caller frees `children`. */
+uint32_t prte_rml_tree_version(void)
+{
+    return prte_rml_base.tree_version;
+}
+
 int prte_rml_release_tree(pmix_rank_t me, pmix_rank_t *parent,
                           pmix_rank_t **children, size_t *nchildren)
 {
-    radix_node_t node, iter, up;
+    radix_node_t node, iter, up, pos;
     pmix_rank_t *kids;
     size_t n = 0;
 
@@ -246,15 +251,44 @@ int prte_rml_release_tree(pmix_rank_t me, pmix_rank_t *parent,
 
     node = radix_node_in(me, (pmix_rank_t) prte_rml_base.radix2);
 
-    /* Walk up past any ancestor that has failed.  The root has no parent, and
-     * that is the only daemon allowed to be without one. */
-    if (0 != me) {
-        up = radix_parent(&node);
-        while (PMIX_RANK_INVALID != up.rank && !radix_is_living(&up)) {
-            if (0 == up.rank) {
-                break;
-            }
-            up = radix_parent(&up);
+    /* Find the position this daemon actually occupies.
+     *
+     * A dead node is replaced in place by the next living node of its own
+     * subtree, so a daemon whose parent slot has failed may be the daemon that
+     * takes it - and if it does, it may equally take that slot's parent, and
+     * so on up a chain of failures.  Climb while the answer is us.
+     *
+     * Both halves below have to be derived from that position rather than from
+     * the base one, and they have to agree.  Walking up past a dead ancestor
+     * to name a parent while computing children in place does not: on eight
+     * daemons at radix 2, losing daemon 1 promotes daemon 4 into its slot, so
+     * daemon 3's parent is 4 - but a walk-up says 0, and 0's children say 4.
+     * Daemon 3 then waits on a parent that is not sending to it, and a
+     * broadcast that must reach every daemon reaches six of seven.  Nothing
+     * detects that: it is not a failure, it is two daemons deriving different
+     * trees, which is the one thing a tree with no protocol cannot survive. */
+    pos = node;
+    while (0 != pos.rank) {
+        radix_node_t repl;
+        up = radix_parent(&pos);
+        if (PMIX_RANK_INVALID == up.rank || radix_is_living(&up)) {
+            break;
+        }
+        repl = radix_rooted_get_next_living(&up, &up);
+        if (repl.rank != me) {
+            break;
+        }
+        pos = up;
+    }
+
+    /* Our parent is whoever occupies our position's parent slot: that daemon
+     * if it lives, and otherwise its replacement - which cannot be us, or the
+     * climb above would not have stopped.  The root has no parent, and is the
+     * only daemon allowed to be without one. */
+    if (0 != pos.rank) {
+        up = radix_parent(&pos);
+        if (PMIX_RANK_INVALID != up.rank && !radix_is_living(&up)) {
+            up = radix_rooted_get_next_living(&up, &up);
         }
         *parent = up.rank;
     }
@@ -264,12 +298,16 @@ int prte_rml_release_tree(pmix_rank_t me, pmix_rank_t *parent,
         return PRTE_ERR_OUT_OF_RESOURCE;
     }
 
-    /* ...and take each child, or the next living node beneath it if that
-     * child has failed - the promotion the routing tree performs, at this
-     * tree's radix. */
-    RADIX_CHILD_FOREACH(node, iter) {
+    /* ...and take each child of that position, or the living node that stands
+     * in for it.  The slot holding our own original subtree is the exception:
+     * there our child is whoever succeeds *us* inside it, since we have left
+     * it to stand where its former root did.  Where we were not promoted, no
+     * slot holds us and this is the plain in-place replacement. */
+    RADIX_CHILD_FOREACH(pos, iter) {
         radix_node_t c = iter;
-        if (!radix_is_living(&c)) {
+        if (radix_subtree_contains(&iter, me)) {
+            c = radix_rooted_get_next_living(&iter, &node);
+        } else if (!radix_is_living(&c)) {
             c = radix_rooted_get_next_living(&iter, &iter);
         }
         if (PMIX_RANK_INVALID == c.rank || c.rank >= prte_rml_base.n_dmns) {
@@ -375,6 +413,11 @@ void prte_rml_repair_routing_tree(pmix_data_array_t* failed_ranks, bool global,
     }
 
     if(!global){
+        /* Count the departures we have just learned of.  Only on the local
+         * pass: a global notice runs the local one first, which screens the
+         * ranks it already knew, and the global list is not screened at all -
+         * counting there would count every rank twice. */
+        prte_rml_base.tree_version += (uint32_t) status.failed_ranks.size;
         // Skip this work for global, since it will have already been done
         // in the local update
         prte_rml_update_ancestors(&prte_rml_base.ancestors);
@@ -504,6 +547,11 @@ void prte_rml_revive_routing_tree(pmix_rank_t rank){
     // constructor captures prev from prte_rml_base as it stands now.
     prte_rml_recovery_status_t status;
     PMIX_CONSTRUCT(&status, prte_rml_recovery_status_t);
+
+    /* A return reshapes every derived tree exactly as a departure does, and
+     * the version has to move for it, or a daemon that has processed this
+     * revival reads every peer that has not as being ahead of it. */
+    prte_rml_base.tree_version++;
 
     // The returned rank is live again. Clear every failure mark for it.
     // dead_dmns is deliberately left alone -- a revivable rank is never in it,

--- a/src/tools/prte_info/prte_info.c
+++ b/src/tools/prte_info/prte_info.c
@@ -245,10 +245,16 @@ int main(int argc, char *argv[])
     /* add those in */
     pmix_pointer_array_add(&mca_types, "pmix");
 
-    /* add the rml and routed types since they are no
-     * longer in a framework */
+    /* add the rml, routed and grpcomm types since they are no
+     * longer in a framework.  prte_register_params() has already registered
+     * their parameters - it calls each of these subsystems' register function
+     * directly for exactly this reason - but nothing walks a framework list
+     * to find them, so the type has to be named here or the parameters are
+     * invisible to prte_info and therefore to anyone trying to discover
+     * them. */
     pmix_pointer_array_add(&mca_types, "rml");
     pmix_pointer_array_add(&mca_types, "routed");
+    pmix_pointer_array_add(&mca_types, "grpcomm");
 
     /* push all the types found by autogen */
     for (i = 0; NULL != prte_frameworks[i]; i++) {

--- a/test/unit/grpcomm/test_grpcomm.c
+++ b/test/unit/grpcomm/test_grpcomm.c
@@ -82,8 +82,31 @@ static int test_release_bcast_default(void)
 {
     int failures = 0;
 
-    CHECK("release path defaults to xcast",
-          prte_grpcomm_release_bcast == prte_grpcomm_xcast);
+    CHECK("release path is wired to the selector",
+          prte_grpcomm_release_bcast == prte_grpcomm_release_bcast_select);
+
+    /* ...and the selector routes by tag.  A fence release is the whole modex,
+     * so it is the one that moves onto the low-radix tree when that is asked
+     * for; a group release is small, where a low radix buys nothing and costs
+     * depth, so it stays on the routing tree either way.  With the knob off,
+     * nothing moves at all - which is the assertion that keeps the default
+     * being the tree we know works. */
+    prte_grpcomm_globals.low_radix_release = false;
+    CHECK("knob off: a fence release travels the routing tree",
+          PRTE_GRPCOMM_TOPO_ROUTING
+              == prte_grpcomm_release_topology(PRTE_RML_TAG_FENCE_RELEASE));
+    CHECK("knob off: a group release travels the routing tree",
+          PRTE_GRPCOMM_TOPO_ROUTING
+              == prte_grpcomm_release_topology(PRTE_RML_TAG_GROUP_RELEASE));
+
+    prte_grpcomm_globals.low_radix_release = true;
+    CHECK("knob on: a fence release travels the release tree",
+          PRTE_GRPCOMM_TOPO_RELEASE
+              == prte_grpcomm_release_topology(PRTE_RML_TAG_FENCE_RELEASE));
+    CHECK("knob on: a group release still travels the routing tree",
+          PRTE_GRPCOMM_TOPO_ROUTING
+              == prte_grpcomm_release_topology(PRTE_RML_TAG_GROUP_RELEASE));
+    prte_grpcomm_globals.low_radix_release = false;
 
     if (0 == failures) {
         fprintf(stdout, "PASSED test_release_bcast_default\n");

--- a/test/unit/grpcomm/test_grpcomm.c
+++ b/test/unit/grpcomm/test_grpcomm.c
@@ -1116,6 +1116,210 @@ static int test_fence_generation(void)
     return failures;
 }
 
+/*
+ * The release tree: the second topology, derived rather than agreed.
+ *
+ * What matters is not whether one daemon's answer looks right but whether all
+ * the answers fit together - every live daemon except the root has exactly
+ * one parent, that parent claims it as a child, and everyone reaches the
+ * root. A derivation that disagreed with itself would satisfy a
+ * single-daemon check and strand a subtree in the field.
+ */
+static int check_release_tree(const char *label)
+{
+    int failures = 0;
+    pmix_rank_t r, live = 0, root = PMIX_RANK_INVALID, reached = 0;
+    pmix_rank_t *parent_of;
+    char buf[160];
+
+    parent_of = (pmix_rank_t *) malloc(prte_rml_base.n_dmns * sizeof(pmix_rank_t));
+    if (NULL == parent_of) {
+        return 1;
+    }
+    for (r = 0; r < prte_rml_base.n_dmns; r++) {
+        parent_of[r] = PMIX_RANK_INVALID;
+    }
+
+    for (r = 0; r < prte_rml_base.n_dmns; r++) {
+        pmix_rank_t parent = PMIX_RANK_INVALID, *kids = NULL;
+        size_t nkids = 0, i;
+
+        if (!prte_rml_is_node_up(r)) {
+            continue;
+        }
+        live++;
+        if (PRTE_SUCCESS != prte_rml_release_tree(r, &parent, &kids, &nkids)) {
+            snprintf(buf, sizeof(buf), "%s: a live rank %u got no tree", label, r);
+            CHECK(buf, false);
+            continue;
+        }
+        if (PMIX_RANK_INVALID == parent) {
+            if (PMIX_RANK_INVALID != root) {
+                snprintf(buf, sizeof(buf), "%s: a second root at %u", label, r);
+                CHECK(buf, false);
+            }
+            root = r;
+        } else {
+            parent_of[r] = parent;
+            /* a parent must be alive - promoting past a dead ancestor is the
+             * whole point of sharing the routing tree's machinery */
+            if (!prte_rml_is_node_up(parent)) {
+                snprintf(buf, sizeof(buf), "%s: %u's parent %u is dead",
+                         label, r, parent);
+                CHECK(buf, false);
+            }
+        }
+        /* every child claimed must name us back */
+        for (i = 0; i < nkids; i++) {
+            pmix_rank_t cp = PMIX_RANK_INVALID, *ck = NULL;
+            size_t cn = 0;
+            if (!prte_rml_is_node_up(kids[i])) {
+                snprintf(buf, sizeof(buf), "%s: %u claims dead child %u",
+                         label, r, kids[i]);
+                CHECK(buf, false);
+                continue;
+            }
+            if (PRTE_SUCCESS == prte_rml_release_tree(kids[i], &cp, &ck, &cn)) {
+                if (cp != r) {
+                    snprintf(buf, sizeof(buf),
+                             "%s: %u claims %u as a child, but %u's parent is %u",
+                             label, r, kids[i], kids[i], cp);
+                    CHECK(buf, false);
+                }
+                if (NULL != ck) {
+                    free(ck);
+                }
+            }
+        }
+        if ((size_t) prte_rml_base.radix2 < nkids) {
+            snprintf(buf, sizeof(buf), "%s: rank %u has %d children, over radix",
+                     label, r, (int) nkids);
+            CHECK(buf, false);
+        }
+        if (NULL != kids) {
+            free(kids);
+        }
+    }
+
+    snprintf(buf, sizeof(buf), "%s: exactly one root", label);
+    CHECK(buf, PMIX_RANK_INVALID != root || 0 == live);
+
+    for (r = 0; r < prte_rml_base.n_dmns; r++) {
+        pmix_rank_t walk = r;
+        int hops = 0;
+        if (!prte_rml_is_node_up(r)) {
+            continue;
+        }
+        while (PMIX_RANK_INVALID != parent_of[walk] && hops <= (int) live) {
+            walk = parent_of[walk];
+            hops++;
+        }
+        if (walk == root && hops <= (int) live) {
+            reached++;
+        }
+    }
+    snprintf(buf, sizeof(buf), "%s: every live daemon reaches the root", label);
+    CHECK(buf, reached == live);
+
+    free(parent_of);
+    return failures;
+}
+
+/* How many edges move when one daemon dies?  This is the number that decided
+ * the design: promoting in place moves the edges below the casualty, while
+ * renumbering over the live daemons moves roughly half the tree - and every
+ * moved edge is a lateral connection to open while the DVM is recovering. */
+static int count_moved_edges(pmix_rank_t victim)
+{
+    pmix_rank_t r, before[128], moved = 0;
+
+    for (r = 0; r < prte_rml_base.n_dmns && r < 128; r++) {
+        pmix_rank_t p = PMIX_RANK_INVALID, *k = NULL;
+        size_t n = 0;
+        before[r] = PMIX_RANK_INVALID;
+        if (prte_rml_is_node_up(r) &&
+            PRTE_SUCCESS == prte_rml_release_tree(r, &p, &k, &n)) {
+            before[r] = p;
+            if (NULL != k) { free(k); }
+        }
+    }
+    pmix_bitmap_set_bit(&prte_rml_base.failed_dmns, victim);
+    for (r = 0; r < prte_rml_base.n_dmns && r < 128; r++) {
+        pmix_rank_t p = PMIX_RANK_INVALID, *k = NULL;
+        size_t n = 0;
+        if (r == victim || !prte_rml_is_node_up(r)) {
+            continue;
+        }
+        if (PRTE_SUCCESS == prte_rml_release_tree(r, &p, &k, &n)) {
+            if (p != before[r]) {
+                moved++;
+            }
+            if (NULL != k) { free(k); }
+        }
+    }
+    pmix_bitmap_clear_bit(&prte_rml_base.failed_dmns, victim);
+    return (int) moved;
+}
+
+static int test_release_tree(void)
+{
+    int failures = 0;
+    pmix_rank_t save_dmns = prte_rml_base.n_dmns;
+    int save_r2 = prte_rml_base.radix2, moved;
+    pmix_rank_t p = PMIX_RANK_INVALID, *k = NULL;
+    size_t n = 0;
+
+    PMIX_CONSTRUCT(&prte_rml_base.failed_dmns, pmix_bitmap_t);
+    pmix_bitmap_init(&prte_rml_base.failed_dmns, 128);
+
+    /* several radices, and sizes that are not powers of them - a complete
+     * tree is the easy case and not the one that breaks */
+    prte_rml_base.n_dmns = 16;
+    prte_rml_base.radix2 = 2;  failures += check_release_tree("16 daemons radix 2");
+    prte_rml_base.radix2 = 3;  failures += check_release_tree("16 daemons radix 3");
+    prte_rml_base.radix2 = 64; failures += check_release_tree("16 daemons radix 64");
+    prte_rml_base.n_dmns = 1;  failures += check_release_tree("1 daemon");
+    prte_rml_base.n_dmns = 2;  failures += check_release_tree("2 daemons");
+    prte_rml_base.n_dmns = 7;  failures += check_release_tree("7 daemons radix 3");
+    prte_rml_base.n_dmns = 13; failures += check_release_tree("13 daemons radix 3");
+
+    /* the release radix is genuinely independent of the routing radix */
+    prte_rml_base.n_dmns = 16;
+    prte_rml_base.radix2 = 3;
+    CHECK("release tree: radix2 is not the routing radix",
+          prte_rml_base.radix2 != prte_rml_base.radix || 3 == prte_rml_base.radix);
+
+    /* failures: a dead node is promoted past, not routed to */
+    pmix_bitmap_set_bit(&prte_rml_base.failed_dmns, 1);
+    failures += check_release_tree("16 daemons, an interior daemon dead");
+    pmix_bitmap_set_bit(&prte_rml_base.failed_dmns, 5);
+    pmix_bitmap_set_bit(&prte_rml_base.failed_dmns, 11);
+    failures += check_release_tree("16 daemons, several dead");
+    pmix_bitmap_clear_all_bits(&prte_rml_base.failed_dmns);
+
+    /* ...and the property that chose promotion over renumbering. Losing one
+     * daemon must disturb a bounded neighbourhood, not half the tree. */
+    prte_rml_base.n_dmns = 64;
+    prte_rml_base.radix2 = 3;
+    moved = count_moved_edges(1);
+    CHECK("release tree: losing a daemon moves few edges, not half the tree",
+          moved <= 2 * prte_rml_base.radix2);
+
+    /* a radix below 2 is not a degenerate tree, it is a division by zero */
+    prte_rml_base.radix2 = 1;
+    CHECK("release tree: radix below 2 is refused",
+          PRTE_SUCCESS != prte_rml_release_tree(0, &p, &k, &n));
+    prte_rml_base.radix2 = save_r2;
+
+    PMIX_DESTRUCT(&prte_rml_base.failed_dmns);
+    prte_rml_base.n_dmns = save_dmns;
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_release_tree\n");
+    }
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0;
@@ -1146,6 +1350,7 @@ int main(void)
     failures += test_group_directives();
     failures += test_fence_operation();
     failures += test_fence_generation();
+    failures += test_release_tree();
     failures += test_fence_tracker();
     failures += test_fence_fault_handler();
     failures += test_recovery_epoch();

--- a/test/unit/rml/test_rml_routing.c
+++ b/test/unit/rml/test_rml_routing.c
@@ -1236,6 +1236,302 @@ static int test_parse_uris(void)
     return failures;
 }
 
+
+/*
+ * The release tree: derived, never agreed.
+ *
+ * A fence's release may fan out over a second radix tree (grpcomm's
+ * low_radix_release), and nothing about that tree is negotiated - every daemon
+ * computes it from the daemon count, the radix and the failed set, which they
+ * already hold in step.  That is what makes it cheap, and it is also what makes
+ * a disagreement fatal rather than merely wrong: there is no originator to
+ * settle one, so a daemon whose parent does not think it is a child simply
+ * waits, and a broadcast that must reach every daemon reaches all but it.
+ *
+ * So the property to pin is not any particular shape but that the two halves
+ * of the derivation agree, for every failure pattern.  Brute-force it: for
+ * each rank ask who its parent is and who its children are, and require the
+ * relation to be a single tree rooted at 0 that covers exactly the live
+ * daemons.
+ *
+ * That is not hypothetical.  Naming a parent by walking up past dead ancestors
+ * while computing children in place is the obvious way to write this and it
+ * does not agree with itself: at eight daemons, radix 2, with daemon 1 dead,
+ * the promotion puts daemon 4 in slot 1 - so daemon 3's parent is 4, while a
+ * walk-up says 0, and 0's children say 4.  Daemon 3 is then in no tree at all.
+ */
+static int check_release_tree(pmix_rank_t ndmns, int radix2, const char *label)
+{
+    int failures = 0;
+    pmix_rank_t r, seen, parent_of[64], nkids[64], kids_of[64][64];
+    bool live[64], reached[64];
+    pmix_rank_t nlive = 0, stack[64], nstack = 0;
+
+    prte_rml_base.radix2 = radix2;
+    prte_process_info.num_daemons = ndmns;
+    /* the tree is derived from prte_rml_base's own count, which normally
+     * comes from prte_rml_compute_routing_tree(); set it directly here so a
+     * shape is not read against the previous case's daemon count */
+    prte_rml_base.n_dmns = ndmns;
+
+    for (r = 0; r < ndmns; r++) {
+        pmix_rank_t *kids = NULL, parent = PMIX_RANK_INVALID;
+        size_t n = 0, i;
+
+        live[r] = !pmix_bitmap_is_set_bit(&prte_rml_base.failed_dmns, r);
+        reached[r] = false;
+        parent_of[r] = PMIX_RANK_INVALID;
+        nkids[r] = 0;
+        if (!live[r]) {
+            continue;
+        }
+        nlive++;
+        if (PRTE_SUCCESS != prte_rml_release_tree(r, &parent, &kids, &n)) {
+            fprintf(stderr, "FAIL [%s]: release tree refused rank %u\n",
+                    label, (unsigned) r);
+            failures++;
+            continue;
+        }
+        parent_of[r] = parent;
+        for (i = 0; i < n; i++) {
+            kids_of[r][nkids[r]++] = kids[i];
+        }
+        if (NULL != kids) {
+            free(kids);
+        }
+    }
+
+    /* every live rank but the root has a living parent; the root has none */
+    for (r = 0; r < ndmns; r++) {
+        if (!live[r]) {
+            continue;
+        }
+        if (0 == r) {
+            if (PMIX_RANK_INVALID != parent_of[r]) {
+                fprintf(stderr, "FAIL [%s]: root claims parent %u\n",
+                        label, (unsigned) parent_of[r]);
+                failures++;
+            }
+            continue;
+        }
+        if (PMIX_RANK_INVALID == parent_of[r] || parent_of[r] >= ndmns
+            || !live[parent_of[r]]) {
+            fprintf(stderr, "FAIL [%s]: rank %u has no living parent (%u)\n",
+                    label, (unsigned) r, (unsigned) parent_of[r]);
+            failures++;
+        }
+    }
+
+    /* ...and the two halves name each other: p lists c iff c names p */
+    for (r = 0; r < ndmns; r++) {
+        pmix_rank_t i;
+        if (!live[r]) {
+            continue;
+        }
+        for (i = 0; i < nkids[r]; i++) {
+            pmix_rank_t c = kids_of[r][i];
+            if (c >= ndmns || !live[c]) {
+                fprintf(stderr, "FAIL [%s]: rank %u lists dead child %u\n",
+                        label, (unsigned) r, (unsigned) c);
+                failures++;
+                continue;
+            }
+            if (parent_of[c] != r) {
+                fprintf(stderr,
+                        "FAIL [%s]: rank %u lists child %u, whose parent is %u\n",
+                        label, (unsigned) r, (unsigned) c,
+                        (unsigned) parent_of[c]);
+                failures++;
+            }
+        }
+        if (0 == r) {
+            continue;
+        }
+        {
+            pmix_rank_t p = parent_of[r], j;
+            bool found = false;
+            if (p < ndmns && live[p]) {
+                for (j = 0; j < nkids[p]; j++) {
+                    if (kids_of[p][j] == r) {
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            if (!found) {
+                fprintf(stderr,
+                        "FAIL [%s]: rank %u names parent %u, which does not "
+                        "list it\n", label, (unsigned) r, (unsigned) p);
+                failures++;
+            }
+        }
+    }
+
+    /* ...and it is one tree, not a forest: walking from the root reaches
+     * every live daemon exactly once */
+    if (live[0]) {
+        stack[nstack++] = 0;
+        reached[0] = true;
+    }
+    seen = 0;
+    while (0 < nstack) {
+        pmix_rank_t cur = stack[--nstack], i;
+        seen++;
+        for (i = 0; i < nkids[cur]; i++) {
+            pmix_rank_t c = kids_of[cur][i];
+            if (c >= ndmns) {
+                continue;
+            }
+            if (reached[c]) {
+                fprintf(stderr, "FAIL [%s]: rank %u reached twice\n",
+                        label, (unsigned) c);
+                failures++;
+                continue;
+            }
+            reached[c] = true;
+            stack[nstack++] = c;
+        }
+    }
+    if (seen != nlive) {
+        fprintf(stderr, "FAIL [%s]: tree covers %u of %u living daemons\n",
+                label, (unsigned) seen, (unsigned) nlive);
+        failures++;
+    }
+
+    return failures;
+}
+
+/*
+ * ...and at the same radix it IS the routing tree.
+ *
+ * rml_base_radix2 defaults to rml_base_radix, so turning
+ * grpcomm_low_radix_release on and setting nothing else sends the release
+ * down a tree of exactly the shape it was already using - every daemon
+ * relaying to the same children as before.  That is worth pinning rather than
+ * assuming, because it is the whole basis for the diagnostic PRRTE prints for
+ * that combination: it is not a cheaper fanout, it is the same fanout carried
+ * through the derived-tree machinery, which is strictly more work for no
+ * change in shape.
+ */
+static int test_release_tree_matches_routing(void)
+{
+    int failures = 0;
+    int radix;
+    pmix_rank_t ndmns, r;
+
+    for (radix = 2; radix <= 5; radix++) {
+        for (ndmns = 1; ndmns <= 12; ndmns++) {
+            for (r = 0; r < ndmns; r++) {
+                pmix_rank_t *kids = NULL, parent = PMIX_RANK_INVALID;
+                pmix_rank_t *rkids, want_parent;
+                size_t n = 0, i, rn;
+
+                build_dvm(radix, ndmns, r);
+                prte_rml_base.radix2 = radix;
+                prte_rml_base.n_dmns = ndmns;
+
+                if (PRTE_SUCCESS != prte_rml_release_tree(r, &parent, &kids, &n)) {
+                    fprintf(stderr, "FAIL [release==routing]: refused rank %u\n",
+                            (unsigned) r);
+                    failures++;
+                    continue;
+                }
+                want_parent = (0 == r) ? PMIX_RANK_INVALID : prte_rml_base.lifeline;
+                if (parent != want_parent) {
+                    fprintf(stderr, "FAIL [release==routing]: radix %d, %u daemons, "
+                            "rank %u: release parent %u, routing parent %u\n",
+                            radix, (unsigned) ndmns, (unsigned) r,
+                            (unsigned) parent, (unsigned) want_parent);
+                    failures++;
+                }
+                rkids = (pmix_rank_t *) prte_rml_base.children.array;
+                rn = 0;
+                for (i = 0; i < prte_rml_base.children.size; i++) {
+                    if (PMIX_RANK_INVALID != rkids[i]) {
+                        rn++;
+                    }
+                }
+                if (rn != n) {
+                    fprintf(stderr, "FAIL [release==routing]: radix %d, %u daemons, "
+                            "rank %u: release has %u children, routing has %u\n",
+                            radix, (unsigned) ndmns, (unsigned) r,
+                            (unsigned) n, (unsigned) rn);
+                    failures++;
+                } else {
+                    size_t j = 0;
+                    for (i = 0; i < prte_rml_base.children.size; i++) {
+                        if (PMIX_RANK_INVALID == rkids[i]) {
+                            continue;
+                        }
+                        if (kids[j] != rkids[i]) {
+                            fprintf(stderr, "FAIL [release==routing]: radix %d, "
+                                    "%u daemons, rank %u: child %u vs %u\n",
+                                    radix, (unsigned) ndmns, (unsigned) r,
+                                    (unsigned) kids[j], (unsigned) rkids[i]);
+                            failures++;
+                        }
+                        j++;
+                    }
+                }
+                if (NULL != kids) {
+                    free(kids);
+                }
+            }
+        }
+    }
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED release tree matches routing at equal radix\n");
+    }
+    return failures;
+}
+
+static int test_release_tree(void)
+{
+    int failures = 0;
+    int radix2;
+    pmix_rank_t ndmns;
+
+    prte_rml_base.radix2 = 2;
+
+    for (radix2 = 2; radix2 <= 4; radix2++) {
+        for (ndmns = 1; ndmns <= 12; ndmns++) {
+            unsigned long mask, limit = 1UL << ndmns;
+            char label[96];
+
+            /* every subset of failures, with rank 0 always alive: the HNP
+             * dying is not a tree repair, it is the end of the DVM */
+            for (mask = 0; mask < limit; mask += 2) {
+                pmix_rank_t r;
+                if (12 == ndmns && 0 != (mask % 37)) {
+                    continue;   /* 4096 subsets a radix is enough at the top end */
+                }
+                pmix_bitmap_clear_all_bits(&prte_rml_base.failed_dmns);
+                for (r = 0; r < ndmns; r++) {
+                    if (mask & (1UL << r)) {
+                        pmix_bitmap_set_bit(&prte_rml_base.failed_dmns, r);
+                    }
+                }
+                snprintf(label, sizeof(label),
+                         "release tree radix %d, %u daemons, failed 0x%lx",
+                         radix2, (unsigned) ndmns, mask);
+                failures += check_release_tree(ndmns, radix2, label);
+                if (0 != failures) {
+                    /* one shape is enough to read; do not print thousands */
+                    pmix_bitmap_clear_all_bits(&prte_rml_base.failed_dmns);
+                    return failures;
+                }
+            }
+        }
+    }
+    pmix_bitmap_clear_all_bits(&prte_rml_base.failed_dmns);
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED release tree agreement\n");
+    }
+    return failures;
+}
+
 int main(void)
 {
     int rc, failures = 0;
@@ -1251,6 +1547,8 @@ int main(void)
     failures += test_radix_shape();
     failures += test_radix_traversal();
     failures += test_routing_tree();
+    failures += test_release_tree();
+    failures += test_release_tree_matches_routing();
     failures += test_departed_ranks_survive_recompute();
     failures += test_global_failures_survive_recompute();
     failures += test_reconcile_ancestry();


### PR DESCRIPTION
Implements the design merged as #2751.

## The problem

A fence's rollup and its release want opposite tree shapes. A gathering
daemon receives `r` messages and sends **one** aggregate, so width costs it
nothing; a broadcasting daemon receives one copy and sends `r`, so width is
the whole cost. Today both use the routing tree, so one of the two is always
wrong.

Giving the release a tree of its own is easy. Giving it *recovery* is not,
and that is what most of this PR is.

## Why a second tree is not just another tree

The release tree is **derived**, not agreed: every daemon computes it from the
daemon count, the failed set and `rml_base_radix2`, which they already hold in
step. That is what makes it cheap — no protocol, no state to synchronize. It
also means **none of the routing tree's recovery inputs describe it**.
`status->promoted`, `->children_changed`, `->prev_children` and
`prte_rml_base.n_children` are all facts about the routing tree. Applied to an
operation travelling another one they are not a near miss but the wrong tree
in every particular: at `rml_base_radix 64` a non-master daemon has *no*
routing children, and the fault handler read that as "my subtree is empty,
this operation is complete" and retired a release it had forwarded nowhere.

Five rules hold the recovery up. Each was found by killing a relay under a
held release on `contrib/dockerswarm`, and each was measured rather than
reasoned about — the count of daemons released went **4, then 5, then 7**.

1. **Both halves of the derivation must agree.** `prte_rml_release_tree()`
   named a parent by walking up past dead ancestors while computing children
   by replacing a dead child in place — two different promotion rules. At
   eight daemons, radix 2, daemon 1 dead, daemon 3's parent is 4 but the
   walk-up says 0 and 0's children say 4: daemon 3 is in no tree at all.
2. **Do not screen a forward on "is the sender my parent".** Sound on the
   routing tree, whose repair notice travels that same tree; wrong on a
   derived tree, where a repaired parent replays to a child that has not heard
   — which silently discarded the one message that would have released it.
3. **An ack answers whoever asked**, not whoever the answering daemon
   currently calls its parent. Answering the wrong daemon costs nothing;
   failing to answer the right one hangs the broadcast.
4. **Nobody defers.** `replay_pending_parent` is a routing-tree device; here a
   daemon deferring to a parent that has already replayed waits for a second
   replay that never comes and strands its subtree.
5. **A forward is read under the view it was computed in.** Every forward
   carries `prte_rml_tree_version()`; a receiver that is behind it *and* was
   addressed by a non-parent parks the operation — taking the payload and
   delivering it locally, but deriving nothing until the notice lands.
   Without this a daemon promoted into a dead relay's slot still reads itself
   as a leaf, retires the operation with zero children, and strands everything
   below.

Anything added here later — Bruck above all — inherits all five. They are
properties of deriving a tree rather than being told one.

## Testing

- `test/unit/rml`: `test_release_tree` brute-forces every failure subset for
  radices 2–4 and requires one tree rooted at 0 covering exactly the living
  daemons. A/B'd red against the old derivation, which it names exactly.
  `test_release_tree_matches_routing` pins that at equal radices the release
  tree *is* the routing tree.
- `contrib/dockerswarm`: a new case holds daemon 1's forward, kills it, and
  requires all seven ranks to be released with the modex intact. Its first
  assertion is a canary on the hold being live — without it every assertion
  below passes vacuously, which is how the low-radix case spent three green
  runs when first written.
- Full multi-node suite: **780 passed, 0 failed, 3 skipped**. Unit suite 25/25.

Two instruments ship with it, for the same reason the existing fence/release
delay knobs do. `grpcomm_xcast_delay_ms` holds one daemon's *forward* on a
non-routing tree, so an operation is still travelling when a daemon is killed
underneath it — its two siblings both act after the forward has gone and
cannot reach this path. `grpcomm_enable_timing` now stamps absolute
microseconds at broadcast start and at each daemon's receipt, so a broadcast's
coverage is measurable directly.

## What it measures, and what that does not settle

Ten daemons, routing radix 64 (release = one hop) vs release radix 2:

| release payload (wire) | radix 64 | radix 2 |
|---|---|---|
| 33 B (a barrier's release) | 408 us | 854 us |
| 10.5 KB | 1810 us | 1770 us |
| 166 KB | 4579 us | 6326 us |
| 658 KB | 9949 us | 11406 us |

**The low radix loses, and it is the harness rather than the idea.** Every
node is a container on one host, so the nine copies the flat tree makes the
controller send contend for nothing, and the term the low radix exists to
reduce is ~0 — while three extra hops are real, at ~150 us each. Settling it
needs a machine where a daemon's outbound bandwidth is shared and finite.

So **the default does not change**: `grpcomm_low_radix_release` is off, and
off means every release travels the routing tree exactly as before with none
of the derived-tree code running. `rml_base_radix2` only gives the tree its
shape and is not consulted while the switch is off.

That default is a trap, and PRRTE now says so: `rml_base_radix2` defaults to
`rml_base_radix`, so turning the switch on and changing nothing else sends the
release down a tree of exactly the shape it was already using — the identical
fanout through more machinery. The master emits `release-radix-noop` once for
that combination and carries on.
