### PR TITLE
rml/oob: make the departed-daemon report reachable, and pin it down

### DIFF
--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -6686,6 +6686,69 @@ test_rml() {
         bad "could not start a DVM with worker threads"
     fi
     cleanup_swarm
+
+    banner "rml/oob: a daemon that died is not reported as a firewall problem"
+    # There are two ways to fail to reach a daemon, and they want opposite
+    # advice.  A daemon we have never reached may not have started, or may be
+    # behind a firewall, so suspecting the configuration is fair.  A daemon we
+    # HAVE reached is a different story: the connection worked, which
+    # exonerates the network and the firewall by itself, and telling that user
+    # to check iptables sends them away from the answer - which on a managed
+    # cluster is usually that the scheduler reclaimed the allocation the
+    # daemon was living in.
+    #
+    # Reaching the second case by timing alone is a race a test cannot win.
+    # The HNP normally sees the socket close, reports the loss, the node is
+    # marked down, and every later message for it is refused before it ever
+    # reaches the oob.  prte_oob_silent_loss_vpid removes the race by naming a
+    # daemon whose departure the HNP must pretend not to have noticed, so the
+    # next message for it has to open a fresh connection and fail there.
+    #
+    # The DVM runs in the foreground here rather than through
+    # prted_dvm_start_mca, because --daemonize sends the HNP's stdout to
+    # /dev/null and this whole case is about what the HNP prints.
+    cleanup_swarm
+    RUN 'rm -f /tmp/oobmsg.out' >/dev/null 2>&1
+    # One line on purpose: RUN_BG appends the redirect to what it is given, so
+    # a command split across newlines would send only its last line to the file.
+    RUN_BG /tmp/oobmsg.out 'prte --host node1:1,node2:1,node3:1 --prtemca prte_oob_silent_loss_vpid 1 --prtemca prte_retry_delay 1 --prtemca prte_max_recon_attempts 2 --prtemca plm_base_verbose 5'
+    n=0
+    while [ "$n" -lt 30 ]; do
+        RUN 'grep -q "DVM ready" /tmp/oobmsg.out' >/dev/null 2>&1 && break
+        sleep 1; n=$((n+1))
+    done
+    if [ "$n" -ge 30 ]; then
+        bad "no DVM came up for the oob message case: $(RUN 'tail -3 /tmp/oobmsg.out' 2>&1 | tr '\n' ' ' | tail -c 200)"
+    else
+        # Which node holds vpid 1 is the launcher's business, so read it back
+        # rather than assume it: the case is about that daemon, and killing
+        # the wrong one would prove nothing.
+        w=$(RUN "grep -oE 'daemon \[[^]]*@0,1\] on node node[0-9]+' /tmp/oobmsg.out | \
+                 grep -oE 'node[0-9]+\$' | head -1" 2>/dev/null | tr -d ' \r')
+        if [ -z "$w" ]; then
+            bad "could not tell which node holds daemon vpid 1"
+        else
+            ok "daemon vpid 1 is on $w"
+            ON "${w#node}" 'pkill -9 -x prted' >/dev/null 2>&1
+            sleep 2
+            # Make the HNP send to it.  With the loss suppressed it still
+            # believes in that daemon, so this goes through a fresh connect
+            # attempt, which is the path under test.
+            RUN "timeout -k 5 90 prun --host $w -n 1 hostname" >/dev/null 2>&1
+            sleep 20
+            RUN 'grep -q "no longer reachable" /tmp/oobmsg.out' \
+                && ok "the HNP said the daemon had gone, not that a firewall was to blame" \
+                || bad "the HNP did not report the loss as a departed daemon: $(RUN 'tail -6 /tmp/oobmsg.out' 2>&1 | tr '\n' ' ' | tail -c 250)"
+            RUN 'grep -q "check that any firewall" /tmp/oobmsg.out' \
+                && bad "the HNP blamed a firewall for a daemon that had been running" \
+                || ok "...and offered no firewall advice for a connection that had worked"
+            RUN "grep -q 'Remote host:.*$w' /tmp/oobmsg.out" \
+                && ok "the report names the node that went away ($w)" \
+                || bad "the report does not name $w"
+        fi
+        RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    fi
+    cleanup_swarm
 }
 
 ########################################################################

--- a/src/rml/oob/oob.h
+++ b/src/rml/oob/oob.h
@@ -104,6 +104,10 @@ typedef struct {
                                delay backs off exponentially up to this value (0 => fixed delay) */
     int connect_max_time;   /**< max seconds to keep retrying a non-lifeline peer before giving up
                                and letting the routing tree heal to an ancestor (0 => forever) */
+    int silent_loss_vpid;   /**< fault injection: daemon vpid whose departure this process must
+                               pretend not to have noticed, so that the next message for it goes
+                               through a fresh connection attempt instead of being short-circuited
+                               by the node already being marked down (-1 => nobody) */
 } prte_oob_base_t;
 PRTE_EXPORT extern prte_oob_base_t prte_oob_base;
 

--- a/src/rml/oob/oob_tcp.c
+++ b/src/rml/oob/oob_tcp.c
@@ -586,6 +586,28 @@ int prte_oob_register(void)
                                         PMIX_MCA_BASE_VAR_TYPE_INT,
                                         &prte_oob_base.connect_max_time);
 
+    /* Fault injection, and deliberately NOT restricted to a debug build - the
+     * behavior it exists to reach is in the build that ships, and a hook that
+     * only exists elsewhere cannot demonstrate it.  It costs one comparison
+     * on a path that runs when a connection is already being torn down.
+     *
+     * Losing a daemon has two shapes, and only one of them is easy to arrange.
+     * Normally this process sees the socket close, reports the loss, the node
+     * is marked down, and every later message for it is refused before it
+     * reaches the oob at all.  The other shape is a daemon that has gone away
+     * while this process still believes in it: the next message then has to
+     * open a fresh connection, and it is that attempt failing which tells the
+     * user their daemon is unreachable.  Reaching it by timing alone is a race
+     * nobody wins reliably, so this names a vpid whose departure is to be
+     * ignored, and the race disappears. */
+    prte_oob_base.silent_loss_vpid = -1;
+    (void) pmix_mca_base_var_register("prte", "prte", NULL, "oob_silent_loss_vpid",
+                                        "Fault injection: pretend not to notice the departure of "
+                                        "this daemon vpid, so the next message for it must open a "
+                                        "fresh connection [default: -1 => notice every departure]",
+                                        PMIX_MCA_BASE_VAR_TYPE_INT,
+                                        &prte_oob_base.silent_loss_vpid);
+
     prte_oob_base.max_msg_size = 100;
     (void) pmix_mca_base_var_register("prte", "prte", NULL, "max_msg_size",
                                         "Max size of an OOB message in Megabytes(default = 100)",

--- a/src/rml/oob/oob_tcp_connection.c
+++ b/src/rml/oob/oob_tcp_connection.c
@@ -1505,7 +1505,22 @@ void prte_oob_tcp_peer_close(prte_oob_tcp_peer_t *peer)
      * it can decide what to do about it.
      */
     if (MCA_OOB_TCP_CONNECTED == old_state) {
-        PRTE_ACTIVATE_TCP_CMP_OP(peer, prte_mca_oob_tcp_component_lost_connection);
+        /* ...unless we have been told to pretend we did not notice this one.
+         * Reporting the loss is what gets the node marked down, and a node
+         * marked down turns every later message for it into an immediate
+         * refusal - which is the whole reason the connect-failure path is so
+         * hard to reach on purpose.  Staying quiet leaves this process still
+         * believing in the daemon, so the next message for it opens a fresh
+         * connection and fails there instead.  See prte_oob_silent_loss_vpid. */
+        if (0 <= prte_oob_base.silent_loss_vpid
+            && (pmix_rank_t) prte_oob_base.silent_loss_vpid == peer->name.rank) {
+            pmix_output_verbose(OOB_TCP_DEBUG_CONNECT, prte_oob_base.output,
+                                "%s tcp_peer_close: NOT reporting loss of %s (fault injection)",
+                                PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
+                                PRTE_NAME_PRINT(&(peer->name)));
+        } else {
+            PRTE_ACTIVATE_TCP_CMP_OP(peer, prte_mca_oob_tcp_component_lost_connection);
+        }
     }
 }
 


### PR DESCRIPTION
Follow-on to #2761, which split the oob connect-failure message so that a daemon which *had been running* is no longer reported as a firewall problem. That PR shipped with a gap I flagged in its description: I could not demonstrate the new branch actually firing.

## Why it could not be demonstrated

Reaching it is a race a test cannot win. Losing a daemon normally goes the other way entirely — the HNP sees the socket close, reports the loss, the node is marked down, and every later message for it is refused before it reaches the oob at all (`Node has gone down`, from `rml_send.c`). The connect attempt that produces the message only happens when a daemon has gone away while the HNP still believes in it.

Arranging that by timing alone failed nine times across five approaches: cancelling an absorbed Slurm allocation (six runs), killing a daemon and then forcing a send, `iptables` (not in the image), a Docker-level network partition, and shrinking the retry window to try to win the race.

## Naming the thing directly

`prte_oob_silent_loss_vpid` says which daemon vpid's departure this process must pretend not to have noticed. With the loss unreported the node stays up, the next message for it has to open a fresh connection, and the failure lands where the message lives. The race disappears, and the assertion becomes deterministic.

It is deliberately **not** restricted to a debug build, for the same reason `odls_base_fork_publish_delay` is not: the behaviour it exists to reach is in the build that ships, and a hook that only exists elsewhere cannot say anything about that build. It costs one comparison on a path that runs when a connection is already being torn down.

## The case

In `contrib/dockerswarm`, `test_rml` — this is oob behaviour with nothing resource-manager-specific about it. It kills the daemon holding vpid 1, makes the HNP send to it, and asserts:

- the report says the daemon went away
- **no firewall advice** for a connection that had demonstrably worked — the actual regression guard
- the report names the node that went away

Which node holds vpid 1 is read back from the launch log rather than assumed. The case is about *that* daemon, and killing the wrong one would prove nothing.

The DVM runs in the foreground via `RUN_BG` rather than `prted_dvm_start_mca`, because `--daemonize` sends the HNP's stdout to `/dev/null` and this case is entirely about what the HNP prints.

## Verification

Observed by hand before any test was written around it:

```
A daemon that was running is no longer reachable:
  Local host:    node1
  Remote host:   node2
The connection to that daemon was working earlier, so this is
not a firewall or network configuration problem. Something
ended the daemon or the node it was on. The usual causes are
that the node failed, that the daemon was killed, or that the
resource manager reclaimed the allocation it was running in -
a job that was cancelled, or that reached its time limit.
```

Full suite: **795 passed, 0 failed, 3 skipped** — the 791 baseline plus this case's four assertions.

One incidental finding, since it wasted a diagnostic cycle and may waste someone else's: help aggregation is a **runtime option** (`--rtos aggregate-help`), not an MCA parameter, so `--prtemca prte_base_help_aggregate 0` is silently a no-op.
