### PR TITLE
Name a job when the DVM first sees it, not when it launches

### DIFF
--- a/src/mca/errmgr/dvm/AGENTS.md
+++ b/src/mca/errmgr/dvm/AGENTS.md
@@ -242,9 +242,16 @@ which routes on the job's originator and room number rather than on its
 name. Nothing is running under such a job and nothing downstream can
 address it, so an answer is the whole of what is owed.
 
-`prte_plm_base_setup_job()` is where this arises: it activates
-`NEVER_LAUNCHED` on two paths that run *before* the job is named.
-`prte_plm_base_spawn_alloc_failed()` and the `dvm_held` unwind in
+**The window this guarded is now closed at its source**, and the guard
+stays as a backstop rather than as the load-bearing fix. A job used to be
+named only when it reached `INIT`, so everything between the HNP unpacking
+a spawn request and `prte_plm_base_setup_job()` ran against the wildcard —
+including `setup_job`'s own two `NEVER_LAUNCHED` paths, which is where
+this was found. `prte_plm_base_recv()` now names the job the moment it is
+unpacked (see [`plm/base`](../../plm/base/AGENTS.md)), so no job should
+reach here without one. Keep the screen: it costs one comparison, and it
+is the only thing standing between a future unnamed job and the daemon
+arm. `prte_plm_base_spawn_alloc_failed()` and the `dvm_held` unwind in
 `prte_ras_base_modify()` avoid the state machine for the same reason and
 call `prte_plm_base_spawn_response()` directly.
 

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -202,9 +202,11 @@ static void job_errors(int fd, short args, void *cbdata)
      * and room number rather than by its name.  prte_plm_base_spawn_alloc_failed()
      * reaches for it directly for exactly the same reason.
      *
-     * prte_plm_base_setup_job() is where this arises: it activates
-     * NEVER_LAUNCHED on two paths that run before prte_plm_base_create_jobid()
-     * has named the job. */
+     * The window this guards is now closed at its source: the HNP names a
+     * job the moment prte_plm_base_recv() unpacks it, rather than when it
+     * reaches INIT, so nothing should arrive here unnamed.  This stays as a
+     * backstop - it costs one comparison, and it is all that stands between
+     * a future unnamed job and the daemon arm below. */
     if (PMIX_NSPACE_INVALID(jdata->nspace)) {
         rc = prte_pmix_convert_job_state_to_error(jobstate);
         rc = prte_plm_base_spawn_response(rc, jdata);

--- a/src/mca/plm/AGENTS.md
+++ b/src/mca/plm/AGENTS.md
@@ -180,7 +180,7 @@ spine of launch:
 
 | Handler | State it services → what it does |
 |---------|----------------------------------|
-| `prte_plm_base_setup_job` | `INIT` → assign a jobid (`prte_plm_base_create_jobid`), record the job as an owner of the reservation(s) it targets (it has a namespace only now — see the command processor below), arm spawn/job timeout timers, then `INIT_COMPLETE`. |
+| `prte_plm_base_setup_job` | `INIT` → enter the job in `prte_job_data` (it was *named* at the DVM's door, in the command processor; reaching `INIT` is what says it will actually be launched), record it as an owner of the reservation(s) it targets, arm spawn/job timeout timers, then `INIT_COMPLETE`. |
 | `prte_plm_base_allocation_complete` | `ALLOCATION_COMPLETE` → `LAUNCH_DAEMONS` (the component's handler). Has a bootstrap-DVM special case that stands up the VM directly. |
 | `prte_plm_base_daemons_launched` | `DAEMONS_LAUNCHED` → **deliberately a no-op**; we wait for daemons to phone home rather than advancing. |
 | `prte_plm_base_daemons_reported` | `DAEMONS_REPORTED` → size any node whose slot count was not given (`PRTE_NODE_FLAG_SLOTS_GIVEN`), sum the job's session nodes into `total_slots_alloc`, then `VM_READY`. |
@@ -342,13 +342,12 @@ thread-safe on the progress thread) and switches on
   must happen before the job is added to `session->jobs`** — that array
   borrows its entries and nothing ever removes one, so a job rejected
   afterwards stays as a phantom for the life of the session. And **the job
-  has no namespace here**: the requester packs an unnamed job and the HNP
-  names it later, in `prte_plm_base_setup_job`. Anything keyed on the
-  job's own identity has to wait for that. The reservation-ownership grant
-  did not, and so recorded an *empty* namespace as an owner — which
-  `PMIx_Check_nspace` treats as a wildcard matching every namespace,
-  retiring the ownership gate on that reservation. The grant now happens
-  in `setup_job`, and `prte_session_add_owner` refuses an empty namespace.
+  arrives with no namespace, so this is where it is named**: the requester
+  cannot name it (the jobid counter is the HNP's), and an empty namespace
+  is a *wildcard* to `PMIx_Check_nspace`, so an unnamed job matches every
+  namespace in the DVM. `prte_plm_base_create_jobid()` runs immediately
+  after the unpack, before anything else looks at the job. Registering it
+  in `prte_job_data` is a separate, later step — see the base guide.
 - **`PRTE_PLM_UPDATE_PROC_STATE`** — daemons report per-proc pid/state/
   exit-code; the handler activates the corresponding proc state.
 - **`PRTE_PLM_REGISTERED_CMD`** — procs registered for sync; advances to
@@ -521,7 +520,9 @@ node (issue #2707).
   HNP procID `base@0`.
 - `prte_plm_base_create_jobid(jdata)` — assigns each new job the nspace
   `base@N` with a monotonic `next_jobid` (wrapping/reusing when
-  exhausted).
+  exhausted). A job that already has a name keeps it. It does **not**
+  register the job in `prte_job_data`; that happens at `INIT`, in
+  `prte_plm_base_setup_job`.
 
 ---
 

--- a/src/mca/plm/base/AGENTS.md
+++ b/src/mca/plm/base/AGENTS.md
@@ -137,19 +137,33 @@ therefore run **before** the job is added to `session->jobs` — that array
 rejected after being added stays there as a phantom for the life of the
 session.
 
-**A spawn request arrives with no namespace.** The requester packs a job
-object the HNP has not named yet; `prte_plm_base_setup_job` assigns the
-nspace (via `prte_plm_base_create_jobid`) when the job reaches `INIT`.
-Anything keyed on the job's identity therefore cannot be done here. That
-caught the reservation-ownership grant: the spawned job is supposed to
-become an owner of the reservation it targets (so it can spawn onto those
-nodes in turn), and recording it at request time wrote an **empty**
-namespace into the owner set. An empty namespace is not merely useless —
-`PMIx_Check_nspace` treats an empty side as a *wildcard*, so an empty
-owner entry matches every namespace and retires the reservation's
-ownership gate entirely. The grant now happens in `setup_job`, once the
-job has a name, and `prte_session_add_owner` refuses an empty namespace
-outright.
+**A spawn request arrives with no namespace — so name it, first thing.**
+The requester cannot name what it sends: the jobid counter is the HNP's,
+so `interim()` packs an unnamed job on whatever daemon hosts the client
+and this is where the HNP first has the object. An unnamed job carries the
+*empty* namespace, and `PMIx_Check_nspace` treats an empty side as a
+**wildcard** — so until it is named, every identity test the job passes
+through answers true against every namespace in the DVM. Three separate
+bugs came out of that window: the reservation-ownership grant recorded an
+empty namespace as an owner and thereby opened the reservation to
+everyone, `errmgr/dvm` took an early-failing job for the *daemon* job and
+brought the whole DVM down, and a completing job cleared another job's
+slot in `session->jobs`. `prte_plm_base_create_jobid()` is therefore
+called immediately after the unpack, before the sender, the personality,
+the session or anything else is looked at.
+
+Naming is **not** registration. Entering the job in `prte_job_data` still
+waits for `INIT` (`prte_plm_base_setup_job`), because that array is what a
+joining daemon is caught up from (`prte_util_pack_job_catchup`) and what
+the job queries enumerate — and a job named here may still be waiting on
+an allocation it requested, or parked in `prte_cache` until the DVM is
+ready, with no map to describe. Reaching `INIT` is what says the job is
+going to be launched.
+
+The reservation-ownership grant stays in `setup_job` for the same reason,
+not for want of a name: a request rejected after `moveon:` — an
+add-hosts failure, a malformed spawn allocation — must not have become an
+owner of a reservation on its way out, and nothing removes an owner.
 
 The requester is still vetted here, before anything is granted:
 `prte_session_is_owned_by(session, requestor)`.

--- a/src/mca/plm/base/plm_base_jobid.c
+++ b/src/mca/plm/base/plm_base_jobid.c
@@ -71,38 +71,62 @@ int prte_plm_base_set_hnp_name(void)
 }
 
 /*
- * Create a jobid
+ * Name a job
+ *
+ * Naming is deliberately separate from entering the job in the global
+ * registry, and it happens as early as the HNP can possibly do it: the
+ * moment a job object exists here.  An unnamed job carries the EMPTY
+ * namespace, and PMIx reads an empty namespace as a WILDCARD -
+ * PMIx_Check_nspace() answers true against anything - so every identity
+ * test an unnamed job passes through silently succeeds.  That has bitten
+ * this code base repeatedly: it disabled a reservation's ownership gate,
+ * it let one application's early failure be taken for the daemon job and
+ * bring the whole DVM down, and it let a completing job clear another
+ * job's slot in session->jobs.  Each was repaired where it was found; a
+ * job that has a name from the outset cannot raise the next one.
+ *
+ * Registration in prte_job_data waits for INIT (prte_plm_base_setup_job).
+ * That array is what a daemon joining the DVM is caught up from
+ * (prte_util_pack_job_catchup) and what the job queries enumerate, and a
+ * job named at the door may still be waiting on an allocation, or parked
+ * in prte_cache until the DVM is ready, with no map to describe yet.
  */
 static bool reuse = false;
 
 int prte_plm_base_create_jobid(prte_job_t *jdata)
 {
-    uint32_t i;
+    uint32_t i, jid;
     pmix_nspace_t pjid;
-    prte_job_t *ptr;
     bool found;
     char *tmp;
-    int rc;
 
-    if (PRTE_FLAG_TEST(jdata, PRTE_JOB_FLAG_RESTART)) {
-        /* this job is being restarted - do not assign it
-         * a new jobid
-         */
+    if (!PMIX_NSPACE_INVALID(jdata->nspace)) {
+        /* already named - a restarted job keeps the name it had, and a job
+         * named at the DVM's door reaches INIT already carrying one */
         return PRTE_SUCCESS;
     }
 
     if (reuse) {
-        /* find the first unused jobid */
+        /* Find an unused jobid at or after next_jobid, wrapping past the
+         * end.  The scan has to start where we left off rather than at 1
+         * because a name is handed out here but not recorded in
+         * prte_job_data until the job reaches INIT: a scan that always
+         * restarted at 1 would hand the same hole to every job named while
+         * the first one is still waiting for its allocation. */
         found = false;
-        for (i = 1; i < UINT32_MAX; i++) {
-            ptr = NULL;
-            (void) snprintf(pjid, PMIX_MAX_NSLEN - 1, "%s@%u", prte_plm_globals.base_nspace, i);
-            ptr = prte_get_job_data_object(pjid);
-            if (NULL == ptr) {
+        jid = prte_plm_globals.next_jobid;
+        for (i = 0; i < UINT32_MAX; i++) {
+            if (0 == jid) {
+                /* "@0" is the DVM itself */
+                jid = 1;
+            }
+            (void) snprintf(pjid, PMIX_MAX_NSLEN - 1, "%s@%u", prte_plm_globals.base_nspace, jid);
+            if (NULL == prte_get_job_data_object(pjid)) {
                 found = true;
-                prte_plm_globals.next_jobid = i;
+                prte_plm_globals.next_jobid = jid;
                 break;
             }
+            ++jid;
         }
         if (!found) {
             /* we have run out of jobids! */
@@ -116,13 +140,6 @@ int prte_plm_base_create_jobid(prte_job_t *jdata)
     pmix_asprintf(&tmp, "%s@%u", prte_plm_globals.base_nspace, prte_plm_globals.next_jobid);
     PMIX_LOAD_NSPACE(jdata->nspace, tmp);
     free(tmp);
-
-    /* store the job object */
-    rc = prte_set_job_data_object(jdata);
-    if (PRTE_SUCCESS != rc) {
-        PRTE_ERROR_LOG(rc);
-        return rc;
-    }
 
     prte_plm_globals.next_jobid++;
     if (UINT32_MAX == prte_plm_globals.next_jobid) {

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -759,9 +759,33 @@ void prte_plm_base_setup_job(int fd, short args, void *cbdata)
     /* update job state */
     caddy->jdata->state = caddy->job_state;
 
-    /* start by getting a jobid */
-    if (PMIX_NSPACE_INVALID(caddy->jdata->nspace)) {
-        if (PRTE_SUCCESS != (rc = prte_plm_base_create_jobid(caddy->jdata))) {
+    /* Start by ensuring the job has a name.  A job that entered the DVM
+     * through the PLM command processor was named the moment it was
+     * unpacked, so this is a no-op for it; a job that reached INIT by some
+     * other route is named here. */
+    if (PRTE_SUCCESS != (rc = prte_plm_base_create_jobid(caddy->jdata))) {
+        PRTE_ERROR_LOG(rc);
+        PRTE_ACTIVATE_JOB_STATE(caddy->jdata, PRTE_JOB_STATE_NEVER_LAUNCHED);
+        PMIX_RELEASE(caddy);
+        return;
+    }
+
+    /* Now enter it in the global job registry.  This is deliberately later
+     * than the naming.  prte_job_data is what a daemon joining the DVM is
+     * caught up from and what the job queries enumerate, and a job is named
+     * before it is known to be launchable at all: it may still be waiting on
+     * an allocation it requested, or parked in prte_cache until the DVM is
+     * ready.  Such a job has no map, and a catch-up entry for an unmapped
+     * job leaves every joining daemon holding a procless copy of it forever
+     * (see prte_util_pack_job_catchup).  Reaching INIT is what says the job
+     * is going to be launched.
+     *
+     * A job that is already registered - it came back through here, or it
+     * was entered by whoever built it - keeps the slot it has; index is -1
+     * until something registers it, and prte_job_destruct clears exactly
+     * that slot. */
+    if (0 > caddy->jdata->index) {
+        if (PRTE_SUCCESS != (rc = prte_set_job_data_object(caddy->jdata))) {
             PRTE_ERROR_LOG(rc);
             PRTE_ACTIVATE_JOB_STATE(caddy->jdata, PRTE_JOB_STATE_NEVER_LAUNCHED);
             PMIX_RELEASE(caddy);
@@ -769,19 +793,22 @@ void prte_plm_base_setup_job(int fd, short args, void *cbdata)
         }
     }
 
-    /* Now - and only now - can the job be recorded as an owner of the
+    /* Now - and only now - is the job recorded as an owner of the
      * reservation(s) it was cleared to run in.  That grant is what lets it
-     * spawn further jobs onto those nodes, and it belongs to the job's own
-     * namespace, which did not exist until the line above: a spawn request
-     * arrives with an empty nspace and the HNP names the job here.
+     * spawn further jobs onto those nodes, and nothing ever removes an
+     * owner, so it waits until the job is known to be launching: a request
+     * rejected in the command processor (a failed add-hosts, a malformed
+     * spawn allocation) must not have made itself an owner on its way out.
      *
-     * Granting it at request-vetting time therefore recorded an EMPTY
-     * namespace as an owner - and an empty namespace matches every other one
-     * (PMIx_Check_nspace treats it as a wildcard), so the first job spawned
-     * into a reservation quietly opened that reservation to every namespace
-     * in the DVM.  prte_session_add_owner now refuses an empty namespace
-     * outright; this is where the real one is recorded.  Both calls are
-     * no-ops for the default session, which everyone may use. */
+     * It also has to be a real namespace.  Granting it at request-vetting
+     * time, back when the job was not named until this function ran,
+     * recorded an EMPTY namespace as an owner - and an empty namespace
+     * matches every other one (PMIx_Check_nspace treats it as a wildcard),
+     * so the first job spawned into a reservation quietly opened that
+     * reservation to every namespace in the DVM.  The job is named at the
+     * DVM's door now, and prte_session_add_owner refuses an empty namespace
+     * outright.  Both calls are no-ops for the default session, which
+     * everyone may use. */
     if (NULL != caddy->jdata->target_sessions) {
         for (n = 0; n < caddy->jdata->num_target_sessions; n++) {
             prte_session_add_owner(caddy->jdata->target_sessions[n], caddy->jdata->nspace);

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -681,6 +681,32 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
         /* we own it until it is handed to a container below */
         own_jdata = true;
 
+        /* Name it, before anything else looks at it.
+         *
+         * This is the door every job comes through - a PMIx_Spawn from an
+         * application or a tool, a session instantiation carrying its own
+         * app definitions - and the requester cannot name what it sends: the
+         * jobid counter is the HNP's, so the job is packed unnamed and
+         * arrives carrying the EMPTY namespace.  PMIx reads an empty
+         * namespace as a WILDCARD (PMIx_Check_nspace answers true against
+         * anything), so until it is named, every identity test this job
+         * passes through succeeds against every other namespace in the DVM.
+         * It is not a hypothetical: an unnamed job has been mistaken for the
+         * daemon job by errmgr/dvm and taken the whole DVM down with it, has
+         * opened a reservation to every namespace by being recorded as its
+         * owner, and has cleared another job's slot in session->jobs.
+         *
+         * So the HNP names it at the first instant it can - here, where the
+         * object first exists on this side - rather than at INIT, several
+         * events and every one of the checks below later.  Entering it in
+         * prte_job_data still waits for INIT; see prte_plm_base_create_jobid
+         * and prte_plm_base_setup_job for why those are separate steps. */
+        rc = prte_plm_base_create_jobid(jdata);
+        if (PRTE_SUCCESS != rc) {
+            PRTE_ERROR_LOG(rc);
+            goto ANSWER_LAUNCH;
+        }
+
         /* record the sender so we know who to respond to */
         PMIX_LOAD_PROCID(&jdata->originator, sender->nspace, sender->rank);
 
@@ -816,7 +842,11 @@ moveon:
          *
          * The matching GRANT - the spawned job becoming an owner itself, so
          * it can spawn onto those nodes in turn - happens in
-         * prte_plm_base_setup_job, once the job has a namespace to record. */
+         * prte_plm_base_setup_job.  The job has a name by now, but nothing
+         * ever removes an owner, so the grant waits until the request is
+         * known to be going ahead: a job rejected below this point (a failed
+         * add-hosts, a malformed spawn allocation) must not leave itself
+         * recorded as an owner of a reservation on its way out. */
         if (NULL == jdata->target_sessions && NULL != session &&
             session != prte_default_session &&
             (PRTE_SESSION_FLAG_RESERVED & session->flags)) {

--- a/test/unit/plm/test_plm.c
+++ b/test/unit/plm/test_plm.c
@@ -520,14 +520,16 @@ static int test_naming(void)
     char *save_base = prte_plm_globals.base_nspace;
     uint32_t save_next = prte_plm_globals.next_jobid;
     pmix_proc_t save_me, save_hnp;
-    prte_job_t *jdata;
+    prte_job_t *jdata, *jdata2;
     char expect[PMIX_MAX_NSLEN + 1];
+    char expect2[PMIX_MAX_NSLEN + 1];
 
     memcpy(&save_me, PRTE_PROC_MY_NAME, sizeof(pmix_proc_t));
     memcpy(&save_hnp, PRTE_PROC_MY_HNP, sizeof(pmix_proc_t));
 
-    /* create_jobid registers the job, so we need the global job array that
-     * a full prte_init() would have built for us */
+    /* create_jobid does not register the job, but it consults the global job
+     * array when it has wrapped and is looking for a reusable jobid -- so we
+     * still need the array a full prte_init() would have built for us */
     if (NULL == prte_job_data) {
         prte_job_data = PMIX_NEW(pmix_pointer_array_t);
         pmix_pointer_array_init(prte_job_data, PRTE_GLOBAL_ARRAY_BLOCK_SIZE,
@@ -563,15 +565,38 @@ static int test_naming(void)
     CHECK("create_jobid succeeds", PRTE_SUCCESS == prte_plm_base_create_jobid(jdata));
     snprintf(expect, sizeof(expect), "%s@1", prte_plm_globals.base_nspace);
     CHECK("first jobid is base@1", 0 == strcmp(jdata->nspace, expect));
-    CHECK("job is registered", jdata == prte_get_job_data_object(jdata->nspace));
     CHECK("next_jobid advanced", 2 == prte_plm_globals.next_jobid);
 
-    /* a restarting job keeps the nspace it already has */
+    /* Naming does NOT enter the job in the global registry.  The two are
+     * separate steps on purpose: a job is named at the DVM's door, where an
+     * empty nspace would be read as a wildcard by every identity test it
+     * then passes, but it is registered only when it reaches INIT -- until
+     * then it may still be waiting on an allocation, or parked in
+     * prte_cache, with no map for a joining daemon to be caught up from. */
+    CHECK("naming did not register the job", NULL == prte_get_job_data_object(jdata->nspace));
+
+    /* ...so a second job named while the first is still unregistered must
+     * still get a name of its own */
+    jdata2 = PMIX_NEW(prte_job_t);
+    CHECK("second create_jobid succeeds", PRTE_SUCCESS == prte_plm_base_create_jobid(jdata2));
+    snprintf(expect2, sizeof(expect2), "%s@2", prte_plm_globals.base_nspace);
+    CHECK("second jobid is base@2", 0 == strcmp(jdata2->nspace, expect2));
+    CHECK("second jobid differs from the first", 0 != strcmp(jdata2->nspace, jdata->nspace));
+    CHECK("next_jobid advanced again", 3 == prte_plm_globals.next_jobid);
+    PMIX_RELEASE(jdata2);
+
+    /* a job that already has a name keeps it -- a restarting job, and the
+     * ordinary case of a job named at the door reaching INIT later */
+    CHECK("create_jobid on a named job succeeds",
+          PRTE_SUCCESS == prte_plm_base_create_jobid(jdata));
+    CHECK("named job kept its nspace", 0 == strcmp(jdata->nspace, expect));
+    CHECK("naming a named job consumed no jobid", 3 == prte_plm_globals.next_jobid);
     PRTE_FLAG_SET(jdata, PRTE_JOB_FLAG_RESTART);
     CHECK("create_jobid on restart succeeds", PRTE_SUCCESS == prte_plm_base_create_jobid(jdata));
     CHECK("restart kept its nspace", 0 == strcmp(jdata->nspace, expect));
-    CHECK("restart did not consume a jobid", 2 == prte_plm_globals.next_jobid);
+    CHECK("restart did not consume a jobid", 3 == prte_plm_globals.next_jobid);
     PRTE_FLAG_UNSET(jdata, PRTE_JOB_FLAG_RESTART);
+    PMIX_RELEASE(jdata);
 
     free(prte_plm_globals.base_nspace);
     prte_plm_globals.base_nspace = save_base;


### PR DESCRIPTION
A job entering the DVM has had no namespace until it reached `PRTE_JOB_STATE_INIT`. The requester cannot supply one — the jobid counter belongs to the HNP — so `pmix_server_dyn.c`'s `interim()` builds the job on whichever daemon hosts the requesting client, packs it unnamed, and the HNP names it several events later in `prte_plm_base_setup_job()`.

Everything in between runs against the **empty** namespace, and an empty namespace is not merely uninformative: PMIx reads it as a **wildcard**. `PMIx_Check_nspace()` answers true if either side is empty, so every identity test an unnamed job passes through succeeds against every other namespace in the DVM.

That has produced three separate defects, each found and repaired where it surfaced:

- the reservation-ownership grant recorded an empty namespace as an owner, and thereby opened the reservation to every namespace in the DVM;
- `errmgr/dvm` took an early-failing application job for the **daemon** job, disabled routing and activated `DAEMONS_TERMINATED` — one application's failure bringing the whole DVM down, with its requester never told anything;
- a completing job cleared another job's slot in `session->jobs`, leaving a dangling borrowed pointer.

Repairing each site individually leaves the wildcard in circulation for the next reader to trip over.

## The change

Name the job at the door. `prte_plm_base_recv()` calls `prte_plm_base_create_jobid()` immediately after unpacking the request, before the sender, the personality, the session or anything else is looked at. The ~100 `PMIX_CHECK_NSPACE` sites downstream become correct without being audited, and a job that has a name from the outset cannot raise the next one of these.

**Naming and registration have to be separated to do this**, and that is the part worth reviewing. `prte_plm_base_create_jobid()` previously did both, and `prte_job_data` is not somewhere an unlaunched job may sit: it is what a daemon joining the DVM is caught up from, and `prte_util_pack_job_catchup()` says plainly that a catch-up entry for an unmapped job leaves every joining daemon holding a procless copy of it forever. A job named at the door may still be waiting on an allocation it requested (`PMIX_SPAWN_ALLOC`), or parked in `prte_cache` until the DVM is ready.

So `create_jobid()` now only names — returning at once for a job that already has a name, which covers a restart as the old `PRTE_JOB_FLAG_RESTART` test did — and `prte_plm_base_setup_job()` enters the job in `prte_job_data` when it reaches `INIT`. Reaching `INIT` is what says the job is going to be launched.

That split needs one more thing: the wrapped-around "find a free jobid" scan has to start at `next_jobid` rather than at 1, because a name handed out but not yet registered is invisible to it, and the same hole would otherwise be given to every job named while the first is still waiting.

Two things deliberately stay put:

- **The reservation-ownership grant stays in `setup_job`** — not for want of a name now, but because nothing ever removes an owner, and a request rejected after the session is resolved (a failed add-hosts, a malformed spawn allocation) must not have made itself an owner on its way out.
- **`errmgr/dvm`'s `PMIX_NSPACE_INVALID` screen stays**, now as a backstop rather than as the load-bearing fix. It costs one comparison and is the only thing between a future unnamed job and the daemon arm.

`AGENTS.md` in `plm`, `plm/base` and `errmgr/dvm` documented the old invariant; all three are corrected.

## Testing

`test/unit/plm`'s naming test is updated to pin the new contract: naming does not register, a second job named while the first is still unregistered still gets a name of its own, and an already-named job keeps it.

- `make check` 25/0
- offline mapper harness 2449/0
- live DVM: repeated `PMIx_Spawn` from an application proc (monotonic `base@N` namespaces returned to the requester), `prterun` and `prun`, and the failure paths — a missing executable and an oversubscription refusal — which answer the requester and leave the DVM running.

Not yet exercised in the multi-node swarm; the grow-while-another-job-is-unregistered case is the one only a multi-node run reaches.
