### PR TITLE
Send a derived tree's edges direct instead of routing them

### DIFF
--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -4732,6 +4732,32 @@ test_low_radix_release() {
         && ok "...and the release travelled the release tree, not the routing one" \
         || bad "no broadcast used the release tree - the knob was ignored"
 
+    # ...and it travelled it over DIRECT links, which is the assertion that
+    # decides whether any of the above means anything.  prte_rml_get_route()
+    # answers on the ROUTING tree, so a release edge sent routed is relayed by
+    # whichever daemon the routing tree puts in between - and at radix 64 that
+    # is the controller itself.  The release then crosses the very link the
+    # second tree exists to keep it off, the controller handles it twice, and
+    # the fanout is not reduced at all.  Every assertion above passes exactly
+    # as well in that state: the release does arrive, over the release tree,
+    # with the right data.  It was shipped that way, and the mistake was
+    # invisible until the routing was read directly.
+    #
+    # rml_base_verbose 2 names the macro each send used.  A forward from a
+    # NON-controller daemon is the one that matters - the controller's own
+    # children are routing children either way, so it is the only daemon whose
+    # sends cannot tell the two apart.
+    out=$(RUN "timeout -k 5 180 prterun --prtemca grpcomm_low_radix_release 1 \
+                   --prtemca rml_base_radix2 2 --prtemca rml_base_radix 64 \
+                   --prtemca rml_base_verbose 2 --leave-session-attached \
+                   --host $hosts -n 8 --map-by node $FENCER collect" 2>&1)
+    # tag 15 is PRTE_RML_TAG_XCAST; node1 hosts the controller, so exclude it
+    n=$(echo "$out" | grep -v '^\[node1:' \
+            | grep -cE 'RML-SEND-PAYLOAD-DIRECT-CB\([0-9]+:15\)')
+    [ "$n" -ge 1 ] \
+        && ok "...over direct links ($n relayed forwards bypassed the routing tree)" \
+        || bad "release forwards went out routed - every edge that is not also a routing edge is being relayed, so the second tree buys nothing"
+
     cleanup_swarm
 }
 

--- a/docs/plans/scalable_collectives/two-radix-release.rst
+++ b/docs/plans/scalable_collectives/two-radix-release.rst
@@ -278,13 +278,46 @@ squashes 250:1.  Medians over 10 releases per cell:
      - 9949 us
      - 11406 us
 
-**The low radix loses here, and the reason is the harness rather than the
-idea.**  Every "node" is a container on one host, so the nine copies the flat
-tree makes the HNP send do not contend for anything — there is no per-node
-uplink, and they go at loopback speed.  The ``r*M*beta`` term the low radix
-exists to reduce is therefore close to free, while the extra hops are real:
-the 33-byte row is the cost of depth with no payload at all, and three extra
-hops cost ~450 us, or ~150 us a hop.
+**Those numbers were taken against a defect and are superseded** — see the
+table below.  The forwards were being sent *routed*, so seven of the nine
+release edges were relayed through the controller and the fanout was not
+reduced at all.  They are kept here because the correction is the more
+interesting number.
+
+Once the release edges are sent direct (``prte_rml_send_payload_direct_cb_nb``,
+with the peer registered as a lateral link):
+
+.. list-table::
+   :header-rows: 1
+
+   * - release payload (on the wire)
+     - routing tree (radix 64)
+     - release tree (radix 2)
+   * - 33 B (a barrier's release)
+     - 476 us
+     - 563 us
+   * - 10.5 KB
+     - 1758 us
+     - 2018 us
+   * - 166 KB
+     - 6381 us
+     - 4963 us
+   * - 658 KB
+     - 7774 us
+     - 7786 us
+
+The trustworthy row is the first: no payload, so it is pure depth, and it has
+55 samples rather than 10.  The low radix's penalty there fell from **+446 us
+to +87 us**, which is the seven relayed edges disappearing at roughly the
+50 us a hop this harness shows.  The payload rows became *inconclusive* rather
+than negative - a single flat-tree cell at 658 KB ranges from 2362 to 36343 us
+over ten samples, so no ordering can be read out of them.
+
+That is still not a case for turning the parameter on.  It is the removal of a
+reason it could never have worked, and the measurement environment is
+unchanged: every "node" is a container on one host, so the copies the flat
+tree makes the controller send contend for nothing, and the ``r*M*beta`` term
+the low radix exists to reduce stays close to free.
 
 So this is not evidence against the design.  It is a measurement of an
 environment in which the quantity being optimized is approximately zero, and
@@ -292,8 +325,9 @@ it is the reading the harness section of ``contrib/dockerswarm/AGENTS.md``
 warns to expect.  What it does establish:
 
 * the mechanism works and is measurable — the release really does travel the
-  other tree, and the instrument resolves it;
-* the depth penalty is real and is roughly linear in hops;
+  other tree, over direct links, and the instrument resolves it;
+* the depth penalty is real, but most of what was measured as depth was
+  relaying, and it went away with the routed sends;
 * nothing here justifies changing the default, which stays the routing tree.
 
 What would settle it is a machine where a daemon's outbound bandwidth is
@@ -302,6 +336,15 @@ tree's nine copies serialize on that NIC while the low radix's extra hops are
 paid against a much larger transfer term.  ``contrib/scaling/cluster-sweep.sh``
 is the harness for that; until it has been run, the parameter ships off by
 default and this table is the only data.
+
+**And check the edges are direct before believing any of it.**  A release tree
+whose edges are sent routed is not a second tree at all - at a high routing
+radix every non-child edge is relayed by the controller, so the bytes cross
+the very link the tree exists to keep them off and the controller handles them
+twice.  ``--prtemca rml_base_verbose 2`` names the macro each send used:
+release-tree forwards must appear as ``RML-SEND-PAYLOAD-DIRECT-CB``, and a
+plain ``RML-SEND-PAYLOAD-CB`` from a non-controller means the measurement is
+of the routing tree wearing a disguise.
 
 One caveat for whoever runs it next: the release is store-and-forward, so a
 deeper tree pays depth times the *transfer* time, not merely depth times a

--- a/src/grpcomm/AGENTS.md
+++ b/src/grpcomm/AGENTS.md
@@ -477,6 +477,42 @@ gathering daemon receives r messages and sends one aggregate, so width is
 free) and the release wants a **narrow** one (a broadcasting daemon receives
 one and sends r, so width is the whole cost).
 
+### A derived tree's edges must be sent DIRECT
+
+`prte_rml_get_route()` answers on the **routing** tree, so an edge of any other
+tree that is not also a routing edge gets *relayed*. At a high routing radix
+the relay is the controller itself, which means the bytes cross the very link
+the second tree exists to keep them off, the controller handles them twice,
+and the fanout is not reduced at all. Measured on eight daemons at routing
+radix 64 with release radix 2: seven of nine release edges went back through
+rank 0, which is worse than not having a second tree.
+
+So `forward_payload_to()` and `send_ack_msg()` route their sends through
+`edge_is_direct()`: the routing tree keeps the routed send (there every edge
+*is* the route), and every other tree gets
+`prte_rml_send_payload_direct_cb_nb()` / `prte_rml_send_buffer_direct_cb_nb()`.
+Both fall back to a routed send on their own when contact information is
+missing, so no caller handles "no direct route".
+
+A peer reached that way and not also a tree neighbour is registered with
+`prte_rml_lateral_register()`. That is about faults, not delivery: losing a
+lateral link means the tree has **not** changed shape, and repairing on the
+strength of it would end every in-flight collective in the DVM.
+`prte_rml_route_lost()` consults `prte_rml_is_lateral_only()`, deregisters,
+and calls the lateral-lost callback instead of repairing.
+
+grpcomm installs that callback (`prte_grpcomm_xcast_lateral_lost`), and it
+closes a hole that only exists once edges are direct: an *undeliverable*
+forward is covered by `forward_lost`, but a link that drops **after** the
+forward landed produces no send completion at all, and the operation then
+waits on an ack that is never coming. The handler re-derives and re-forwards,
+and deliberately concludes nothing about the peer being dead — the RML reached
+it precisely because it decided the loss was not a tree fault.
+
+**Check this when measuring.** `--prtemca rml_base_verbose 2` names the macro
+each send used; a release-tree forward from a non-controller must appear as
+`RML-SEND-PAYLOAD-DIRECT-CB`.
+
 ### A derived tree repairs by different rules, and they are not optional
 
 An op may travel a tree other than the routing one — today a fence release

--- a/src/grpcomm/grpcomm.c
+++ b/src/grpcomm/grpcomm.c
@@ -200,6 +200,11 @@ int prte_grpcomm_init(void)
                        prte_rml_base.radix, prte_rml_base.radix2);
     }
 
+    /* Losing a lateral link is not a tree fault, so the RML deliberately does
+     * not repair on it - but a derived tree's broadcast may have been relying
+     * on that link, and nothing else will tell it.  See lateral_link_lost(). */
+    prte_rml_lateral_set_lost_callback(prte_grpcomm_xcast_lateral_lost);
+
     /* setup the trackers */
     PMIX_CONSTRUCT(&prte_grpcomm_globals.xcast_ops,
                    prte_grpcomm_xcast_t);

--- a/src/grpcomm/grpcomm_internal.h
+++ b/src/grpcomm/grpcomm_internal.h
@@ -271,6 +271,9 @@ typedef int (*prte_grpcomm_release_bcast_fn_t)(prte_rml_tag_t tag, pmix_data_buf
 PRTE_EXPORT extern prte_grpcomm_release_bcast_fn_t prte_grpcomm_release_bcast;
 /* Which tree a release for this tag travels - the decision alone, so it can
  * be asserted without a DVM to send over. */
+/* Told by the RML that a lateral link died - see the definition for why a
+ * derived tree needs this and the routing tree does not. */
+PRTE_EXPORT void prte_grpcomm_xcast_lateral_lost(pmix_rank_t rank);
 PRTE_EXPORT prte_grpcomm_topology_t prte_grpcomm_release_topology(prte_rml_tag_t tag);
 PRTE_EXPORT int prte_grpcomm_release_bcast_select(prte_rml_tag_t tag,
                                                   pmix_data_buffer_t *msg);

--- a/src/grpcomm/grpcomm_xcast.c
+++ b/src/grpcomm/grpcomm_xcast.c
@@ -180,6 +180,9 @@ static void topo_children(prte_grpcomm_topology_t topo, pmix_rank_t **children,
                           size_t *n, bool *owned);
 static size_t topo_n_children(prte_grpcomm_topology_t topo);
 static pmix_rank_t topo_parent(prte_grpcomm_topology_t topo);
+/* Is an edge of this tree sent direct rather than routed?  Registers the peer
+ * as a lateral link when it is one - see the definition. */
+static bool edge_is_direct(prte_grpcomm_topology_t topo, pmix_rank_t dest);
 
 
 // Pack the xcast message forwarded to our children.  Takes no destination:
@@ -786,6 +789,40 @@ static void release_tree_fault(op_t* op)
 }
 
 
+/* A lateral link died while we were relying on it.
+ *
+ * This is the hole that opens the moment a derived tree's edges stop being
+ * routing edges.  An undeliverable forward is already covered - the send
+ * completes with an error and forward_lost drops the expectation - but a link
+ * that drops AFTER the forward landed produces no send completion at all, and
+ * the op then waits on an ack that is never coming.
+ *
+ * Note what this is not allowed to conclude.  prte_rml_route_lost() reaches
+ * here precisely because it has decided the loss is NOT a routing-tree fault,
+ * and it deliberately does not diagnose the peer as dead: the socket may
+ * simply have dropped.  So this must not fail anything or mark anyone dead.
+ * Re-deriving and re-forwarding is the whole response, and it is safe for both
+ * readings - if the peer is alive the direct send re-opens the connection, and
+ * if it really died the global notice arrives later and the repair runs again
+ * on a live set that no longer contains it. */
+void prte_grpcomm_xcast_lateral_lost(pmix_rank_t rank)
+{
+    op_t *op, *next_op;
+
+    PMIX_OUTPUT_VERBOSE((1, prte_grpcomm_globals.output,
+                         "%s grpcomm:xcast lateral link to %s lost -"
+                         " replaying any derived-tree ops that used it",
+                         PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                         PRTE_VPID_PRINT(rank)));
+
+    PMIX_LIST_FOREACH_SAFE(op, next_op, &XCAST.ops, op_t){
+        if (PRTE_GRPCOMM_TOPO_ROUTING == op->sig.topology) {
+            continue;
+        }
+        release_tree_fault(op);
+    }
+}
+
 void prte_grpcomm_xcast_fault_handler(
     const prte_rml_recovery_status_t* status
 ) {
@@ -980,14 +1017,28 @@ static void send_ack_msg(
         return;
     }
 
+    /* An ack retraces an edge of the same tree, so it is sent the same way -
+     * routed for the routing tree, direct for a derived one.  Acks are a few
+     * bytes, so this is about hops rather than bandwidth: routing one on a
+     * derived tree sends it through the controller and back out, which is two
+     * hops and a wakeup at the busiest daemon in the DVM for a message that
+     * had one hop to travel. */
+    bool direct = edge_is_direct(sig->topology, dest);
     if(is_request){
         /* A re-poll aimed at a child we cannot reach says exactly what an
          * undeliverable forward says - no ack is ever coming from that subtree
          * - so it is tracked the same way.  The upward direction is not: a
          * failure there is our lifeline, which is the fault machinery's
          * business and not this op's. */
-        PRTE_RML_SEND_CB(ret, dest, msg, PRTE_RML_TAG_XCAST_ACK,
-                         forward_lost, SIG_TO_CBDATA(*sig));
+        if (direct) {
+            PRTE_RML_SEND_DIRECT_CB(ret, dest, msg, PRTE_RML_TAG_XCAST_ACK,
+                                    forward_lost, SIG_TO_CBDATA(*sig));
+        } else {
+            PRTE_RML_SEND_CB(ret, dest, msg, PRTE_RML_TAG_XCAST_ACK,
+                             forward_lost, SIG_TO_CBDATA(*sig));
+        }
+    } else if (direct) {
+        PRTE_RML_SEND_DIRECT(ret, dest, msg, PRTE_RML_TAG_XCAST_ACK);
     } else {
         PRTE_RML_SEND(ret, dest, msg, PRTE_RML_TAG_XCAST_ACK);
     }
@@ -1511,6 +1562,40 @@ static prte_rml_payload_t* build_forward_payload(op_t* op){
     return payload;
 }
 
+/* An edge of a derived tree is sent DIRECT, and the peer is registered.
+ *
+ * The routed send picks the next hop the *routing* tree would take, so an edge
+ * that is not also a routing edge gets relayed - and at a high routing radix
+ * the relay is the controller itself.  The bytes then cross the very link the
+ * second tree exists to keep them off, the controller handles them twice, and
+ * the fanout is not reduced at all: measured on eight daemons at routing radix
+ * 64 with release radix 2, seven of nine release edges went back through rank
+ * 0.  A direct send is what makes the tree mean anything, and the design said
+ * so from the start ("A radix-3 release edge is a sibling edge in a radix-64
+ * routing tree, so this needs direct sends to non-children").
+ *
+ * Registering the peer is a separate obligation and it is about faults, not
+ * delivery: losing a lateral link means the tree has NOT changed shape, and
+ * repairing on the strength of it would end every in-flight collective in the
+ * DVM.  prte_rml_is_lateral_only() is the test the fault path uses, and it
+ * answers false for anything that is also a tree neighbour, so registering a
+ * peer that happens to be our parent or child costs nothing.
+ *
+ * The routing tree keeps the routed send unchanged: there every edge IS the
+ * route. */
+static bool edge_is_direct(prte_grpcomm_topology_t topo, pmix_rank_t dest)
+{
+    if (PRTE_GRPCOMM_TOPO_ROUTING == topo) {
+        return false;
+    }
+    if (dest != prte_rml_get_route(dest)) {
+        /* not reachable in one routing hop, so this is a genuine lateral edge
+         * and the fault machinery has to be told about the link */
+        prte_rml_lateral_register(dest);
+    }
+    return true;
+}
+
 static void forward_payload_to(op_t* op, prte_rml_payload_t* payload,
                                pmix_rank_t dest){
     int rc;
@@ -1525,8 +1610,13 @@ static void forward_payload_to(op_t* op, prte_rml_payload_t* payload,
     /* The op-id is carried by value rather than by pointer: the send outlives
      * the op on precisely the paths that matter, so the callback has to be
      * able to look the op up and find it gone. */
-    PRTE_RML_SEND_PAYLOAD_CB(rc, dest, payload, PRTE_RML_TAG_XCAST,
-                             forward_lost, SIG_TO_CBDATA(op->sig));
+    if (edge_is_direct(op->sig.topology, dest)) {
+        PRTE_RML_SEND_PAYLOAD_DIRECT_CB(rc, dest, payload, PRTE_RML_TAG_XCAST,
+                                        forward_lost, SIG_TO_CBDATA(op->sig));
+    } else {
+        PRTE_RML_SEND_PAYLOAD_CB(rc, dest, payload, PRTE_RML_TAG_XCAST,
+                                 forward_lost, SIG_TO_CBDATA(op->sig));
+    }
     if (PMIX_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
         PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);

--- a/src/rml/rml.h
+++ b/src/rml/rml.h
@@ -160,6 +160,37 @@ PRTE_EXPORT int prte_rml_send_payload_cb_nb(pmix_rank_t rank,
     } while (0)
 
 /**
+ * As prte_rml_send_payload_cb_nb, but bypass the routing tree.
+ *
+ * This is the combination a broadcast on a *derived* tree needs and no other
+ * caller does: one packed payload shared by every destination, a completion
+ * callback (an undeliverable forward means that subtree's ack is never
+ * coming), and a destination chosen by a tree that is not the routing one.
+ * Sent routed, such a forward is relayed by whichever daemon the routing tree
+ * puts in between - which at a high routing radix is the controller itself,
+ * so the bytes cross the very link the second tree exists to keep them off
+ * and the fanout is not reduced at all.
+ *
+ * Falls back to a routed send when the peer's contact information is not
+ * available, exactly as prte_rml_send_buffer_direct_nb does.  Register the
+ * peer with prte_rml_lateral_register() unless it is also a tree neighbour.
+ */
+PRTE_EXPORT int prte_rml_send_payload_direct_cb_nb(pmix_rank_t rank,
+                                                   prte_rml_payload_t *payload,
+                                                   prte_rml_tag_t tag,
+                                                   prte_rml_buffer_callback_fn_t cbfunc,
+                                                   void *cbdata);
+
+#define PRTE_RML_SEND_PAYLOAD_DIRECT_CB(_r, r, p, t, cf, cd)               \
+    do {                                                                   \
+        pmix_output_verbose(2, prte_rml_base.rml_output,                   \
+                            "RML-SEND-PAYLOAD-DIRECT-CB(%s:%d): %s:%s:%d", \
+                            PMIX_RANK_PRINT(r), t,                         \
+                            __FILE__, __func__, __LINE__);                 \
+        (_r) = prte_rml_send_payload_direct_cb_nb(r, p, t, cf, cd);        \
+    } while (0)
+
+/**
  * As prte_rml_send_buffer_nb, but bypass the routing tree and deliver straight
  * to the named peer.
  *
@@ -180,6 +211,23 @@ PRTE_EXPORT int prte_rml_send_payload_cb_nb(pmix_rank_t rank,
 PRTE_EXPORT int prte_rml_send_buffer_direct_nb(pmix_rank_t rank,
                                                pmix_data_buffer_t *buffer,
                                                prte_rml_tag_t tag);
+
+/* As prte_rml_send_buffer_cb_nb, but bypass the routing tree.  The ack half of
+ * a derived tree's traffic needs this for the same reason the forward does. */
+PRTE_EXPORT int prte_rml_send_buffer_direct_cb_nb(pmix_rank_t rank,
+                                                  pmix_data_buffer_t *buffer,
+                                                  prte_rml_tag_t tag,
+                                                  prte_rml_buffer_callback_fn_t cbfunc,
+                                                  void *cbdata);
+
+#define PRTE_RML_SEND_DIRECT_CB(_r, r, b, t, cf, cd)               \
+    do {                                                           \
+        pmix_output_verbose(2, prte_rml_base.rml_output,           \
+                            "RML-SEND-DIRECT-CB(%s:%d): %s:%s:%d", \
+                            PMIX_RANK_PRINT(r), t,                 \
+                            __FILE__, __func__, __LINE__);         \
+        (_r) = prte_rml_send_buffer_direct_cb_nb(r, b, t, cf, cd); \
+    } while(0)
 
 #define PRTE_RML_SEND_DIRECT(_r, r, b, t)                       \
     do {                                                        \

--- a/src/rml/rml_send.c
+++ b/src/rml/rml_send.c
@@ -171,6 +171,28 @@ int prte_rml_send_payload_cb_nb(pmix_rank_t rank,
     return send_buffer(rank, NULL, payload, tag, false, cbfunc, cbdata);
 }
 
+int prte_rml_send_payload_direct_cb_nb(pmix_rank_t rank,
+                                       prte_rml_payload_t *payload,
+                                       prte_rml_tag_t tag,
+                                       prte_rml_buffer_callback_fn_t cbfunc,
+                                       void *cbdata)
+{
+    if (NULL == payload || NULL == payload->dbuf) {
+        PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
+        return PRTE_ERR_BAD_PARAM;
+    }
+    return send_buffer(rank, NULL, payload, tag, true, cbfunc, cbdata);
+}
+
+int prte_rml_send_buffer_direct_cb_nb(pmix_rank_t rank,
+                                      pmix_data_buffer_t *buffer,
+                                      prte_rml_tag_t tag,
+                                      prte_rml_buffer_callback_fn_t cbfunc,
+                                      void *cbdata)
+{
+    return send_buffer(rank, buffer, NULL, tag, true, cbfunc, cbdata);
+}
+
 int prte_rml_send_buffer_direct_nb(pmix_rank_t rank,
                                    pmix_data_buffer_t *buffer,
                                    prte_rml_tag_t tag)


### PR DESCRIPTION
Follow-up to #2753, which shipped the two-radix release with a defect that
made it unable to do the one thing it exists for.

## The problem

`prte_rml_get_route()` answers on the **routing** tree. The release-tree
forwards were sent with the ordinary routed send, so every release edge that
was not *also* a routing edge got relayed — and at a high routing radix the
relay is the controller itself.

Measured on eight daemons, routing radix 64, release radix 2:

```
[@0,1] routed_radix_get(3) --> 0     daemon 1 forwarding to its release children
[@0,1] routed_radix_get(5) --> 0
[@0,2] routed_radix_get(4) --> 0
[@0,2] routed_radix_get(6) --> 0
```

Seven of nine release edges went back through rank 0. The bytes crossed the
very link the second tree exists to keep them off, the controller handled each
twice, and the fanout was not reduced at all — strictly worse than not having
a second tree.

**Nothing detected it.** The release arrived, over the release tree, with the
right data, and all four assertions in the existing case passed. The design
had said what was needed — *"a radix-3 release edge is a sibling edge in a
radix-64 routing tree, so this needs direct sends to non-children"* — and named
the entry points, which were on master and unused.

## The fix

`edge_is_direct()` is the one place that decides: the routing tree keeps the
routed send (there every edge *is* the route), every other tree gets a direct
one. That needed two new RML entry points, because the combination a derived
tree wants — one shared payload, a completion callback, and a destination the
routing tree would not choose — did not exist. Both fall back to routed when
contact info is missing, so no caller handles "no direct route".

Peers reached that way and not also tree neighbours are registered with
`prte_rml_lateral_register()`, which is about faults rather than delivery:
losing a lateral link means the tree has **not** changed shape, and repairing
on the strength of it would end every in-flight collective in the DVM.

That opens a hole which only exists once edges are direct, closed in the same
commit. An *undeliverable* forward is covered by `forward_lost`, but a link
that drops **after** the forward landed produces no send completion at all and
the operation waits on an ack that never comes.
`prte_grpcomm_xcast_lateral_lost()` re-derives and re-forwards, and
deliberately concludes nothing about the peer being dead.

## What it changes in the numbers

| release payload | flat — before | low — before | flat — after | low — after |
|---|---|---|---|---|
| 33 B (barrier) | 408 µs | **854 µs** | 476 µs | **563 µs** |
| 10.5 KB | 1810 | 1770 | 1758 | 2018 |
| 166 KB | 4579 | **6326** | 6381 | **4963** |
| 658 KB | 9949 | **11406** | 7774 | 7786 |

The trustworthy row is the first — no payload, so pure depth, and 55 samples
rather than 10. The low-radix penalty falls from **+446 µs to +87 µs**: the
seven relayed edges disappearing. The payload rows go from consistently
negative to *inconclusive* (one flat cell at 658 KB spans 2362–36343 µs over
ten samples).

**The default does not change.** This removes a reason the feature could never
have worked; it is not a case for turning it on. The 658 KB dead heat is also
what the store-and-forward model predicts — unpipelined, a low radix trades
fanout for depth roughly one-for-one — which makes payload pipelining the
precondition for the parameter to be worth anything, on any hardware.

## Testing

- New assertion counts `RML-SEND-PAYLOAD-DIRECT-CB` from non-controller
  daemons. **A/B'd**: revert the fix and the four assertions above it stay
  green while this one alone goes red.
- Full multi-node suite **780 passed, 0 failed, 3 skipped**; unit suite 25/25.
