### PR TITLE
rml/oob: stop blaming the firewall for a daemon that has died

### DIFF
--- a/src/rml/oob/oob_tcp_component.c
+++ b/src/rml/oob/oob_tcp_component.c
@@ -173,6 +173,7 @@ static void peer_cons(prte_oob_tcp_peer_t *peer)
     peer->active_addr = NULL;
     peer->state = MCA_OOB_TCP_UNCONNECTED;
     peer->established = false;
+    peer->ever_connected = false;
     peer->num_retries = 0;
     peer->first_attempt = 0;
     PMIX_CONSTRUCT(&peer->send_queue, pmix_list_t);

--- a/src/rml/oob/oob_tcp_connection.c
+++ b/src/rml/oob/oob_tcp_connection.c
@@ -517,19 +517,53 @@ void prte_oob_tcp_peer_try_connect(int fd, short args, void *cbdata)
         if (NULL == host && NULL != peer->active_addr) {
             host = pmix_net_get_hostname((struct sockaddr *) &(peer->active_addr->addr));
         }
-        /* use an pmix_output here instead of show_help as we may well
-         * not be connected to the HNP at this point */
-        pmix_output(prte_clean_output,
-                    "------------------------------------------------------------\n"
-                    "A daemon was unable to complete a TCP connection\n"
-                    "to another daemon:\n"
-                    "  Local host:    %s\n"
-                    "  Remote host:   %s\n"
-                    "This is usually caused by a firewall on the remote host. Please\n"
-                    "check that any firewall (e.g., iptables) has been disabled and\n"
-                    "try again.\n"
-                    "------------------------------------------------------------",
-                    prte_process_info.nodename, (NULL == host) ? "<unknown>" : host);
+        /* Say which of the two failures this is, because they need opposite
+         * advice and only one of them is about the network.
+         *
+         * A peer we have NEVER reached may not have started yet, may have
+         * failed to start, or may be behind a firewall - the connection has
+         * never worked, so the configuration is a fair thing to suspect.
+         *
+         * A peer we HAVE reached is a different story: the connection worked,
+         * so the network and the firewall are exonerated by that fact alone.
+         * The daemon has gone away since. Telling that user to check iptables
+         * sends them at their network when the answer is almost always their
+         * node or their scheduler - a cancelled or expired allocation takes
+         * its daemons with it, and that is the common case on a managed
+         * cluster. (The errmgr's own "lost communication" report says this
+         * properly, but show_help aggregates by topic and this message
+         * usually gets there first, so this is the one the user reads.)
+         *
+         * pmix_output rather than show_help throughout: we may well not be
+         * connected to the HNP at this point. */
+        if (peer->ever_connected) {
+            pmix_output(prte_clean_output,
+                        "------------------------------------------------------------\n"
+                        "A daemon that was running is no longer reachable:\n"
+                        "  Local host:    %s\n"
+                        "  Remote host:   %s\n"
+                        "The connection to that daemon was working earlier, so this is\n"
+                        "not a firewall or network configuration problem. Something\n"
+                        "ended the daemon or the node it was on. The usual causes are\n"
+                        "that the node failed, that the daemon was killed, or that the\n"
+                        "resource manager reclaimed the allocation it was running in -\n"
+                        "a job that was cancelled, or that reached its time limit.\n"
+                        "------------------------------------------------------------",
+                        prte_process_info.nodename, (NULL == host) ? "<unknown>" : host);
+        } else {
+            pmix_output(prte_clean_output,
+                        "------------------------------------------------------------\n"
+                        "A daemon was unable to complete a TCP connection\n"
+                        "to another daemon:\n"
+                        "  Local host:    %s\n"
+                        "  Remote host:   %s\n"
+                        "This connection has never succeeded, so the daemon may have\n"
+                        "failed to start, or may not be reachable. This is usually\n"
+                        "caused by a firewall on the remote host. Please check that any\n"
+                        "firewall (e.g., iptables) has been disabled and try again.\n"
+                        "------------------------------------------------------------",
+                        prte_process_info.nodename, (NULL == host) ? "<unknown>" : host);
+        }
         /* close the socket */
         CLOSE_THE_SOCKET(peer->sd);
         /* let the TCP component know that this module failed to make
@@ -1326,6 +1360,7 @@ static void tcp_peer_connected(prte_oob_tcp_peer_t *peer)
     tcp_peer_rebind_events(peer);
     peer->state = MCA_OOB_TCP_CONNECTED;
     peer->established = true;
+    peer->ever_connected = true;
 
     /* initiate send of first message on queue */
     if (NULL == peer->send_msg) {

--- a/src/rml/oob/oob_tcp_peer.h
+++ b/src/rml/oob/oob_tcp_peer.h
@@ -62,6 +62,14 @@ typedef struct {
                                     the connection being closed.  Separates a connection that
                                     died while still being established, whose untried addresses
                                     must still be tried, from the loss of a working one. */
+    bool ever_connected;       /**< has a connection to this peer EVER reached CONNECTED?
+                                    Unlike `established`, this is never cleared, so it answers
+                                    a different question: not "is the connection being closed
+                                    a working one" but "did this peer ever work at all".  That
+                                    is what separates a daemon we have never reached - which
+                                    may not have started, or may be behind a firewall - from
+                                    one that was running and has since gone away, and the two
+                                    need opposite advice. */
     int num_retries;
     time_t first_attempt; /**< wall-clock time of the first connection attempt in the current
                                retry sequence; 0 until the first retry is scheduled.  Used to

--- a/src/rml/oob/oob_tcp_sendrecv.c
+++ b/src/rml/oob/oob_tcp_sendrecv.c
@@ -461,6 +461,7 @@ void prte_oob_tcp_recv_handler(int sd, short flags, void *cbdata)
             }
             /* update our state */
             peer->state = MCA_OOB_TCP_CONNECTED;
+            peer->ever_connected = true;
             pmix_mutex_unlock(&peer->lock);
         } else if (PRTE_ERR_UNREACH != rc) {
             /* we get an unreachable error returned if a connection


### PR DESCRIPTION
When a daemon cannot be reached, the oob layer says the same thing however it got there:

```
A daemon was unable to complete a TCP connection to another daemon:
  Local host:    node1
  Remote host:   node4
This is usually caused by a firewall on the remote host. Please
check that any firewall (e.g., iptables) has been disabled and try again.
```

That is sound advice for a peer we have **never** reached — it may not have started, or something may indeed be blocking the port.

It is actively misleading for a peer we **have** reached. The connection worked earlier, so the network and the firewall are exonerated by that fact alone; the daemon has gone away since. On a managed cluster the usual reason is that the resource manager reclaimed the allocation it was running in — a job cancelled, or one that hit its time limit — and a user sent to look at `iptables` is being pointed away from the answer.

The errmgr does report this properly (`PRTE has lost communication with a remote daemon`), but `show_help` aggregates by topic and the oob message usually gets there first, so the firewall text is the one the user actually reads. That is how this was noticed: chasing a revoked allocation in `contrib/slurmswarm`, where the accurate message was the one aggregation collapsed.

## Why a new flag

`peer->established` cannot answer the question. It is cleared by `prte_oob_tcp_peer_close` so that it always describes *the connection being closed* — and at this point that is a connection which never came up, so it is false in both cases. The question here is a different one: did this peer ever work at all. So `ever_connected` records that and is never cleared.

Both messages get more precise as a result: the never-reached one now says so, rather than leaving the reader to work out which case they are in.

## Verification, and its limit

Message-only change; no behaviour changes. Builds warning-free with `--enable-debug`, and `contrib/slurmswarm` is unchanged at 138 passed / 0 failed under `proctrack/cgroup`.

**I was not able to observe the new "no longer reachable" text in situ, and would rather say so than imply otherwise.** Nine attempts across five mechanisms — cancelling an absorbed allocation, killing a daemon and then forcing a send, a Docker-level network partition, and shrinking the retry window to win the race — all ended with PRRTE noticing the loss on the *existing* socket first and short-circuiting with `Node has gone down`, so `prte_oob_tcp_peer_try_connect`'s failure path never ran.

The path is real and I have seen the old message from exactly this scenario; reaching it needs the HNP to open a *fresh* connection before it has processed the socket close, which is what happens amid concurrent grow/launch activity. If it is worth pinning down, the reliable way is a deliberate fault-injection hook that drives a peer into `try_connect` against a dead target — happy to add one.
