### PR TITLE
Stop reading a staged file faster than it can be delivered

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -152,6 +152,16 @@ an `"OAC_HAVE_APPLE" redefined` error when the two trees were configured
 for different platforms; the quiet and far worse version is same-platform
 with a different `--with-pmix`.
 
+**A second source tree is refused, not cleaned.** `PMIX_SRC` and `OMPI_SRC`
+are bind-mounted read-only and configured VPATH just as this tree is, so an
+in-tree build in one of them is fatal for exactly the same reasons — but
+those trees are not ours to destroy: `build.sh` was pointed at the PRRTE
+tree and owns it, while `PMIX_SRC` is somebody's working tree lent to us.
+So `check_foreign_srcdir` names the tree and the variable and stops. Without
+it the failure was the builder's own `configure: error: source directory
+already configured; run "make distclean" there first` — which names no tree,
+no variable, and no way to tell which of the two builds it came from.
+
 The only way to stop paying for the distclean is to stop keeping an
 in-tree build (below). Removing the destructive step entirely would mean
 building from a *snapshot* of the source inside the volume rather than a

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -181,6 +181,35 @@ $(find "$tree" -name '*.l' 2>/dev/null)
 EOF
 }
 
+# A second source tree - PMIX_SRC, OMPI_SRC - is built out of tree too, over a
+# READ-ONLY bind mount, so an in-tree build in one of those is fatal for the
+# same reason it is fatal in this one.  It is not ours to distclean, though:
+# build.sh was pointed at the PRRTE tree and owns it, while PMIX_SRC is
+# somebody's working tree that happens to have been lent to us.  So say what is
+# wrong and stop, rather than either destroying their build or letting the
+# builder die on
+#
+#     configure: error: source directory already configured; run "make
+#     distclean" there first
+#
+# which names no tree, no variable, and nothing to do about it.
+check_foreign_srcdir() {
+    local tree="$1" var="$2"
+    [ -n "$tree" ] || return 0
+    if [ -f "$tree/config.status" ] || [ -f "$tree/Makefile" ] || \
+       [ -n "$(find "$tree/src" -name '*.lo' -print -quit 2>/dev/null)" ]; then
+        echo ">>> ERROR: $var points at a tree that holds an IN-TREE build:" >&2
+        echo ">>>          $tree" >&2
+        echo ">>>        It is bind-mounted read-only and configured VPATH, so" \
+             "configure refuses to run and VPATH=srcdir would link its stale" \
+             "objects even if it did." >&2
+        echo ">>>        Run 'make distclean' there (it is your build, so this" \
+             "script will not), or unset $var to use the PMIx baked into the" \
+             "image." >&2
+        exit 2
+    fi
+}
+
 # --- make the source tree VPATH-ready (idempotent) --------------------------
 prep_srcdir() {
     if srcdir_has_intree && [ "$distclean" != never ]; then
@@ -279,11 +308,13 @@ build_linux() {
 
     local pmix_mount=()
     if [ -n "$PMIX_SRC" ]; then
+        check_foreign_srcdir "$(cd "$PMIX_SRC" && pwd)" PMIX_SRC
         gen_lex "$(cd "$PMIX_SRC" && pwd)"
         pmix_mount=(-v "$(cd "$PMIX_SRC" && pwd)":/pmix-src:ro)
     fi
     local ompi_mount=()
     if [ -n "$OMPI_SRC" ]; then
+        check_foreign_srcdir "$(cd "$OMPI_SRC" && pwd)" OMPI_SRC
         gen_lex "$(cd "$OMPI_SRC" && pwd)"
         ompi_mount=(-v "$(cd "$OMPI_SRC" && pwd)":/ompi-src:ro)
     fi

--- a/docs/how-things-work/preloading-files.rst
+++ b/docs/how-things-work/preloading-files.rst
@@ -128,3 +128,21 @@ the directory they launched from.
 
 Note that the staged files remain in the working directory after the job
 completes |mdash| they were delivered there, not borrowed.
+
+
+How much of a file is in flight at once
+---------------------------------------
+
+A staged file is read on the DVM master in 16 KByte chunks and broadcast to
+the daemons, and the broadcast layer holds each chunk on every daemon it
+passes through until that daemon's part of the DVM has confirmed receipt.
+So a file being staged occupies memory in the daemons in proportion to how
+far ahead of delivery the master is allowed to read.
+
+``filem_raw_chunk_window`` (default 64, so one MByte) is how many chunks of
+one file may be outstanding before the master waits for the oldest of them
+to arrive everywhere.  It is the only bound on that memory.  The default
+fills the round trip of the fabrics PRRTE is usually run on with room to
+spare; raise it if staging is measurably slower than the network should
+allow, and expect the daemons' footprint during a transfer to rise with it.
+Several files preloaded by one job each get a window of their own.

--- a/src/grpcomm/AGENTS.md
+++ b/src/grpcomm/AGENTS.md
@@ -112,7 +112,7 @@ Plain functions, all `PRTE_EXPORT`, declared in `grpcomm.h`:
 | `prte_grpcomm_finalize()` | Tear down trackers, cancel the RML receives. |
 | `prte_grpcomm_fault_handler(status)` | Invoked on **every** daemon by `src/rml/routed_radix.c` when the routing tree changes. Called twice per death (LOCAL scope then GLOBAL scope); which scope a collective keys on depends on what it needs, so read *Surviving a daemon failure* before adding a third. |
 | `prte_grpcomm_xcast(tag, msg)` | Broadcast to **every** daemon, delivered at `tag`. Non-destructive to `msg`. Returns `PRTE_SUCCESS` on *acceptance*, not completion. |
-| `prte_grpcomm_xcast_nb(tag, msg, cbfunc, cbdata)` | As above, but `cbfunc` fires on the **master** once the whole DVM has confirmed receipt. `cbfunc`/`cbdata` are ignored on non-master daemons. `xcast` is just `xcast_nb(tag, msg, NULL, NULL)`. |
+| `prte_grpcomm_xcast_nb(tag, msg, cbfunc, cbdata)` | As above, but `cbfunc` fires on the **master** once the whole DVM has confirmed receipt — or, if the broadcast is abandoned before it is ever emitted, as soon as that is known (`abandon_xcast`), because a caller waiting on it would otherwise wait forever. It carries no status, so it means only "stop waiting". `cbfunc`/`cbdata` are ignored on non-master daemons. `xcast` is just `xcast_nb(tag, msg, NULL, NULL)`. |
 | `prte_grpcomm_fence(procs, nprocs, info, ninfo, data, ndata, cbfunc, cbdata)` | Non-blocking allgather/barrier across the daemons hosting `procs`. A barrier supplies no data. Returns `PRTE_SUCCESS` once queued. |
 | `prte_grpcomm_group(op, grpid, procs, nprocs, directives, ndirs, cbfunc, cbdata)` | PMIx group construct/destruct/cancel. |
 

--- a/src/grpcomm/grpcomm_xcast.c
+++ b/src/grpcomm/grpcomm_xcast.c
@@ -944,6 +944,25 @@ void prte_grpcomm_xcast_fault_handler(
     drive_completions();
 }
 
+/* Discard a broadcast that was never emitted, telling its caller.
+ *
+ * A completion callback is normally fired by finish_op, from the op the
+ * master builds when this broadcast is relayed back to it - which never
+ * happens if the broadcast dies here.  A caller that is waiting on that
+ * callback would then wait forever: the collective shrink never emits its
+ * completion event, and filem's chunk pump never restarts a read.  Neither
+ * failure announces itself, so say so here instead.  The callback carries no
+ * status, so it means only "stop waiting"; the error itself has already been
+ * logged by the caller of this function.
+ */
+static void abandon_xcast(op_t *op)
+{
+    if (PRTE_PROC_IS_MASTER && NULL != op->cbfunc) {
+        op->cbfunc(op->cbdata);
+    }
+    PMIX_RELEASE(op);
+}
+
 static void begin_xcast(int sd, short args, void* cbdata){
     PRTE_HIDE_UNUSED_PARAMS(sd, args);
 
@@ -960,7 +979,7 @@ static void begin_xcast(int sd, short args, void* cbdata){
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_DATA_BUFFER_RELEASE(xcast_msg);
-        PMIX_RELEASE(op);
+        abandon_xcast(op);
         return;
     }
 
@@ -993,7 +1012,7 @@ static void begin_xcast(int sd, short args, void* cbdata){
             PMIX_RELEASE(pc);
         }
         PMIX_DATA_BUFFER_RELEASE(xcast_msg);
-        PMIX_RELEASE(op);
+        abandon_xcast(op);
         return;
     }
 

--- a/src/mca/filem/raw/AGENTS.md
+++ b/src/mca/filem/raw/AGENTS.md
@@ -49,16 +49,21 @@ job proceeds to mapping.
 
 | File | Contents |
 |------|----------|
-| `filem_raw_component.c` | Registration, the single `flatten_directory_trees` MCA param, `query` (priority 0). |
-| `filem_raw.h` | The four private classes, `PRTE_FILEM_RAW_CHUNK_MAX` (16384), `PRTE_FILEM_RAW_COPY_MAX` (8192), the `flatten_trees` flag. |
+| `filem_raw_component.c` | Registration, the two MCA params (`flatten_directory_trees`, `chunk_window`), `query` (priority 0). |
+| `filem_raw.h` | The four private classes, `PRTE_FILEM_RAW_CHUNK_MAX` (16384), `PRTE_FILEM_RAW_COPY_MAX` (8192), the `flatten_trees` flag and the `chunk_window`. |
 | `filem_raw_module.c` | Everything: the module vtable, HNP send path, daemon receive path, placement, and class instances. |
 | `help-prte-filem-raw.txt` | The daemon-side collision message. |
 
-### MCA parameter
+### MCA parameters
 
 `filem_raw_flatten_directory_trees` (bool, default false). When true, a
 staged file's remote target is just its basename — all files land flat in
 the working directory instead of recreating their directory tree.
+
+`filem_raw_chunk_window` (int, default 64). How many 16 KB chunks of one
+file may be broadcast before the reader waits for the oldest of them to
+reach the whole DVM. See *flow control* below — this is the only bound on
+how much of a staged file the daemons hold at once.
 
 ---
 
@@ -67,7 +72,7 @@ the working directory instead of recreating their directory tree.
 | Class | Lives on | Role |
 |-------|----------|------|
 | `prte_filem_raw_outbound_t` | HNP | One preposition request. Holds the list of `xfers`, the aggregate `status`, and the caller's `cbfunc`/`cbdata`. When its `xfers` list drains, the callback fires. |
-| `prte_filem_raw_xfer_t` | HNP | One file being sent. Carries the read `fd`, the libevent `ev` (the caddy field — **named `ev`** as required), `src` (local path, for dup detection), `file` (remote-relative path), `type`, `mode` (the source file's permission bits), `nchunk` (next chunk index), and the delivery accounting (`nexpected`, `nrecvd`, the `acked` bitmap, `horizon`) described under *completion accounting*. |
+| `prte_filem_raw_xfer_t` | HNP | One file being sent. Carries the read `fd`, the libevent `ev` (the caddy field — **named `ev`** as required), `src` (local path, for dup detection), `file` (remote-relative path), `type`, `mode` (the source file's permission bits), `nchunk` (next chunk index), the flow-control state (`inflight`, `paused`, `retired`) described under *flow control*, and the delivery accounting (`nexpected`, `nrecvd`, the `acked` bitmap, `horizon`) described under *completion accounting*. |
 | `prte_filem_raw_incoming_t` | daemon | One file being received. Carries the write `fd`, `ev`, `file`/`fullpath`, `type`, `mode`, the `outputs` list of pending write buffers, and `link_pts` (the paths, relative to the session dir, to place). |
 | `prte_filem_raw_output_t` | daemon | One received chunk: `numbytes` + a `PRTE_FILEM_RAW_CHUNK_MAX` data buffer, queued on an incoming file's `outputs` list for the write handler. |
 
@@ -184,11 +189,67 @@ Runs on the progress thread, re-arming itself until EOF:
 4. `prte_grpcomm.xcast(PRTE_RML_TAG_FILEM_BASE, &chunk)` — broadcast to
    **all daemons at once**. Increment `nchunk`.
 5. If `numbytes == 0` this was the EOF chunk: close the fd and stop.
+6. Otherwise, if this file already has `filem_raw_chunk_window` chunks in
+   flight, set `paused` and stop; `chunk_delivered` restarts the read.
    Otherwise re-arm the read event (`prte_event_active(..., PRTE_EV_WRITE,
    1)`) to pump the next chunk.
 
 So a file of *N* chunks produces *N* payload broadcasts plus one final
 zero-byte broadcast that tells receivers to close and finalize.
+
+### Flow control — why the pump has to be gated
+
+**Nothing else stops this loop from reading the whole file into memory.**
+The broadcast is fire-and-forget and the only ack this component receives
+is one per *file*, sent by each daemon at EOF, so it can never gate a read.
+And `prte_event_active()` does not go back through the event loop's poll —
+under `event_base_new()`'s defaults (`limit_callbacks_after_prio` is
+INT_MAX, so `max_to_process` is INT_MAX and there is no dispatch deadline)
+libevent keeps taking `TAILQ_FIRST(activeq)`, and a callback that re-arms
+itself is simply run again. A self-re-arming event therefore starves the
+poll outright: 2,000,000 iterations of that pattern against a real
+libevent 2.1.12 base never let it service a socket once.
+
+That matters because `xcast` **holds a broadcast's payload on every daemon
+along the path** until that daemon's subtree confirms receipt, and
+`finish_op` retires those holdings in strict broadcast order — so one slow
+subtree pins every chunk behind it. Measured on the ten-node swarm with a
+256 MB `--preload-files` and `prte_num_worker_threads 0` (which puts the
+OOB's own events on the starved base, so nothing at all gets in): the HNP
+went from 9 MB to **744 MB**, and the transfer took 84 s. With the window
+it is 13 MB and 5.9 s — the read pauses, the loop polls, and the bytes
+actually move.
+
+The default configuration escaped the worst of it only by accident: the
+OOB worker threads (`prte_num_worker_threads`, default 8) read acks on
+their own bases and inject them with `PRTE_RML_ACTIVATE_MESSAGE`, i.e. a
+cross-thread `prte_event_active` on `prte_event_base`, which *does* get in.
+That is incidental relief, not flow control — the in-flight window was
+still rate × ack-latency with no cap, and it grew with the file (+17 MB at
+256 MB, +27 MB at 1 GB).
+
+So `send_chunk` broadcasts with `prte_grpcomm_xcast_nb()` and asks to be
+told when the chunk has reached the whole DVM:
+
+| Field | Meaning |
+|-------|---------|
+| `inflight` | Chunks of this file broadcast and not yet confirmed delivered DVM-wide. |
+| `paused` | The read stopped because `inflight` reached the window; a delivery restarts it. |
+| `retired` | `xfer_retire` has run. A delivery arriving afterwards must give back its reference and nothing else. |
+
+**Each in-flight chunk holds a reference on the xfer** (`PMIX_RETAIN` at
+the broadcast, `PMIX_RELEASE` in `chunk_delivered`). Without it a transfer
+retired while chunks are still travelling — by an error ack, by
+`prte_dvm_abort_ordered`, by the fault handler — would have its completions
+land on freed memory. `retired` is what stops a late completion re-arming a
+read on a file that is finished; the reference is what stops it touching
+anything at all.
+
+The counterpart in grpcomm is that a broadcast **never** disappears without
+telling its caller: `begin_xcast`'s pack and send failures now go through
+`abandon_xcast`, which fires the completion callback before discarding the
+op. Without that a failed broadcast would leave this pump paused forever
+with the job wedged at `VM_READY`.
 
 ### `recv_ack` + `xfer_complete` — completion accounting
 

--- a/src/mca/filem/raw/filem_raw.h
+++ b/src/mca/filem/raw/filem_raw.h
@@ -32,6 +32,11 @@ PRTE_EXPORT extern prte_filem_base_module_t prte_filem_raw_module;
 
 extern bool prte_filem_raw_flatten_trees;
 
+/* How many chunks of one file may be in flight at once - see the flow
+ * control commentary on prte_filem_raw_xfer_t below.
+ */
+extern int prte_filem_raw_chunk_window;
+
 #define PRTE_FILEM_RAW_CHUNK_MAX 16384
 
 /* buffer size used when copying a staged file into a working directory,
@@ -61,6 +66,32 @@ typedef struct {
     uint32_t mode;
     int32_t nchunk;
     int status;
+    /* Flow control for the chunk pump.
+     *
+     * send_chunk hands a chunk to the non-blocking xcast and immediately
+     * re-arms its own read event.  Nothing in that loop waits for the bytes
+     * to arrive anywhere: the only ack this component receives is one per
+     * *file*, sent by each daemon at EOF, so it cannot gate a read.  Without
+     * a cap the file is therefore read as fast as the progress thread can
+     * turn, and every chunk stays resident until it is delivered - xcast
+     * holds a broadcast's payload on every daemon along the path until that
+     * daemon's subtree confirms receipt, and retires those holdings in
+     * strict broadcast order, so one slow subtree pins every chunk behind
+     * it.  Measured on a ten-node DVM, a 256 MB preload took the HNP from
+     * 9 MB to 744 MB.
+     *
+     * "inflight" is how many of this file's chunks have been broadcast and
+     * not yet confirmed delivered to the whole DVM.  "paused" says the read
+     * stopped because that reached prte_filem_raw_chunk_window, and a
+     * delivery is what will restart it.
+     */
+    int32_t inflight;
+    bool paused;
+    /* The transfer has been retired.  A delivery that arrives afterwards
+     * still has to give back the reference it holds, but must not re-arm a
+     * read on a file that is finished.
+     */
+    bool retired;
     /* Delivery accounting, all four fields maintained together.
      *
      * "nexpected" is how many daemons still owe an ack.  It is seeded from

--- a/src/mca/filem/raw/filem_raw_component.c
+++ b/src/mca/filem/raw/filem_raw_component.c
@@ -37,6 +37,7 @@ static int filem_raw_close(void);
 static int filem_raw_query(pmix_mca_base_module_t **module, int *priority);
 
 bool prte_filem_raw_flatten_trees = false;
+int prte_filem_raw_chunk_window = 64;
 
 prte_filem_base_component_t prte_mca_filem_raw_component = {
     PRTE_MCA_BASE_VERSION(filem),
@@ -65,6 +66,23 @@ static int filem_raw_register(void)
                                                 "creating their respective directory trees",
                                                 PMIX_MCA_BASE_VAR_TYPE_BOOL,
                                                 &prte_filem_raw_flatten_trees);
+
+    prte_filem_raw_chunk_window = 64;
+    (void) pmix_mca_base_component_var_register(c, "chunk_window",
+                                                "Maximum number of 16KByte chunks of one "
+                                                "file that may be broadcast before the "
+                                                "reader waits for the oldest of them to "
+                                                "reach the whole DVM. "
+                                                "This is the only thing bounding how much of "
+                                                "a staged file the daemons hold in memory at "
+                                                "once; raise it on a fabric whose round trip "
+                                                "the default cannot fill, and never set it "
+                                                "below 1.",
+                                                PMIX_MCA_BASE_VAR_TYPE_INT,
+                                                &prte_filem_raw_chunk_window);
+    if (1 > prte_filem_raw_chunk_window) {
+        prte_filem_raw_chunk_window = 1;
+    }
 
     return PRTE_SUCCESS;
 }

--- a/src/mca/filem/raw/filem_raw_module.c
+++ b/src/mca/filem/raw/filem_raw_module.c
@@ -91,6 +91,7 @@ static pmix_list_t incoming_files;
 static pmix_list_t positioned_files;
 
 static void send_chunk(int fd, short argc, void *cbdata);
+static void chunk_delivered(void *cbdata);
 static void recv_files(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer,
                        prte_rml_tag_t tag, void *cbdata);
 static void recv_ack(int status, pmix_proc_t *sender, pmix_data_buffer_t *buffer,
@@ -342,6 +343,12 @@ static const char *type_name(int32_t type)
 static void xfer_retire(int status, prte_filem_raw_xfer_t *xfer, bool positioned)
 {
     prte_filem_raw_outbound_t *outbound = xfer->outbound;
+
+    /* chunks of this file may still be travelling; each holds a reference
+     * and will call back.  Say the transfer is over so that none of them
+     * restarts a read on it - see chunk_delivered.
+     */
+    xfer->retired = true;
 
     /* transfer the status, if not success */
     if (PRTE_SUCCESS != status) {
@@ -1443,9 +1450,19 @@ static void send_chunk(int xxx, short argc, void *cbdata)
         return;
     }
 
-    /* goes to all daemons */
-    if (PRTE_SUCCESS != (rc = prte_grpcomm_xcast(PRTE_RML_TAG_FILEM_BASE, &chunk))) {
+    /* Goes to all daemons, and we ask to be told when it got there.
+     *
+     * The reference is what makes that callback safe: this transfer can be
+     * retired - by an error ack, by an aborting DVM, by the fault handler -
+     * while chunks it broadcast are still travelling, and the callback for
+     * one of those would otherwise land on freed memory.  Each in-flight
+     * chunk holds one, and chunk_delivered gives it back.
+     */
+    PMIX_RETAIN(rev);
+    rc = prte_grpcomm_xcast_nb(PRTE_RML_TAG_FILEM_BASE, &chunk, chunk_delivered, rev);
+    if (PRTE_SUCCESS != rc) {
         PRTE_ERROR_LOG(rc);
+        PMIX_RELEASE(rev);
         PMIX_DATA_BUFFER_DESTRUCT(&chunk);
         close(fd);
         rev->fd = -1;
@@ -1454,6 +1471,7 @@ static void send_chunk(int xxx, short argc, void *cbdata)
     }
     PMIX_DATA_BUFFER_DESTRUCT(&chunk);
     rev->nchunk++;
+    rev->inflight++;
 
     /* if num_bytes was zero, then we need to terminate the event
      * and close the file descriptor
@@ -1462,12 +1480,49 @@ static void send_chunk(int xxx, short argc, void *cbdata)
         close(fd);
         rev->fd = -1;
         return;
-    } else {
-        /* restart the read event */
+    }
+
+    /* Read on only while this file has fewer than the window's worth of
+     * chunks still travelling.  Nothing else limits how far ahead of
+     * delivery this loop can run: the file-level ack cannot gate it (a
+     * daemon sends that once, at EOF), and re-arming with prte_event_active
+     * does not even return to the event loop's poll, so the whole file
+     * would be read, compressed and queued without the progress thread
+     * servicing anything at all.  See the flow-control commentary on
+     * prte_filem_raw_xfer_t.
+     */
+    if (rev->inflight >= prte_filem_raw_chunk_window) {
+        rev->paused = true;
+        return;
+    }
+    /* restart the read event */
+    rev->pending = true;
+    PMIX_POST_OBJECT(rev);
+    prte_event_active(&rev->ev, PRTE_EV_WRITE, 1);
+}
+
+/* One broadcast chunk has reached every daemon in the DVM.
+ *
+ * Fires on the progress thread from grpcomm's completion path, so it may
+ * simply restart a read the window had stopped - but only if the transfer
+ * is still running.  A transfer that has been retired still owes this
+ * callback its reference; it just has nothing left to read.
+ */
+static void chunk_delivered(void *cbdata)
+{
+    prte_filem_raw_xfer_t *rev = (prte_filem_raw_xfer_t *) cbdata;
+
+    if (0 < rev->inflight) {
+        rev->inflight--;
+    }
+    if (rev->paused && !rev->retired && 0 <= rev->fd &&
+        rev->inflight < prte_filem_raw_chunk_window) {
+        rev->paused = false;
         rev->pending = true;
         PMIX_POST_OBJECT(rev);
         prte_event_active(&rev->ev, PRTE_EV_WRITE, 1);
     }
+    PMIX_RELEASE(rev);
 }
 
 static void send_complete(char *file, int status)
@@ -1943,6 +1998,9 @@ static void xfer_construct(prte_filem_raw_xfer_t *ptr)
     ptr->file = NULL;
     ptr->nchunk = 0;
     ptr->status = PRTE_SUCCESS;
+    ptr->inflight = 0;
+    ptr->paused = false;
+    ptr->retired = false;
     ptr->nexpected = 0;
     ptr->nrecvd = 0;
     PMIX_CONSTRUCT(&ptr->acked, pmix_bitmap_t);


### PR DESCRIPTION
## The problem

`filem/raw`'s chunk pump has no flow control, so a `--preload-files` transfer
accumulates the whole file in the daemons rather than streaming it.

Two mechanisms compound:

1. **Nothing gates the read.** `send_chunk()` reads 16 KB, hands it to the
   non-blocking `prte_grpcomm_xcast()`, and immediately re-arms its own read
   event. The only ack this component receives (`recv_ack`) is **one per
   file**, sent by each daemon at EOF — it cannot gate a read, and nothing
   else does.

2. **`prte_event_active()` does not return to the event loop's poll.** PRRTE
   builds its base with a bare `event_base_new()`, whose defaults leave
   `limit_callbacks_after_prio` at `INT_MAX`, so
   `event_process_active_single_queue()` runs with `max_to_process = INT_MAX`
   and no dispatch deadline and simply keeps taking `TAILQ_FIRST(activeq)`. A
   callback that re-arms itself is run again without the loop ever polling. A
   standalone program with that shape against libevent 2.1.12 ran 2,000,000
   iterations without the loop servicing a socket once.

Those matter together because `xcast` **holds a broadcast's payload on every
daemon along the path** until that daemon's subtree confirms receipt
(`op_t.msg`), and `finish_op` retires those holdings in strict broadcast
order — so one slow subtree pins every chunk behind it.

The default configuration was not immune, only luckier: the OOB worker
threads inject arriving acks with a *cross-thread* `prte_event_active`, which
does get in, so ops retire and the in-flight window is whatever rate times ack
latency happens to be. Nothing bounds it, and it grew with the file.

## Measured — ten-node DVM, `--preload-files`

| | payload | HNP peak RSS | time |
|---|---|---|---|
| before, `prte_num_worker_threads 0` | 256 MB | 9 MB → **744 MB** | 84 s |
| before, default | 256 MB | +17 MB | 11.4 s |
| before, default | 1 GB | +27 MB | 37.8 s |
| **after**, workers 0 | 256 MB | +4 MB | **5.9 s** |
| **after**, default | 256 MB | +4.4 MB | 9.7 s |
| **after**, default | 1 GB | **+4.3 MB** | 28.8 s |

The peak no longer follows the file at all, and staging is *faster* than
before, because the progress thread now services the network instead of being
monopolised by the reader.

## The change

`send_chunk` broadcasts with `xcast_nb` and waits, once
`filem_raw_chunk_window` chunks (default 64, so 1 MB per file) are
outstanding, for the oldest to reach the whole DVM before reading further.
Each in-flight chunk holds a reference on the transfer, because a transfer can
be retired while its chunks are still travelling — by an error ack, by
`prte_dvm_abort_ordered`, by the fault handler — and their completions would
otherwise land on freed memory.

Window sweep at 256 MB: `w=1` → +1.1 MB / 14.3 s; `w=8` → +1.5 MB / 9.5 s;
`w=64` → +4.4 MB / 9.7 s; `w=512` → +14.8 MB / 9.1 s. Throughput plateaus by
`w=8`, so the default sits well past the knee.

## Two things found on the way

- **A latent hang in `grpcomm`** (first commit). `begin_xcast`'s pack and send
  failure paths released the op without ever firing the caller's completion
  callback, after `xcast_topo` had already returned `PRTE_SUCCESS` from before
  the thread-shift. A caller waiting on that callback waits forever — the
  collective DVM-shrink caller in `ras_base_allocate.c` has the same exposure
  and would never emit its completion event. Both bailouts now go through
  `abandon_xcast()`.

- **`contrib/dockerswarm/build.sh` never checked `PMIX_SRC`** (third commit)
  for an in-tree build, though it is bind-mounted read-only and configured
  VPATH exactly as the PRRTE tree is. The builder died on
  `configure: error: source directory already configured`, which names no
  tree, no variable, and no build — and the run compiles two of them. It now
  refuses by name. Refuses rather than distcleans: `build.sh` owns the tree it
  was pointed at, but `PMIX_SRC` is somebody's working tree lent to us.

## Verification

- `contrib/dockerswarm` filem block: **31 passed, 0 failed** (includes the two
  fault cases — a daemon lost after staging, and one lost while files are in
  flight, which exercise the window against the fault handler).
- `make check`: 0 failures.
- Docs build clean; `docs/how-things-work/preloading-files.rst` documents the
  new parameter, and `src/mca/filem/raw/AGENTS.md` records the mechanism and
  the numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NbvZ4vF4VEr4rArzW4Vcsz