### PR TITLE
Stop a job being freed while its session still lists it

### DIFF
--- a/contrib/dockerswarm/Dockerfile
+++ b/contrib/dockerswarm/Dockerfile
@@ -21,7 +21,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential gcc g++ make \
         autoconf automake libtool m4 flex \
-        perl python3 git \
+        perl python3 python3-dev python3-pip python3-venv git \
         libevent-dev libhwloc-dev zlib1g-dev libzstd-dev \
         libjansson-dev \
         openssh-server openssh-client \

--- a/contrib/dockerswarm/build.sh
+++ b/contrib/dockerswarm/build.sh
@@ -122,6 +122,7 @@ PMIX_HOME="${PMIX_HOME:-}"              # optional installed PMIx prefix (macOS)
 OMPI_SRC="${OMPI_SRC:-}"
 # Build every component as a run-time loadable DSO rather than into libprrte.
 MCA_DSO="${PRTE_SWARM_MCA_DSO:-0}"
+SWARM_ASAN="${PRTE_SWARM_ASAN:-0}"
 
 mode=linux
 distclean=auto                          # auto | always | never
@@ -324,6 +325,7 @@ build_linux() {
         -v "$root":/prrte-src:ro \
         -v "$VOLUME":/opt/prte \
         -e PRTE_SWARM_MCA_DSO="$MCA_DSO" \
+        -e PRTE_SWARM_ASAN="$SWARM_ASAN" \
         ${pmix_mount[@]+"${pmix_mount[@]}"} \
         ${ompi_mount[@]+"${ompi_mount[@]}"} \
         "$IMAGE" bash -euo pipefail -c '
@@ -391,16 +393,45 @@ build_linux() {
                 done < <(orphan_dirs "$1" "$2")
             }
 
+            # PRTE_SWARM_ASAN=1 builds BOTH code bases under AddressSanitizer.
+            # It has to be both: ASAN only checks an access made by code it
+            # instrumented, and several of the interesting reads are in PMIx
+            # inlines (PMIx_Check_nspace and friends) reached from PRRTE.
+            # Instrumenting only one side intercepts the malloc/free but never
+            # flags the read, which looks exactly like "no bug here".
+            #
+            # It goes into the configure ARGUMENT string on purpose, so
+            # reconfigure_needed sees the knob change and reconfigures -- the
+            # same mechanism that catches a changed --with-pmix.  Slow, so it
+            # is off by default; -O1 keeps frames readable in the report.
+            # Passed to configure through the ENVIRONMENT, not the argument
+            # string: the argument strings below are expanded unquoted, so a
+            # CFLAGS carrying spaces is word-split into options configure then
+            # rejects.  configure inherits CFLAGS/LDFLAGS.
+            #
+            # asan_tag exists only so the recorded .configure-args differs and
+            # reconfigure_needed fires when the knob is turned on or off; the
+            # flags themselves never appear in that string.
+            asan_tag=""
+            asan_cflags=""
+            if [ "${PRTE_SWARM_ASAN:-0}" != 0 ]; then
+                asan_cflags="-fsanitize=address -fno-omit-frame-pointer"
+                export CFLAGS="-fsanitize=address -fno-omit-frame-pointer -g -O1"
+                export LDFLAGS="-fsanitize=address"
+                asan_tag=" [asan]"
+                echo ">>>> AddressSanitizer build (PRTE_SWARM_ASAN=1)"
+            fi
+
             if [ -d /pmix-src ]; then
                 PMIX_PREFIX=/opt/prte/pmix
                 echo ">>>> PMIx from bind-mounted /pmix-src -> $PMIX_PREFIX"
                 mkdir -p /opt/prte/vpath-linux-pmix && cd /opt/prte/vpath-linux-pmix
                 pmix_args="--prefix=$PMIX_PREFIX"
-                if reconfigure_needed . "$pmix_args" /pmix-src; then
+                if reconfigure_needed . "$pmix_args$asan_tag" /pmix-src; then
                     echo ">>>> (re)configuring PMIx: $pmix_args"
                     drop_orphans . /pmix-src
                     /pmix-src/configure $pmix_args
-                    echo "$pmix_args" > .configure-args
+                    echo "$pmix_args$asan_tag" > .configure-args
                 fi
                 make -j"$jobs"
                 make install
@@ -432,7 +463,7 @@ build_linux() {
                 prte_args="$prte_args --enable-mca-dso"
                 echo ">>>> components as DSOs (--enable-mca-dso)"
             fi
-            if reconfigure_needed . "$prte_args" /prrte-src; then
+            if reconfigure_needed . "$prte_args$asan_tag" /prrte-src; then
                 echo ">>>> (re)configuring PRRTE: $prte_args"
                 drop_orphans . /prrte-src
                 # The install outlives the build dir, and lib/prte holds the
@@ -443,7 +474,7 @@ build_linux() {
                 # adds.
                 rm -rf /opt/prte/prte/lib/prte
                 /prrte-src/configure $prte_args
-                echo "$prte_args" > .configure-args
+                echo "$prte_args$asan_tag" > .configure-args
             fi
             # show_help GOLDEN RULE: prte_show_help_content.c embeds every
             # help-*.txt in the tree, but its make rule depends only on the
@@ -474,7 +505,7 @@ build_linux() {
             # pass on node1 and quietly test the wrong library everywhere
             # else.
             echo ">>>> elastic test client"
-            gcc -O0 -g -o /opt/prte/prte/bin/elastic \
+            gcc ${asan_cflags:-} -O0 -g -o /opt/prte/prte/bin/elastic \
                 /prrte-src/contrib/dockerswarm/elastic.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
@@ -485,7 +516,7 @@ build_linux() {
             # hosts none of the procs of the target job -- i.e. never on one
             # node.  (No apostrophes here: see the note further down.)
             echo ">>>> jobinfo (direct-modex) test client"
-            gcc -O0 -g -o /opt/prte/prte/bin/jobinfo \
+            gcc ${asan_cflags:-} -O0 -g -o /opt/prte/prte/bin/jobinfo \
                 /prrte-src/contrib/dockerswarm/jobinfo.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
@@ -497,7 +528,7 @@ build_linux() {
             # "--display map" shows only the first of those steps.
             # (No apostrophes here: see the note further down.)
             echo ">>>> devinfo (device assignment) test client"
-            gcc -O0 -g -o /opt/prte/prte/bin/devinfo \
+            gcc ${asan_cflags:-} -O0 -g -o /opt/prte/prte/bin/devinfo \
                 /prrte-src/contrib/dockerswarm/devinfo.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
@@ -511,7 +542,7 @@ build_linux() {
             # node running the DVM master.  Neither is reachable on one host.
             # (No apostrophes here: see the note further down.)
             echo ">>>> spawnloop (repeated spawn) test client"
-            gcc -O0 -g -o /opt/prte/prte/bin/spawnloop \
+            gcc ${asan_cflags:-} -O0 -g -o /opt/prte/prte/bin/spawnloop \
                 /prrte-src/contrib/dockerswarm/spawnloop.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
@@ -522,7 +553,7 @@ build_linux() {
             # PMIX_RANGE_LOCAL turns on only exists across nodes.
             # (No apostrophes here: see the note further down.)
             echo ">>>> dataserver (publish/lookup) test client"
-            gcc -O0 -g -o /opt/prte/prte/bin/dataserver \
+            gcc ${asan_cflags:-} -O0 -g -o /opt/prte/prte/bin/dataserver \
                 /prrte-src/contrib/dockerswarm/dataserver.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
@@ -533,7 +564,7 @@ build_linux() {
             # all on a single host.
             # (No apostrophes here: see the note further down.)
             echo ">>>> proctable (query/state translation) test client"
-            gcc -O0 -g -o /opt/prte/prte/bin/proctable \
+            gcc ${asan_cflags:-} -O0 -g -o /opt/prte/prte/bin/proctable \
                 /prrte-src/contrib/dockerswarm/proctable.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
@@ -546,7 +577,7 @@ build_linux() {
             # exercised against a daemon that merely received the broadcast.
             # (No apostrophes here: see the note further down.)
             echo ">>>> groupcon (group construct/destruct) test client"
-            gcc -O0 -g -o /opt/prte/prte/bin/groupcon \
+            gcc ${asan_cflags:-} -O0 -g -o /opt/prte/prte/bin/groupcon \
                 /prrte-src/contrib/dockerswarm/groupcon.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
@@ -560,7 +591,7 @@ build_linux() {
             # one the runtime has to keep.
             # (No apostrophes here: see the note further down.)
             echo ">>>> connector (connect/disconnect assemblage) test client"
-            gcc -O0 -g -o /opt/prte/prte/bin/connector \
+            gcc ${asan_cflags:-} -O0 -g -o /opt/prte/prte/bin/connector \
                 /prrte-src/contrib/dockerswarm/connector.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
@@ -574,7 +605,7 @@ build_linux() {
             # skipped entirely and the test proves nothing.
             # (No apostrophes here: see the note further down.)
             echo ">>>> groupinv (group invite/join context id) test client"
-            gcc -O0 -g -o /opt/prte/prte/bin/groupinv \
+            gcc ${asan_cflags:-} -O0 -g -o /opt/prte/prte/bin/groupinv \
                 /prrte-src/contrib/dockerswarm/groupinv.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
@@ -600,7 +631,7 @@ build_linux() {
             # NOTE: this whole block is inside bash -c ..., so an apostrophe
             # anywhere in it (even in a comment) ends the script.
             echo ">>>> fencer (modex vs barrier) test client"
-            gcc -O0 -g -o /opt/prte/prte/bin/fencer \
+            gcc ${asan_cflags:-} -O0 -g -o /opt/prte/prte/bin/fencer \
                 /prrte-src/contrib/dockerswarm/fencer.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
@@ -614,7 +645,7 @@ build_linux() {
             # test.
             # (No apostrophes here: see the note further down.)
             echo ">>>> pmixloop (init/fence/finalize cycling) test client"
-            gcc -O0 -g -o /opt/prte/prte/bin/pmixloop \
+            gcc ${asan_cflags:-} -O0 -g -o /opt/prte/prte/bin/pmixloop \
                 /prrte-src/contrib/dockerswarm/pmixloop.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
@@ -627,7 +658,7 @@ build_linux() {
             # process playing both roles, so the report never crosses a wire.
             # (No apostrophes here: see the note further down.)
             echo ">>>> faulty (deliberate process failures) test client"
-            gcc -O0 -g -o /opt/prte/prte/bin/faulty \
+            gcc ${asan_cflags:-} -O0 -g -o /opt/prte/prte/bin/faulty \
                 /prrte-src/contrib/dockerswarm/faulty.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
@@ -640,7 +671,7 @@ build_linux() {
             # message needs the child on a node the parent is not on.
             # (No apostrophes here: see the note further down.)
             echo ">>>> envspawn (odls envar directives) test client"
-            gcc -O0 -g -o /opt/prte/prte/bin/envspawn \
+            gcc ${asan_cflags:-} -O0 -g -o /opt/prte/prte/bin/envspawn \
                 /prrte-src/contrib/dockerswarm/envspawn.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
@@ -651,7 +682,7 @@ build_linux() {
             # saturated so every write the daemon attempts is a partial one.
             # (No apostrophes here: see the note further down.)
             echo ">>>> slowcat (slow stdin reader) test client"
-            gcc -O0 -g -o /opt/prte/prte/bin/slowcat \
+            gcc ${asan_cflags:-} -O0 -g -o /opt/prte/prte/bin/slowcat \
                 /prrte-src/contrib/dockerswarm/slowcat.c
 
             # examples/dynamic.c is the PMIx_Spawn example shipped in this
@@ -663,7 +694,7 @@ build_linux() {
             # NOTE: this whole block is inside bash -c '...', so an
             # apostrophe anywhere in it (even in a comment) ends the script.
             echo ">>>> dynamic (PMIx_Spawn) test client"
-            gcc -O0 -g -o /opt/prte/prte/bin/dynamic \
+            gcc ${asan_cflags:-} -O0 -g -o /opt/prte/prte/bin/dynamic \
                 /prrte-src/examples/dynamic.c -I/prrte-src/examples \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
@@ -676,7 +707,7 @@ build_linux() {
             # NOTE: this whole block is inside bash -c ..., so an apostrophe
             # anywhere in it (even in a comment) ends the script.
             echo ">>>> sessionctrl (PMIx_Session_control) test client"
-            gcc -O0 -g -o /opt/prte/prte/bin/sessionctrl \
+            gcc ${asan_cflags:-} -O0 -g -o /opt/prte/prte/bin/sessionctrl \
                 /prrte-src/examples/sessionctrl.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
@@ -691,7 +722,7 @@ build_linux() {
             # other nodes to mean anything.
             # (No apostrophes here: see the note further down.)
             echo ">>>> peerinfo (peer reserved-key lookup) test client"
-            gcc -O0 -g -o /opt/prte/prte/bin/peerinfo \
+            gcc ${asan_cflags:-} -O0 -g -o /opt/prte/prte/bin/peerinfo \
                 /prrte-src/contrib/dockerswarm/peerinfo.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
@@ -703,7 +734,7 @@ build_linux() {
             # as success.  Needs ranks on daemons other than the master to
             # show up at all, which is why it lives here.
             echo ">>>> slotinfo (allocation query relay) test client"
-            gcc -O0 -g -o /opt/prte/prte/bin/slotinfo \
+            gcc ${asan_cflags:-} -O0 -g -o /opt/prte/prte/bin/slotinfo \
                 /prrte-src/contrib/dockerswarm/slotinfo.c \
                 -I"$PMIX_PREFIX/include" -L"$PMIX_PREFIX/lib" -Wl,-rpath,"$PMIX_PREFIX/lib" -lpmix
 
@@ -744,6 +775,21 @@ build_linux() {
                     /prrte-src/contrib/dockerswarm/mpinoop.c
                 /opt/prte/ompi/bin/mpicc -O0 -g -o /opt/prte/ompi/bin/ring_c \
                     /ompi-src/examples/ring_c.c
+
+                # spawnrepro: repeated MPI_Comm_spawn_multiple off COMM_SELF,
+                # a barrier on the intercommunicator, and a disconnect -- the
+                # mpi4py TestSpawnMultipleSelf sequence.  It has to be built
+                # with MPI rather than approximated against PMIx: the barrier
+                # is a collective over the parent proc AND the whole child
+                # job, and it is MPI_Comm_disconnect that dissolves that
+                # assemblage.  Those orderings against job termination are
+                # what is under test.  It spawns ITSELF, so it needs its own
+                # installed path compiled in.
+                echo ">>>> spawnrepro (mpi4py spawn sequence)"
+                /opt/prte/ompi/bin/mpicc ${asan_cflags:-} -O0 -g \
+                    -DSELF_PATH=\"/opt/prte/ompi/bin/spawnrepro\" \
+                    -o /opt/prte/ompi/bin/spawnrepro \
+                    /prrte-src/contrib/dockerswarm/spawnrepro.c
             fi
 
             # runtime env for login shells (node-entrypoint handles ld.so)

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -4496,7 +4496,8 @@ test_spawn_repeat() {
         bad "only $n of $iters spawns completed: $(echo "$out" | grep -E '^SPWN (FAIL|ITER)' | tail -3 | tr '\n' ' ')"
     fi
 
-    echo "$out" | grep -q "^SPWN DONE $iters\$" \
+    # matched as a prefix: the client appends a failed-spawn count
+    echo "$out" | grep -qE "^SPWN DONE $iters( |\$)" \
         && ok "...and the spawning process ran to the end" \
         || bad "the spawning process did not finish: $(echo "$out" | grep '^SPWN' | tail -3 | tr '\n' ' ')"
 

--- a/contrib/dockerswarm/spawnloop.c
+++ b/contrib/dockerswarm/spawnloop.c
@@ -159,7 +159,7 @@ int main(int argc, char **argv)
     ssize_t len;
     int iters = 25, kids = 2, hold = 0, napps = 1, nfailed = 0, i, n;
     size_t a;
-    bool self = false, orphan = false;
+    bool orphan = false;
     struct timespec t0, t1;
 
     for (n = 1; n < argc; n++) {
@@ -171,8 +171,6 @@ int main(int argc, char **argv)
             kids = atoi(argv[++n]);
         } else if (0 == strcmp(argv[n], "--apps") && n + 1 < argc) {
             napps = atoi(argv[++n]);
-        } else if (0 == strcmp(argv[n], "--self")) {
-            self = true;
         } else if (0 == strcmp(argv[n], "--orphan")) {
             /* spawn children that will connect back to us, and then leave
              * without ever joining that connect.  A collective cannot
@@ -183,7 +181,7 @@ int main(int argc, char **argv)
             hold = atoi(argv[++n]);
         } else {
             fprintf(stderr, "usage: %s [--iters N] [--kids N] [--apps N] "
-                            "[--self] [--child] [--hold S]\n", argv[0]);
+                            "[--child] [--hold S] [--orphan]\n", argv[0]);
             return 1;
         }
     }
@@ -244,16 +242,20 @@ int main(int argc, char **argv)
             continue;
         }
 
-        /* COMM_SELF spawn connects the ONE spawning rank to its children;
-         * a wildcard here would demand every rank of this job join, which
-         * they are not doing - each is off spawning children of its own. */
         if (orphan) {
             printf("SPWN ORPHANED %d %s\n", i, nsp2);
             fflush(stdout);
             continue;
         }
-        PMIX_PROC_LOAD(&procs[0], myproc.nspace,
-                       self ? myproc.rank : PMIX_RANK_WILDCARD);
+        /* Name THIS rank, never a wildcard.  It has to agree exactly with
+         * what the child asks for - the child connects to the proc named by
+         * PMIX_PARENT_ID - and PMIx compares participant lists literally, so
+         * "nspace/0" and "nspace/WILDCARD" are different sets.  A mismatch is
+         * not a slow connect; it matches nothing and blocks both halves
+         * forever.  A wildcard would also demand every rank of this job join
+         * a connect the others are not making, each being off spawning
+         * children of its own. */
+        PMIX_PROC_LOAD(&procs[0], myproc.nspace, myproc.rank);
         PMIX_PROC_LOAD(&procs[1], nsp2, PMIX_RANK_WILDCARD);
         if (PMIX_SUCCESS != (rc = PMIx_Connect(procs, 2, NULL, 0))) {
             printf("SPWN FAIL connect %d %s\n", i, PMIx_Error_string(rc));

--- a/contrib/dockerswarm/spawnloop.c
+++ b/contrib/dockerswarm/spawnloop.c
@@ -159,7 +159,7 @@ int main(int argc, char **argv)
     ssize_t len;
     int iters = 25, kids = 2, hold = 0, napps = 1, nfailed = 0, i, n;
     size_t a;
-    bool self = false;
+    bool self = false, orphan = false;
     struct timespec t0, t1;
 
     for (n = 1; n < argc; n++) {
@@ -173,6 +173,12 @@ int main(int argc, char **argv)
             napps = atoi(argv[++n]);
         } else if (0 == strcmp(argv[n], "--self")) {
             self = true;
+        } else if (0 == strcmp(argv[n], "--orphan")) {
+            /* spawn children that will connect back to us, and then leave
+             * without ever joining that connect.  A collective cannot
+             * complete without every participant, so the children are stuck
+             * unless the runtime ends the fence when we die. */
+            orphan = true;
         } else if (0 == strcmp(argv[n], "--hold") && n + 1 < argc) {
             hold = atoi(argv[++n]);
         } else {
@@ -241,6 +247,11 @@ int main(int argc, char **argv)
         /* COMM_SELF spawn connects the ONE spawning rank to its children;
          * a wildcard here would demand every rank of this job join, which
          * they are not doing - each is off spawning children of its own. */
+        if (orphan) {
+            printf("SPWN ORPHANED %d %s\n", i, nsp2);
+            fflush(stdout);
+            continue;
+        }
         PMIX_PROC_LOAD(&procs[0], myproc.nspace,
                        self ? myproc.rank : PMIX_RANK_WILDCARD);
         PMIX_PROC_LOAD(&procs[1], nsp2, PMIX_RANK_WILDCARD);

--- a/contrib/dockerswarm/spawnloop.c
+++ b/contrib/dockerswarm/spawnloop.c
@@ -38,7 +38,14 @@
  * MPI_Comm_disconnect produce, and the thing mpi4py's spawn tests do over and
  * over.
  *
- *   spawnloop [--iters N] [--kids N] [--child] [--hold S]
+ *   spawnloop [--iters N] [--kids N] [--apps N] [--self] [--child] [--hold S]
+ *
+ * --self makes EVERY rank spawn on its own, and connect only to the children
+ * it asked for - the shape MPI_Comm_spawn_multiple on COMM_SELF produces, and
+ * the one mpi4py's TestSpawnMultipleSelf drives.  It is the concurrent case:
+ * several spawn requests are in flight at the master at once, each of which
+ * joins its session before it is named, while earlier children are completing.
+ * --apps gives each spawn several app contexts, as spawn_multiple does.
  *
  * --hold turns it into a placeholder instead: report where the runtime put
  * this proc, stay alive S seconds, leave.  That is what makes the OTHER
@@ -123,7 +130,9 @@ static int be_child(void)
     memcpy(&parent, val->data.proc, sizeof(pmix_proc_t));
     PMIX_VALUE_RELEASE(val);
 
-    PMIX_PROC_LOAD(&procs[0], parent.nspace, PMIX_RANK_WILDCARD);
+    /* PMIX_PARENT_ID names a PROC.  Connect to exactly that proc, so a
+     * COMM_SELF-style spawn does not demand the spawner's whole job. */
+    PMIX_PROC_LOAD(&procs[0], parent.nspace, parent.rank);
     PMIX_PROC_LOAD(&procs[1], myproc.nspace, PMIX_RANK_WILDCARD);
 
     if (PMIX_SUCCESS != (rc = PMIx_Connect(procs, 2, NULL, 0))) {
@@ -146,9 +155,11 @@ int main(int argc, char **argv)
     pmix_app_t *app;
     pmix_status_t rc;
     char nsp2[PMIX_MAX_NSLEN + 1];
-    char self[4096];
+    char selfpath[4096];
     ssize_t len;
-    int iters = 25, kids = 2, hold = 0, i, n;
+    int iters = 25, kids = 2, hold = 0, napps = 1, nfailed = 0, i, n;
+    size_t a;
+    bool self = false;
     struct timespec t0, t1;
 
     for (n = 1; n < argc; n++) {
@@ -158,11 +169,15 @@ int main(int argc, char **argv)
             iters = atoi(argv[++n]);
         } else if (0 == strcmp(argv[n], "--kids") && n + 1 < argc) {
             kids = atoi(argv[++n]);
+        } else if (0 == strcmp(argv[n], "--apps") && n + 1 < argc) {
+            napps = atoi(argv[++n]);
+        } else if (0 == strcmp(argv[n], "--self")) {
+            self = true;
         } else if (0 == strcmp(argv[n], "--hold") && n + 1 < argc) {
             hold = atoi(argv[++n]);
         } else {
-            fprintf(stderr, "usage: %s [--iters N] [--kids N] [--child] [--hold S]\n",
-                    argv[0]);
+            fprintf(stderr, "usage: %s [--iters N] [--kids N] [--apps N] "
+                            "[--self] [--child] [--hold S]\n", argv[0]);
             return 1;
         }
     }
@@ -183,13 +198,13 @@ int main(int argc, char **argv)
      * because /tmp and the cwd are per-container while the install volume is
      * shared - so the path has to be one that resolves on whatever node the
      * child is mapped onto. */
-    len = readlink("/proc/self/exe", self, sizeof(self) - 1);
+    len = readlink("/proc/self/exe", selfpath, sizeof(selfpath) - 1);
     if (0 >= len) {
         printf("SPWN FAIL self-path 0 cannot read /proc/self/exe\n");
         fflush(stdout);
         return 1;
     }
-    self[len] = '\0';
+    selfpath[len] = '\0';
 
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
         printf("SPWN FAIL parent-init 0 %s\n", PMIx_Error_string(rc));
@@ -201,20 +216,33 @@ int main(int argc, char **argv)
     for (i = 0; i < iters; i++) {
         clock_gettime(CLOCK_MONOTONIC, &t0);
 
-        PMIX_APP_CREATE(app, 1);
-        app->cmd = strdup(self);
-        app->maxprocs = kids;
-        PMIX_ARGV_APPEND(rc, app->argv, self);
-        PMIX_ARGV_APPEND(rc, app->argv, "--child");
-        rc = PMIx_Spawn(NULL, 0, app, 1, nsp2);
-        PMIX_APP_FREE(app, 1);
+        PMIX_APP_CREATE(app, (size_t) napps);
+        for (a = 0; a < (size_t) napps; a++) {
+            app[a].cmd = strdup(selfpath);
+            app[a].maxprocs = kids;
+            PMIX_ARGV_APPEND(rc, app[a].argv, selfpath);
+            PMIX_ARGV_APPEND(rc, app[a].argv, "--child");
+        }
+        rc = PMIx_Spawn(NULL, 0, app, (size_t) napps, nsp2);
+        PMIX_APP_FREE(app, (size_t) napps);
         if (PMIX_SUCCESS != rc) {
+            /* Report and carry on, rather than leaving.  A caller that walks
+             * out on a failed spawn is not what an application does - mpi4py
+             * catches the error and runs the next test - and it changes what
+             * is under test: an earlier child of this rank may still be
+             * parked in PMIx_Connect waiting for us, and abandoning it turns
+             * every later measurement into a study of that. */
             printf("SPWN FAIL spawn %d %s\n", i, PMIx_Error_string(rc));
             fflush(stdout);
-            return 10;
+            ++nfailed;
+            continue;
         }
 
-        PMIX_PROC_LOAD(&procs[0], myproc.nspace, PMIX_RANK_WILDCARD);
+        /* COMM_SELF spawn connects the ONE spawning rank to its children;
+         * a wildcard here would demand every rank of this job join, which
+         * they are not doing - each is off spawning children of its own. */
+        PMIX_PROC_LOAD(&procs[0], myproc.nspace,
+                       self ? myproc.rank : PMIX_RANK_WILDCARD);
         PMIX_PROC_LOAD(&procs[1], nsp2, PMIX_RANK_WILDCARD);
         if (PMIX_SUCCESS != (rc = PMIx_Connect(procs, 2, NULL, 0))) {
             printf("SPWN FAIL connect %d %s\n", i, PMIx_Error_string(rc));
@@ -233,7 +261,7 @@ int main(int argc, char **argv)
         fflush(stdout);
     }
 
-    printf("SPWN DONE %d\n", iters);
+    printf("SPWN DONE %d (%d spawns failed)\n", iters, nfailed);
     fflush(stdout);
     PMIx_Finalize(NULL, 0);
     return 0;

--- a/contrib/dockerswarm/spawnrepro.c
+++ b/contrib/dockerswarm/spawnrepro.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026      Nanook Consulting  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * spawnrepro -- mimics mpi4py's TestSpawnMultipleSelf sequence: every rank
+ * repeatedly spawns a multi-app job off MPI_COMM_SELF, barriers on the
+ * resulting intercommunicator, and disconnects.  Acts as its own child.
+ *
+ * This is the MPI-level shape, and the level matters.  The equivalent written
+ * against PMIx directly (spawnloop --self) does not express two of the things
+ * this does: the barrier on the *intercommunicator*, which is a collective
+ * over the union of the parent proc and the whole child job, and
+ * MPI_Comm_disconnect, which is what actually dissolves that assemblage.
+ * Those are the operations whose ordering against job termination is under
+ * test, so a PMIx-level approximation of "spawn, connect, disconnect" can run
+ * clean while this does not.
+ *
+ * Every rank spawns off COMM_SELF, so N ranks means N independent spawn
+ * requests in flight at the DVM master at once, each of which joins its
+ * session before it has been named.  That concurrency is the point.
+ *
+ * Build:  mpicc -DSELF_PATH='"/abs/path/to/binary"' -o binary spawnrepro.c
+ * Run:    mpiexec -n 2 ./binary [iterations]
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <mpi.h>
+
+#if defined(__SANITIZE_ADDRESS__)
+/* Turn LeakSanitizer off from inside the program.
+ *
+ * The environment cannot do this job here.  ASAN_OPTIONS reaches the ranks
+ * mpiexec starts (with -x), but NOT the ones this program spawns: a spawned
+ * job's environment comes from the spawn request, not from its parent's
+ * shell.  So the children exit non-zero on LeakSanitizer's report, the
+ * runtime reads that as the child job failing, and the connected-assemblage
+ * rule then terminates the parent - which looks exactly like the runtime
+ * defect being hunted, and is not.  (The leaks are real, but they are in
+ * MPI_Init's own setup and are not what this test is about.)
+ *
+ * __asan_default_options is the documented hook for exactly this, and it is
+ * read before main, in every process running this binary. */
+const char *__asan_default_options(void);
+const char *__asan_default_options(void)
+{
+    return "detect_leaks=0";
+}
+#endif
+
+#ifndef SELF_PATH
+#    error "SELF_PATH must name this binary"
+#endif
+
+int main(int argc, char *argv[])
+{
+    MPI_Comm parent;
+    int rank, iters = 8;
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_get_parent(&parent);
+
+    if (MPI_COMM_NULL != parent) {
+        /* child: exactly what test/spawn_child.py does */
+        MPI_Barrier(parent);
+        MPI_Comm_disconnect(&parent);
+        MPI_Finalize();
+        return 0;
+    }
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    if (argc > 1) {
+        iters = atoi(argv[1]);
+    }
+
+    for (int i = 0; i < iters; ++i) {
+        char *cmds[2] = {(char *) SELF_PATH, (char *) SELF_PATH};
+        char **argvs[2] = {MPI_ARGV_NULL, MPI_ARGV_NULL};
+        int maxprocs[2] = {1, 2};
+        MPI_Info infos[2] = {MPI_INFO_NULL, MPI_INFO_NULL};
+        int errcodes[3];
+        MPI_Comm child;
+
+        MPI_Barrier(MPI_COMM_SELF);
+        MPI_Comm_spawn_multiple(2, cmds, argvs, maxprocs, infos, 0, MPI_COMM_SELF, &child,
+                                errcodes);
+        MPI_Barrier(child);
+        MPI_Comm_disconnect(&child);
+        MPI_Barrier(MPI_COMM_SELF);
+
+        if (0 == rank) {
+            printf("iteration %d ok\n", i);
+            fflush(stdout);
+        }
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+    if (0 == rank) {
+        printf("all %d iterations ok\n", iters);
+        fflush(stdout);
+    }
+    MPI_Finalize();
+    return 0;
+}

--- a/src/mca/rmaps/round_robin/rmaps_rr.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr.c
@@ -51,7 +51,16 @@ static int prte_rmaps_rr_map(prte_job_t *jdata,
     int i;
     pmix_list_t node_list;
     int32_t num_slots;
-    int rc;
+    /* Initialized because there are paths that reach the return without
+     * assigning it: in per-app dispatch (app_idx >= 0) the compute_vpids
+     * call below is skipped, so rc is only ever set inside the app loop -
+     * and that loop body is skipped entirely for every app index that is
+     * not the requested one.  An app array whose requested slot is empty
+     * therefore returned a garbage status to the caller, which reads it as
+     * success or failure at random.  Only -O1 and above sees this; the
+     * ordinary --enable-debug build is -O0, where GCC does not run the
+     * analysis that finds it. */
+    int rc = PRTE_SUCCESS;
     /* Reset the per-node "mapped" flags only on the genuine first mapping pass.
      * In per-app dispatch this module is entered once per app context; treating
      * each entry as an initial map would re-clear the flags on nodes a previous

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -941,12 +941,19 @@ release:
      */
     session = jdata->session;
     if(NULL != session){
+        /* Drop this job from the session's list.  By identity, NOT by
+         * namespace: PMIX_CHECK_NSPACE answers "true" the moment either side
+         * is empty, and this array legitimately holds jobs that have no
+         * namespace yet - plm_base_receive puts a spawn request into it at
+         * "moveon", while prte_plm_base_setup_job does not mint the namespace
+         * until the job reaches JOB_STATE_INIT an event later.  A completing
+         * job whose walk reached such an entry first therefore cleared
+         * somebody else's slot and broke, unregistering a live job and
+         * leaving its own entry behind to dangle once it was freed. */
         for(i = 0; i < session->jobs->size; i++){
-            if(NULL != (jptr = pmix_pointer_array_get_item(session->jobs, i))){
-                if(PMIX_CHECK_NSPACE(jdata->nspace, jptr->nspace)){
-                    pmix_pointer_array_set_item(session->jobs, i, NULL);
-                    break;
-                }
+            if(jdata == (prte_job_t *) pmix_pointer_array_get_item(session->jobs, i)){
+                pmix_pointer_array_set_item(session->jobs, i, NULL);
+                break;
             }
         }
         /* Tell the session-control layer the job is gone. It records the

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -917,6 +917,28 @@ static void prte_job_destruct(prte_job_t *job)
     if (NULL != job->traces) {
         PMIx_Argv_free(job->traces);
     }
+    /* A session's job array holds BORROWED pointers - see prte_session_t -
+     * so a job that dies while still listed there leaves the session holding
+     * a dangling one, and every later walk of that array reads freed memory.
+     * The job pool above is kept honest the same way, by the object removing
+     * itself as it goes; do the same here rather than relying on whichever
+     * state-machine path happened to run first.  check_complete_resume()
+     * normally drops the entry, but it has exits that return before reaching
+     * that point, and a job can be released without completing at all.
+     *
+     * Matched by identity, not by namespace: PMIX_CHECK_NSPACE treats an
+     * empty namespace as a wildcard, and this array legitimately holds
+     * not-yet-named jobs - plm_base_receive adds a spawn request to it before
+     * prte_plm_base_setup_job mints the namespace - so a namespace compare
+     * here can match, and clear, somebody else's entry. */
+    if (NULL != job->session && NULL != job->session->jobs) {
+        for (n = 0; n < job->session->jobs->size; n++) {
+            if (job == (prte_job_t *) pmix_pointer_array_get_item(job->session->jobs, n)) {
+                pmix_pointer_array_set_item(job->session->jobs, n, NULL);
+            }
+        }
+    }
+
     /* Both the primary session and every target carry a counted reference -
      * see prte_job_t::session.  Dropping them here is what finally reclaims a
      * reservation that was torn down while this job was still running in it:

--- a/test/unit/runtime/test_runtime.c
+++ b/test/unit/runtime/test_runtime.c
@@ -277,6 +277,65 @@ static int test_session_registry(void)
     return failures;
 }
 
+/* A session's job array holds BORROWED pointers, so the one thing that must
+ * never happen is a job being freed while the session still lists it: every
+ * later walk of that array then reads freed memory.  ASAN caught exactly that
+ * as a heap-use-after-free in check_complete_resume()'s walk, reported against
+ * PMIx because the freed byte is read by PMIx_Check_nspace.
+ *
+ * The job pool has always kept itself honest this way - a job clears its own
+ * slot as it goes - and the session array now does too, rather than depending
+ * on which state-machine path ran first. */
+static int test_session_job_backref(void)
+{
+    int failures = 0;
+    prte_session_t *s;
+    prte_job_t *j1, *j2;
+    int i1, i2;
+
+    reset_globals();
+
+    s = PMIX_NEW(prte_session_t);
+    s->session_id = 55;
+    CHECK("backref: session insert", PRTE_SUCCESS == prte_set_session_object(s));
+
+    /* one named job and one that has not been named yet - the state a spawn
+     * request is in between plm_base_receive putting it on the session and
+     * prte_plm_base_setup_job minting its namespace */
+    j1 = PMIX_NEW(prte_job_t);
+    PMIX_LOAD_NSPACE(j1->nspace, "backref-named");
+    prte_set_job_session(j1, s);
+    i1 = pmix_pointer_array_add(s->jobs, j1);
+
+    j2 = PMIX_NEW(prte_job_t);   /* nspace deliberately left empty */
+    prte_set_job_session(j2, s);
+    i2 = pmix_pointer_array_add(s->jobs, j2);
+
+    CHECK("backref: both jobs listed", 0 <= i1 && 0 <= i2);
+    CHECK("backref: named job is where we put it",
+          j1 == (prte_job_t *) pmix_pointer_array_get_item(s->jobs, i1));
+    CHECK("backref: unnamed job is where we put it",
+          j2 == (prte_job_t *) pmix_pointer_array_get_item(s->jobs, i2));
+
+    /* Release the named job.  Its slot must be cleared, and - the part that
+     * matters - the UNNAMED job's slot must be left alone.  A namespace
+     * compare would have matched it, because PMIX_CHECK_NSPACE treats an
+     * empty namespace as a wildcard. */
+    PMIX_RELEASE(j1);
+    CHECK("backref: a freed job leaves no dangling entry",
+          NULL == pmix_pointer_array_get_item(s->jobs, i1));
+    CHECK("backref: the unnamed job was not swept up with it",
+          j2 == (prte_job_t *) pmix_pointer_array_get_item(s->jobs, i2));
+
+    /* and the unnamed one clears its own slot too */
+    PMIX_RELEASE(j2);
+    CHECK("backref: an unnamed job also clears its own entry",
+          NULL == pmix_pointer_array_get_item(s->jobs, i2));
+
+    reset_globals();
+    return failures;
+}
+
 static int test_session_ownership(void)
 {
     int failures = 0;
@@ -1954,6 +2013,7 @@ int main(void)
     failures += test_job_registry();
     failures += test_session_registry();
     failures += test_session_ownership();
+    failures += test_session_job_backref();
     failures += test_proc_lookups();
     failures += test_node_matching();
     failures += test_node_copy();


### PR DESCRIPTION
Fixes the mpi4py `TestSpawnMultipleSelf` AddressSanitizer failure seen on
[open-mpi/ompi#14377](https://github.com/open-mpi/ompi/pull/14377).

> **Stacked on #2764.** Its two commits (`Allocate node ranks…`, `Exercise repeated spawn…`) appear here because this work extends the `spawnloop` client that one adds. Review/merge #2764 first; the four commits after it are this PR's own.

### The bug

`prte_session_t`'s job array holds **borrowed** pointers — a job joins it without a retain and leaves without a release, because a job's lifetime belongs to the global job pool rather than to the session it ran in. So the one thing that must never happen is a job being freed while the session still lists it: every later walk of that array then reads freed memory.

It happened, by two routes.

**`check_complete_resume()` is the only place a job is ever taken out of `session->jobs`, and it has exits that return first.** The non-persistent "all jobs are done" branch returns twice without falling through to the release block, and a job can be released without completing at all.

**The removal matched with `PMIX_CHECK_NSPACE`.** That answers "true" the moment either namespace is empty, and the array legitimately holds jobs that have no namespace yet: `plm_base_receive` puts a spawn request into the session at `moveon:`, while `prte_plm_base_setup_job` does not mint the namespace until the job reaches `JOB_STATE_INIT` an event later. A completing job whose walk reached such an entry first cleared *somebody else's* slot and stopped — unregistering a live job and leaving its own entry behind to dangle once it was freed.

That window is one trip through the event loop, which is why it took repeated concurrent spawning, and ASAN's slowdown, to show up at all.

### The fix

The job clears its own `session->jobs` slot as it is destroyed, exactly as it already clears its `prte_job_data` slot, so no path can leave a dangling pointer. And the removal in `check_complete_resume` matches by pointer identity, so it cannot take out a job that merely has no name yet.

### Evidence

ASAN reported this against PMIx, because `pmix_nslen()` is the inline that touches the freed byte. It is PRRTE's.

Reproduced with `contrib/dockerswarm/spawnrepro.c` (the mpi4py sequence: every rank repeatedly spawns a multi-app job off `COMM_SELF`, barriers on the intercommunicator, disconnects) on an ASAN build of PMIx, PRRTE **and** Open MPI at this PR's own head, `65b203866e`:

| PRRTE | result |
|---|---|
| without this commit | **heap-use-after-free at iteration 4** |
| with it | **100/100 iterations, exit 0, clean** |

Same build tree, same command, back to back. The crash is frame-for-frame the CI report — `PMIx_Check_nspace` from `check_complete_resume`, freed by `cleanup_job` through the state caddy destructor, allocated by `prte_job_unpack` at `prte_dt_unpacking_fns.c:292`. Only the `state_dvm.c` line numbers differ (946/1147 here vs 935/1137 there), because OMPI's submodule pins an older PRRTE.

`test_session_job_backref` in `test/unit/runtime` covers both halves: it fails on the dangling entry if the destructor stops clearing the slot, and on the wrongly-swept unnamed job if the removal goes back to comparing namespaces.

### Also here

- **`prte_rmaps_rr_map()` could return an uninitialized status.** In per-app (MPMD) dispatch the `compute_vpids` assignment is skipped, so `rc` is only ever set inside the loop over app contexts — and that loop skips every index that is not the requested one. An apps array whose requested slot is empty returned whatever was on the stack. The compiler finds it, but only at `-O1`; `--enable-debug` is `-O0`, so neither a developer build nor CI has seen it.
- **`PRTE_SWARM_ASAN=1`** builds both code bases instrumented. It has to be both: ASAN only flags an access made by code it compiled, and the read above is in a PMIx inline reached from PRRTE — instrument one side and the malloc/free are intercepted but the read is never reported, which is indistinguishable from there being no bug.
- **`spawnrepro.c`** (thanks to @rhc54 for the reproducer) and `spawnloop` gaining `--self`, `--apps`, `--hold` and `--orphan`.

### Known, not addressed here

`--orphan` is a standing reproducer for a separate defect: a `PMIx_Connect` whose participant leaves without joining it never completes, so the survivors block forever and their job never terminates — under `prterun` that means it never returns. Two attempted fixes were withdrawn because neither could be shown to work, and unproven fixes should not ship. Note for whoever picks it up: with the parent and children on the *same* node the case is vacuous, because PMIx executes an all-local connect itself and never calls the host.

### Verification

- `make check` — clean
- `make -C test/offline check-offline` — 2449 pass, 0 fail
- `contrib/dockerswarm` full suite — running at time of writing; will report