### PR TITLE
docs: record what issue #2757 taught, where it will be looked for

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -929,7 +929,32 @@ The corollary for a **persistent** DVM: the diagnostic is produced on the
 HNP, and `prte --daemonize` has detached from stdio, so `>/tmp/prte.out`
 captures nothing. PRRTE relays the message back to the submitting tool, so
 assert on `prun`'s own output; if you need the HNP's stdio, start it in the
-foreground under `docker exec -d` (see §5).
+foreground under `docker exec -d` (see §5). `RUN_BG` does exactly that, and
+`prted_dvm_start_mca` does not — the `rml/oob` firewall-message case uses
+`RUN_BG` for precisely this reason.
+
+**`RUN_BG` appends its redirect to what you hand it**, so a command written
+across several lines sends only its *last* line to the file and the rest to
+nowhere. Keep such a command on one line. The symptom is a case that fails
+claiming the log does not exist.
+
+**Aggregation is a runtime option, not an MCA parameter.** `--rtos
+aggregate-help` controls it; `--prtemca prte_base_help_aggregate 0` is
+silently a no-op, so a diagnostic run that passes it is not doing what it
+looks like it is doing. With aggregation on, only the *first* message of a
+topic is printed in full and the rest collapse into a one-line summary naming
+that topic — so a case asserting on a message that lost the race to another
+one should accept either form.
+
+**Some paths cannot be reached by timing, and there are knobs for those.**
+`prte_oob_silent_loss_vpid` names a daemon whose departure the HNP must
+pretend not to have noticed, which is the only reliable way to make it
+attempt a *fresh* connection to a daemon that has gone (normally the node is
+marked down first and the send is refused before the oob sees it). See
+[`src/rml/oob/AGENTS.md`](../../src/rml/oob/AGENTS.md). Reach for a knob like
+this rather than writing a case that wins a race some of the time: nine
+attempts across five mechanisms failed to hit that path before the knob
+existed, which is a flaky test waiting to be committed.
 
 ---
 

--- a/contrib/slurmswarm/AGENTS.md
+++ b/contrib/slurmswarm/AGENTS.md
@@ -351,6 +351,41 @@ as "the grow did not happen", several cases further on. `slurm-alloc free
 --all` cancels *every* job in the queue, deliberately: this is a dedicated
 single-purpose cluster and there is nothing in it that is not the harness.
 
+### Never scancel an allocation the DVM is still using
+
+Between elastic groups the harness gives the scheduler back everything except
+the DVM's own allocation. It must do that **through the DVM**, not with
+`scancel`, and `drop_extra_jobs` is where that is enforced.
+
+Those extra jobs are not all leftovers. Some are expander allocations the
+*running* DVM has absorbed, whose daemons live inside those jobs' SLURM steps.
+Cancelling one behind PRRTE's back kills daemons it still believes in, and the
+HNP does the right thing with that — reports a communication failure on a
+daemon nobody released and takes a non-recoverable DVM down. Every group after
+that point is then testing a DVM that no longer exists. That is exactly what
+happened: four failures, all of them one death and its cascade, and the tell
+was in `slurmctld.log` rather than PRRTE's — `REQUEST_KILL_JOB`s for jobs PRRTE
+never logged killing, immediately followed by comm failures on those jobs'
+nodes.
+
+**Wait for the release to complete.** A release is asynchronous, and a
+`scancel` issued while one is in flight beats PRRTE to its own daemons and
+causes precisely the failure being avoided — the first attempt at this fix did
+exactly that. A completed release cancels the SLURM job with it, so nothing is
+left to cancel; the `scancel` survives only as the fallback for a job the DVM
+does not hold, such as a pending expander it never absorbed.
+
+Like almost everything else in this file, this was survivable for as long as a
+`prted` daemonized out of its step and so sat beyond `scancel`'s reach. It is
+not survivable now that a daemon stays inside the allocation it was launched
+in, and `elastic_external_cancel_group` is the case that states what the DVM
+owes a user whose allocation is revoked: notice it, say so, orphan nothing, and
+leave the user's own allocation alone. That case deliberately does **not**
+assert whether the DVM survives — it currently ends, which is defensible for a
+non-recoverable DVM, but an elastic DVM shrinking instead would be equally
+defensible, and freezing an answer to an open question in a test is the mistake
+this whole area started from.
+
 Two things about cgroups being off (§9): SLURM's process tracking is
 best-effort here, so a stray application process is SLURM's to lose — the
 per-node `pkill` sweep is what actually guarantees a clean slate — and

--- a/src/mca/errmgr/dvm/AGENTS.md
+++ b/src/mca/errmgr/dvm/AGENTS.md
@@ -167,6 +167,24 @@ For the communication-loss family — `COMM_FAILED`, `HEARTBEAT_FAILED`,
 Any non-comm daemon state hits the `pmix_output(0, "UNSUPPORTED DAEMON
 ERROR STATE …")` branch — a real one indicates a bug upstream.
 
+**Step 2 versus step 6 is the most useful thing in a verbose log.** Both
+report the same event — a daemon's socket died — and which branch a given
+daemon takes says whether PRRTE *was told* it was going away:
+
+```
+Comm failure for already-departed daemon [...] - ignoring it   <- PRRTE released it
+Comm failure: daemon [...] - aborting                          <- nobody told PRRTE
+```
+
+A DVM that dies with both kinds in one trace is not usually an errmgr defect;
+it is something destroying daemons behind PRRTE's back, and the ones that were
+released prove the guard works. That contrast is what identified a test harness
+`scancel`ing allocations a live DVM had absorbed — the daemons PRRTE had
+genuinely released were all swallowed, and only the ones taken from underneath
+it were fatal. Aborting there is correct: a daemon that vanishes without being
+released *is* a fault for a non-recoverable DVM. Read the scheduler's log
+alongside PRRTE's before suspecting this component.
+
 ### Application proc errors
 
 First, idempotency: `pptr->state = state` only if

--- a/src/mca/plm/slurm/AGENTS.md
+++ b/src/mca/plm/slurm/AGENTS.md
@@ -61,10 +61,7 @@ If no Slurm command can be run, or the version cannot be parsed
    - `srun`
    - `--external-launcher` (unless `early`)
    - `--ntasks-per-node=1` (one `prted` per node)
-   - `--kill-on-bad-exit` — **unless** the job is recoverable/continuous
-     or `prte_elastic_mode`, in which case `--no-kill
-     --kill-on-bad-exit=0` (a node/daemon dying must not tear down an
-     elastic DVM).
+   - `--no-kill --kill-on-bad-exit=0`, always — see the rule below.
    - `--mpi=none` (daemons aren't MPI tasks), `--cpu-bind=none` (don't
      let TaskAffinity pin the prted to one core).
    - any `plm_slurm_args`.
@@ -162,9 +159,23 @@ not srun).
   [`common/slurm`](../../common/slurm/AGENTS.md) parsed out of
   `srun --version`. Change a threshold there, not here — and remember a
   third component reads the same struct.
-- **Elastic mode changes the kill flags.** `--no-kill
-  --kill-on-bad-exit=0` in elastic/recoverable/continuous mode is
-  deliberate — a node loss must not kill the whole srun.
+- **The kill flags are unconditional, and must stay that way.**
+  `--kill-on-bad-exit` tells `srun` to take down the *whole step* when any
+  one task exits non-zero, and `--no-kill` is what stops a single node's
+  failure doing the same — so between them they decide whether losing one
+  daemon costs us one daemon or all of the daemons that `srun` launched.
+  Which daemon losses are survivable is PRRTE's judgement to make: that is
+  what [`errmgr/dvm`](../../errmgr/dvm/AGENTS.md) and the `recoverable` and
+  `continuous` runtime options are for, and the scheduler must not pre-empt
+  it by killing the survivors.
+
+  This has been got wrong once already, and quietly. `8d67814366` made the
+  flags unconditional; `538e4ada35`, whose subject describes only *adding*
+  them for elastic mode, reinstated the `--kill-on-bad-exit` branch for
+  everything else and said nothing about it. It went unnoticed for as long
+  as it did because a `prted` daemonized out of its step, so the flags only
+  ever governed a fork's parent that had already exited. They reach live
+  daemons now.
 - **Environment purge in the child is mandatory** — SLURM forwards the
   full environment; leaving `PMIX_`/`PRTE_` vars in breaks tool
   connections and duplicates command-line settings.

--- a/src/rml/oob/AGENTS.md
+++ b/src/rml/oob/AGENTS.md
@@ -140,6 +140,48 @@ Two knobs modify this (both default to preserving the original behavior):
   timestamp) before giving up so the routing tree can heal to an ancestor. `0`
   means retry forever. The HNP is never subject to this — it is retried forever.
 
+## When a peer cannot be reached, say which kind of failure it is
+
+`try_connect` giving up produces the message the user actually reads about a
+lost daemon, and there are **two failures behind it that want opposite
+advice**:
+
+- A peer we have **never** reached may not have started yet, may have failed
+  to start, or may be behind a firewall. Suspecting the configuration is fair.
+- A peer we **have** reached is a different story. The connection worked once,
+  which exonerates the network and the firewall by that fact alone; the daemon
+  has gone away since. On a managed cluster the usual reason is that the
+  resource manager reclaimed the allocation it was living in — a job cancelled,
+  or one that hit its time limit. Telling *that* user to check `iptables`
+  points them away from the answer.
+
+`peer->ever_connected` is what separates them, and it is not the same question
+as `peer->established`: that one is cleared by `prte_oob_tcp_peer_close` so it
+always describes *the connection being closed*, which at the failure site is a
+connection that never came up — false in both cases. `ever_connected` is set
+wherever a connection reaches `CONNECTED` and is never cleared.
+
+Note also which layer the user hears first. `errmgr/dvm` reports the loss
+properly (`node-died`, "PRTE has lost communication with a remote daemon"), but
+`show_help` aggregates by topic and this message usually arrives ahead of it,
+so this is the text that gets read. Keep it accurate.
+
+### Reaching that path on purpose: `prte_oob_silent_loss_vpid`
+
+The second case is nearly impossible to arrange by timing. Losing a daemon
+normally goes the other way entirely: this process sees the socket close,
+reports the loss, the node is marked down, and every later message for it is
+refused (`PRTE_ERR_NODE_DOWN`) before it reaches the oob at all. The connect
+attempt only happens when a daemon has gone away while we still believe in it.
+
+`prte_oob_silent_loss_vpid` names a daemon vpid whose departure this process
+must pretend not to have noticed — `peer_close` skips the `lost_connection`
+notification for it. The node stays up, the next message opens a fresh
+connection, and the failure lands where the message lives. It is fault
+injection, not a tuning knob, and like `odls_base_fork_publish_delay` it is
+**deliberately not restricted to a debug build**: the behavior it exists to
+reach is in the build that ships. `contrib/dockerswarm`'s `test_rml` uses it.
+
 ## Bootstrap specifics
 
 In a launcher-less (bootstrapped) DVM daemons boot independently, so:


### PR DESCRIPTION
Six fixes came out of #2757 and the guides did not describe any of them. One guide actively described behaviour that no longer exists.

## `src/mca/plm/slurm` — a correction, not an addition

It said the kill flags were conditional, gated on elastic/recoverable/continuous. They are unconditional as of #2758's follow-on, so both the argument list and the "things to watch" entry were wrong.

The replacement also records *how* they came to be gated, because that is the part worth not repeating: `8d67814366` made them unconditional; `538e4ada35`, whose subject describes only *adding* them for elastic mode, reinstated the `--kill-on-bad-exit` branch for everything else and said nothing about it. It went unnoticed for as long as it did because a `prted` daemonized out of its step, so the flags only ever governed a fork's parent that had already exited.

## `src/rml/oob` — why the message has two forms

A peer never reached and a peer that has gone away want opposite advice; `ever_connected` is what separates them, and `peer->established` cannot, because `prte_oob_tcp_peer_close` clears it so that it always describes *the connection being closed*.

Also documents `prte_oob_silent_loss_vpid` — not as a knob list entry but with the reason it exists, since "this path is otherwise a race nobody wins" is precisely what a reader needs before trying to test anything on it.

## `src/mca/errmgr/dvm` — its guard is a diagnostic

Which branch a daemon takes in a verbose log says whether PRRTE *was told* it was going away:

```
Comm failure for already-departed daemon [...] - ignoring it   <- PRRTE released it
Comm failure: daemon [...] - aborting                          <- nobody told PRRTE
```

A trace carrying both kinds points away from this component and at whatever is destroying daemons behind its back. That contrast is what found the harness bug below, so it is written down as a technique rather than left to be rediscovered — along with the point that aborting there is *correct*: a daemon that vanishes without being released is a fault for a non-recoverable DVM.

## `contrib/slurmswarm` — the rule that cost four failures

An allocation the DVM has absorbed is given back **through the DVM**, and the release is **waited for**. A `scancel` racing an in-flight release beats PRRTE to its own daemons and causes exactly the failure being avoided — which is what the first version of that fix did.

## `contrib/dockerswarm` — three things that wasted diagnostic cycles

- `RUN_BG` appends its redirect, so a command written across newlines sends only its last line to the file.
- Help aggregation is a **runtime option** (`--rtos aggregate-help`); `--prtemca prte_base_help_aggregate 0` is a silent no-op, so a diagnostic run passing it is not doing what it appears to.
- A path that cannot be reached by timing should be reached with a knob, not with a case that wins a race sometimes — nine attempts across five mechanisms failed to hit the oob path before the knob existed, which is a flaky test waiting to be committed.

Documentation only; no code changes. Relative links checked from their own directories and fences balanced.
