### PR TITLE
Send a fence's release down a low-radix tree by default

### DIFF
--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -4758,6 +4758,28 @@ test_low_radix_release() {
         && ok "...over direct links ($n relayed forwards bypassed the routing tree)" \
         || bad "release forwards went out routed - every edge that is not also a routing edge is being relayed, so the second tree buys nothing"
 
+    # And now with NO parameters at all, because that is the contract as
+    # shipped: grpcomm_low_radix_release defaults on and rml_base_radix2
+    # defaults to 4.  Every assertion above sets both, so all of them would go
+    # on passing if a later change quietly turned the feature back off, and
+    # nobody would be measuring what the runtime actually does.  The routing
+    # radix is left alone too - at its default of 64 over eight daemons a
+    # radix-4 release tree is genuinely a different shape, so "on tree 1" here
+    # means the derived tree really was built and used.
+    cleanup_swarm
+    out=$(RUN "timeout -k 5 180 prterun --prtemca grpcomm_base_verbose 1 \
+                   --host $hosts -n 8 --map-by node $FENCER collect" 2>&1)
+    n=$(echo "$out" | grep -c 'FENCER collect rank .* rc PMIX_SUCCESS')
+    [ "$n" = 8 ] && ok "a fence with no parameters at all completes on 8 ranks" \
+                 || bad "$n of 8 ranks completed a default-configuration fence"
+    n=$(echo "$out" | grep -c 'on tree 1')
+    [ "$n" -ge 1 ] \
+        && ok "...and its release took the release tree BY DEFAULT" \
+        || bad "the default configuration put the release on the routing tree"
+    n=$(echo "$out" | grep -c 'peers-bad 0')
+    [ "$n" = 8 ] && ok "...delivering every peer's contribution" \
+                 || bad "$n of 8 ranks got a complete modex by default"
+
     cleanup_swarm
 }
 

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -5789,6 +5789,93 @@ test_errmgr() {
     [ "$c" = 0 ] && ok "...and no daemon is left behind" \
                  || bad "$c stray prted after a failed start"
     cleanup_swarm
+
+    banner "errmgr: a launch that fails on ONE node still accounts for the others"
+    # The case above fails every rank, and that is the easy one: nothing ever
+    # started, so nothing is left to account for.  The interesting shape is a
+    # launch that succeeds on some nodes and fails on one, which is what a
+    # path present on only part of a cluster produces -- the ordinary way to
+    # meet this, not an exotic one.
+    #
+    # job_errors used to declare such a job TERMINATED the instant the failure
+    # arrived, on the grounds that "the job never launched, so no proc state
+    # will be triggered".  That holds only when no daemon was given anything
+    # to run.  Here the other daemons launched their ranks and are still
+    # reporting it, so check_job_complete releases the job object underneath
+    # them: their "local launch complete" lands on an HNP that no longer has
+    # the job (plm_base_receive's PRTE_ERR_NOT_FOUND), and so does the death
+    # of every rank that did start (state/base's orphaned-proc path, which
+    # asks the user to file a bug for what is only a mistyped path).
+    #
+    # And the consequence is not confined to diagnostics: a PERSISTENT DVM
+    # does not survive it.  Releasing the job while its daemons are mid-report
+    # leaves the HNP with nothing it can account for, and it comes down -- so
+    # a mistyped path on one node of a long-lived DVM destroys the DVM, which
+    # is the one thing a persistent DVM exists not to do.  The last assertion
+    # below is the one that catches that.
+    #
+    # The first of them needs no log at all: a partial launch failure reported
+    # a DIFFERENT exit status from a total one, because the status was taken
+    # while the accounting was still incomplete.  On the unfixed runtime this
+    # block scores 4 of 7 -- 183 against 75, a PRTE_ERR_NOT_FOUND out of
+    # plm_base_receive, and a DVM that is gone by the next job.
+    cleanup_swarm
+    # A binary on node2 and node3 and NOT on node4.  /tmp is per-container
+    # here, which is what makes this expressible at all.
+    for n in 2 3; do
+        docker exec "$NODE$n" sh -c \
+            'printf "#!/bin/sh\nexit 0\n" > /tmp/partial-app && chmod +x /tmp/partial-app' \
+            >/dev/null 2>&1
+    done
+    docker exec "$NODE"4 rm -f /tmp/partial-app >/dev/null 2>&1
+
+    out=$(RUN 'timeout -k 5 90 prterun --host node2:1,node3:1,node4:1 -np 3 --map-by node \
+                  /tmp/partial-app' 2>&1); rc_partial=$?
+    RUN 'timeout -k 5 90 prterun --host node2:1,node3:1 -np 2 --map-by node \
+                  /no/such/executable' >/dev/null 2>&1; rc_total=$?
+    [ "$rc_partial" != 0 ] && ok "a launch that fails on one node fails the job (rc=$rc_partial)" \
+                           || bad "a missing executable on node4 was reported as success"
+    [ "$rc_partial" = "$rc_total" ] \
+        && ok "...reporting the same status as a launch that failed everywhere ($rc_total)" \
+        || bad "partial launch failure exited $rc_partial, total failure $rc_total"
+    echo "$out" | grep -q 'node4' \
+        && ok "...naming the node that could not run it" \
+        || bad "the diagnostic did not name node4: $(echo "$out" | tr '\n' ' ' | tail -c 250)"
+    c=$(prted_settle 10 1 2 3 4)
+    [ "$c" = 0 ] && ok "...and every daemon came down afterwards" \
+                 || bad "$c stray prted after a partial launch failure"
+    cleanup_swarm
+
+    # The same launch against a PERSISTENT DVM, whose HNP has to survive it
+    # and go on working.  Run in the foreground so the HNP's own output is
+    # readable -- a --daemonize'd DVM discards it, and the whole point here is
+    # what the HNP says to itself.
+    HNPLOG=/tmp/partial-hnp.log
+    RUN "rm -f $PRTED_URI $HNPLOG" >/dev/null 2>&1
+    RUN_BG "$HNPLOG" "prte --report-uri $PRTED_URI --host node2:1,node3:1,node4:1"
+    for _ in $(seq 30); do RUN "grep -q 'DVM ready' $HNPLOG" 2>/dev/null && break; sleep 1; done
+    if RUN "test -s $PRTED_URI" 2>/dev/null; then
+        PRUN "--map-by node -np 3 /tmp/partial-app" >/dev/null 2>&1
+        sleep 2
+        hnp=$(RUN "cat $HNPLOG" 2>&1)
+        echo "$hnp" | grep -q 'PRTE ERROR' \
+            && bad "the HNP lost the job while its daemons were still reporting it: $(echo "$hnp" | grep 'PRTE ERROR' | head -1)" \
+            || ok "the HNP kept the job object until every daemon had reported"
+        echo "$hnp$out" | grep -qi 'holds no record of the job\|internal inconsistency' \
+            && bad "a mistyped path produced an internal-inconsistency report" \
+            || ok "...so no bug report is asked of the user for a mistyped path"
+        out=$(PRUN "--map-by node -np 3 hostname" 2>&1)
+        [ "$(echo "$out" | grep -c 'node[234]')" = 3 ] \
+            && ok "...and the DVM still runs the next job" \
+            || bad "the DVM did not survive a partial launch failure: $(echo "$out" | tr '\n' ' ' | tail -c 200)"
+        RUN "timeout -k 5 30 pterm --dvm-uri file:$PRTED_URI" >/dev/null 2>&1
+    else
+        skp "could not start a persistent DVM for the partial-launch test"
+    fi
+    for n in 2 3; do
+        docker exec "$NODE$n" rm -f /tmp/partial-app >/dev/null 2>&1
+    done
+    cleanup_swarm
 }
 
 ########################################################################

--- a/contrib/scaling/cluster-sweep.sh
+++ b/contrib/scaling/cluster-sweep.sh
@@ -63,6 +63,20 @@
 #   * A DVM that came up with fewer nodes than you asked for reports a
 #     perfectly plausible number for the wrong scale.  Every DVM is verified
 #     by counting distinct hostnames before anything is measured.
+#   * That verification must run the CLIENT, not `hostname`.  The client is
+#     built into the results directory, and a cluster whose nodes do not
+#     share that directory launches `hostname` perfectly and the client not
+#     at all -- 36 jobs failing identically, an empty summary, and no clue
+#     on the console.  Preflight launches the client itself and turns on
+#     --preload-binary when it has to.
+#   * "prte --daemonize" tells you nothing about why a DVM did not start: the
+#     child closes stdout and stderr before it launches a daemon, and it has
+#     already written the --report-uri file by then.  A failed launch is
+#     therefore indistinguishable from a healthy DVM until the first job is
+#     refused.  So the DVM is started in the background WITHOUT --daemonize
+#     and is not considered up until it says "DVM ready".
+#   * A sweep that cannot take a single sample must say so on the console and
+#     stop.  Printing an empty table after an hour is the worst of both.
 #   * A run whose client failed still prints timings for the phases that did
 #     run.  Rows are only recorded when the client reported every phase.
 #   * The absolute numbers depend on the build.  --enable-debug roughly
@@ -219,9 +233,11 @@ if [ "$quick" -eq 1 ]; then
     sizes="1024"
     reps=3
     phases="env,radix,barrier"
-    # smallest, middle and full allocation
+    # smallest, middle and full allocation -- de-duplicated, because a small
+    # allocation collapses them onto each other and measuring the same point
+    # three times looks like three points
     mid=$((NNODES / 2)); [ "$mid" -lt 2 ] && mid=2
-    nodes_list="2,$mid,$NNODES"
+    nodes_list=$(printf '%s\n' 2 "$mid" "$NNODES" | sort -n -u | paste -sd, -)
 fi
 
 # ---------------------------------------------------------------------------
@@ -258,6 +274,7 @@ write_manifest() {
         echo "  sizes:   $sizes"
         echo "  reps:    $reps"
         echo "  phases:  $phases"
+        echo "  preload: ${PRELOAD:-none (client is on a shared filesystem)}"
         echo
         echo "== prte_info =="
         prte_info --all 2>/dev/null | grep -iE "prte:version|repo rev|pmix:version|configure command|c compiler:|build cflags" || true
@@ -309,6 +326,44 @@ preflight() {
     # shellcheck disable=SC2086
     ${CC:-cc} -O2 -g -o "$BIN" "$here/scaletest.c" $cflags $ldflags -lpmix 2>"$outdir/build.log" \
         || { sed -n '1,20p' "$outdir/build.log" >&2; die "could not build scaletest.c (see $outdir/build.log)"; }
+
+    check_client_reach
+}
+
+# Can the compute nodes run the client we just built?
+#
+# We build it into the results directory, which on most clusters is a shared
+# home and on some is not -- and where it is not, EVERY job of the sweep fails
+# identically while the DVM itself is perfectly healthy.  PRRTE has the answer
+# already (--preload-binary stages the executable to each node), so the only
+# question is whether we need it, and that is settled here by launching the
+# client rather than reasoned about from the filesystem.
+#
+# Two nodes is enough: the failure is "this path does not exist over there",
+# and node 2 is over there.  We try the plain launch first so that a cluster
+# with a shared filesystem does not pay the staging cost on every job.
+check_client_reach() {
+    local n=2
+    [ "$NNODES" -ge 2 ] || n=$NNODES
+
+    say "checking that the compute nodes can launch the client"
+
+    PRELOAD=""
+    if dvm_start "$n" 1 64; then
+        dvm_stop
+        say "client is visible on the compute nodes"
+        return 0
+    fi
+
+    PRELOAD="--preload-binary"
+    if dvm_start "$n" 1 64; then
+        dvm_stop
+        say "client is NOT on a shared filesystem -- using --preload-binary"
+        return 0
+    fi
+
+    PRELOAD=""
+    die "cannot launch $BIN on $n nodes, with or without --preload-binary -- see $LOG"
 }
 
 # ---------------------------------------------------------------------------
@@ -316,7 +371,16 @@ preflight() {
 # ---------------------------------------------------------------------------
 
 URI=""
+DVM_LOG=""
+DVM_PID=""
 DVM_UP=0
+# --preload-binary, when the client is not on a filesystem the nodes share.
+# Decided once, by experiment, in preflight.
+PRELOAD=""
+# How the sweep is going, so that a run which cannot take a sample at all can
+# say so while there is still someone watching.
+NSAMPLES=0
+NFAILED=0
 
 hostspec() {   # <nodes> <slots>
     local n=$1 slots=$2 i out=""
@@ -324,29 +388,70 @@ hostspec() {   # <nodes> <slots>
     echo "$out"
 }
 
+# We deliberately do NOT use --daemonize here, even though this is exactly the
+# persistent DVM it is meant for.  Two things about it make a failure to start
+# undiagnosable:
+#
+#   * the daemonized child points its stdout and stderr at /dev/null before it
+#     launches a single daemon, so whatever prte has to say about why the DVM
+#     did not come up is discarded -- redirecting the command does not help,
+#     because the redirection is undone in the child;
+#   * the URI file is written by the PMIx server at init, long before any
+#     daemon has reported, so its existence proves only that the HNP started.
+#
+# Together those turn "prte could not launch the daemons" into a DVM that
+# looks up, answers nothing, and gets reported as a mapping problem.  Run it
+# in the background instead and wait for the "DVM ready" it prints once every
+# daemon has checked in: then success is a positive statement, and a failure
+# leaves its reason in a log we can show the user.
 dvm_start() {  # <nodes> <slots> <radix> <extra mca...>
     local n=$1 slots=$2 radix=$3; shift 3
     local extra="$*" tries seen
 
     URI="$outdir/dvm.uri"
+    DVM_LOG="$outdir/dvm.log"
     rm -f "$URI"
+    : > "$DVM_LOG"
     # shellcheck disable=SC2086
-    prte --daemonize --report-uri "$URI" \
+    prte --report-uri "$URI" \
          --prtemca rml_base_radix "$radix" $extra \
-         --host "$(hostspec "$n" "$slots")" >> "$LOG" 2>&1
+         --host "$(hostspec "$n" "$slots")" < /dev/null > "$DVM_LOG" 2>&1 &
+    DVM_PID=$!
 
     for ((tries = 0; tries < dvm_timeout; tries++)); do
-        [ -s "$URI" ] && break
+        grep -q "DVM ready" "$DVM_LOG" 2>/dev/null && break
+        kill -0 "$DVM_PID" 2>/dev/null || break      # it died -- stop waiting
         sleep 1
     done
-    [ -s "$URI" ] || { echo "    DVM never reported a URI" >&2; return 1; }
+    if ! grep -q "DVM ready" "$DVM_LOG" 2>/dev/null; then
+        echo "    DVM did not start -- prte said:" >&2
+        sed -n '1,12p' "$DVM_LOG" >&2
+        cat "$DVM_LOG" >> "$LOG"
+        dvm_stop
+        return 1
+    fi
+    cat "$DVM_LOG" >> "$LOG"
+    [ -s "$URI" ] || { echo "    DVM never reported a URI" >&2; dvm_stop; return 1; }
 
     # A DVM that came up short reports a believable number for the wrong
     # scale, so count the daemons that actually answer before measuring.
-    seen=$($TIMEOUT 120 prun --dvm-uri "file:$URI" --map-by ppr:1:node -n "$n" hostname 2>/dev/null \
+    #
+    # This runs the CLIENT rather than `hostname`, and that is the whole
+    # point of it: `hostname` is on every node's PATH by construction, so a
+    # check that uses it proves the DVM formed and says nothing about whether
+    # the thing we are about to measure can be launched at all.  On a cluster
+    # whose nodes do not share the results directory that difference is the
+    # entire run.  --version touches no PMIx call, so this stays a launch
+    # test and not a measurement.
+    #
+    # prun's stderr goes to the log, not down the pipe: it must not be
+    # counted as a node, and it is the only explanation we will get.
+    # shellcheck disable=SC2086
+    seen=$($TIMEOUT 120 prun --dvm-uri "file:$URI" $PRELOAD --map-by ppr:1:node -n "$n" \
+               "$BIN" --probe 2>>"$LOG" \
            | sort -u | grep -c . || true)
     if [ "${seen:-0}" -ne "$n" ]; then
-        echo "    DVM came up with ${seen:-0} of $n nodes -- skipping" >&2
+        echo "    DVM answered for ${seen:-0} of $n nodes -- skipping (see $LOG)" >&2
         dvm_stop
         return 1
     fi
@@ -355,7 +460,19 @@ dvm_start() {  # <nodes> <slots> <radix> <extra mca...>
 }
 
 dvm_stop() {
+    local w
     [ -n "$URI" ] && [ -s "$URI" ] && $TIMEOUT 60 pterm --dvm-uri "file:$URI" >> "$LOG" 2>&1
+    # The DVM is our child now, so reap it -- and make sure it is really gone
+    # before the next cycle starts another one on the same nodes.
+    if [ -n "$DVM_PID" ]; then
+        for ((w = 0; w < 30; w++)); do
+            kill -0 "$DVM_PID" 2>/dev/null || break
+            sleep 1
+        done
+        kill -0 "$DVM_PID" 2>/dev/null && kill -TERM "$DVM_PID" 2>/dev/null
+        wait "$DVM_PID" 2>/dev/null || true
+        DVM_PID=""
+    fi
     DVM_UP=0
     rm -f "$URI"
 }
@@ -395,6 +512,37 @@ parse_sample() {   # <capture-file> -> "put,collect,barrier" in microseconds
         END { if (n > 0) printf "%.1f,%.1f,%.1f", mp, mc, mb }' "$1"
 }
 
+# A job that produced nothing.  Keep its output -- it is the only account of
+# why, and a summary of empty rows is not one -- and give up if the sweep has
+# yet to produce a single sample.  The failure that made this necessary took
+# an hour to print an empty table.
+GIVE_UP_AFTER=6
+
+job_failed() {   # <what> <tag> <rep> <capture-file>
+    local what=$1 tag=$2 rep=$3 cap=$4 keep
+
+    NFAILED=$((NFAILED + 1))
+    mkdir -p "$outdir/failures"
+    keep="$outdir/failures/$tag-rep$rep.txt"
+    mv -f "$cap" "$keep" 2>/dev/null || true
+    {
+        echo "    $what $tag rep$rep -- kept $keep"
+        sed -n '1,20p' "$keep" | sed 's/^/        /'
+    } >> "$LOG"
+
+    if [ "$NSAMPLES" -eq 0 ] && [ "$NFAILED" -ge "$GIVE_UP_AFTER" ]; then
+        echo >&2
+        echo "ERROR: $NFAILED jobs have failed and not one sample has been taken." >&2
+        echo "       Stopping rather than sweeping a configuration that cannot run." >&2
+        echo "       The last job said:" >&2
+        grep -vE '^-{10,}$|^[[:space:]]*$|https://github.com/openpmix' "$keep" \
+            | sed -n '1,10p' | sed 's/^/       /' >&2
+        echo "       Full output: $keep" >&2
+        dvm_stop
+        exit 1
+    fi
+}
+
 run_job() {   # <phase> <nodes> <radix> <ppn> <nkeys> <size> <gds> <threads> <rep>
     local phase=$1 n=$2 radix=$3 ppn=$4 k=$5 s=$6 gds=$7 thr=$8 rep=$9
     local nprocs=$((n * ppn)) cap tag vals mca=""
@@ -404,19 +552,20 @@ run_job() {   # <phase> <nodes> <radix> <ppn> <nkeys> <size> <gds> <threads> <re
     tag="${phase}-n${n}r${radix}p${ppn}k${k}s${s}"
 
     # shellcheck disable=SC2086
-    if ! $TIMEOUT "$job_timeout" prun --dvm-uri "file:$URI" $mca \
+    if ! $TIMEOUT "$job_timeout" prun --dvm-uri "file:$URI" $mca $PRELOAD \
              --map-by "ppr:$ppn:node" --bind-to none -n "$nprocs" \
              "$BIN" --tag "$tag" --nkeys "$k" --sizes "$s" \
                     --iters 1 --warmup 0 --entropy >"$cap" 2>&1; then
-        echo "    FAILED $tag rep$rep: $(tail -2 "$cap" | tr '\n' ' ')" >> "$LOG"
-        rm -f "$cap"; return 1
+        job_failed FAILED "$tag" "$rep" "$cap"
+        return 1
     fi
     vals=$(parse_sample "$cap")
     if [ -z "$vals" ]; then
-        echo "    NO DATA $tag rep$rep: $(tail -2 "$cap" | tr '\n' ' ')" >> "$LOG"
-        rm -f "$cap"; return 1
+        job_failed "NO DATA" "$tag" "$rep" "$cap"
+        return 1
     fi
     rm -f "$cap"
+    NSAMPLES=$((NSAMPLES + 1))
 
     local put col bar
     IFS=, read -r put col bar <<< "$vals"
@@ -425,6 +574,16 @@ run_job() {   # <phase> <nodes> <radix> <ppn> <nkeys> <size> <gds> <threads> <re
         "$gds" "$thr" "$rep" "$put" "$col" "$bar" \
         "$(awk -v a="$col" -v b="$bar" 'BEGIN{print a-b}')" >> "$RAW"
     return 0
+}
+
+# The first job on a fresh DVM, whose result is thrown away: it pays for the
+# connections, the session directories and the first-touch of everything the
+# measured jobs then reuse.  Its failure is not counted against the sweep --
+# it is not a sample, and the give-up rule must fire on measurements.
+warm_job() {  # <nodes> <radix> <nkeys> <size> [gds] [threads]
+    local saved=$NFAILED
+    run_job warm "$1" "$2" 1 "$3" "$4" "${5:-default}" "${6:-0}" 0 >/dev/null 2>&1 || true
+    NFAILED=$saved
 }
 
 # Every configuration that shares a DVM runs inside one start/stop.
@@ -471,7 +630,7 @@ sweep() {
             for r in ${radices//,/ }; do
                 say "radix phase: nodes=$n radix=$r"
                 if dvm_start "$n" "$slots" "$r"; then
-                    run_job warm "$n" "$r" 1 "$nkeys" 1024 default 0 0 >/dev/null 2>&1 || true
+                    warm_job "$n" "$r" "$nkeys" 1024
                     for p in ${ppn_list//,/ }; do
                         run_reps radix "$n" "$r" "$p" "$nkeys" 1024 default 0
                     done
@@ -485,7 +644,7 @@ sweep() {
             for r in ${radices//,/ }; do
                 say "barrier phase: nodes=$n radix=$r"
                 if dvm_start "$n" "$slots" "$r"; then
-                    run_job warm "$n" "$r" 1 0 1 default 0 0 >/dev/null 2>&1 || true
+                    warm_job "$n" "$r" 0 1
                     run_reps barrier "$n" "$r" 1 0 1 default 0
                     dvm_stop
                 fi
@@ -497,7 +656,7 @@ sweep() {
             for r in 3 64; do
                 say "payload phase: nodes=$n radix=$r"
                 if dvm_start "$n" "$slots" "$r"; then
-                    run_job warm "$n" "$r" 1 "$nkeys" 1024 default 0 0 >/dev/null 2>&1 || true
+                    warm_job "$n" "$r" "$nkeys" 1024
                     for s in ${sizes//,/ }; do
                         run_reps payload "$n" "$r" 1 "$nkeys" "$s" default 0
                     done
@@ -511,7 +670,7 @@ sweep() {
             for g in default hash; do
                 say "gds phase: nodes=$n gds=$g"
                 if dvm_start "$n" "$slots" 64 "$([ "$g" = hash ] && echo '--pmixmca gds hash')"; then
-                    run_job warm "$n" 64 1 "$nkeys" 1024 "$g" 0 0 >/dev/null 2>&1 || true
+                    warm_job "$n" 64 "$nkeys" 1024 "$g"
                     run_reps gds "$n" 64 1 "$nkeys" 1024 "$g" 0
                     dvm_stop
                 fi
@@ -523,7 +682,7 @@ sweep() {
             for t in 0 $((64 / 4)); do
                 say "threads phase: nodes=$n worker_threads=$t"
                 if dvm_start "$n" "$slots" 64 "--prtemca prte_num_worker_threads $t"; then
-                    run_job warm "$n" 64 1 "$nkeys" 1024 default "$t" 0 >/dev/null 2>&1 || true
+                    warm_job "$n" 64 "$nkeys" 1024 default "$t"
                     run_reps threads "$n" 64 1 "$nkeys" 1024 default "$t"
                     dvm_stop
                 fi
@@ -565,7 +724,12 @@ summarize() {
         }' "$RAW" | (read -r h; echo "$h"; sort -k1,1 -k2,2n -k3,3n -k5,5n) > "$out"
 
     echo
-    say "summary (medians over reps):"
+    if [ "$NSAMPLES" -eq 0 ]; then
+        say "NO SAMPLES -- $NFAILED jobs ran and none reported a fence."
+        say "See $outdir/failures/ for what each of them said."
+        return
+    fi
+    say "summary (medians over reps): $NSAMPLES samples, $NFAILED failed jobs"
     echo
     column -t < "$out" 2>/dev/null || cat "$out"
     echo

--- a/contrib/scaling/scaletest.c
+++ b/contrib/scaling/scaletest.c
@@ -129,7 +129,7 @@ static void usage(const char *argv0)
     fprintf(stderr,
             "usage: %s [--nkeys N] [--sizes A,B,C] [--iters N] [--warmup N]\n"
             "          [--scope global|remote|local] [--tag STR] [--verify]\n"
-            "          [--neighbors] [--entropy]\n",
+            "          [--neighbors] [--entropy] [--probe]\n",
             argv0);
 }
 
@@ -146,6 +146,7 @@ int main(int argc, char **argv)
     bool verify = false;
     bool neighbors = false;
     bool entropy = false;
+    bool probe = false;
     char hostname[256];
     char key[PMIX_MAX_KEYLEN + 1];
     char *payload = NULL;
@@ -185,6 +186,8 @@ int main(int argc, char **argv)
             neighbors = true;
         } else if (0 == strcmp(argv[a], "--entropy")) {
             entropy = true;
+        } else if (0 == strcmp(argv[a], "--probe")) {
+            probe = true;
         } else if (0 == strcmp(argv[a], "--scope") && a + 1 < argc) {
             ++a;
             if (0 == strcmp(argv[a], "global")) {
@@ -205,6 +208,21 @@ int main(int argc, char **argv)
     if (0 == iters) {
         usage(argv[0]);
         return 1;
+    }
+    /* A launch test, and nothing else: print this node's name and go, without
+     * touching PMIx.  A sweep has to know that the binary it is about to
+     * measure can be started on every node it named, and it cannot learn that
+     * by launching `hostname` -- that is on every node's PATH by
+     * construction, whereas this program was built into a results directory
+     * the cluster may not share.  Printing the hostname is what lets the
+     * caller count distinct nodes from the same run that proves the launch. */
+    if (probe) {
+        if (0 != gethostname(hostname, sizeof(hostname))) {
+            return 1;
+        }
+        hostname[sizeof(hostname) - 1] = '\0';
+        printf("%s\n", hostname);
+        return 0;
     }
     /* --verify fetches rank+1, which is exactly one of the two peers the
      * NEIGHBORS phase then times.  Run together, verify warms the cache the

--- a/docs/plans/scalable_collectives/two-radix-release.rst
+++ b/docs/plans/scalable_collectives/two-radix-release.rst
@@ -216,27 +216,34 @@ for it, so there is nothing to choose.
 
 As implemented, the two are separate and only the first is a switch:
 
-``grpcomm_low_radix_release`` (bool, default **false**)
-   Whether a fence's release leaves the routing tree at all.  False is the
-   whole of the old behaviour: every release travels the routing tree, and
-   nothing in the derived-tree path runs.  This is the parameter that
-   collapses it all back.
+``grpcomm_low_radix_release`` (bool, default **true**)
+   Whether a fence's release leaves the routing tree at all.  Turned off is
+   the whole of the old behaviour: every release travels the routing tree,
+   and nothing in the derived-tree path runs.  This is the parameter that
+   collapses it all back, which is what makes it the right thing to reach
+   for if a release ever misbehaves.
 
-``rml_base_radix2`` (int, default **rml_base_radix**)
+``rml_base_radix2`` (int, default **4**)
    The shape of the release tree.  It selects nothing on its own — with the
    switch off it is not consulted at all.
 
-That default is a trap and PRRTE now says so.  At equal radices the release
-tree *is* the routing tree — same parent and same children for every rank and
-every failure pattern, which ``test_release_tree_matches_routing`` pins — so
-turning the switch on and leaving the radix alone gets the identical fanout
-carried through more machinery, which can only be slower.  The
-``release-radix-noop`` help topic is emitted once by the master for that
-combination, and the run continues.
+Both defaults changed once the radix question below was worked through, and
+they changed together: 4 is where the optimum sits for every payload past
+the crossover, and a fence release is never anywhere near the crossover, so
+there was no longer a reason to ship the thing switched off.  The original
+reason — "no data to choose a winner" — was answered by a model rather than
+by the measurement it was waiting for, and the model is decisive in a way a
+single machine's numbers would not have been: the conclusion survives an
+eightfold sweep of every constant in it.
 
-A second parameter gives the release radix, so the 16x above can be explored
-rather than asserted; the cost model says 3 but the model's constants are the
-ones we do not have.
+Setting the two radices *equal* remains a trap, and PRRTE still says so.  At
+equal radices the release tree *is* the routing tree — same parent and same
+children for every rank and every failure pattern, which
+``test_release_tree_matches_routing`` pins — so that combination gets the
+identical fanout carried through more machinery, which can only be slower.
+It is no longer what leaving the radix alone gives you, but it is still one
+setting away in either direction.  The ``release-radix-noop`` help topic is
+emitted once by the master for it, and the run continues.
 
 **The topology must be stamped on the wire and checked, not merely
 configured.**  A release is a broadcast and does have an originator, so

--- a/docs/plans/scalable_collectives/two-radix-release.rst
+++ b/docs/plans/scalable_collectives/two-radix-release.rst
@@ -413,10 +413,141 @@ Open questions
    done, and the *payload* over participants only.  The notice is O(1)
    against the payload's ``D``, so the saving survives and the invariant
    holds.  Not worth building until a subset-fence workload asks for it.
-#. **Where does the release radix come from at scale?**  A fixed 3 is the
-   cost model's answer for a large DVM and is plainly wrong for a small one,
-   where the extra depth buys nothing.  A rule of thumb wants data we do not
-   have.
+#. **Where does the release radix come from at scale?**
+   **Answered: from the payload, through one ratio - and the answer is a
+   step rather than a curve, which is why a constant is the right shape for
+   it after all.  The number is 4.**
+
+   Write ``N`` for the daemon count, ``M`` for the bytes on the wire,
+   ``alpha`` for a hop's latency - the time from a daemon holding the payload
+   to its first byte going back out - ``c`` for the software cost of *one*
+   forwarded copy, ``B`` for one link's bandwidth, and ``t`` for
+   ``prte_num_worker_threads``.  A daemon at radix ``r`` sends ``r`` copies;
+   the tree is ``ceil(log_r N)`` deep; and the last daemon at the bottom
+   waits for all of it:
+
+   .. code-block:: text
+
+       T(r) = ceil(log_r N) * ( alpha  +  ceil(r/t) * c  +  r * M/B )
+
+   The two fanout terms are there separately because they parallelise
+   differently, and that turns out to be the whole answer.  The **software**
+   cost of a copy is spread across the worker pool - the OOB does its
+   ``writev`` on ``peer->evbase``, and the pool hands out ``t`` bases in
+   rotation - so ``r`` copies cost ``ceil(r/t)`` of them.  The **wire** cost
+   is not: ``r`` copies of ``M`` bytes cross one NIC whatever thread issued
+   them.  So fanout is nearly free until the wire term per copy overtakes the
+   thread-divided software term, and ruinous afterwards.  The crossover is
+   just those two being equal:
+
+   .. code-block:: text
+
+       M* = B * c / t
+
+   Below ``M*`` the depth term dominates and a *high* radix is right.  Above
+   it every copy is bandwidth, and ``r`` multiplies it while only
+   ``log_r N`` divides the depth - so the optimum falls to a small constant
+   and **stays there for every larger payload**.  Minimising the expression
+   above over ``r`` in ``[2, N-1]``, at ``alpha = 100 us``, ``c = 25 us``
+   (measured, below), ``t = 8`` and a 10 GbE link (so ``M* = 3.9 KB``):
+
+   ============  =========  ===========  =============  =============
+   payload       N = 128    N = 1024     N = 10000      cost of r=64
+   ============  =========  ===========  =============  =============
+   barrier       12         32           22             1.5 - 1.7x
+   10 KB         12         6            7              ~2x
+   100 KB        6          4            5              4.4 - 4.7x
+   10 MB         2          4            3              6.4 - 7.1x
+   256 MB        2          4            3              6.4 - 7.1x
+   ============  =========  ===========  =============  =============
+
+   Three things fall out of that table, and each settles something.
+
+   **The optimum barely depends on N.**  Four orders of magnitude of DVM
+   size move it between 2 and 6 once the payload is past ``M*``.  It is not a
+   function of scale, so it does not want a rule that reads the scale: the
+   question "where does it come from at scale" has the answer "not from the
+   scale".  What was right in the original worry - that a fixed radix is
+   wrong for a *small* DVM - is real but narrow, and it is handled by the
+   clamp rather than by a rule: below ``N = 4`` the flat tree is already
+   optimal because ``r`` is capped at ``N-1``, and it is beaten by 1.17x at
+   ``N = 4``, 2.4x at 16 and 53x at 1024.
+
+   **The number is 4.**  Across every row past the crossover the optimum is
+   2, 3, 4 or 5, and 4 is within a few percent of the best of them
+   everywhere.  There is nothing to tune and no table to carry.
+
+   **And the tag-based selection already in the code is exactly right.**
+   ``prte_grpcomm_release_topology()`` moves the *fence* release to the low
+   radix and leaves the group's alone, on the argument that the operations
+   differ in what they carry and a byte threshold cannot express that.  The
+   model agrees for a better reason than the one given: a fence release is
+   the whole modex, always far past ``M*``, and a group release is small,
+   always far below it.  The tag is a reliable proxy for which side of ``M*``
+   the payload sits on, and the two regimes want genuinely different radices
+   rather than different points on a curve.
+
+   **Why nobody has noticed the default is wrong.**  Radix 64 costs only
+   1.5 - 1.7x on a barrier and 4.4 - 7.1x on a real modex release.  The
+   operations a DVM performs constantly are the small ones, so the penalty
+   that shows up in ordinary use is the small one, and the large one appears
+   only in the operation nobody profiles.
+
+   **What ``c`` actually is, measured.**  ``grpcomm_enable_timing``'s
+   ``started``-to-``completed`` span prices a release directly, with no fence
+   and no client around it.  Taken on ``contrib/dockerswarm``, flat radix (so
+   the tree is one level and the span is ``alpha' + (N-1)*c`` by
+   construction), a bare barrier's release, 15 independent jobs at each of
+   ``N = 2, 4, 6, 8, 10``:
+
+   .. code-block:: text
+
+       median of 15:   T =  179 us  +  129 us * (N-1)
+       minimum of 15:  T =  235 us  +   25 us * (N-1)
+
+   The median's slope is the ten containers contending for eight cores; the
+   minimum's is the closest this harness comes to an uncontended copy.  So
+   ``c`` is about **25 us** and the broadcast's fixed floor about **200 us**,
+   in a debug build, on loopback, with the acknowledgement tree's return
+   included in both.
+
+   That floor is worth noticing on its own.  The barrier fit recorded
+   earlier in this document - ``165 us + 40 us * (N-1)`` end to end - was
+   read as a client-to-server-to-daemon round trip that "no topology
+   touches".  It is not: **the release broadcast by itself, with no client in
+   the picture at all, already costs ~200 us fixed and ~25 us a daemon.**
+   Both of that fit's terms are substantially the broadcast's own, which
+   makes them ours rather than PMIx's, and makes them things a topology
+   change does touch.
+
+   **What is still not measured.**  ``alpha``, and ``c`` and ``B`` on
+   anything but a shared-kernel container swarm.  The *ordering* survives a
+   wide range of them, which is the reason to publish a number now: sweeping
+   ``(alpha, c)`` from ``(150, 40)`` to ``(20, 5)`` microseconds - an eight-
+   fold change in both - moves ``r*`` between 3 and 5 for every payload past
+   10 KB and leaves radix 64 costing 6.1x to 6.4x the optimum throughout.
+   Reaching an optimum of 64 needs a hop's latency to be something like 128
+   times the cost of a copy, which is not a machine.  What the constants do
+   move is ``M*``, which scales directly with ``c`` and inversely with ``t``:
+   between those same two pairs it runs from 6.2 KB down to 780 B.  Where the
+   step sits is a measurement; which side of it a modex sits on is not in
+   doubt.
+
+   It is also a much cheaper measurement than the radix sweep it replaces.
+   Fitting ``T = alpha + (N-1) * c`` to a *flat* release over increasing
+   ``N`` gives both constants from one curve, and ``B`` comes from the same
+   curve repeated at a second payload - no sweep over radices, and no DVM
+   cycle per radix.  ``contrib/scaling/cluster-sweep.sh`` should be asking
+   for those three numbers rather than for a ranking of radices, and the
+   ``completed`` stamp exists so that it can: the span it closes is measured
+   on the master's own clock, which is the only one a real cluster has.
+
+   **The coupling worth recording.**  ``M*`` has ``t`` in the denominator,
+   so the worker pool and the release radix are one question, not two.
+   Raising ``prte_num_worker_threads`` moves the crossover *down* - more
+   threads make software fanout cheaper, so the payload at which bandwidth
+   takes over is smaller, and the low radix becomes right sooner.  Any future
+   measurement of one of them has to record the other.
 #. **Does the group collective's release want the same treatment?**
    **Answered: it gets the mechanism for free, and should keep the tree's
    radix.**

--- a/src/grpcomm/AGENTS.md
+++ b/src/grpcomm/AGENTS.md
@@ -500,12 +500,14 @@ The in-file comments are the real spec — read them. The load-bearing ideas:
 
 ### Turning the release onto its own tree takes ONE parameter
 
-`grpcomm_low_radix_release` (bool, **default false**) is the switch: it alone
-decides whether a fence's release leaves the routing tree. Off, every release
-goes down the routing tree and none of the derived-tree code below runs.
+`grpcomm_low_radix_release` (bool, **default true**) is the switch: it alone
+decides whether a fence's release leaves the routing tree. Turned off, every
+release goes down the routing tree and none of the derived-tree code below
+runs — which makes it the one thing to reach for if a release misbehaves,
+since it restores the single-tree behaviour exactly.
 
 `rml_base_radix2` (int, **default 4**) only gives the release tree its shape,
-and is not consulted at all while the switch is off. Four is where the cost
+and is not consulted at all when the switch is off. Four is where the cost
 model puts the optimum for every payload past the point at which a copy's
 bandwidth overtakes its thread-divided software cost, which is the only kind
 of payload this tree ever carries — see

--- a/src/grpcomm/AGENTS.md
+++ b/src/grpcomm/AGENTS.md
@@ -498,20 +498,28 @@ The in-file comments are the real spec — read them. The load-bearing ideas:
   assuming its *newly-acquired* subtree finished ops it completed before
   promotion.
 
-### Turning the release onto its own tree takes TWO parameters
+### Turning the release onto its own tree takes ONE parameter
 
 `grpcomm_low_radix_release` (bool, **default false**) is the switch: it alone
 decides whether a fence's release leaves the routing tree. Off, every release
 goes down the routing tree and none of the derived-tree code below runs.
 
-`rml_base_radix2` (int, **defaults to `rml_base_radix`**) only gives the
-release tree its shape, and is not consulted at all while the switch is off.
+`rml_base_radix2` (int, **default 4**) only gives the release tree its shape,
+and is not consulted at all while the switch is off. Four is where the cost
+model puts the optimum for every payload past the point at which a copy's
+bandwidth overtakes its thread-divided software cost, which is the only kind
+of payload this tree ever carries — see
+[`two-radix-release.rst`](../../docs/plans/scalable_collectives/two-radix-release.rst),
+"Where does the release radix come from at scale".
 
-Setting the switch and leaving the radix alone does nothing useful, and it is
-the obvious mistake: at equal radices the release tree *is* the routing tree,
-identical parent and children for every rank and every failure pattern
+Setting the two to the SAME value does nothing useful, and it used to be the
+obvious mistake because that is what leaving the radix alone gave you: at
+equal radices the release tree *is* the routing tree, identical parent and
+children for every rank and every failure pattern
 (`test_release_tree_matches_routing` in `test/unit/rml`). The master emits the
-`release-radix-noop` help topic for that combination and carries on. Note
+`release-radix-noop` help topic for that combination and carries on. It is
+still reachable — by setting `rml_base_radix` to 4, or `rml_base_radix2` to
+64 — which is why the diagnostic stays. Note
 which way round the two want to be: the rollup wants a **wide** tree (a
 gathering daemon receives r messages and sends one aggregate, so width is
 free) and the release wants a **narrow** one (a broadcasting daemon receives

--- a/src/grpcomm/AGENTS.md
+++ b/src/grpcomm/AGENTS.md
@@ -393,6 +393,46 @@ broadcast path. There is no separate size gate to sweep — the compressor's own
 --pmixmca pcompress zstd --pmixmca pcompress_zstd_level 1
 ```
 
+### How long a broadcast took: three stamps, and which pair to use
+
+`grpcomm_enable_timing` also stamps absolute microseconds at three points, so
+that the quantity a change to the fanout tree is actually about — how long the
+payload took to reach the whole DVM — can be measured. An end-to-end fence
+cannot resolve it: the rollup's noise is larger than the effect.
+
+```text
+grpcomm:xcast:timing started   op_id N tree K at <sec>.<usec>   originator only
+grpcomm:xcast:timing processed op_id N tag T tree K at ...      every daemon
+grpcomm:xcast:timing completed op_id N tag T tree K at ...      master only
+```
+
+Pair them on **(tree, op_id)**, never on the tag: the `started` line cannot
+name the payload tag, because at that point `tag` is the tag the message
+*arrived* on (`PRTE_RML_TAG_XCAST`) and the real one is still packed inside.
+Several broadcasts are in flight at once and they complete out of order, so
+the pairing key is load-bearing rather than a convenience.
+
+**Which span to measure depends on whose clock you have.**
+
+- `started` → last `processed` is the coverage itself, and it is only
+  meaningful where the clocks are common: a container swarm sharing one
+  kernel, yes; a real cluster, no. NTP holds a cluster to about a
+  millisecond and the whole broadcast is shorter than that, so the answer
+  there is clock skew with a broadcast buried in it.
+- `started` → `completed` is the same span measured **at one end**, on the
+  master, and is what to use anywhere else. It reads high by the ack tree's
+  return path, which is separable: a zero-byte broadcast is very nearly a
+  measurement of it on its own.
+
+Pair either with the census line's own `raw`/`wire` sizes, printed by
+`grpcomm_base_verbose 1` just before `started` on the same thread. Do not
+average a tag's spans without doing that — **a fence emits two releases per
+iteration on the same tag**, the allgather's (large) and the barrier's (tens
+of bytes), so a median over all of them is a median of the barrier.
+
+A `--daemonize`d DVM discards the HNP's output, so any of this needs a
+foreground `prte` or `prterun`.
+
 ### Timing runs want an optimized build — a debug build measures itself
 
 **Do not draw conclusions about sizes or times from a `--enable-debug` build.**

--- a/src/grpcomm/grpcomm.c
+++ b/src/grpcomm/grpcomm.c
@@ -165,15 +165,34 @@ void prte_grpcomm_register(void)
                                &prte_grpcomm_globals.xcast_delay_vpid);
 
     /* Send a fence's release down the low-radix tree instead of the routing
-     * tree.  Off by default, and that is the point of shipping it at all: we
-     * will not have data to choose a winner before release, so the tree we
-     * know works stays the default and this exists to be evaluated against
-     * it.  The radix it uses is rml_base_radix2. */
-    prte_grpcomm_globals.low_radix_release = false;
+     * tree.  ON by default.  The radix it uses is rml_base_radix2.
+     *
+     * It shipped off, on the grounds that there was no data to choose a
+     * winner with.  There is now a model instead, and it is decisive in a way
+     * a measurement of one swarm would not have been: a broadcasting daemon's
+     * r copies cost ceil(r/t) software sends but r whole payloads on one NIC,
+     * so past a payload of B*c/t bytes the fanout is pure bandwidth and the
+     * optimum radix drops to 3-5 and stays there for every larger payload and
+     * every DVM size.  A fence release is the modex, which is far past that
+     * crossover on any machine - kilobytes at worst, and the crossover is
+     * kilobytes at best.  Radix 64 costs 6.1x to 6.4x the optimum there, and
+     * that figure survives sweeping the machine constants eightfold.
+     *
+     * What is not settled is where the crossover sits, which is a property of
+     * a real network and moves with B, c and prte_num_worker_threads.  It
+     * does not have to be settled to make this the default: nothing this
+     * tree carries is anywhere near it.  The derivation is in
+     * docs/plans/scalable_collectives/two-radix-release.rst.
+     *
+     * Turning it off restores the single-tree behaviour exactly - the release
+     * goes down the routing tree and none of the derived-tree code runs - so
+     * this remains the one switch to reach for if a release misbehaves. */
+    prte_grpcomm_globals.low_radix_release = true;
     pmix_mca_base_var_register("prte", "grpcomm", NULL, "low_radix_release",
                                "Fan a fence's release out over the low-radix "
                                "release tree (rml_base_radix2) rather than the "
-                               "routing tree. Off by default.",
+                               "routing tree. On by default; turn it off to "
+                               "put every release back on the routing tree.",
                                PMIX_MCA_BASE_VAR_TYPE_BOOL,
                                &prte_grpcomm_globals.low_radix_release);
 }

--- a/src/grpcomm/grpcomm_xcast.c
+++ b/src/grpcomm/grpcomm_xcast.c
@@ -468,7 +468,11 @@ void prte_grpcomm_xcast_recv(
          *
          * It is only comparable where the clocks are: fine on a container
          * swarm sharing one kernel, meaningless across a real cluster without
-         * a synchronized clock. */
+         * a synchronized clock - which is why finish_op stamps a "completed"
+         * line on the master as well.  That span is start-to-finish on ONE
+         * clock and is the measurement to use anywhere the clocks are not
+         * common; it costs the ack tree's return path on top of the coverage,
+         * which a zero-byte broadcast prices on its own. */
         if (prte_grpcomm_globals.enable_timing) {
             struct timeval tnow;
             gettimeofday(&tnow, NULL);
@@ -1140,6 +1144,27 @@ static void finish_op(op_t* op) {
      * own subtree completed, not the whole DVM. */
     if (PRTE_PROC_IS_MASTER && NULL != op->cbfunc) {
         op->cbfunc(op->cbdata);
+    }
+    /* The other end of a coverage measurement that needs only one clock.
+     * The "processed" stamps say when each daemon got the payload, which is
+     * the quantity a change to the fanout is about - but comparing them with
+     * the originator's "started" needs the daemons' clocks to agree with it,
+     * and off a single-kernel container swarm they do not: NTP holds a
+     * cluster to about a millisecond and the whole broadcast is shorter than
+     * that.  Completion on the master is the same span measured at one end.
+     * It arrives once every daemon has both received the payload and rolled
+     * its acknowledgement back up, so it reads high by the return path - and
+     * that is separable, being very nearly what a zero-byte broadcast
+     * measures. */
+    if (PRTE_PROC_IS_MASTER && prte_grpcomm_globals.enable_timing) {
+        struct timeval tnow;
+        gettimeofday(&tnow, NULL);
+        pmix_output(0, "%s grpcomm:xcast:timing completed op_id %lu tag %u "
+                    "tree %d at %ld.%06ld",
+                    PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                    (unsigned long) op->sig.op_id, (unsigned) op->msg_tag,
+                    (int) op->sig.topology, (long) tnow.tv_sec,
+                    (long) tnow.tv_usec);
     }
     PMIX_RELEASE(op);
 }

--- a/src/grpcomm/help-prte-grpcomm.txt
+++ b/src/grpcomm/help-prte-grpcomm.txt
@@ -49,6 +49,7 @@ relays to the same children it already had. The release will still be
 correct, but it buys nothing and is carried through more machinery than
 the routing tree needs, so it can only be slower.
 
-Set rml_base_radix2 to the radix you actually want for the release, or
-turn grpcomm_low_radix_release off. The runtime is continuing with the
-settings as given.
+Set rml_base_radix2 to the radix you actually want for the release - it
+defaults to 4, which is where the cost model puts the optimum for a
+payload the size of a modex - or turn grpcomm_low_radix_release off. The
+runtime is continuing with the settings as given.

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -284,17 +284,40 @@ static void job_errors(int fd, short args, void *cbdata)
     /* ensure we terminate any processes left running in the DVM */
     _terminate_job(jdata->nspace);
 
-    /* if the job never launched, then we need to let the
-     * state machine know this job failed - it has no
-     * other means of being alerted since no proc states
-     * will be triggered */
-    if (PRTE_JOB_STATE_FAILED_TO_START == jdata->state
-        || PRTE_JOB_STATE_NEVER_LAUNCHED == jdata->state
-        || PRTE_JOB_STATE_FAILED_TO_LAUNCH == jdata->state
+    /* If the job never got as far as a process, nothing else will ever tell
+     * the state machine it is over: no proc state can be triggered for a proc
+     * that was never handed to a daemon, so the completion accounting has
+     * nothing to count down and the job object would sit here forever.  Say
+     * so directly for the states that mean exactly that - the job stopped
+     * before any daemon was given anything to run.
+     *
+     * The two launch failures are NOT among them, and the difference matters.
+     * They mean the daemons DID receive the job and act on it, so every one
+     * of its procs is already accounted for or shortly will be: proc_errors
+     * force-marks a failed proc WAITPID_FIRED and IOF_COMPLETE, and the
+     * _terminate_job() above brings down whichever ones did start.  Declaring
+     * the job TERMINATED here instead runs check_job_complete, which releases
+     * the job object - and on a multi-node launch that routinely happens with
+     * ranks still alive on the other nodes, because a job whose executable is
+     * missing on ONE node has already started every rank on the others.  Their
+     * deaths then arrive with no job to account them to, which is the
+     * orphaned-proc path in state/base: an internal-inconsistency banner
+     * asking the user to file a bug, for a mistyped path.
+     *
+     * So take the shortcut for those two only once every proc really has been
+     * counted, and otherwise leave it to the ordinary accounting, which is
+     * already driving.  Nothing is lost by waiting: the exit code and the
+     * aborted-proc attribute are set above, before either arm.
+     */
+    if (PRTE_JOB_STATE_NEVER_LAUNCHED == jdata->state
         || PRTE_JOB_STATE_ALLOC_FAILED == jdata->state
         || PRTE_JOB_STATE_MAP_FAILED == jdata->state
         || PRTE_JOB_STATE_FILES_POSN_FAILED == jdata->state
         || PRTE_JOB_STATE_CANNOT_LAUNCH == jdata->state) {
+        PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_TERMINATED);
+    } else if ((PRTE_JOB_STATE_FAILED_TO_START == jdata->state
+                || PRTE_JOB_STATE_FAILED_TO_LAUNCH == jdata->state)
+               && jdata->num_terminated >= jdata->num_procs) {
         PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_TERMINATED);
     }
 

--- a/src/rml/rml.c
+++ b/src/rml/rml.c
@@ -306,14 +306,28 @@ void prte_rml_register(void)
      * going up and is the whole cost coming down.  See
      * docs/plans/scalable_collectives/two-radix-release.rst.
      *
-     * Defaulting it to the routing radix means the second tree is the same
-     * shape as the first until someone asks otherwise, which is what keeps
-     * the default behaviour exactly what it is today. */
-    prte_rml_base.radix2 = prte_rml_base.radix;
+     * Four, which changes nothing on its own: this radix is not consulted
+     * at all unless grpcomm_low_radix_release is turned on, and that is off.
+     * What it does is make turning that switch on do the useful thing with
+     * one parameter rather than two - it used to default to the routing
+     * radix, which made the same tree twice and left the feature a silent
+     * no-op for anyone who set only the switch.
+     *
+     * Four rather than three because the cost model's optimum, minimised
+     * over the radix at each of several DVM sizes and payloads, is 2, 3, 4 or
+     * 5 for every payload past the point where bandwidth overtakes the
+     * thread-divided software cost of a copy - and 4 is within a few percent
+     * of the best of them everywhere.  The release tree exists for exactly
+     * those payloads: it carries a fence release, which is the whole modex.
+     * The derivation, the crossover it turns on, and what remains unmeasured
+     * about it are in docs/plans/scalable_collectives/two-radix-release.rst
+     * under "Where does the release radix come from at scale". */
+    prte_rml_base.radix2 = 4;
     (void) pmix_mca_base_var_register("prte", "rml", "base", "radix2",
                                       "Radix of the tree used to fan a "
                                       "collective's release out (minimum 2). "
-                                      "Defaults to the routing tree's radix.",
+                                      "Consulted only when "
+                                      "grpcomm_low_radix_release is set.",
                                       PMIX_MCA_BASE_VAR_TYPE_INT,
                                       &prte_rml_base.radix2);
     /* Same clamp and the same reason: the tree math divides by (radix - 1). */

--- a/test/unit/rml/test_rml_routing.c
+++ b/test/unit/rml/test_rml_routing.c
@@ -1404,14 +1404,14 @@ static int check_release_tree(pmix_rank_t ndmns, int radix2, const char *label)
 /*
  * ...and at the same radix it IS the routing tree.
  *
- * rml_base_radix2 defaults to rml_base_radix, so turning
- * grpcomm_low_radix_release on and setting nothing else sends the release
- * down a tree of exactly the shape it was already using - every daemon
- * relaying to the same children as before.  That is worth pinning rather than
- * assuming, because it is the whole basis for the diagnostic PRRTE prints for
- * that combination: it is not a cheaper fanout, it is the same fanout carried
+ * Set rml_base_radix2 equal to rml_base_radix and the release goes down a
+ * tree of exactly the shape it was already using - every daemon relaying to
+ * the same children as before.  That is worth pinning rather than assuming,
+ * because it is the whole basis for the diagnostic PRRTE prints for that
+ * combination: it is not a cheaper fanout, it is the same fanout carried
  * through the derived-tree machinery, which is strictly more work for no
- * change in shape.
+ * change in shape.  (It is no longer what you get by leaving the radix
+ * alone - that default is 4 - but it remains one setting away.)
  */
 static int test_release_tree_matches_routing(void)
 {


### PR DESCRIPTION
The two-radix release shipped switched off, with the reason given that there
would be no data to choose a winner with before release. This works the radix
question through rather than waiting for the measurement, turns the feature
on, and carries the instrument and harness fixes it took to get there — plus
a launch-accounting bug found on the way.

## Where a release's radix comes from

A broadcasting daemon's `r` copies cost `ceil(r/t)` software sends — the OOB
writes on `peer->evbase` and the worker pool hands out `t` bases in rotation —
but `r` whole payloads across one NIC, which no thread count divides. Keeping
those two terms separate is the whole answer:

    T(r) = ceil(log_r N) * ( alpha + ceil(r/t)*c + r*M/B )

Fanout is nearly free below a payload of `B*c/t` bytes and pure bandwidth
above it, so the optimum is a **step, not a curve**: high below the crossover,
and 3–5 above it for every larger payload and every DVM size. Four orders of
magnitude of `N` move it by two, so the question "where does it come from at
scale" answers *not from the scale*, and a constant is the right shape after
all.

A fence release is the modex, and it is nowhere near the crossover on any
machine — the crossover is kilobytes at best. Radix 64 costs **6.1x to 6.4x**
the optimum there, and that figure survives sweeping the machine constants
eightfold, which is what makes this a decision rather than a guess. What is
genuinely unsettled is where the crossover sits; it does not need to be
settled for this.

So `rml_base_radix2` defaults to **4** and `grpcomm_low_radix_release`
defaults to **true**. Turning the switch off restores the previous behaviour
exactly, so it remains the single thing to reach for if a release misbehaves.

`c` was measured rather than assumed, which the earlier work had not done —
see the commit message for the method and the numbers. It incidentally
corrects a reading in the collectives document: the barrier's 165 µs fixed
term was put down to a client round trip "no topology touches", and the
broadcast alone, with no client in it, already costs about that much.

## The rest

* **A completion stamp for broadcasts.** The existing coverage instrument
  spans two clocks — fine on a swarm sharing one kernel, meaningless on a
  cluster NTP holds to a millisecond. The master's `finish_op` already knows
  when every daemon has the payload; stamping it makes the span measurable at
  one end, which is the only way to take it on the hardware where the radix
  question can actually be settled.

* **`cluster-sweep.sh` can now launch its client.** It built the client into
  the results directory and assumed a shared filesystem; where that does not
  hold, every job failed identically and an empty summary appeared an hour
  later with nothing on the console. The DVM check now runs the *client*
  rather than `hostname` (which is on every node's PATH by construction and so
  proves nothing about the binary being measured), starts the DVM in the
  foreground so a failure leaves its reason readable, turns on
  `--preload-binary` when it has to, keeps each failed job's output, and stops
  after six failures with no sample.

* **A job whose launch fails on one node keeps its other ranks.** A failed
  job is declared TERMINATED at once because "the job never launched, so no
  proc state will be triggered" — true for the states that mean no daemon was
  given anything to run, false for the two launch failures. On more than one
  node they part company routinely: a path present on some nodes and not one
  fails there while the others have already started their ranks, and releasing
  the job object out from under them produces a `PRTE_ERR_NOT_FOUND` from
  `plm_base_receive`, an internal-inconsistency banner asking the user to file
  a bug for a mistyped path, an exit status that disagreed with the same
  failure on every node (183 against 75) — and **a persistent DVM that did not
  survive it**.

## Testing

Both harnesses, run against this exact tree, built against openpmix master
with `PMIX_SRC`:

| harness | result |
|---|---|
| `contrib/dockerswarm` | **791 passed, 0 failed, 3 skipped** |
| `contrib/slurmswarm` | **137 passed, 0 failed, 0 skipped** |

The 3 skips are the standing "no network device in these topologies" ones.
`make check` is green (25 unit tests).

Two new dockerswarm cases, both shown to fail without their fix rather than
merely to pass with it:

* the partial-launch case scores **4 of 7** on the unfixed runtime;
* `test_low_radix_release` gains an arm that passes **no parameters at all**
  and still counts `on tree 1`, because every existing assertion in that case
  sets both parameters and would go on passing if the default were quietly
  turned back off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019C3vCVrsQKPdDAW7WVTL97