### PR TITLE
Keep a prted inside the step its resource manager launched it in

### DIFF
--- a/contrib/slurmswarm/AGENTS.md
+++ b/contrib/slurmswarm/AGENTS.md
@@ -417,7 +417,53 @@ not ordinary cluster configuration:
 - **`ProctrackType=proctrack/linuxproc`, `TaskPlugin=task/none`.** The cgroup
   plugins want a cgroup hierarchy to own. `linuxproc` tracks a step by walking
   `/proc` parentage, which needs nothing a container lacks. See §7 for the
-  consequence.
+  cleanup consequence and §9a for the much larger one.
+
+### 9a. Process tracking, and why the default hides bugs
+
+`ProctrackType` is not a tuning knob here. It decides which PRRTE behaviors
+this harness is *able* to observe, so a run's coverage depends on it and
+preflight prints which mode is in force.
+
+Under **`proctrack/linuxproc`** a step is the set of processes reachable by
+walking `/proc` parentage from the task `slurmd` started. A task that forks,
+calls `setsid()` and lets its parent exit is reparented to PID 1 and is no
+longer reachable from anything the step knows about: it escapes, and outlives
+the step. That is the mode a container gets for free, and it is the default.
+
+Under **`proctrack/cgroup`** — what every production cluster runs — the same
+process cannot escape. `setsid()` leaves a process tree; it does not leave a
+cgroup. When the last task of a step exits, `slurmstepd` signals the step's
+cgroup, and anything still in it dies.
+
+A `prted` is exactly a process that forks and detaches. So the difference
+between the two modes is the difference between "the daemon survives its
+`srun` and the DVM works" and "the daemon is killed the instant `srun`
+returns and every node goes down right after reporting in" — and the harness
+running only the first of those is why
+[issue #2757](https://github.com/openpmix/prrte/issues/2757) was found on a
+user's cluster rather than here.
+
+To run the real-cluster mode, both variables are required — the mode, and the
+privilege the writable cgroup hierarchy needs:
+
+```sh
+export PRTE_SLURM_PROCTRACK=cgroup PRTE_SLURM_PRIVILEGED=true
+docker compose up -d --force-recreate
+./run-tests.sh
+```
+
+The entrypoint rewrites `ProctrackType`/`TaskPlugin` and replaces
+`CgroupPlugin=disabled` with `autodetect` + `IgnoreSystemd=yes` before
+`slurmd` starts, and **refuses to start** if the mode was asked for without
+the privilege — the alternative being a `slurmd` that dies with a message
+about D-Bus that names neither. Going back is the same two variables unset
+plus another `--force-recreate`.
+
+The default stays `linuxproc` and unprivileged: it is what a developer's
+machine can do without being asked for anything, and it covers everything in
+this suite that is not about a process outliving its step. It just must not
+be mistaken for the cluster.
 - **`InactiveLimit=0`.** Load-bearing. The harness holds its allocations with
   `salloc --no-shell`-style background jobs and runs steps into them minutes
   later; a non-zero `InactiveLimit` kills an allocation with no active step,

--- a/contrib/slurmswarm/Dockerfile
+++ b/contrib/slurmswarm/Dockerfile
@@ -51,10 +51,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential gcc g++ make \
-        autoconf automake libtool m4 flex \
+        autoconf automake libtool m4 flex pkg-config \
         perl python3 git curl bzip2 \
         libevent-dev libhwloc-dev zlib1g-dev libzstd-dev \
         libjansson-dev \
+        libdbus-1-dev libbpf-dev \
         munge libmunge-dev libjson-c-dev libyaml-dev \
         openssh-server openssh-client \
         iproute2 iputils-ping procps less vim ca-certificates \
@@ -67,7 +68,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # ras/slurm's entire modify surface has nothing to parse.  configure does not
 # fail when it is missing, it just quietly builds less, so the plugin is
 # checked for after install rather than assumed.
-ARG SLURM_VERSION=24.11.6
+#
+# libdbus-1-dev and libbpf-dev, above, are the same kind of silent
+# dependency for cgroup_v2.so: without them configure builds only the v1
+# plugin, and a node configured for cgroup/v2 -- which is what
+# PRTE_SLURM_PROCTRACK=cgroup asks for, and the only version a modern kernel
+# offers -- dies at startup with "cannot create cgroup context for
+# cgroup/v2", naming a plugin rather than the packages it wanted.  So that
+# plugin is checked for after install too.  (IgnoreSystemd=yes spares us
+# dbus at RUN time; it does not spare us the headers at build time.)
+ARG SLURM_VERSION=25.11.6
 ARG SLURM_URL=https://download.schedmd.com/slurm
 RUN groupadd -r slurm && useradd -r -g slurm -d /var/lib/slurm -s /usr/sbin/nologin slurm \
     && curl -fsSL "$SLURM_URL/slurm-$SLURM_VERSION.tar.bz2" -o /tmp/slurm.tar.bz2 \
@@ -79,6 +89,7 @@ RUN groupadd -r slurm && useradd -r -g slurm -d /var/lib/slurm -s /usr/sbin/nolo
     && make install \
     && ldconfig \
     && test -f /usr/local/lib/slurm/serializer_json.so \
+    && test -f /usr/local/lib/slurm/cgroup_v2.so \
     && rm -rf /src/slurm /tmp/slurm.tar.bz2
 
 # ---- baked PMIx (default) ----

--- a/contrib/slurmswarm/build.sh
+++ b/contrib/slurmswarm/build.sh
@@ -89,6 +89,7 @@ VOLUME="${VOLUME:-$PRTE_SLURM_SWARM-build}"
 PMIX_REF="${PMIX_REF:-master}"          # baked-image PMIx branch
 PMIX_REPO="${PMIX_REPO:-https://github.com/openpmix/openpmix.git}"
 PMIX_SRC="${PMIX_SRC:-}"                # optional openpmix checkout to build
+SLURM_VERSION="${SLURM_VERSION:-}"      # override the image's baked SLURM release
 
 mode=linux
 distclean=auto                          # auto | always | never
@@ -205,8 +206,16 @@ prep_srcdir() {
 # --- (re)build the base image if needed -------------------------------------
 build_image() {
     if [ "${1:-}" = force ] || ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-        echo ">>> docker build $IMAGE (SLURM from the distribution, baked PMIx $PMIX_REF)"
+        # Empty means "whatever the Dockerfile pins", so that the version
+        # lives in exactly one place.  The expansion has to survive `set -u`
+        # with an empty array on bash 3.2 (macOS), hence the [@]+ guard.
+        local slurm_arg=()
+        if [ -n "$SLURM_VERSION" ]; then
+            slurm_arg=(--build-arg "SLURM_VERSION=$SLURM_VERSION")
+        fi
+        echo ">>> docker build $IMAGE (SLURM ${SLURM_VERSION:-as pinned in the Dockerfile}, baked PMIx $PMIX_REF)"
         docker build -t "$IMAGE" \
+            ${slurm_arg[@]+"${slurm_arg[@]}"} \
             --build-arg PMIX_REPO="$PMIX_REPO" \
             --build-arg PMIX_REF="$PMIX_REF" \
             "$here"

--- a/contrib/slurmswarm/build.sh
+++ b/contrib/slurmswarm/build.sh
@@ -90,6 +90,13 @@ PMIX_REF="${PMIX_REF:-master}"          # baked-image PMIx branch
 PMIX_REPO="${PMIX_REPO:-https://github.com/openpmix/openpmix.git}"
 PMIX_SRC="${PMIX_SRC:-}"                # optional openpmix checkout to build
 SLURM_VERSION="${SLURM_VERSION:-}"      # override the image's baked SLURM release
+# Extra configure arguments for a PMIX_SRC build.  The reason this exists is
+# --enable-debug: PMIX_SRC is how an uncommitted PMIx change is tested here,
+# and the moment such a change needs debugging, valgrind and gdb have only
+# addresses to work with because the default build carries no symbols.  It is
+# part of the recorded configure arguments, so changing it forces the
+# reconfigure it needs.
+PMIX_CONFIG_ARGS="${PMIX_CONFIG_ARGS:-}"
 
 mode=linux
 distclean=auto                          # auto | always | never
@@ -240,6 +247,7 @@ build_linux() {
     docker run --rm \
         -v "$root":/prrte-src:ro \
         -v "$VOLUME":/opt/prte \
+        -e PMIX_CONFIG_ARGS="$PMIX_CONFIG_ARGS" \
         ${pmix_mount[@]+"${pmix_mount[@]}"} \
         "$IMAGE" bash -euo pipefail -c '
             jobs=$(nproc)
@@ -268,7 +276,7 @@ build_linux() {
                 PMIX_PREFIX=/opt/prte/pmix
                 echo ">>>> PMIx from bind-mounted /pmix-src -> $PMIX_PREFIX"
                 mkdir -p /opt/prte/vpath-linux-pmix && cd /opt/prte/vpath-linux-pmix
-                pmix_args="--prefix=$PMIX_PREFIX"
+                pmix_args="--prefix=$PMIX_PREFIX ${PMIX_CONFIG_ARGS:-}"
                 if reconfigure_needed . "$pmix_args" /pmix-src; then
                     echo ">>>> (re)configuring PMIx: $pmix_args"
                     /pmix-src/configure $pmix_args

--- a/contrib/slurmswarm/docker-compose.yml
+++ b/contrib/slurmswarm/docker-compose.yml
@@ -42,14 +42,27 @@ x-node: &node
   tty: true
   volumes:
     - prte-build:/opt/prte:ro
-  # NOTE what is NOT here: no privileged flag, no added capability, no bind
+  # The process-tracking mode, read by node-entrypoint.sh, which writes the
+  # matching ProctrackType/TaskPlugin into slurm.conf before slurmd starts.
+  # See "Process tracking" in AGENTS.md -- this is not a tuning knob, it
+  # decides whether a `prted` that detaches from its step can be observed
+  # surviving it, so it decides which PRRTE bugs this harness can see.
+  environment:
+    PRTE_SLURM_PROCTRACK: ${PRTE_SLURM_PROCTRACK:-linuxproc}
+  # `cgroup` needs a writable cgroup hierarchy, which an ordinary container
+  # does not have.  Default false: the harness stays unprivileged exactly
+  # like contrib/dockerswarm's, and `linuxproc` needs nothing from the kernel
+  # a container lacks.  Both variables must be set together, and run-tests.sh
+  # refuses the mismatch rather than running a suite whose containers cannot
+  # do what its configuration claims.
+  privileged: ${PRTE_SLURM_PRIVILEGED:-false}
+  # NOTE on the default (unprivileged) path: no added capability, no bind
   # mount of the host's /sys/fs/cgroup.  slurmd insists on initializing a
   # cgroup context at startup whatever the configured plugins are, and a
   # container has neither a systemd to ask nor a writable cgroup filesystem --
   # so this harness used to need CAP_SYS_ADMIN to remount that filesystem
   # read-write.  `CgroupPlugin=disabled` (SLURM 24.05 and newer, see
-  # cgroup.conf) removes the need entirely, and these are ordinary
-  # unprivileged containers exactly like contrib/dockerswarm's.
+  # cgroup.conf) removes the need entirely.
   #
   # If you ever run this against an older SLURM, that is the wall you will
   # hit, and the symptom is ten "unk*" nodes in sinfo with slurmd dead on

--- a/contrib/slurmswarm/node-entrypoint.sh
+++ b/contrib/slurmswarm/node-entrypoint.sh
@@ -68,6 +68,51 @@ fi
 mkdir -p /var/spool/slurmctld /var/spool/slurmd /var/log/slurm
 chown slurm:slurm /var/spool/slurmctld /var/log/slurm
 
+# ---------------------------------------------------------------------------
+# process tracking
+# ---------------------------------------------------------------------------
+# The baked slurm.conf/cgroup.conf ask for proctrack/linuxproc with cgroups
+# switched off, because that is all an unprivileged container can do.  That
+# choice is not neutral: linuxproc tracks a step by walking /proc parentage,
+# so a task that forks, setsid()s and lets its parent exit is no longer a
+# descendant of anything the step knows about and simply outlives it.  A real
+# cluster runs proctrack/cgroup, where the same process cannot escape -- it
+# is still in the step's cgroup, and slurmstepd kills the cgroup once the
+# last task exits.  Any PRRTE bug that lives in that gap is invisible here
+# under linuxproc, so the mode is selectable and the harness can be run both
+# ways.  See "Process tracking" in AGENTS.md.
+#
+# cgroup mode needs a writable /sys/fs/cgroup, i.e. a privileged container
+# (docker-compose.yml's PRTE_SLURM_PRIVILEGED).  Refuse loudly rather than
+# starting a slurmd that will die with an unrelated-looking message.
+case "${PRTE_SLURM_PROCTRACK:-linuxproc}" in
+    linuxproc)
+        ;;
+    cgroup)
+        # The probe has to be a mkdir.  A cgroup2 filesystem refuses to create
+        # an ordinary file however writable it is -- a directory IS the write
+        # it supports -- so `touch` reports "Permission denied" on a hierarchy
+        # slurmd would have been perfectly happy with.
+        if ! mountpoint -q /sys/fs/cgroup || ! mkdir /sys/fs/cgroup/.prte-rw-probe 2>/dev/null; then
+            log "ERROR: PRTE_SLURM_PROCTRACK=cgroup needs a writable /sys/fs/cgroup;"
+            log "ERROR: bring the swarm up with PRTE_SLURM_PRIVILEGED=true as well."
+            exit 1
+        fi
+        rmdir /sys/fs/cgroup/.prte-rw-probe
+        log "process tracking: proctrack/cgroup + task/cgroup"
+        sed -i -e 's|^ProctrackType=.*|ProctrackType=proctrack/cgroup|' \
+               -e 's|^TaskPlugin=.*|TaskPlugin=task/cgroup|' /etc/slurm/slurm.conf
+        # autodetect finds cgroup/v2; IgnoreSystemd is required because there
+        # is no systemd in the container for slurmd to ask over D-Bus, and
+        # without it slurmd exits exactly as it does with no cgroup at all.
+        printf 'CgroupPlugin=autodetect\nIgnoreSystemd=yes\n' > /etc/slurm/cgroup.conf
+        ;;
+    *)
+        log "ERROR: PRTE_SLURM_PROCTRACK must be linuxproc or cgroup, not '${PRTE_SLURM_PROCTRACK}'"
+        exit 1
+        ;;
+esac
+
 # Which node is the controller is read out of slurm.conf rather than
 # hardcoded here, so changing SlurmctldHost is a one-file edit.
 ctld_host="$(sed -n 's/^SlurmctldHost=\([^ ]*\).*/\1/p' /etc/slurm/slurm.conf | head -1)"

--- a/contrib/slurmswarm/run-tests.sh
+++ b/contrib/slurmswarm/run-tests.sh
@@ -244,6 +244,25 @@ preflight() {
     out=$(SQ 'sinfo --version' | tr -d '\r')
     [ -n "$out" ] && ok "SLURM answers: $out" \
                   || { bad "slurmctld is not answering on node1"; exit 2; }
+
+    # How SLURM tracks a step's processes decides which PRRTE bugs this suite
+    # can see at all, so it is reported here rather than left implicit.  Under
+    # proctrack/linuxproc a process that forks, setsid()s and orphans itself
+    # leaves the step's /proc parentage and outlives it; under proctrack/cgroup
+    # -- what every real cluster runs -- it cannot, and slurmstepd kills it
+    # with the rest of the cgroup once the last task exits.  See "Process
+    # tracking" in AGENTS.md.
+    PROCTRACK=$(SQ 'scontrol show config' \
+                | sed -n 's|^ProctrackType *= *proctrack/\([a-z]*\).*|\1|p' | tr -d ' \r')
+    case "$PROCTRACK" in
+        cgroup)
+            ok "process tracking: proctrack/cgroup -- a detached prted cannot outlive its step" ;;
+        linuxproc)
+            skp "process tracking: proctrack/linuxproc -- a process that escapes its parent outlives the step, so step-escape cases will skip; rerun with PRTE_SLURM_PROCTRACK=cgroup PRTE_SLURM_PRIVILEGED=true docker compose up -d --force-recreate" ;;
+        *)
+            skp "cannot determine ProctrackType from scontrol show config"
+            PROCTRACK=unknown ;;
+    esac
     # Sweep BEFORE asserting the cluster is idle.  Anything hand-driven leaves
     # an allocation behind -- that is what `slurm-alloc new` is for -- and a
     # suite that reported it as a failure would be red for a condition it is
@@ -698,21 +717,44 @@ test_plm() {
         && ok "a daemon is running on each non-head allocated node" \
         || bad "only $(prted_count 2 3 4)/3 daemons came up"
 
-    banner "plm/slurm: srun hands off and exits, and the daemons outlive it"
-    # prted daemonizes by default, so the srun that launched it completes as
-    # soon as the fork is done -- and PRRTE has to recognize that exit as a
-    # hand-off rather than as a launch failure.  On a real scheduler the step
-    # really does end, and SLURM really does reap it; nothing in the sibling
-    # harness can show either.
-    SA 'grep -q "primary srun exited after daemon hand-off" /tmp/prte.out' \
-        && ok "PRRTE recognized the srun exit as a hand-off, not a failure" \
-        || bad "no hand-off note from plm/slurm: $(SA 'grep -c srun /tmp/prte.out')"
+    banner "plm/slurm: the daemons stay inside the step srun launched them in"
+    #
+    # THIS IS THE CASE THAT MATTERS ON A REAL CLUSTER, and it is the one this
+    # harness could not previously state.  A prted that forks, setsid()s and
+    # lets its parent exit leaves behind the process srun is tracking: srun's
+    # task completes, srun returns, and SLURM ends the step.  Under
+    # proctrack/cgroup the daemon is still in that step's cgroup -- setsid()
+    # escapes a process tree, not a cgroup -- so slurmstepd kills it moments
+    # after it reported in to the HNP, and every node goes down at once.  That
+    # is https://github.com/openpmix/prrte/issues/2757.
+    #
+    # So the invariant is: the prted must REMAIN the task srun is tracking,
+    # which means plm/slurm must not tell it to daemonize.  Both assertions
+    # below hold in either process-tracking mode; what differs is the damage
+    # when they fail.  Under proctrack/cgroup the DVM dies here.  Under
+    # proctrack/linuxproc the detached daemon escapes and survives, so only
+    # these two assertions notice -- which is exactly the value of stating
+    # them, because linuxproc is the default (see "Process tracking" in
+    # AGENTS.md).
     SA 'pgrep -x srun >/dev/null' \
-        && bad "an srun is still running after the hand-off" \
-        || ok "no srun survives the hand-off"
+        && ok "the srun that launched the daemons is still running" \
+        || bad "no srun survives the launch -- the daemons detached from their step"
     n=$(SQ "squeue -h -s -j $jid -o '%i'" | grep -c . | tr -d ' ')
-    [ "$n" = 0 ] && ok "SLURM has no leftover job step for the daemons" \
-                 || bad "$n job step(s) still registered against job $jid"
+    [ "$n" -ge 1 ] 2>/dev/null \
+        && ok "SLURM still has the daemon job step registered against job $jid" \
+        || bad "no job step against job $jid -- the step ended the moment the daemons launched"
+    # And say it the way SLURM says it: the daemon's pid is one the scheduler
+    # accounts to the step, not an orphan the node happens to be running.
+    # `scontrol listpids` only knows about the node it runs on, so it has to
+    # be asked on the node the daemon is actually on.
+    out=$(ON 2 'pgrep -x prted' | tr -d ' \r' | head -1)
+    if [ -n "$out" ]; then
+        ON 2 "scontrol listpids 2>/dev/null | awk '{print \$1}' | grep -qx $out" \
+            && ok "node2's prted (pid $out) is a pid SLURM accounts to a step" \
+            || bad "node2's prted (pid $out) is in no SLURM step -- it escaped the step"
+    else
+        bad "no prted on node2 to check against the step"
+    fi
     out=$(SA 'timeout 60 prun -n 4 --map-by node hostname' 2>&1)
     n=$(echo "$out" | grep -E '^node[0-9]+$' | sort -u | wc -l | tr -d ' ')
     [ "$n" = 4 ] && ok "a job runs across the srun-launched DVM" \
@@ -1634,6 +1676,7 @@ test_launch() {
 ########################################################################
 
 HAVE_JSON=0
+PROCTRACK=unknown
 preflight
 test_cluster
 test_ras_alloc

--- a/src/mca/plm/slurm/AGENTS.md
+++ b/src/mca/plm/slurm/AGENTS.md
@@ -118,18 +118,18 @@ meaningless (it's srun's, not the failed proc's). The callback:
 - Refuses to proceed against an `ancient` SLURM (`ancient-version`).
 - On non-zero exit → `srun-failed` help + activate
   `DAEMONS_TERMINATED`.
-- On clean exit of the **primary** srun, whether that means the DVM is
-  gone depends on whether the `prted`s daemonized. By default a `prted`
-  forks and detaches (see `src/tools/prted/AGENTS.md`), and its parent —
-  the process srun actually tracks as the task — exits as soon as the
-  real daemon signals it is up, long before the daemon itself does. So a
-  clean exit here is normally just that hand-off, not termination: it is
-  ignored, and real daemon loss is instead caught when the daemon's RML
-  connection to the HNP drops. Only with `--debug-daemons` or
-  `--leave-session-attached` (no forking, `prted` stays attached) does
-  srun genuinely track the daemon's own lifetime, so only then does a
-  clean exit fire `DAEMONS_TERMINATED` (set `num_terminated = num_procs`
-  first to avoid a bogus error message) so `prun`/the HNP can exit.
+- On clean exit of the **primary** srun → `DAEMONS_TERMINATED` (set
+  `num_terminated = num_procs` first to avoid a bogus error message) so
+  `prun`/the HNP can exit. That is sound because **this component never
+  passes `--daemonize`**, so the process srun tracks *is* the daemon: a
+  `prted` forks only when told to, and a `prted` launched by a resource
+  manager must remain the task the RM is watching. See
+  [`src/tools/prted/AGENTS.md`](../../../tools/prted/AGENTS.md) —
+  detaching ends the step, and under `proctrack/cgroup` `slurmstepd` then
+  kills the daemon along with it. Do not "fix" a spurious termination here
+  by teaching this callback to ignore the exit; if srun is exiting while
+  the DVM is alive, the daemon has left its step and *that* is the bug
+  ([#2757](https://github.com/openpmix/prrte/issues/2757)).
 
 `plm_slurm_terminate_prteds` similarly special-cases the "we never
 launched additional daemons" case (`primary_pid_set == false`) by firing
@@ -178,7 +178,10 @@ not srun).
   containers running a real SLURM, where the daemons really do go out over
   `srun --jobid=<the allocation>`. It asserts the three things only a live
   scheduler shows — that the step joins the caller's job rather than
-  queueing a second one, that the srun exit after `prted` daemonizes is
-  read as a hand-off and not a launch failure (and leaves SLURM no dangling
-  step), and that `pterm` does not take the user's allocation down with the
-  DVM.
+  queueing a second one, that the daemons stay *inside* the step srun
+  launched them in (the srun is still running, the step is still
+  registered, and SLURM accounts the `prted`'s pid to it), and that `pterm`
+  does not take the user's allocation down with the DVM. Run it with
+  `PRTE_SLURM_PROCTRACK=cgroup PRTE_SLURM_PRIVILEGED=true` for the process
+  tracking a real cluster does; the unprivileged default lets a detached
+  daemon escape its step and survive, which hides that whole class.

--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -698,6 +698,22 @@ static void srun_wait_cb(int sd, short fd, void *cbdata)
          * lets prun/the HNP exit.
          */
         if (primary_srun_pid == proc->pid) {
+            /* An elastic release ends the daemons this srun launched on
+             * purpose, and because the prted stays attached it ends them
+             * CLEANLY - so a zero exit reaches us for the same reason a
+             * non-zero one does below, and needs the same question asked of
+             * it. Without this the release of a node belonging to the
+             * primary step reads as the DVM ending and takes the whole DVM
+             * down with it. */
+            if (NULL != job_id && srun_exit_expected(*job_id)) {
+                PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
+                                     "%s plm:slurm: srun for elastic job %" PRIu32
+                                     " exited cleanly after its daemons were released",
+                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), *job_id));
+                free(job_id);
+                PMIX_RELEASE(t2);
+                return;
+            }
             PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
                                  "%s plm:slurm: primary daemons complete!",
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));

--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -688,33 +688,22 @@ static void srun_wait_cb(int sd, short fd, void *cbdata)
                        proc->exit_code);
         PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_DAEMONS_TERMINATED);
     } else {
-        /* otherwise, check to see if this is the primary pid */
+        /* otherwise, check to see if this is the primary pid.
+         *
+         * We never pass --daemonize to the prteds we launch, so the process
+         * srun is tracking IS the daemon and not a fork's parent that exits
+         * the moment the daemon is up - see src/tools/prted/AGENTS.md for why
+         * a prted must stay inside its Slurm step. A clean exit here is
+         * therefore the daemons genuinely ending, so fire the trigger that
+         * lets prun/the HNP exit.
+         */
         if (primary_srun_pid == proc->pid) {
-            if (prte_debug_daemons_flag || prte_leave_session_attached) {
-                /* the prted stayed attached instead of forking off and
-                 * daemonizing, so the process srun is tracking really is
-                 * the persistent daemon - its clean exit means the DVM
-                 * is genuinely gone. Fire the proper trigger so mpirun
-                 * can exit.
-                 */
-                PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
-                                     "%s plm:slurm: primary daemons complete!",
-                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
-                /* need to set the #terminated value to avoid an incorrect error msg */
-                jdata->num_terminated = jdata->num_procs;
-                PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_DAEMONS_TERMINATED);
-            } else {
-                /* the prted forked and daemonized (the default): srun was
-                 * only ever tracking the fork's parent, which exits as
-                 * soon as the real daemon signals it is up and running.
-                 * A clean exit here is that hand-off, not termination -
-                 * daemon loss is instead caught when its RML connection
-                 * to the HNP actually drops. */
-                PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
-                                     "%s plm:slurm: primary srun exited after "
-                                     "daemon hand-off",
-                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
-            }
+            PMIX_OUTPUT_VERBOSE((1, prte_plm_base_framework.framework_output,
+                                 "%s plm:slurm: primary daemons complete!",
+                                 PRTE_NAME_PRINT(PRTE_PROC_MY_NAME)));
+            /* need to set the #terminated value to avoid an incorrect error msg */
+            jdata->num_terminated = jdata->num_procs;
+            PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_DAEMONS_TERMINATED);
         }
     }
 

--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -349,16 +349,21 @@ static void launch_daemons(int fd, short args, void *cbdata)
     /* start one orted on each node */
     pmix_argv_append(&argc, &argv, "--ntasks-per-node=1");
 
-    if (!prte_get_attribute(&state->jdata->attributes, PRTE_JOB_RECOVERABLE, NULL, PMIX_BOOL) &&
-        !prte_get_attribute(&state->jdata->attributes, PRTE_JOB_CONTINUOUS, NULL, PMIX_BOOL) &&
-        !prte_elastic_mode) {
-        /* kill the job if any prteds die */
-        pmix_argv_append(&argc, &argv, "--kill-on-bad-exit");
-    } else {
-        /* don't kill if a node or prted dies */
-        pmix_argv_append(&argc, &argv, "--no-kill");
-        pmix_argv_append(&argc, &argv, "--kill-on-bad-exit=0");
-    }
+    /* Never let Slurm kill the step because one prted died.
+     *
+     * This is unconditional on purpose.  --kill-on-bad-exit tells srun to
+     * take down the WHOLE step when any one task exits non-zero, and --no-kill
+     * is what stops a single node's failure doing the same - so between them
+     * they decide whether losing one daemon costs us one daemon or all of the
+     * daemons that srun launched.  PRRTE decides what a lost daemon means
+     * (see errmgr/dvm, and the recoverable/continuous runtime options); the
+     * scheduler must not pre-empt that decision by killing the survivors.
+     *
+     * It matters far more now than it used to: a prted stays inside its step
+     * rather than daemonizing out of it, so these flags reach real, live
+     * daemons instead of a fork's parent that had already exited. */
+    pmix_argv_append(&argc, &argv, "--no-kill");
+    pmix_argv_append(&argc, &argv, "--kill-on-bad-exit=0");
 
     /* our daemons are not an MPI task */
     pmix_argv_append(&argc, &argv, "--mpi=none");

--- a/src/mca/plm/ssh/AGENTS.md
+++ b/src/mca/plm/ssh/AGENTS.md
@@ -112,8 +112,14 @@ This is the intricate part. It assembles the argv passed to the agent:
 - Splits the daemon command via `prte_plm_base_setup_prted_cmd` (default
   `prted`), prepends the prefix `bindir` when it's the stock `prted`, and
   handles a wrapper (`valgrind ... prted`).
-- Joins the whole shell script with `;`, appends `--daemonize` (non-tree,
-  non-debug), then the standard daemon options via
+- Joins the whole shell script with `;`, appends `--daemonize` (unless
+  debugging or `--leave-session-attached`; the qrsh/llspawn toggles still
+  apply). This flag is load-bearing rather than advisory: a `prted` forks
+  only when told to, so without it the daemon stays in the foreground and
+  holds the ssh session open for its whole life. It is withheld by the RM
+  launchers on purpose — see
+  [`src/tools/prted/AGENTS.md`](../../../tools/prted/AGENTS.md). Then the
+  standard daemon options via
   `prte_plm_base_prted_append_basic_args(..., "env", &proc_vpid_index)`.
 - Forces `--prtemca plm ssh` on the remote daemon, and — **when
   tree-spawning** — adds `--tree-spawn --prtemca prte_parent_uri

--- a/src/mca/plm/ssh/plm_ssh_module.c
+++ b/src/mca/plm/ssh/plm_ssh_module.c
@@ -724,11 +724,17 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
     pmix_argv_append(&argc, &argv, final_cmd);
     free(final_cmd); /* done with this */
 
-    /* if we are not tree launching or debugging, tell the daemon
-     * to daemonize so we can launch the next group
+    /* Unless we are debugging, tell the daemon to daemonize: an ssh session
+     * held open for the daemon's whole life is one process per node on both
+     * ends and, without tree spawn, a concurrency slot we cannot get back to
+     * launch the next group.  prted forks only when it is told to (see
+     * src/tools/prted/AGENTS.md), so this flag is what makes it happen -
+     * which is exactly why the RM launchers, whose tracked task the daemon
+     * must remain, do not pass it.  Tree spawn wants the release just as much
+     * as a flat launch does; it simply had no concurrency reason to ask, and
+     * used to get the fork regardless.
      */
-    if (prte_mca_plm_ssh_component.no_tree_spawn &&
-        !prte_debug_daemons_flag &&
+    if (!prte_debug_daemons_flag &&
         !prte_debug_daemons_file_flag && !prte_leave_session_attached &&
         /* Daemonize when not using qrsh.  Or, if using qrsh, only
          * daemonize if told to by user with daemonize_qrsh flag. */

--- a/src/tools/prted/AGENTS.md
+++ b/src/tools/prted/AGENTS.md
@@ -33,13 +33,41 @@ schizo open/select/detect_proxy
 schizo->parse_cli(...)               <- SILENT: a daemon has no user to warn
 prte_ess_base_bootstrap()            <- bootstrap only: am I the controller?
 prte_register_params()
-daemonize (unless --leave-session-attached or --debug-daemons)
+daemonize -- ONLY on --daemonize, and not when debugging (see below)
 prte_init(MASTER or DAEMON)          <- the whole runtime
 [bind to prte_daemon_cores]
 register PRTE_RML_TAG_DAEMON recv    <- from here on we can be given orders
 check-in sequence (below)
 event loop
 ```
+
+- **A `prted` forks only when its launcher tells it to.** The fork +
+  `setsid()` in `prte_daemon_init_callback` leaves the launcher tracking
+  a process that exits the moment the real daemon is up, and whether that
+  is a favor or a fatal mistake depends entirely on who is doing the
+  tracking:
+  - `plm/ssh` **wants** it, and passes `--daemonize`. The ssh session
+    closes, and without tree spawn the concurrency slot frees so the next
+    group of daemons can go out.
+  - A resource manager does **not**. `srun`, `lsb_launch` and `palsd`
+    each hand the daemon a task slot and watch the process they started;
+    detaching from it tells the RM the task finished. Under Slurm that
+    ends the step, and `slurmstepd` then SIGKILLs whatever is left in the
+    step's cgroup — which includes the daemon, because `setsid()` escapes
+    a process tree and not a cgroup. `plm/slurm`, `plm/lsf` and
+    `plm/pals` therefore withhold `--daemonize`, and the daemon remains
+    the task. (This was
+    [issue #2757](https://github.com/openpmix/prrte/issues/2757): the
+    detach was unconditional and `--daemonize`, though `prted` accepts it,
+    was never read. It was survivable only for as long as a separate bug
+    left the fork's parent blocked forever, accidentally keeping the step
+    alive.)
+
+  Even when it does not fork, a non-debug `prted` still points its
+  stdin/stdout/stderr at `/dev/null` via `prte_daemon_detach_io()` — it
+  has no more business writing on the launcher's terminal than a
+  daemonized one does. `--leave-session-attached` and `--debug-daemons`
+  suppress both halves, which is the whole point of them.
 
 - **The pristine environment must be captured before we add to it.**
   `prte_launch_environ` is what every application process inherits; it is

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -354,10 +354,29 @@ int main(int argc, char *argv[])
                 prte_process_info.nodename);
     }
 
-    /* detach from controlling terminal
-     * otherwise, remain attached so output can get to us
+    /* Detach from the controlling terminal - but ONLY if our launcher said
+     * to.  Forking and calling setsid() leaves the process the launcher is
+     * tracking behind: our parent exits as soon as we signal we are up, and
+     * whether that is a favor or a fatal mistake depends entirely on who
+     * launched us.  plm/ssh wants it (the ssh session closes and its
+     * concurrency slot frees for the next group), and says so with
+     * --daemonize.  A resource manager does NOT: srun, lsb_launch and palsd
+     * each hand us a task slot and watch the process they started, so the
+     * detach tells the RM the task finished.  Under Slurm that ends the step,
+     * and slurmstepd then SIGKILLs everything still in the step's cgroup -
+     * which includes us, because setsid() escapes a process tree and not a
+     * cgroup.  Those launchers therefore withhold --daemonize and we stay put.
+     *
+     * A bootstrapped daemon has no launcher at all - it is started by hand
+     * or by a service manager on every node - so nothing is tracking it and
+     * it detaches as it always has.
+     *
+     * --leave-session-attached and --debug-daemons override in the other
+     * direction: they exist so the daemon's output reaches the user, and a
+     * fork to /dev/null would defeat them.
      */
-    if (!prte_leave_session_attached && !prte_debug_daemons_flag) {
+    if ((pmix_cmd_line_is_taken(&results, PRTE_CLI_DAEMONIZE) || prte_bootstrap_setup) &&
+        !prte_leave_session_attached && !prte_debug_daemons_flag) {
         if (0 > pipe(wait_pipe)) {
             return PRTE_ERROR;
         }
@@ -365,6 +384,14 @@ int main(int argc, char *argv[])
         prte_daemon_init_callback(NULL, wait_dvm);
         close(wait_pipe[0]);
     } else {
+        if (!prte_leave_session_attached && !prte_debug_daemons_flag) {
+            /* we are staying in our launcher's process, but that is no reason
+             * to write on its terminal - take the half of the daemonization
+             * that only silences us */
+            if (PRTE_SUCCESS != prte_daemon_detach_io()) {
+                return PRTE_ERROR;
+            }
+        }
         // the daemon_init_callback fn already setsid, so don't
         // do it twice!
     #if defined(HAVE_SETSID)

--- a/src/util/daemon_init.c
+++ b/src/util/daemon_init.c
@@ -38,11 +38,44 @@
 #include "constants.h"
 #include "src/util/daemon_init.h"
 
+int prte_daemon_detach_io(void)
+{
+    int fd;
+
+    /* connect input to /dev/null */
+    fd = open("/dev/null", O_RDONLY);
+    if (0 > fd) {
+        return PRTE_ERR_FATAL;
+    }
+    dup2(fd, STDIN_FILENO);
+    if (fd != STDIN_FILENO) {
+        close(fd);
+    }
+
+    /* connect outputs to /dev/null */
+    fd = open("/dev/null", O_RDWR | O_CREAT | O_TRUNC, 0666);
+    if (0 > fd) {
+        return PRTE_ERR_FATAL;
+    }
+    dup2(fd, STDOUT_FILENO);
+    dup2(fd, STDERR_FILENO);
+    /* just to be safe, make sure we aren't trying
+     * to close stdout or stderr! since we dup'd both
+     * of them to the same fd, we can't just close it
+     * since one of the two would still be open and
+     * someone could attempt to use it.
+     */
+    if (fd != STDOUT_FILENO && fd != STDERR_FILENO) {
+        close(fd);
+    }
+
+    return PRTE_SUCCESS;
+}
+
 int prte_daemon_init_callback(char *working_dir, int (*parent_fn)(pid_t))
 {
 #if defined(HAVE_FORK)
     pid_t pid;
-    int fd;
 
     if ((pid = fork()) < 0) {
         return PRTE_ERROR;
@@ -66,35 +99,7 @@ int prte_daemon_init_callback(char *working_dir, int (*parent_fn)(pid_t))
         }
     }
 
-    /* connect input to /dev/null */
-    fd = open("/dev/null", O_RDONLY);
-    if (0 > fd) {
-        return PRTE_ERR_FATAL;
-    }
-    dup2(fd, STDIN_FILENO);
-    if (fd != STDIN_FILENO) {
-        close(fd);
-    }
-
-    /* connect outputs to /dev/null */
-    fd = open("/dev/null", O_RDWR | O_CREAT | O_TRUNC, 0666);
-    if (fd >= 0) {
-        dup2(fd, STDOUT_FILENO);
-        dup2(fd, STDERR_FILENO);
-        /* just to be safe, make sure we aren't trying
-         * to close stdout or stderr! since we dup'd both
-         * of them to the same fd, we can't just close it
-         * since one of the two would still be open and
-         * someone could attempt to use it.
-         */
-        if (fd != STDOUT_FILENO && fd != STDERR_FILENO) {
-            close(fd);
-        }
-    } else {
-        return PRTE_ERR_FATAL;
-    }
-
-    return PRTE_SUCCESS;
+    return prte_daemon_detach_io();
 
 #else /* HAVE_FORK */
     return PRTE_ERR_NOT_SUPPORTED;

--- a/src/util/daemon_init.h
+++ b/src/util/daemon_init.h
@@ -46,6 +46,22 @@ BEGIN_C_DECLS
  */
 PRTE_EXPORT int prte_daemon_init_callback(char *working_dir, int (*parent_fn)(pid_t child));
 
+/**
+ * Point stdin/stdout/stderr at /dev/null without forking.
+ *
+ * This is the second half of prte_daemon_init_callback - the half that
+ * detaches a daemon's *output* from whoever launched it - broken out so
+ * that a daemon which must NOT fork can still be silent.  A prted
+ * launched by a resource manager is exactly that case: it has to remain
+ * the process the RM is tracking (see src/tools/prted/AGENTS.md), but it
+ * has no more business writing on the launcher's terminal than a
+ * daemonized one does.
+ *
+ * @retval PRTE_SUCCESS the descriptors were redirected
+ * @retval PRTE_ERR_FATAL /dev/null could not be opened
+ */
+PRTE_EXPORT int prte_daemon_detach_io(void);
+
 END_C_DECLS
 
 static inline int prte_daemon_init(char *working_dir)


### PR DESCRIPTION
Fixes #2757.

## The problem

`prted` daemonizes out from under its Slurm step. When the process `srun` is tracking exits, the step ends, and `slurmstepd` kills whatever is left in the step's cgroup — the daemon included, a moment after it reported in to the HNP. Every node goes down at once, with nothing but a lost connection to show for it.

The detach in `src/tools/prted/prted.c` was **unconditional**, gated only on `--leave-session-attached` / `--debug-daemons`. `prted` accepted `--daemonize` and never read it, so the flag decided nothing: the daemon detached from `srun` exactly as it detached from `ssh`. `setsid()` escapes a process tree; it does not escape a cgroup.

Two things worth stating, because the issue thread reasonably suspected both:

- **Slurm did not change.** `srun` is not exiting on its own — it exits because we told it its task finished.
- **`--external-launcher` is not implicated.** It is the 23.11 version gate, so it correlates with the failing systems, but it plays no part in the mechanism.

Nor did `fcd60b9bbc` ("prted: release the daemonize parent once up and running") cause this. Before that commit nothing ever wrote the readiness byte, so the fork's parent blocked forever — and that stranded process was the step's accidental keep-alive. Fixing the leak exposed a bug that had been latent behind it. Reverting it restores the leak, not correctness.

## The fix

`prted` honors `--daemonize`. `plm/ssh` already passed it and wants it — the ssh session closes, and without tree spawn the concurrency slot frees for the next group. The resource-manager launchers withhold it, because `srun`, `lsb_launch` and `palsd` each hand the daemon a task slot and watch the process they started, so the daemon has to remain that process. This also puts the daemon back inside the step for accounting, confinement and `scancel` cleanup, which it had been escaping.

Around that:

- A daemon that does not fork still points stdin/stdout/stderr at `/dev/null` — it has no more business writing on the launcher's terminal than a daemonized one does. The redirect is split out of `prte_daemon_init_callback()` as `prte_daemon_detach_io()`.
- `plm/ssh` now asks for the daemonization when tree-spawning too. It had no concurrency reason to ask and used to get the fork regardless; now that the flag decides, withholding it would hold every ssh session in the tree open for the life of the DVM.
- A bootstrapped daemon has no launcher watching it and detaches as before.
- With `srun` tracking the daemon itself, a clean exit of the primary `srun` once again means the daemons are genuinely gone, so `srun_wait_cb` fires `DAEMONS_TERMINATED` for it instead of reading the exit as a hand-off from a fork that no longer happens.

## Why the harness never caught it

`contrib/slurmswarm` ran `ProctrackType=proctrack/linuxproc` with cgroups disabled, because that is all an unprivileged container can do, and `slurm.conf` said so plainly: *"a process that escapes its parent can outlive the step."*

That is not a neutral simplification — it decides which bugs the harness is able to see. Under `linuxproc` a detached `prted` escapes and survives; under `proctrack/cgroup`, which every production cluster runs, it cannot. The suite was asserting the escape as correct behaviour ("no srun survives the hand-off", "SLURM has no leftover job step"), which is this bug written down as the expected result. Those assertions are replaced by the invariant that actually has to hold: the `srun` is still running, the step is still registered, and the node's own `scontrol listpids` accounts the `prted`'s pid to it. All three hold in either tracking mode, so the case is not conditional on how the swarm was brought up.

The mode is now selectable, default unchanged:

```sh
export PRTE_SLURM_PROCTRACK=cgroup PRTE_SLURM_PRIVILEGED=true
docker compose up -d --force-recreate
```

Both are required and the entrypoint refuses the mode without the privilege; preflight prints which mode is in force so a run's coverage is on the record. The pinned SLURM moves to 25.11.6, which is what the clusters reporting trouble are running.

## Verification

Ten-node swarm, SLURM 25.11.6, `proctrack/cgroup`.

Unmodified master, three runs, all identical: the daemons check in (`recvd 2 of 4 reported daemons`), then

```
PRTE has lost communication with a remote daemon ... node2
PRTE has lost communication with a remote daemon ... node3
plm:slurm: primary srun exited after daemon hand-off
```

and node2's `slurmd.log`, one second apart:

```
17:44:07  launch task StepId=1.0 request from UID:0 ...
17:44:08  [1.0] done with step
```

With this branch: daemons alive on every allocated node, the `srun` still running, the step still registered, zero lost-communication messages, and `scontrol listpids` on node2 showing the daemon's pid against the step. `make check` passes; the harness's `plm/slurm` phase is green.

## Status of the test suite, and one thing this branch does not resolve

`make check` passes. Against the same PMIx, the slurmswarm suite gives **137 passed / 0 failed** on master and **127 / 4** here, so the four are this branch's to answer for. They are one cascade: the elastic phase's shared DVM dies part-way through, and every later tool connection then fails with `PMIX_ERR_NOT_FOUND`.

With help aggregation off, the HNP says what actually happens, and the `ras` trace says why:

```
ras:slurm:add_modified_resources: discovered node node10 with 8 slots
ras:base:node_insert inserting 1 nodes
ras:base:node_insert node node10 slots 8     <- absorbed into the DVM (expander job 94)
ras:slurm:kill_job: killing job 94           <- that job cancelled right afterwards
...
A daemon was unable to complete a TCP connection to another daemon:
  Local host:    node1
  Remote host:   node10
```

then `help-errmgr-base.txt / node-died`, which `errmgr/dvm` raises on a communication failure to a daemon it still believes is alive. The same pattern repeats for node6 against job 95 and again around `kill_job 98`.

So this is not a daemon killed mid-operation. PRRTE **absorbs the nodes of an expander job into the DVM and then `scancel`s that job without giving the nodes up**, leaving entries in its pool whose daemons the scheduler has just destroyed. The next operation that reaches one cannot connect, and the DVM comes down.

The reason master does not show it is the same shape as the bug this PR fixes. `scancel` never used to reach a `prted`, because the daemon had daemonized out of the step — so those stale entries stayed *reachable* and the leak was invisible. A daemon that stays inside its step really does die with its allocation. This branch does not introduce the bookkeeping gap; it stops masking it.

Fixing it means releasing the absorbed nodes (and retiring their daemons) whenever a scheduler-backed expander job is cancelled, which is an elastic/`ras` change rather than part of this one, and it is not attempted here.

One note on what is and is not evidence in this PR: the `srun_exit_expected()` guard added to `srun_wait_cb`'s clean-exit branch is **reasoned, not observed**. With an attached daemon an elastic release ends its `srun` cleanly rather than non-zero, so the branch that already asks that question is no longer the only one that needs to — but the failure above emits no `srun-failed` and never enters that callback. It is included because it is a hole this change opens, not because it fixes anything measured.

By contrast the PMIx work behind these numbers is measured. `lost_connection()` released `peer->recv_msg` and then used the peer for its whole body, and `pmix_server_peer_finalized()` retired a peer the connection handler's tombstone reclaim had already retired — together killing the HNP with a corrupted malloc arena on the elastic and `--activate` paths. Both are fixed in openpmix, which is what took this suite from 21 failures to 4.
