### PR TITLE
Allocate node ranks instead of counting the procs on a node

### DIFF
--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -501,6 +501,20 @@ build_linux() {
                 /prrte-src/contrib/dockerswarm/devinfo.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
+            # spawnloop: repeated PMIx_Spawn from one long-lived process.
+            # Every other spawn client here spawns once, and the state that
+            # only exists BETWEEN spawns is where the interesting failures
+            # are: the requesting daemon tracks each spawn in a recycled slot
+            # of local_reqs (the room number), stamps that index on the job,
+            # and never clears it -- and the response only travels by RML,
+            # carrying that index, when the requesting process is not on the
+            # node running the DVM master.  Neither is reachable on one host.
+            # (No apostrophes here: see the note further down.)
+            echo ">>>> spawnloop (repeated spawn) test client"
+            gcc -O0 -g -o /opt/prte/prte/bin/spawnloop \
+                /prrte-src/contrib/dockerswarm/spawnloop.c \
+                -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
+
             # dataserver: a bare PMIx client for the publish/lookup service
             # in src/runtime/data_server.  The store is a single array on
             # the HNP and every client reaches it through its own daemon, so

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -4446,6 +4446,127 @@ test_connect() {
     cleanup_swarm
 }
 
+
+SL=/opt/prte/prte/bin/spawnloop
+
+test_spawn_repeat() {
+    local out n a b iters nsps uniq phost aranks held cnr
+
+    iters=40
+
+    banner "spawn: many spawns in a row, from a process off the master node"
+    # Every other spawn case here spawns once.  What only exists BETWEEN
+    # spawns is the requesting daemon's request table: each spawn takes a
+    # slot in prte_pmix_server_globals.local_reqs, the index is stamped on
+    # the job as PRTE_JOB_ROOM_NUM and shipped to the master so the answer
+    # can be matched back, slots are recycled by pmix_pointer_array_add as
+    # requests retire, and the index is never cleared from the job.  A stale
+    # room number therefore does not fail -- it completes whatever spawn now
+    # holds that slot.
+    #
+    # None of it runs on one node: prte_plm_base_spawn_response takes a
+    # local shortcut when the requestor is on the master's own node, so the
+    # room number never crosses the wire.  Hence --host node3:1 below, and
+    # hence the assertion that the parent really did land off node1: if it
+    # did not, everything after it passes vacuously.
+    cleanup_swarm
+    if ! RUN "test -x $SL"; then
+        skp "spawnloop client not installed -- re-run ./build.sh"
+        return
+    fi
+    if ! prted_dvm_start 'node1:4,node2:4,node3:4,node4:4'; then
+        bad "could not start a DVM for the repeated-spawn tests"
+        cleanup_swarm
+        return
+    fi
+
+    out=$(PRUN "--host node3:1 -n 1 $SL --iters $iters --kids 2" 2>&1)
+
+    phost=$(echo "$out" | awk '$1=="SPWN" && $2=="PARENT" {print $5}' | head -1)
+    if [ -n "$phost" ] && [ "$phost" != "node1" ]; then
+        ok "the spawning process ran on $phost, so its spawns are relayed to the master"
+    else
+        skp "parent landed on '$phost' -- the relayed-response path is not being tested"
+    fi
+
+    n=$(echo "$out" | grep -c '^SPWN ITER .* OK ')
+    if [ "$n" = "$iters" ]; then
+        ok "$iters consecutive spawns all completed"
+    else
+        bad "only $n of $iters spawns completed: $(echo "$out" | grep -E '^SPWN (FAIL|ITER)' | tail -3 | tr '\n' ' ')"
+    fi
+
+    echo "$out" | grep -q "^SPWN DONE $iters\$" \
+        && ok "...and the spawning process ran to the end" \
+        || bad "the spawning process did not finish: $(echo "$out" | grep '^SPWN' | tail -3 | tr '\n' ' ')"
+
+    # A repeated child namespace would mean two spawns were answered with the
+    # same job -- the shape a recycled room number produces.
+    nsps=$(echo "$out" | awk '$1=="SPWN" && $2=="ITER" && $4=="OK" {print $5}')
+    n=$(echo "$nsps" | grep -c .)
+    uniq=$(echo "$nsps" | sort -u | grep -c .)
+    if [ "$n" = "$uniq" ]; then
+        ok "...and every spawn was answered with a distinct namespace ($uniq)"
+    else
+        bad "$n spawns produced only $uniq distinct namespaces -- an answer went to the wrong request"
+    fi
+
+    echo "$out" | grep -q '^SPWN FAIL' \
+        && bad "spawnloop reported: $(echo "$out" | grep '^SPWN FAIL' | head -2 | tr '\n' ' ')" \
+        || ok "...with no failed spawn, connect or disconnect along the way"
+
+    banner "spawn: a node rank is not reissued while its holder is still running"
+    # A node rank names a proc among everything alive on its node, across
+    # every job there -- that is the whole difference between it and
+    # local_rank, which is numbered within one job.  It used to be read off
+    # node->num_procs, which is a population count and goes back DOWN when
+    # any job's procs leave, so a job mapped after an earlier job ended was
+    # handed the ranks a third, still-running job was using.
+    #
+    # Three jobs, and the OVERLAP is the whole case: A and B have to be
+    # alive together, so that when A leaves it is A's ranks that come free
+    # while B still holds the ones after them.  Run A to completion before
+    # starting B and the counter is back at zero either way -- the case
+    # passes against the defect it was written for.
+    RUN 'rm -f /tmp/spawn-hold-a.out /tmp/spawn-hold-b.out' >/dev/null 2>&1
+    PRUN_BG /tmp/spawn-hold-a.out "--host node2:6 -n 2 $SL --hold 12"
+    sleep 5
+    PRUN_BG /tmp/spawn-hold-b.out "--host node2:6 -n 2 $SL --hold 40"
+    sleep 6
+    aranks=$(RUN 'cat /tmp/spawn-hold-a.out' 2>/dev/null | \
+             awk '$1=="SPWN" && $2=="HOLD" {print $8}' | sort -n | tr '\n' ' ')
+    held=$(RUN 'cat /tmp/spawn-hold-b.out' 2>/dev/null | \
+           awk '$1=="SPWN" && $2=="HOLD" {print $8}' | sort -n | tr '\n' ' ')
+    if [ -z "$aranks" ] || [ -z "$held" ]; then
+        skp "node ranks not reported (first='$aranks' second='$held') -- cannot check for reissue"
+    else
+        ok "two overlapping jobs on node2 took node ranks $aranks and $held"
+        # let the first job leave, then map a third into the gap it left
+        sleep 8
+        cnr=$(PRUN "--host node2:6 -n 2 $SL --hold 1" 2>&1 | \
+              awk '$1=="SPWN" && $2=="HOLD" {print $8}' | sort -n | tr '\n' ' ')
+        if [ -z "$cnr" ]; then
+            skp "third job reported no node ranks -- cannot check for reissue"
+        else
+            n=0
+            for a in $cnr; do
+                for b in $held; do
+                    [ "$a" = "$b" ] && n=$((n + 1))
+                done
+            done
+            if [ "$n" = 0 ]; then
+                ok "...and a job mapped after the first left got $cnr, held by nobody"
+            else
+                bad "a job mapped after the first left got $cnr -- $n of those are still held by live procs ($held)"
+            fi
+        fi
+    fi
+    RUN 'rm -f /tmp/spawn-hold-a.out /tmp/spawn-hold-b.out' >/dev/null 2>&1
+
+    RUN 'timeout -k 5 30 pterm' >/dev/null 2>&1
+    cleanup_swarm
+}
+
 GC=/opt/prte/prte/bin/groupcon
 GINV=/opt/prte/prte/bin/groupinv
 FENCER=/opt/prte/prte/bin/fencer
@@ -8968,6 +9089,8 @@ gcc -o /root/staged_marker /root/staged_marker.c' >/dev/null 2>&1
     test_grpcomm
 
     test_connect
+
+    test_spawn_repeat
 
     test_pmix_cycling
 

--- a/contrib/dockerswarm/spawnloop.c
+++ b/contrib/dockerswarm/spawnloop.c
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * spawnloop -- call PMIx_Spawn many times from one long-lived process, from a
+ * node that is NOT the DVM master.
+ *
+ * Every other spawn client here spawns once.  One spawn cannot reach the
+ * state that only exists between spawns, and there is a good deal of it:
+ *
+ *   - The requesting daemon tracks each spawn in a slot of
+ *     prte_pmix_server_globals.local_reqs (the "room number"), writes that
+ *     index onto the job as PRTE_JOB_ROOM_NUM, and ships it to the master so
+ *     the answer can be matched back.  Slots are recycled by
+ *     pmix_pointer_array_add as requests retire, and the room number is never
+ *     cleared from the job - so a second, later use of a job's stored room
+ *     number does not fail, it completes whatever spawn now holds that slot.
+ *     There IS a second user: prted_comm.c answers again out of
+ *     DVM_CLEANUP_JOB_CMD when the job ends.  It is guarded, and the guard is
+ *     a flag on the daemon's own copy of the job; repetition is what makes a
+ *     window in that guard show up as a wrong or missing completion.
+ *
+ *   - The response only travels by RML - and the room number only means
+ *     anything on a remote daemon - when the requesting process is NOT on the
+ *     master's node.  On one node prte_plm_base_spawn_response takes the
+ *     local shortcut and none of the above is exercised, which is why this
+ *     client belongs in this harness rather than in a unit test.
+ *
+ * The child is this same binary run with --child: it finds its parent through
+ * PMIX_PARENT_ID, connects, and disconnects, so each iteration also builds and
+ * dissolves a connected assemblage - the shape MPI_Comm_spawn and
+ * MPI_Comm_disconnect produce, and the thing mpi4py's spawn tests do over and
+ * over.
+ *
+ *   spawnloop [--iters N] [--kids N] [--child] [--hold S]
+ *
+ * --hold turns it into a placeholder instead: report where the runtime put
+ * this proc, stay alive S seconds, leave.  That is what makes the OTHER
+ * cross-job property checkable - a node rank names a proc among everything
+ * alive on its node, across every job there, so it takes three overlapping
+ * jobs to show whether the runtime is handing out duplicates.
+ *
+ * Output lines, all prefixed SPWN so the harness can grep:
+ *
+ *   SPWN PARENT <rank> HOST <hostname> NODERANK <nr>
+ *   SPWN CHILD <nspace> <rank> HOST <hostname> NODERANK <nr>
+ *   SPWN ITER <i> OK <child nspace> <seconds>
+ *   SPWN FAIL <what> <iter> <status string>
+ *   SPWN DONE <iterations completed>
+ *
+ * A hang is a failure too, and the harness times the whole run out; the
+ * per-iteration line is what tells you which iteration it hung on.
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <pmix.h>
+
+static pmix_proc_t myproc;
+
+/* Where am I, and what node rank did the runtime give me?  Printed rather
+ * than checked: two live procs sharing a node rank is a real defect, but it
+ * is the harness that can compare across jobs, not a proc inside one. */
+static void whereami(const char *role, const char *nspace)
+{
+    pmix_value_t *val = NULL;
+    char host[256];
+    unsigned nr = 0;
+
+    if (0 > gethostname(host, sizeof(host))) {
+        snprintf(host, sizeof(host), "?");
+    }
+    host[sizeof(host) - 1] = '\0';
+    if (PMIX_SUCCESS == PMIx_Get(&myproc, PMIX_NODE_RANK, NULL, 0, &val) &&
+        NULL != val) {
+        nr = (unsigned) val->data.uint16;
+        PMIX_VALUE_RELEASE(val);
+    }
+    if (NULL == nspace) {
+        printf("SPWN %s %u HOST %s NODERANK %u\n", role, myproc.rank, host, nr);
+    } else {
+        printf("SPWN %s %s %u HOST %s NODERANK %u\n", role, nspace, myproc.rank,
+               host, nr);
+    }
+    fflush(stdout);
+}
+
+/* The child half: attach to the parent named by PMIX_PARENT_ID, then leave
+ * cleanly.  A child that cannot find its parent is a failure of the spawn,
+ * not of the child - PMIX_PARENT_ID is what the runtime publishes to say who
+ * asked for this job. */
+static int be_child(void)
+{
+    pmix_proc_t parent, procs[2];
+    pmix_value_t *val = NULL;
+    pmix_status_t rc;
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        printf("SPWN FAIL child-init 0 %s\n", PMIx_Error_string(rc));
+        fflush(stdout);
+        return 1;
+    }
+    whereami("CHILD", myproc.nspace);
+
+    PMIX_PROC_LOAD(&parent, myproc.nspace, myproc.rank);
+    rc = PMIx_Get(&parent, PMIX_PARENT_ID, NULL, 0, &val);
+    if (PMIX_SUCCESS != rc || NULL == val) {
+        printf("SPWN FAIL child-parentid 0 %s\n", PMIx_Error_string(rc));
+        fflush(stdout);
+        return 2;
+    }
+    memcpy(&parent, val->data.proc, sizeof(pmix_proc_t));
+    PMIX_VALUE_RELEASE(val);
+
+    PMIX_PROC_LOAD(&procs[0], parent.nspace, PMIX_RANK_WILDCARD);
+    PMIX_PROC_LOAD(&procs[1], myproc.nspace, PMIX_RANK_WILDCARD);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Connect(procs, 2, NULL, 0))) {
+        printf("SPWN FAIL child-connect 0 %s\n", PMIx_Error_string(rc));
+        fflush(stdout);
+        return 3;
+    }
+    if (PMIX_SUCCESS != (rc = PMIx_Disconnect(procs, 2, NULL, 0))) {
+        printf("SPWN FAIL child-disconnect 0 %s\n", PMIx_Error_string(rc));
+        fflush(stdout);
+        return 4;
+    }
+    PMIx_Finalize(NULL, 0);
+    return 0;
+}
+
+int main(int argc, char **argv)
+{
+    pmix_proc_t procs[2];
+    pmix_app_t *app;
+    pmix_status_t rc;
+    char nsp2[PMIX_MAX_NSLEN + 1];
+    char self[4096];
+    ssize_t len;
+    int iters = 25, kids = 2, hold = 0, i, n;
+    struct timespec t0, t1;
+
+    for (n = 1; n < argc; n++) {
+        if (0 == strcmp(argv[n], "--child")) {
+            return be_child();
+        } else if (0 == strcmp(argv[n], "--iters") && n + 1 < argc) {
+            iters = atoi(argv[++n]);
+        } else if (0 == strcmp(argv[n], "--kids") && n + 1 < argc) {
+            kids = atoi(argv[++n]);
+        } else if (0 == strcmp(argv[n], "--hold") && n + 1 < argc) {
+            hold = atoi(argv[++n]);
+        } else {
+            fprintf(stderr, "usage: %s [--iters N] [--kids N] [--child] [--hold S]\n",
+                    argv[0]);
+            return 1;
+        }
+    }
+
+    if (0 < hold) {
+        if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+            printf("SPWN FAIL hold-init 0 %s\n", PMIx_Error_string(rc));
+            fflush(stdout);
+            return 1;
+        }
+        whereami("HOLD", myproc.nspace);
+        sleep((unsigned) hold);
+        PMIx_Finalize(NULL, 0);
+        return 0;
+    }
+
+    /* The child is this same binary, and the spawn names it by absolute path
+     * because /tmp and the cwd are per-container while the install volume is
+     * shared - so the path has to be one that resolves on whatever node the
+     * child is mapped onto. */
+    len = readlink("/proc/self/exe", self, sizeof(self) - 1);
+    if (0 >= len) {
+        printf("SPWN FAIL self-path 0 cannot read /proc/self/exe\n");
+        fflush(stdout);
+        return 1;
+    }
+    self[len] = '\0';
+
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        printf("SPWN FAIL parent-init 0 %s\n", PMIx_Error_string(rc));
+        fflush(stdout);
+        return 1;
+    }
+    whereami("PARENT", NULL);
+
+    for (i = 0; i < iters; i++) {
+        clock_gettime(CLOCK_MONOTONIC, &t0);
+
+        PMIX_APP_CREATE(app, 1);
+        app->cmd = strdup(self);
+        app->maxprocs = kids;
+        PMIX_ARGV_APPEND(rc, app->argv, self);
+        PMIX_ARGV_APPEND(rc, app->argv, "--child");
+        rc = PMIx_Spawn(NULL, 0, app, 1, nsp2);
+        PMIX_APP_FREE(app, 1);
+        if (PMIX_SUCCESS != rc) {
+            printf("SPWN FAIL spawn %d %s\n", i, PMIx_Error_string(rc));
+            fflush(stdout);
+            return 10;
+        }
+
+        PMIX_PROC_LOAD(&procs[0], myproc.nspace, PMIX_RANK_WILDCARD);
+        PMIX_PROC_LOAD(&procs[1], nsp2, PMIX_RANK_WILDCARD);
+        if (PMIX_SUCCESS != (rc = PMIx_Connect(procs, 2, NULL, 0))) {
+            printf("SPWN FAIL connect %d %s\n", i, PMIx_Error_string(rc));
+            fflush(stdout);
+            return 11;
+        }
+        if (PMIX_SUCCESS != (rc = PMIx_Disconnect(procs, 2, NULL, 0))) {
+            printf("SPWN FAIL disconnect %d %s\n", i, PMIx_Error_string(rc));
+            fflush(stdout);
+            return 12;
+        }
+
+        clock_gettime(CLOCK_MONOTONIC, &t1);
+        printf("SPWN ITER %d OK %s %.3f\n", i, nsp2,
+               (double) (t1.tv_sec - t0.tv_sec) + 1.0e-9 * (double) (t1.tv_nsec - t0.tv_nsec));
+        fflush(stdout);
+    }
+
+    printf("SPWN DONE %d\n", iters);
+    fflush(stdout);
+    PMIx_Finalize(NULL, 0);
+    return 0;
+}

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -633,14 +633,36 @@ prte_proc_t *prte_rmaps_base_setup_proc(prte_job_t *jdata,
         PMIX_RELEASE(proc); // releases node to maintain accounting
         return NULL;
     }
+    /* A node rank has to be unique among the procs alive on this node at any
+     * one time, across every job running there - that is the entire
+     * difference between it and local_rank, which is numbered within one job.
+     * The slot this proc just took in node->procs is exactly that property:
+     * pmix_pointer_array_add() hands back the lowest index no live proc
+     * holds, and a job's completion NULLs the slot as it releases the proc.
+     *
+     * node->num_procs cannot supply it, which is what this used to read.  It
+     * is a population count, and it goes back *down* when any job's procs
+     * leave, so a job mapped after an earlier job ended was handed the node
+     * ranks a third, still-running job was already using.  Two live procs on
+     * one node then answered PMIX_NODE_RANK with the same number.  On a
+     * persistent DVM - and on anything doing repeated PMIx_Spawn - that is
+     * the common case, not a corner. */
+    if (PRTE_NODE_RANK_INVALID <= rc) {
+        /* more live procs on this node than a node rank can name.  Refuse
+         * rather than hand back a value that aliases the invalid marker */
+        PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+        pmix_pointer_array_set_item(node->procs, rc, NULL);
+        PMIX_RELEASE(proc); // releases node to maintain accounting
+        return NULL;
+    }
 
     /* if this is a tool app, then it doesn't count against
      * available slots - otherwise, it does */
     if (PRTE_FLAG_TEST(app, PRTE_APP_FLAG_TOOL)) {
         proc->local_rank = 0;
-        proc->node_rank = UINT16_MAX;
+        proc->node_rank = PRTE_NODE_RANK_INVALID;
     } else {
-        proc->node_rank = node->num_procs;
+        proc->node_rank = (prte_node_rank_t) rc;
         node->num_procs++;
         ++node->slots_inuse;
         /* slots_available is what this mapping operation may still take

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -1007,7 +1007,6 @@ void prte_state_base_recover_resources(prte_job_t *jdata, prte_proc_t *pptr)
     // recover node resources
     node->slots_inuse--;
     node->num_procs--;
-    node->next_node_rank--;
 
     // find the node in the map
     node_idx = INT_MAX;

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -992,7 +992,6 @@ release:
                     !PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_TOOL)) {
                     node->slots_inuse--;
                     node->num_procs--;
-                    node->next_node_rank--;
                 }
                 /* release the resources held by the proc - only the first
                  * cpu in the proc's cpuset was used to mark usage.  The

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -958,7 +958,6 @@ static void prte_node_construct(prte_node_t *node)
     node->procs = PMIX_NEW(pmix_pointer_array_t);
     pmix_pointer_array_init(node->procs, PRTE_GLOBAL_ARRAY_BLOCK_SIZE, PRTE_GLOBAL_ARRAY_MAX_SIZE,
                             PRTE_GLOBAL_ARRAY_BLOCK_SIZE);
-    node->next_node_rank = 0;
 
     node->state = PRTE_NODE_STATE_UNKNOWN;
     node->slots = 0;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -366,8 +366,6 @@ typedef struct {
     prte_node_rank_t num_procs;
     /* array of pointers to procs on this node */
     pmix_pointer_array_t *procs;
-    /* next node rank on this node */
-    prte_node_rank_t next_node_rank;
     /** State of this node */
     prte_node_state_t state;
     /** A "soft" limit on the number of slots available on the node.

--- a/test/unit/rmaps/Makefile.am
+++ b/test/unit/rmaps/Makefile.am
@@ -19,6 +19,7 @@ test_rmaps_SOURCES = \
     test_ranking.c         \
     test_binding.c         \
     test_check_avail.c     \
+    test_node_rank.c       \
     test_resize.c          \
     test_dispatch.c        \
     test_round_robin.c     \

--- a/test/unit/rmaps/test_node_rank.c
+++ b/test/unit/rmaps/test_node_rank.c
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * Tests the node rank prte_rmaps_base_setup_proc() hands each proc.
+ *
+ * A node rank names a process among everything alive on its node, across
+ * every job running there - that is the whole difference between it and
+ * local_rank, which is numbered within one job.  So the property under test
+ * is uniqueness across jobs, and the case that breaks it is the ordinary
+ * life of a persistent DVM: a job ends while another is still running, and
+ * a third is mapped into the space the first left behind.
+ *
+ * This used to be read off node->num_procs, a population count that goes
+ * back *down* when any job's procs leave, so the third job was handed the
+ * node ranks the second was still using and two live procs answered
+ * PMIX_NODE_RANK with the same number.  Repeated PMIx_Spawn makes that the
+ * common case rather than a corner.
+ *
+ * With bind-to-none there is no cpuset arithmetic, so setup_proc is
+ * reachable here without a topology.
+ */
+
+#include "prte_config.h"
+#include <stdio.h>
+#include <string.h>
+
+#include "constants.h"
+#include "src/runtime/prte_globals.h"
+#include "src/hwloc/hwloc-internal.h"
+#include "src/mca/rmaps/base/base.h"
+#include "src/mca/rmaps/base/rmaps_private.h"
+#include "src/mca/rmaps/rmaps_types.h"
+
+int test_node_rank(void);
+
+#define CHECK(label, cond)                                              \
+    do {                                                                \
+        if (!(cond)) {                                                  \
+            fprintf(stderr, "FAIL [%s]: %s\n", label, #cond);           \
+            failures++;                                                 \
+        }                                                               \
+    } while (0)
+
+static prte_job_t *mkjob(const char *nspace, bool tool)
+{
+    prte_job_t *jdata;
+    prte_app_context_t *app;
+
+    jdata = PMIX_NEW(prte_job_t);
+    PMIX_LOAD_NSPACE(jdata->nspace, nspace);
+    jdata->map = PMIX_NEW(prte_job_map_t);
+    app = PMIX_NEW(prte_app_context_t);
+    app->app = strdup("hostname");
+    if (tool) {
+        PRTE_FLAG_SET(app, PRTE_APP_FLAG_TOOL);
+    }
+    app->idx = pmix_pointer_array_add(jdata->apps, app);
+    jdata->num_apps++;
+    return jdata;
+}
+
+static void opts_init(prte_rmaps_options_t *opts)
+{
+    memset(opts, 0, sizeof(*opts));
+    opts->app_idx = -1;
+    opts->bind = PRTE_BIND_TO_NONE;
+    opts->cpus_per_rank = 1;
+    opts->nprocs = 1;
+}
+
+/* Retire a job's procs from the node exactly as check_complete() does when
+ * the job terminates: clear the node's slot, drop the counts, and give up
+ * the map's reference. */
+static void retire(prte_node_t *node, prte_job_t *jdata)
+{
+    prte_proc_t *proc;
+    int i;
+
+    for (i = 0; i < node->procs->size; i++) {
+        proc = (prte_proc_t *) pmix_pointer_array_get_item(node->procs, i);
+        if (NULL == proc) {
+            continue;
+        }
+        if (!PMIX_CHECK_NSPACE(proc->name.nspace, jdata->nspace)) {
+            continue;
+        }
+        node->slots_inuse--;
+        node->num_procs--;
+        pmix_pointer_array_set_item(node->procs, i, NULL);
+        PMIX_RELEASE(proc);
+    }
+}
+
+int test_node_rank(void)
+{
+    int failures = 0;
+    prte_job_t *jobA, *jobB, *jobC, *jtool;
+    prte_node_t *node;
+    prte_proc_t *a[2], *b[2], *c[2], *t;
+    prte_rmaps_options_t opts;
+    int i, j;
+
+    node = PMIX_NEW(prte_node_t);
+    node->name = strdup("node0");
+    node->slots = 16;
+    node->slots_available = 16;
+
+    jobA = mkjob("nrtestA", false);
+    jobB = mkjob("nrtestB", false);
+    jobC = mkjob("nrtestC", false);
+    jtool = mkjob("nrtestT", true);
+
+    /* === job A takes the first two ranks on an empty node === */
+    opts_init(&opts);
+    for (i = 0; i < 2; i++) {
+        a[i] = prte_rmaps_base_setup_proc(jobA, 0, node, NULL, &opts);
+    }
+    CHECK("A: both procs placed", NULL != a[0] && NULL != a[1]);
+    CHECK("A: rank 0", 0 == a[0]->node_rank);
+    CHECK("A: rank 1", 1 == a[1]->node_rank);
+
+    /* === job B, mapped while A is still running, gets its own === */
+    for (i = 0; i < 2; i++) {
+        b[i] = prte_rmaps_base_setup_proc(jobB, 0, node, NULL, &opts);
+    }
+    CHECK("B: both procs placed", NULL != b[0] && NULL != b[1]);
+    CHECK("B: distinct from A[0]",
+          b[0]->node_rank != a[0]->node_rank && b[1]->node_rank != a[0]->node_rank);
+    CHECK("B: distinct from A[1]",
+          b[0]->node_rank != a[1]->node_rank && b[1]->node_rank != a[1]->node_rank);
+    CHECK("B: distinct from each other", b[0]->node_rank != b[1]->node_rank);
+
+    /* === A terminates; B is still running === */
+    retire(node, jobA);
+
+    /* === job C is mapped into the space A left.  It may reuse A's ranks -
+     * nothing holds them now - but it must not collide with B, which is
+     * still on the node.  This is the regression: read off num_procs, C
+     * came back with B's ranks. === */
+    for (i = 0; i < 2; i++) {
+        c[i] = prte_rmaps_base_setup_proc(jobC, 0, node, NULL, &opts);
+    }
+    CHECK("C: both procs placed", NULL != c[0] && NULL != c[1]);
+    CHECK("C: distinct from each other", c[0]->node_rank != c[1]->node_rank);
+    for (i = 0; i < 2; i++) {
+        for (j = 0; j < 2; j++) {
+            CHECK("C: no collision with the live job",
+                  c[i]->node_rank != b[j]->node_rank);
+        }
+    }
+
+    /* === a tool proc occupies no rank at all, and does not disturb the
+     * ranks of the procs mapped after it === */
+    t = prte_rmaps_base_setup_proc(jtool, 0, node, NULL, &opts);
+    CHECK("tool: placed", NULL != t);
+    CHECK("tool: no node rank", PRTE_NODE_RANK_INVALID == t->node_rank);
+    if (NULL != t) {
+        prte_proc_t *after = prte_rmaps_base_setup_proc(jobC, 0, node, NULL, &opts);
+        CHECK("after tool: placed", NULL != after);
+        if (NULL != after) {
+            CHECK("after tool: not the tool's slot value",
+                  PRTE_NODE_RANK_INVALID != after->node_rank);
+            for (j = 0; j < 2; j++) {
+                CHECK("after tool: no collision with the live job",
+                      after->node_rank != b[j]->node_rank);
+                CHECK("after tool: no collision with its own job",
+                      after->node_rank != c[j]->node_rank);
+            }
+            PMIX_RELEASE(after);
+        }
+        PMIX_RELEASE(t);
+    }
+
+    /* setup_proc retains each proc for the caller on top of the node's own
+     * reference - drop ours, then let the node's teardown do the rest */
+    for (i = 0; i < 2; i++) {
+        PMIX_RELEASE(b[i]);
+        PMIX_RELEASE(c[i]);
+    }
+    retire(node, jobB);
+    retire(node, jobC);
+
+    PMIX_RELEASE(jobA);
+    PMIX_RELEASE(jobB);
+    PMIX_RELEASE(jobC);
+    PMIX_RELEASE(jtool);
+    PMIX_RELEASE(node);
+
+    if (0 == failures) {
+        fprintf(stderr, "test_node_rank: PASS\n");
+    }
+    return failures;
+}

--- a/test/unit/rmaps/test_rmaps_main.c
+++ b/test/unit/rmaps/test_rmaps_main.c
@@ -26,6 +26,7 @@ extern int test_resolve_options(void);
 extern int test_ranking(void);
 extern int test_binding(void);
 extern int test_check_avail(void);
+extern int test_node_rank(void);
 extern int test_resize(void);
 extern int test_hostfile_cap(void);
 extern int test_dispatch(void);
@@ -106,6 +107,7 @@ int main(void)
     failures += test_ranking();
     failures += test_binding();
     failures += test_check_avail();
+    failures += test_node_rank();
     failures += test_resize();
     failures += test_hostfile_cap();
     failures += test_dispatch();


### PR DESCRIPTION
### The problem

A node rank names a process among everything alive on its node, across every job running there. That is the entire difference between it and `local_rank`, which is numbered within one job, and it is the only reason the key spans jobs at all.

The mapper did not allocate it. `prte_rmaps_base_setup_proc()` read it off `node->num_procs` and then incremented that — but `num_procs` is a *population count*: it goes back down when any job's procs leave. So a job mapped after an earlier job ended was handed the very numbers a third, still-running job was using, and two live processes on one node answered `PMIX_NODE_RANK` with the same value.

Reproduced deterministically on a persistent DVM, and again across daemons in the container harness:

```
job A (2 procs), then exits      node ranks 0, 1
job B (2 procs), still running   node ranks 2, 3
job C, mapped after A left       node ranks 2, 3   <- collides with live B
```

On a persistent DVM — and on anything doing repeated `PMIx_Spawn` — that is the common case rather than a corner, since every spawn/terminate cycle churns the count.

Note this is *not* forbidden reuse. What the definition rules out is renumbering a process after the fact, and nothing here does that: B keeps 2 and 3 for its whole life whether or not A is still there. Handing C the numbers B is still using is the defect.

### The fix

Take the identity from the slot the proc just claimed in `node->procs`. `pmix_pointer_array_add()` returns the lowest index no live proc holds, and job completion already NULLs the slot as it releases the proc, so the value is unique among the procs actually on the node. It is assigned once at mapping time and never touched again.

`node->next_node_rank` was evidently meant to be this allocator and never became one: nothing in the tree ever incremented it, while two paths decremented it on proc termination, so from its initial 0 it underflowed its `uint16` the first time any process exited. It is neither packed nor copied and has no readers, so it goes.

### Tests

`test/unit/rmaps/test_node_rank.c` builds the three-job overlap directly against `prte_rmaps_base_setup_proc()` and also checks that a tool proc consumes no rank. Verified to **fail** against the old line (`C: no collision with the live job`, twice) and pass with the fix.

The second commit adds multi-node coverage the harness did not have. Every spawn client in `contrib/dockerswarm` spawned exactly once, so nothing exercised the state that only exists *between* spawns — the requesting daemon's recycled `local_reqs` slot, the `PRTE_JOB_ROOM_NUM` stamped on the job and never cleared, and the RML path that carries it, none of which runs when the requestor is on the master's own node. `spawnloop` calls `PMIx_Spawn` in a loop from a process deliberately placed off node1, each child finding its parent through `PMIX_PARENT_ID` and connecting and disconnecting. Its `--hold` mode drives the node-rank case in the same phase; the overlap of the first two jobs is what gives that case teeth, and it too was A/B'd against a swarm rebuilt with the old line.

### Verification

- `make check` — green
- `make -C test/offline check-offline` — 2449 pass, 0 fail
- `contrib/dockerswarm` full suite — **802 passed, 0 failed, 3 skipped**, built against openpmix `master`