### PR TITLE
Say "the same namespace" once, instead of nine times

### DIFF
--- a/src/mca/iof/hnp/iof_hnp_send.c
+++ b/src/mca/iof/hnp/iof_hnp_send.c
@@ -212,10 +212,12 @@ void prte_iof_hnp_relay_to_tool(const pmix_proc_t *source,
      * seed of the set below rather than as a second mechanism: a job that
      * nobody has since subscribed to has exactly this one destination,
      * which is the behavior this function has always had. */
-    if (!PMIX_NSPACE_INVALID(jdata->originator.nspace) &&
-        /* an originator outside the daemon namespace is a tool attached
-         * to us, so there is nothing to relay anywhere */
-        PMIX_CHECK_NSPACE(jdata->originator.nspace, PRTE_PROC_MY_NAME->nspace)) {
+    /* STRICT: an unset originator - a job nobody is waiting on - must not
+     * be read as the daemon namespace, which PMIX_CHECK_NSPACE's wildcard
+     * would do.  An originator outside the daemon namespace is a tool
+     * attached to us, so there is nothing to relay anywhere. */
+    if (PMIX_CHECK_NSPACE_STRICT(jdata->originator.nspace,
+                                 PRTE_PROC_MY_NAME->nspace)) {
         relay_one(jdata->originator.rank, source, stream, data, numbytes,
                   already_delivered);
     }
@@ -231,8 +233,8 @@ void prte_iof_hnp_relay_to_tool(const pmix_proc_t *source,
             continue;
         }
         dmn = (pmix_rank_t) n;
-        if (!PMIX_NSPACE_INVALID(jdata->originator.nspace) &&
-            PMIX_CHECK_NSPACE(jdata->originator.nspace, PRTE_PROC_MY_NAME->nspace) &&
+        if (PMIX_CHECK_NSPACE_STRICT(jdata->originator.nspace,
+                                     PRTE_PROC_MY_NAME->nspace) &&
             dmn == jdata->originator.rank) {
             continue;   // already served as the seed above
         }

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -1155,21 +1155,6 @@ static void cleanup_job(int sd, short args, void *cbdata)
 }
 
 #ifdef PMIX_SPAWN_TREE_ROOT
-/* Do these two namespaces name the same thing?
- *
- * NOT PMIX_CHECK_NSPACE, which answers "true" the moment either side is
- * empty - wildcard semantics that are right for a match against a request
- * and wrong here.  Most jobs in a DVM carry an empty launcher, and reading
- * every one of them as a member of whatever tree we are asking about would
- * put a stranger's job in a tool's wait set. */
-static bool same_nspace(const char *a, const char *b)
-{
-    if (PMIX_NSPACE_INVALID(a) || PMIX_NSPACE_INVALID(b)) {
-        return false;
-    }
-    return (0 == strncmp(a, b, PMIX_MAX_NSLEN));
-}
-
 /* The root of the spawn tree JDATA belongs to.  prte_job_t::launcher already
  * holds it, recorded when the job was created and copied transitively from
  * the parent, so a grandchild names the same root as its parent does.  It is
@@ -1213,8 +1198,14 @@ static uint32_t spawn_tree_active(prte_job_t *jdata, const char *root)
             PRTE_FLAG_TEST(jptr, PRTE_JOB_FLAG_TOOL)) {
             continue;
         }
-        if (!same_nspace(jptr->launcher, root) &&
-            !same_nspace(jptr->nspace, root)) {
+        /* PMIX_CHECK_NSPACE_STRICT, not PMIX_CHECK_NSPACE: the latter
+         * answers "true" the moment either side is empty - wildcard
+         * semantics that are right for a match against a request and wrong
+         * here.  Most jobs in a DVM carry an empty launcher, and reading
+         * every one of them as a member of whatever tree we are asking
+         * about would put a stranger's job in a tool's wait set. */
+        if (!PMIX_CHECK_NSPACE_STRICT(jptr->launcher, root) &&
+            !PMIX_CHECK_NSPACE_STRICT(jptr->nspace, root)) {
             continue;
         }
         if (jptr->state < PRTE_JOB_STATE_TERMINATED) {

--- a/src/prted/pmix/pmix_server_allocate.c
+++ b/src/prted/pmix/pmix_server_allocate.c
@@ -203,10 +203,12 @@ pmix_status_t prte_pmix_set_primary_server(const pmix_proc_t *target)
 {
     pmix_status_t rc;
 
-    /* PMIX_CHECK_PROCID answers "true" for an empty nspace, so the flag -
-     * not the identity - is what says we have ever designated one */
+    /* STRICT: PMIX_CHECK_PROCID answers "true" for an empty nspace, so it
+     * would call an undesignated primary server the same process as whoever
+     * is being designated now.  The flag still says whether we have ever
+     * designated one - it is set on paths that do not come through here */
     if (prte_pmix_server_globals.primary_server_set &&
-        PMIX_CHECK_PROCID(&prte_pmix_server_globals.primary_server, target)) {
+        PMIX_CHECK_PROCID_STRICT(&prte_pmix_server_globals.primary_server, target)) {
         return PMIX_SUCCESS;
     }
 

--- a/src/prted/pmix/pmix_server_connect.c
+++ b/src/prted/pmix/pmix_server_connect.c
@@ -75,11 +75,11 @@ static bool registry_live(void)
  * NOT PMIX_CHECK_NSPACE, which answers "true" the moment either side is
  * empty - wildcard semantics that are right for matching a request and wrong
  * for deciding who is in an assemblage, where an empty nspace would put a
- * proc in every one of them. */
-static bool same_nspace(const pmix_nspace_t a, const pmix_nspace_t b)
-{
-    return (0 == strncmp(a, b, PMIX_MAX_NSLEN));
-}
+ * proc in every one of them.  PMIX_CHECK_NSPACE_STRICT is that question,
+ * and it also declines to call two *unset* namespaces the same one: an
+ * assemblage member with no namespace is malformed input, not a participant
+ * two requests can agree on. */
+#define same_nspace(a, b) PMIX_CHECK_NSPACE_STRICT((a), (b))
 
 /* Does this member entry cover this proc?  An entry naming a wildcard rank
  * stands for every proc of that namespace, which is how a connect between

--- a/src/prted/pmix/pmix_server_connect.c
+++ b/src/prted/pmix/pmix_server_connect.c
@@ -96,16 +96,13 @@ static bool member_covers(const pmix_proc_t *member, const pmix_proc_t *proc)
  * order carries no meaning - the PMIx definition says so explicitly - so this
  * compares them as sets.
  *
- * The comparison of a single entry is literal, deliberately: PMIX_CHECK_PROCID
- * would call "nspace/0" and "nspace/WILDCARD" a match, and the two are
- * different participant lists.  PMIx itself will not match a connect
- * expressed one way with a connect expressed the other, so neither may we -
- * a disconnect naming a set we never recorded must fail to find it rather
- * than drop somebody else's. */
-static bool same_proc(const pmix_proc_t *a, const pmix_proc_t *b)
-{
-    return (a->rank == b->rank && same_nspace(a->nspace, b->nspace));
-}
+ * The comparison of a single entry wildcards on neither half, which is what
+ * PMIX_CHECK_PROCID_STRICT is for: PMIX_CHECK_PROCID would call "nspace/0"
+ * and "nspace/WILDCARD" a match, and the two are different participant
+ * lists.  PMIx itself will not match a connect expressed one way with a
+ * connect expressed the other, so neither may we - a disconnect naming a set
+ * we never recorded must fail to find it rather than drop somebody else's. */
+#define same_proc(a, b) PMIX_CHECK_PROCID_STRICT((a), (b))
 
 static bool same_membership(prte_pmix_server_connection_t *cptr,
                             const pmix_proc_t *members, size_t nmembers)

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -662,12 +662,12 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
      * half of itself. The identical screen, and the reasoning, is in
      * prte_pmix_server_connection_spawned() (pmix_server_connect.c).
      *
-     * strncmp, not PMIX_CHECK_NSPACE: that macro treats an empty nspace on
-     * either side as a wildcard match, and this test must answer only for the
-     * namespace it was actually given.
+     * PMIX_CHECK_NSPACE_STRICT, not PMIX_CHECK_NSPACE: the latter treats an
+     * empty nspace on either side as a wildcard match, and this test must
+     * answer only for the namespace it was actually given.
      */
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_LAUNCH_PROXY, (void **) &parentproc, PMIX_PROC)) {
-        if (0 != strncmp(PRTE_PROC_MY_NAME->nspace, parentproc->nspace, PMIX_MAX_NSLEN)) {
+        if (!PMIX_CHECK_NSPACE_STRICT(PRTE_PROC_MY_NAME->nspace, parentproc->nspace)) {
             parent = prte_get_job_data_object(parentproc->nspace);
         }
         if (NULL != parent && PRTE_FLAG_TEST(parent, PRTE_JOB_FLAG_TOOL)) {

--- a/src/prted/prted_comm.c
+++ b/src/prted/prted_comm.c
@@ -666,7 +666,7 @@ void prte_daemon_recv(int status, pmix_proc_t *sender,
          * the first finds its request already retired and logs a spurious
          * "not found". */
         if (PRTE_PROC_IS_MASTER ||
-            PMIX_CHECK_PROCID(&jdata->originator, PRTE_PROC_MY_NAME)) {
+            PMIX_CHECK_PROCID_STRICT(&jdata->originator, PRTE_PROC_MY_NAME)) {
             ret = prte_plm_base_spawn_response(PMIX_SUCCESS, jdata);
             if (PRTE_SUCCESS != ret) {
                 PRTE_ERROR_LOG(ret);

--- a/src/prted/prun_common.c
+++ b/src/prted/prun_common.c
@@ -251,14 +251,14 @@ progress:
  * all, and this is what keeps it from making us wait on strangers. */
 static bool in_our_tree(const char *jobid, const char *root)
 {
-    if (0 == strncmp(jobid, spawnednspace, PMIX_MAX_NSLEN)) {
+    /* STRICT throughout: spawnednspace is empty until we have spawned
+     * something, and PMIX_CHECK_NSPACE's wildcard would then claim every
+     * job on a shared DVM as ours. */
+    if (PMIX_CHECK_NSPACE_STRICT(jobid, spawnednspace)) {
         return true;
     }
-    if (NULL == root || '\0' == root[0]) {
-        return false;
-    }
-    return (0 == strncmp(root, myproc.nspace, PMIX_MAX_NSLEN) ||
-            0 == strncmp(root, spawnednspace, PMIX_MAX_NSLEN));
+    return (PMIX_CHECK_NSPACE_STRICT(root, myproc.nspace) ||
+            PMIX_CHECK_NSPACE_STRICT(root, spawnednspace));
 }
 
 static void evhandler(size_t evhdlr_registration_id, pmix_status_t status,
@@ -312,7 +312,7 @@ static void evhandler(size_t evhdlr_registration_id, pmix_status_t status,
         /* somebody else's job on a DVM we share */
         goto progress;
     }
-    primary = (0 == strncmp(jobid, spawnednspace, PMIX_MAX_NSLEN));
+    primary = PMIX_CHECK_NSPACE_STRICT(jobid, spawnednspace);
 
     if (verbose) {
         pmix_output(0, "JOB %s COMPLETED WITH STATUS %d, %u LEFT IN TREE",

--- a/src/rml/rml_purge.c
+++ b/src/rml/rml_purge.c
@@ -21,9 +21,10 @@ void prte_rml_purge(pmix_proc_t* peer){
     PMIX_LIST_FOREACH_SAFE(
         post, next_post, &prte_rml_base.posted_recvs, prte_rml_posted_recv_t
     ) {
-        // Don't use PMIX_CHECK_PROCID, because we don't want to match wildcards
-        if(!PMIx_Check_nspace(post->peer.nspace, peer->nspace)) continue;
-        if(post->peer.rank   != peer->rank  ) continue;
+        // PMIX_CHECK_PROCID_STRICT, not PMIX_CHECK_PROCID: purging is by
+        // identity, and neither an unset nspace nor a wildcard rank may be
+        // allowed to stand for anybody else's posted receive
+        if(!PMIX_CHECK_PROCID_STRICT(&post->peer, peer)) continue;
 
         pmix_list_remove_item(&prte_rml_base.posted_recvs, &post->super);
         PMIX_RELEASE(post);
@@ -33,11 +34,10 @@ void prte_rml_purge(pmix_proc_t* peer){
     PMIX_LIST_FOREACH_SAFE(
         msg, next_msg, &prte_rml_base.unmatched_msgs, prte_rml_recv_t
     ) {
-        // as above: compare the nspace strings, not the addresses of the two
-        // char arrays - "!=" on those is a pointer comparison that is always
-        // true, so no held message was ever purged
-        if(!PMIx_Check_nspace(msg->sender.nspace, peer->nspace)) continue;
-        if(msg->sender.rank   != peer->rank  ) continue;
+        // as above; and note it compares the nspace strings rather than the
+        // addresses of the two char arrays - "!=" on those is a pointer
+        // comparison that is always true, so no held message was ever purged
+        if(!PMIX_CHECK_PROCID_STRICT(&msg->sender, peer)) continue;
 
         pmix_list_remove_item(&prte_rml_base.unmatched_msgs, &msg->super);
         PMIX_RELEASE(msg);


### PR DESCRIPTION
> **Depends on openpmix/openpmix#4236** — needs a PMIx carrying `PMIx_Check_nspace_strict()` and `PMIx_Check_procid_strict()`. Do not merge before that.

`PMIX_CHECK_NSPACE` treats an empty namespace as a wildcard, and `PMIX_CHECK_PROCID` adds a second wildcard on the rank. Both are right for matching a request against a specification and wrong for asking whether two things name the same job or the same process.

PRRTE asks the second question in a good many places, and about fields that are legitimately empty — a job's `launcher` is empty for anything nobody spawned, its `originator` for anything nobody is waiting on — so the wildcard is not a corner case here but the ordinary state of the data.

Everywhere that mattered this was noticed and worked around, and **each site worked around it differently**:

- `state/dvm` and `pmix_server_connect` each grew a private `same_nspace()` helper — with *different* semantics, one rejecting an empty namespace and the other not;
- `iof/hnp` wrote the guard out longhand as `!PMIX_NSPACE_INVALID(x) && PMIX_CHECK_NSPACE(x, y)`, twice;
- `prun_common`, `pmix_server_register_fns` and `rml_purge` used a bare `strncmp`;
- `pmix_server_connect` hand-rolled the procID comparison as well.

Seven of the nine carry a comment explaining that the obvious macro could not be used. That is seven chances to write the version with the guard left off, and no way for a reader to tell a deliberate wildcard from a forgotten one.

PMIx now offers both comparisons directly, so use them. The two private helpers, the hand-rolled procID compare and the longhand guards go away, and each site says in one token which of the two questions it is asking.

## Behavior changes, and why each is the answer the comment already asked for

Four sites change behavior, in the cases where the old spellings disagreed with each other:

- **`rml_purge`** had escaped only *half* the problem. Its comment says it does not want to match wildcards, but it compared the rank by hand while using `PMIx_Check_nspace()` — the wildcard one — for the namespace. Purging on behalf of a peer with an unset namespace would have taken every posted receive and held message whose rank happened to agree.
- **`prted_comm`** carried no comment because nobody had noticed. A job whose originator was never recorded has an empty namespace, which the wildcard reads as this daemon's own — so a bystander daemon holding an unpacked copy of the job would answer a spawn request if its vpid matched the unset originator's rank. Only the daemon hosting the requestor has a local notification, and it is the only one that should answer.
- **`pmix_server_connect`**'s `same_nspace()` was a bare `strncmp`, so it called two *unset* namespaces the same participant. An assemblage member with no namespace is malformed input, not something two requests can agree on.
- **`prun_common`**'s `in_our_tree()` compared against `spawnednspace`, which is empty until we have spawned something — so before the first spawn it claimed every job ending on a shared DVM as one of ours.

## Deliberately not converted

The **data server** keeps `PMIX_CHECK_PROCID`. Its session horizon relies on an empty namespace matching everybody, and `src/runtime/data_server/AGENTS.md` says so explicitly. Those sites now read as intentional by contrast, which is most of the value here.

## Testing

- warning-free build against openpmix/openpmix#4236
- `make check` 25/0
- live DVM exercising each converted path: `prun` waiting on a spawn tree (`in_our_tree`/`primary`), repeated `comm_spawn` under both `prun` and `prterun` (the `PMIX_PARENT_ID` screen), IOF relay, and a launch failure.
