### PR TITLE
slurmswarm: give absorbed allocations back through the DVM, not scancel

### DIFF
--- a/contrib/slurmswarm/run-tests.sh
+++ b/contrib/slurmswarm/run-tests.sh
@@ -851,9 +851,30 @@ grantable_count() {
 }
 
 drop_extra_jobs() {   # $1 = the job id to keep
-    local j
+    local j out
     for j in $(SQ "squeue -h -o '%i'" | tr -d ' \r'); do
         [ "$j" = "$1" ] && continue
+        # ASK THE DVM TO GIVE IT UP -- do not just scancel it.
+        #
+        # These extra jobs are not all leftovers.  Some are expander
+        # allocations the running DVM has absorbed, and their daemons live
+        # inside those jobs' Slurm steps.  scancel'ing one behind PRRTE's back
+        # kills daemons it still believes in, and the HNP does the right thing
+        # with that -- reports a comm failure on an unreleased daemon and takes
+        # a non-recoverable DVM down.  Every later group is then lost to a DVM
+        # that is simply gone.  This was survivable only while a prted
+        # daemonized out of its step, beyond scancel's reach; it is not
+        # survivable now that a daemon stays in the allocation it launched in.
+        #
+        # A completed release cancels the Slurm job itself, so there is
+        # nothing left to scancel afterwards.  Waiting for that completion is
+        # the point: the release is asynchronous, and a scancel issued while
+        # it is still in flight beats PRRTE to the daemons and causes exactly
+        # the failure this is avoiding.  Only fall back to scancel when the
+        # DVM did not take the job -- a pending expander it never absorbed,
+        # or one it has already given up.
+        out=$(SA "timeout 90 elastic release-id $j" 2>&1)
+        echo "$out" | grep -q PMIX_DVM_IS_READY && continue
         SQ "scancel $j" >/dev/null 2>&1
     done
 }


### PR DESCRIPTION
Restores the elastic phase, which has been taking the whole DVM down with it since a `prted` started staying inside its Slurm step (#2757 / #2758). No PRRTE change is needed: the harness was the one at fault.

## What was happening

`drop_extra_jobs` runs between elastic groups and `scancel`s every Slurm job except the DVM's own allocation. Not all of those are leftovers. Some are expander allocations the *running* DVM has absorbed, and their daemons live inside those jobs' Slurm steps — so cancelling one behind PRRTE's back kills daemons it still believes in.

PRRTE's response to that is correct. `errmgr/dvm` reports a communication failure for a daemon nobody released and takes a non-recoverable DVM down. But every group after that point was then exercising a DVM that no longer existed, which is where the four failures came from — one death and three cascades.

`slurmctld`'s log is what named it. Within 300 ms of PRRTE's own release of one job, two more `REQUEST_KILL_JOB`s arrived for jobs PRRTE never logged killing, and the daemons that failed immediately afterwards were exactly the ones on those jobs' nodes.

The contrast inside a single `errmgr` trace is the clearest statement of it:

```
[0,4] … [0,10], [0,15]   Comm failure for already-departed daemon - ignoring it
[0,11] [0,12] [0,13] [0,14]   Comm failure: daemon ... - aborting
```

Seven daemons PRRTE had genuinely released, all swallowed by the already-departed guard exactly as intended. Four cancelled out from under it, all fatal. The guard works; nothing was reaching it for those four.

This was survivable only for as long as a `prted` daemonized out of its step and so sat beyond `scancel`'s reach — the same masking that hid the original bug. A daemon now stays inside the allocation it was launched in, which is the point of that fix, and the harness has to give an allocation back the way a user would.

## The fix, and the wrong version of it

Ask the DVM to release the job, and **wait for that to complete**.

The wait is not incidental. A release is asynchronous — the suite's own release cases already wait for `PMIX_DVM_IS_READY` before asserting anything — and a `scancel` issued while one is still in flight beats PRRTE to its own daemons and causes precisely the failure being removed. That is not hypothetical: it is what the first version of this change did, and its `errmgr` trace showed the same four aborts with the release requests sitting right above them.

A completed release cancels the Slurm job along with it, so there is nothing left to cancel. The `scancel` therefore survives only as the fallback for a job the DVM does not hold — a pending expander it never absorbed, or one it has already given up.

## Result

Under `PRTE_SLURM_PROCTRACK=cgroup` (the mode that tracks processes the way a real cluster does):

| | before | after |
|---|---|---|
| passed | 127 | **143** |
| failed | 4 | **0** |
| skipped | 2 | 0 |

`contrib/dockerswarm` is unaffected and green on the same tree (791 passed, 0 failed, 3 skipped).

## A case for the behaviour this exposed

The second commit adds `elastic_external_cancel_group`, because an absorbed allocation being taken away without asking PRRTE is a real thing — a user, an admin, or a job's own time limit — and nothing pinned down what the DVM does about it. That gap is exactly what let the bug above sit unnoticed.

The DVM cannot prevent the cancellation and must not pretend it did not happen; the nodes are gone. What it owes the user is to notice, to say so, and to leave nothing behind. So the case asserts four things: the cancelled allocation's daemons are gone, the HNP reported the loss rather than waiting on it, no daemon is orphaned anywhere in the cluster, and the user's own allocation is left alone.

It deliberately does **not** assert whether the DVM survives. It currently ends, which is defensible for a non-recoverable DVM that lost a daemon nobody released — but an elastic DVM shrinking instead would be equally defensible. That is an open question, and freezing an answer to it in a test is precisely the mistake this line of work started from: the suite used to assert "no srun survives the hand-off", which was a bug written down as the expected result. The group runs on its own allocation and its own DVM so either outcome stays harmless.

One incidental finding worth recording: help aggregation is a runtime option (`--rtos aggregate-help`), not an MCA parameter, so `--prtemca prte_base_help_aggregate 0` is silently a no-op. The case therefore accepts the report in either form — the full `node-died` text, or the summary line naming that topic — since which one is displayed depends on the `oob` layer's connection-failure message winning the race, and that is not the property under test.
