### PR TITLE
Explain what --external-launcher does and does not guarantee

### DIFF
--- a/contrib/dockerswarm/connector.c
+++ b/contrib/dockerswarm/connector.c
@@ -13,6 +13,7 @@
  * that "connected" makes.
  *
  *   connector [--child-host <node>] [--disconnect] [--abort] [--wait <s>]
+ *   connector --siblings [--child-host <node>] [--wait <s>]
  *
  * The parent (no PMIX_PARENT_ID in its job info) spawns one copy of itself,
  * registers for PMIX_ERR_PROC_TERM_WO_SYNC, and connects to the child.  The
@@ -24,6 +25,17 @@
  * the assemblage as one application, so a failure that terminates the child
  * is to terminate the parent along with it.  The parent prints nothing more
  * in that case - it is killed - which is exactly what the harness checks.
+ *
+ * --siblings asks whether that termination is TRANSITIVE, which is the shape
+ * an MPI_Comm_spawn test produces and the shape a single spawn cannot.  The
+ * parent spawns TWO children and connects to neither explicitly: a spawn
+ * connects the child to the parent PROCESS by itself, so the assemblages are
+ * {parent, A} and {parent, B} and neither one names the other.  A aborts.
+ * Terminating the parent is then only the first step - B is connected to a
+ * job that is now being terminated for a failure, and has to come down with
+ * it.  Stop after one step and B runs on with nothing left to talk to, and
+ * the DVM waits on it forever: the run does not end at all.  So this case is
+ * as much about prterun exiting as about which processes die.
  *
  * That difference is the whole test.  The PMIx definition of "connected" is
  * that the host environment must generate PMIX_ERR_PROC_TERM_WO_SYNC to the
@@ -40,6 +52,7 @@
  *   CNCT <role> <rank> DISCONNECT <status>
  *   CNCT <role> <rank> EVENT <status> FROM <nspace>:<rank>
  *   CNCT <role> <rank> EVENTS <n>
+ *   CNCT <role> <rank> ALIVE <secs>
  *   CNCT <role> <rank> DONE <rc>
  *
  * Why this cannot be a unit test, or even a single-node run: the PMIx server
@@ -97,6 +110,35 @@ static void reg_cb(pmix_status_t status, size_t errhandler_ref, void *cbdata)
     handler_done = true;
 }
 
+/* Spawn one copy of ourselves, off this node where the harness asked for it.
+ * Returns the child namespace in "child". */
+static pmix_status_t spawn_self(char *self, const char *child_host,
+                                const char *extra, pmix_nspace_t child)
+{
+    pmix_app_t app;
+    pmix_info_t jobinfo;
+    pmix_status_t rc;
+
+    PMIX_APP_CONSTRUCT(&app);
+    app.cmd = strdup(self);
+    app.maxprocs = 1;
+    PMIx_Argv_append_nosize(&app.argv, self);
+    PMIx_Argv_append_nosize(&app.argv, "--siblings");
+    if (NULL != extra) {
+        PMIx_Argv_append_nosize(&app.argv, (char *) extra);
+    }
+    if (NULL != child_host) {
+        PMIX_INFO_CREATE(app.info, 1);
+        PMIX_INFO_LOAD(&app.info[0], PMIX_HOST, child_host, PMIX_STRING);
+        app.ninfo = 1;
+    }
+    PMIX_INFO_LOAD(&jobinfo, PMIX_NOTIFY_COMPLETION, NULL, PMIX_BOOL);
+    rc = PMIx_Spawn(&jobinfo, 1, &app, 1, child);
+    PMIX_INFO_DESTRUCT(&jobinfo);
+    PMIX_APP_DESTRUCT(&app);
+    return rc;
+}
+
 int main(int argc, char **argv)
 {
     pmix_status_t rc;
@@ -109,6 +151,9 @@ int main(int argc, char **argv)
     bool disconnect = false;
     bool doabort = false;
     bool ischild = false;
+    bool siblings = false;
+    bool bystander = false;
+    pmix_nspace_t sibling;
     int wait_secs = 15;
     char *child_host = NULL;
     char host[256];
@@ -119,6 +164,10 @@ int main(int argc, char **argv)
             disconnect = true;
         } else if (0 == strcmp(argv[i], "--abort")) {
             doabort = true;
+        } else if (0 == strcmp(argv[i], "--siblings")) {
+            siblings = true;
+        } else if (0 == strcmp(argv[i], "--bystander")) {
+            bystander = true;
         } else if (0 == strcmp(argv[i], "--child-host") && i + 1 < argc) {
             child_host = argv[++i];
         } else if (0 == strcmp(argv[i], "--wait") && i + 1 < argc) {
@@ -144,6 +193,10 @@ int main(int argc, char **argv)
         PMIX_VALUE_RELEASE(val);
     }
 
+    if (ischild && bystander) {
+        role = "bystander";
+    }
+
     if (0 != gethostname(host, sizeof(host))) {
         strcpy(host, "unknown");
     }
@@ -154,6 +207,65 @@ int main(int argc, char **argv)
     PMIx_Register_event_handler(&code, 1, NULL, 0, evhandler, reg_cb, NULL);
     while (!handler_done) {
         usleep(10000);
+    }
+
+    /* The transitive case runs entirely here and never reaches the explicit
+     * connect below: the assemblages it is about are the ones the two spawns
+     * create by themselves, and an explicit connect on top of them would add
+     * a third that names both children and hide the very gap under test. */
+    if (siblings) {
+        if (!ischild) {
+            rc = spawn_self(argv[0], child_host, "--abort", child);
+            if (PMIX_SUCCESS != rc) {
+                printf("CNCT %s %u DONE %d\n", role, myproc.rank, rc);
+                fflush(stdout);
+                PMIx_Finalize(NULL, 0);
+                return 1;
+            }
+            printf("CNCT %s %u CHILD %s\n", role, myproc.rank, child);
+            fflush(stdout);
+
+            rc = spawn_self(argv[0], child_host, "--bystander", sibling);
+            if (PMIX_SUCCESS != rc) {
+                printf("CNCT %s %u DONE %d\n", role, myproc.rank, rc);
+                fflush(stdout);
+                PMIx_Finalize(NULL, 0);
+                return 1;
+            }
+            printf("CNCT %s %u CHILD %s\n", role, myproc.rank, sibling);
+            fflush(stdout);
+
+            /* the parent is expected to be killed somewhere in here */
+            for (i = 0; i < wait_secs; i++) {
+                sleep(1);
+                printf("CNCT %s %u ALIVE %d\n", role, myproc.rank, i + 1);
+                fflush(stdout);
+            }
+            printf("CNCT %s %u DONE 0\n", role, myproc.rank);
+            fflush(stdout);
+            PMIx_Finalize(NULL, 0);
+            return 0;
+        }
+        if (bystander) {
+            /* connected to the parent by the spawn, and to nothing else - so
+             * whether this job ends is entirely the runtime's decision */
+            for (i = 0; i < wait_secs; i++) {
+                sleep(1);
+                printf("CNCT %s %u ALIVE %d\n", role, myproc.rank, i + 1);
+                fflush(stdout);
+            }
+            printf("CNCT %s %u DONE 0\n", role, myproc.rank);
+            fflush(stdout);
+            PMIx_Finalize(NULL, 0);
+            return 0;
+        }
+        /* the one that fails - late enough that its sibling is up */
+        sleep(3);
+        printf("CNCT %s %u ABORTING\n", role, myproc.rank);
+        fflush(stdout);
+        raise(SIGSEGV);
+        sleep(5);
+        return 1;
     }
 
     if (!ischild) {

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -4432,6 +4432,38 @@ test_connect() {
         && bad "the parent ran to completion despite the failure" \
         || ok "...and it did not reach the end of its own run"
 
+    banner "connect: the termination that failure causes is transitive"
+    # A spawn connects the child to the parent PROCESS, so a parent with two
+    # children sits in the two assemblages {parent, A} and {parent, B} and
+    # neither of them names the other.  When A fails, terminating the parent
+    # is only the first step: B is connected to a job that is now coming down
+    # for a failure, and comes down with it.  Sweeping only the assemblages
+    # that name A stops after the parent, and B keeps running with nothing
+    # left to talk to -- so the DVM never sees its last job end and prterun
+    # does not exit at all.  That is how an mpi4py MPI_Comm_spawn test whose
+    # child aborts wedges a whole CI run rather than merely failing.
+    #
+    # No explicit connect here on purpose: the assemblages under test are the
+    # ones the two spawns create by themselves.
+    out=$(PRUN "--host node1:1 -n 1 $CN --siblings --child-host node2 --wait 25" 2>&1)
+    n=$(echo "$out" | grep -c 'CNCT parent 0 CHILD ')
+    if [ "$n" = 2 ]; then
+        ok "the parent spawned two children, in two assemblages that do not name each other"
+    else
+        skp "only $n child job(s) spawned -- the sibling case is not being tested"
+    fi
+    echo "$out" | grep -q 'CNCT bystander 0 ALIVE' \
+        && ok "...and the second child was running when the first one failed" \
+        || skp "the second child never reported running -- nothing to orphan"
+    echo "$out" | grep -q 'A job is being terminated because a job it was connected to has failed' \
+        && ok "...and the failure terminated the job connected to it" \
+        || bad "nothing was terminated by the failure: $(echo "$out" | tr '\n' ' ' | tail -c 400)"
+    # the assertion that separates the fix from the bug: orphaned, the second
+    # child runs its wait out and reports DONE
+    echo "$out" | grep -q 'CNCT bystander 0 DONE' \
+        && bad "the second child outlived its parent -- prterun waits on it, and the run hangs" \
+        || ok "...including the sibling of the job that failed"
+
     banner "connect: a member that disconnected first is left out of that"
     # ...and the same failure, after both halves have disconnected, is the
     # child's own business.  This is what shows the teardown is driven by the

--- a/src/mca/plm/slurm/AGENTS.md
+++ b/src/mca/plm/slurm/AGENTS.md
@@ -59,7 +59,9 @@ If no Slurm command can be run, or the version cannot be parsed
    `num_new_daemons == 0` by fast-forwarding to `DAEMONS_REPORTED`.
 2. **Build the `srun` argv:**
    - `srun`
-   - `--external-launcher` (unless `early`)
+   - `--external-launcher` (unless `early`) — a compact with SLURM about
+     the *command line*; see the rule below for what it does and does not
+     promise.
    - `--ntasks-per-node=1` (one `prted` per node)
    - `--no-kill --kill-on-bad-exit=0`, always — see the rule below.
    - `--mpi=none` (daemons aren't MPI tasks), `--cpu-bind=none` (don't
@@ -159,6 +161,25 @@ not srun).
   [`common/slurm`](../../common/slurm/AGENTS.md) parsed out of
   `srun --version`. Change a threshold there, not here — and remember a
   third component reads the same struct.
+- **`--external-launcher` freezes the command line, not the behavior.**
+  SLURM added the option precisely for projects like this one. SLURM wants
+  to keep changing `srun`'s command line at will — adding options,
+  removing them, changing what a flag means — and any of those changes can
+  break an integration that execs `srun` the way we do. Passing
+  `--external-launcher` declares that we are one of those integrations, and
+  in exchange SLURM undertakes that the `srun` command line we see will not
+  change under us. So when something goes wrong here, the argv we build is
+  an *unlikely* culprit — not impossible, but look elsewhere first.
+
+  What that guarantee explicitly does **not** cover is `srun`'s *behavior*.
+  SLURM does change it, occasionally in ways that reach us: how the procs
+  `srun` starts get bound is the standing example, and a binding change on
+  SLURM's side can require a matching change in what the `prted` does, or in
+  the `prted` command line we hand it. So a failure that survives an
+  unchanged argv is far more likely to be a behavioral change on SLURM's
+  side than a command-line one — diagnose it by looking at what `srun`
+  *did* to the daemons (binding, environment, step membership), not at what
+  we typed.
 - **The kill flags are unconditional, and must stay that way.**
   `--kill-on-bad-exit` tells `srun` to take down the *whole step* when any
   one task exits non-zero, and `--no-kill` is what stops a single node's

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -982,6 +982,33 @@ Two things follow from that record, and they are the rest of the definition:
   The assemblage is marked `terminating` as it goes, so the failures its own
   teardown produces do not drive it again.
 
+  **That termination is transitive, and has to be.** Killing a job because a
+  job it was connected to failed is itself the loss of that job, so whatever
+  *it* was connected to has lost a member too. The case is ordinary rather
+  than exotic, because a spawn connects the child to the parent **process**: a
+  parent that spawns two children sits in `{parent, A}` and `{parent, B}`, and
+  neither assemblage names the other. Sweeping only the assemblages that name
+  A takes the parent down and stops — leaving B running with nothing left to
+  talk to, and the DVM waiting forever on a job that will never end. The
+  symptom is not an untidy exit but a **hang**: `prterun` does not return
+  while a job it launched is alive, which is how an `MPI_Comm_spawn` test
+  whose child aborts wedges an entire CI run instead of merely failing it.
+  So the sweep runs to a fixed point over the `condemned` set, each pass
+  seeing the jobs the pass before it condemned; `terminating` is what bounds
+  it, since an assemblage is marked as it is swept and never revisited.
+
+  The closure extends **only through jobs the sweep is itself taking down**.
+  A member that is already gone, or already flagged `PRTE_JOB_FLAG_ABORTED`,
+  is skipped and deliberately not added to `condemned`: a job that ended on
+  its own terms notified its assemblages when it went and killed nobody, and
+  reading it as a failure now would reach through a job that is no longer
+  there to take down peers that survived it.
+
+  `connector --siblings` in [`contrib/dockerswarm`](../../../contrib/dockerswarm/)
+  is the multi-node case, and `test_connection_fate_sharing()` in
+  [`test/unit/prted/`](../../../test/unit/prted/) the offline one; both fail
+  against a one-step sweep.
+
 **Dissolving is more generous than recording, deliberately.** Recording
 compares memberships exactly; a disconnect dissolves any assemblage all of
 whose members it *names*, wildcards covering ranks. That asymmetry is what

--- a/src/prted/pmix/pmix_server_connect.c
+++ b/src/prted/pmix/pmix_server_connect.c
@@ -440,14 +440,14 @@ done:
     PMIX_PROC_RELEASE(proxy);
 }
 
-/* Does this assemblage name this job at all? */
-static bool connection_names_job(prte_pmix_server_connection_t *cptr,
-                                 const pmix_nspace_t nspace)
+/* Is this job already coming down - the one the failure happened in, or one
+ * an earlier pass of the sweep below has already ordered killed? */
+static bool nspace_condemned(char **condemned, const pmix_nspace_t nspace)
 {
-    size_t n;
+    int i;
 
-    for (n = 0; n < cptr->nmembers; n++) {
-        if (same_nspace(cptr->members[n].nspace, nspace)) {
+    for (i = 0; NULL != condemned && NULL != condemned[i]; i++) {
+        if (same_nspace(condemned[i], nspace)) {
             return true;
         }
     }
@@ -461,8 +461,10 @@ void prte_pmix_server_connection_job_failed(const pmix_nspace_t nspace)
     pmix_proc_t target;
     pmix_pointer_array_t procs;
     prte_proc_t *pobj;
-    size_t n, m;
-    bool done;
+    char **condemned = NULL;
+    const char *cause;
+    size_t n;
+    bool swept;
     int i;
 
     if (!registry_live() || !prte_pmix_server_globals.terminate_connected) {
@@ -473,63 +475,103 @@ void prte_pmix_server_connection_job_failed(const pmix_nspace_t nspace)
         return;
     }
 
-    PMIX_LIST_FOREACH(cptr, &prte_pmix_server_globals.connections,
-                      prte_pmix_server_connection_t) {
-        if (cptr->terminating || !connection_names_job(cptr, nspace)) {
-            continue;
-        }
-        /* the rest of this assemblage is coming down with it, and each of
-         * those jobs will report its own procs failing as it goes - none of
-         * which should drive this again */
-        cptr->terminating = true;
+    /* the closure starts with the job the failure actually happened in */
+    PMIx_Argv_append_nosize(&condemned, nspace);
 
-        for (n = 0; n < cptr->nmembers; n++) {
-            if (same_nspace(cptr->members[n].nspace, nspace)) {
+    /* Fate sharing has to be transitive.  Killing a job because a job it was
+     * connected to failed is itself the loss of that job, so whatever *it*
+     * was connected to has lost a member too and comes down in its turn.
+     *
+     * The case is ordinary rather than exotic, because a spawn connects the
+     * child to the parent *process*: a parent that spawns two children sits
+     * in the two assemblages {parent, A} and {parent, B}, and neither of them
+     * names the other.  Sweeping only the assemblages that name A takes the
+     * parent down and stops there - leaving B running with nothing left to
+     * talk to, and the DVM waiting on it forever.  That is a hang, not an
+     * untidiness: prterun does not exit while a job it launched is alive, so
+     * an MPI_Comm_spawn test whose child aborts wedges the whole run.
+     *
+     * So sweep to a fixed point.  Each pass condemns the assemblages naming a
+     * job that is already coming down, and the pass after it sees the jobs
+     * that pass just condemned.  It terminates because an assemblage is
+     * marked `terminating` as it is swept and is never revisited, so every
+     * pass either marks at least one more or is the last one. */
+    do {
+        swept = false;
+        PMIX_LIST_FOREACH(cptr, &prte_pmix_server_globals.connections,
+                          prte_pmix_server_connection_t) {
+            if (cptr->terminating) {
                 continue;
             }
-            /* a namespace can appear more than once in a membership - one
-             * entry per rank - and it is to be killed once */
-            done = false;
-            for (m = 0; m < n; m++) {
-                if (same_nspace(cptr->members[m].nspace, cptr->members[n].nspace)) {
-                    done = true;
+            /* an assemblage is condemned by naming a job that is coming down,
+             * and the member that does so is the one to report as the cause -
+             * naming the original failure instead would point the user at a
+             * job this assemblage was never connected to */
+            cause = NULL;
+            for (n = 0; n < cptr->nmembers; n++) {
+                if (nspace_condemned(condemned, cptr->members[n].nspace)) {
+                    cause = cptr->members[n].nspace;
                     break;
                 }
             }
-            if (done) {
-                continue;
-            }
-            jptr = prte_get_job_data_object(cptr->members[n].nspace);
-            if (NULL == jptr || PRTE_FLAG_TEST(jptr, PRTE_JOB_FLAG_ABORTED) ||
-                PRTE_JOB_STATE_TERMINATED <= jptr->state) {
-                /* already gone, or already on its way */
+            if (NULL == cause) {
                 continue;
             }
 
-            /* the user is about to lose a job they did not ask about, so say
-             * why - "connected" is not a property they can see in ps */
-            prte_show_help("help-prted.txt", "connected-term", true,
-                           nspace, jptr->nspace);
+            /* the rest of this assemblage is coming down with it, and each of
+             * those jobs will report its own procs failing as it goes - none of
+             * which should drive this again */
+            cptr->terminating = true;
+            swept = true;
 
-            PMIX_LOAD_PROCID(&target, jptr->nspace, PMIX_RANK_WILDCARD);
-            notify_assemblage(cptr->members, cptr->nmembers,
-                              PMIX_ERR_JOB_TERM_WO_SYNC, &target, -1);
-
-            PMIX_CONSTRUCT(&procs, pmix_pointer_array_t);
-            pmix_pointer_array_init(&procs, 1, 1, 1);
-            pobj = PMIX_NEW(prte_proc_t);
-            PMIX_XFER_PROCID(&pobj->name, &target);
-            pmix_pointer_array_add(&procs, pobj);
-            prte_plm.terminate_procs(&procs);
-            for (i = 0; i < procs.size; i++) {
-                pobj = (prte_proc_t *) pmix_pointer_array_get_item(&procs, i);
-                if (NULL != pobj) {
-                    PMIX_RELEASE(pobj);
+            for (n = 0; n < cptr->nmembers; n++) {
+                /* a namespace can appear more than once in a membership - one
+                 * entry per rank - and it is to be killed once.  The condemned
+                 * list is what keeps it to one, here and on every later pass */
+                if (nspace_condemned(condemned, cptr->members[n].nspace)) {
+                    continue;
                 }
+                jptr = prte_get_job_data_object(cptr->members[n].nspace);
+                if (NULL == jptr || PRTE_FLAG_TEST(jptr, PRTE_JOB_FLAG_ABORTED) ||
+                    PRTE_JOB_STATE_TERMINATED <= jptr->state) {
+                    /* Already gone, or already on its way - and deliberately
+                     * NOT added to the condemned list.  The closure extends
+                     * only through jobs this sweep is itself taking down: a
+                     * member that ended on its own terms notified its
+                     * assemblages when it went and killed nobody, and reading
+                     * it now as a failure would reach through a job that is
+                     * no longer there to take down peers that survived it. */
+                    continue;
+                }
+                PMIx_Argv_append_nosize(&condemned, cptr->members[n].nspace);
+
+                /* the user is about to lose a job they did not ask about, so say
+                 * why - "connected" is not a property they can see in ps */
+                prte_show_help("help-prted.txt", "connected-term", true,
+                               cause, jptr->nspace);
+
+                PMIX_LOAD_PROCID(&target, jptr->nspace, PMIX_RANK_WILDCARD);
+                notify_assemblage(cptr->members, cptr->nmembers,
+                                  PMIX_ERR_JOB_TERM_WO_SYNC, &target, -1);
+
+                PMIX_CONSTRUCT(&procs, pmix_pointer_array_t);
+                pmix_pointer_array_init(&procs, 1, 1, 1);
+                pobj = PMIX_NEW(prte_proc_t);
+                PMIX_XFER_PROCID(&pobj->name, &target);
+                pmix_pointer_array_add(&procs, pobj);
+                prte_plm.terminate_procs(&procs);
+                for (i = 0; i < procs.size; i++) {
+                    pobj = (prte_proc_t *) pmix_pointer_array_get_item(&procs, i);
+                    if (NULL != pobj) {
+                        PMIX_RELEASE(pobj);
+                    }
+                }
+                PMIX_DESTRUCT(&procs);
             }
-            PMIX_DESTRUCT(&procs);
         }
-    }
+    } while (swept);
+
+    PMIx_Argv_free(condemned);
 }
 
 void prte_pmix_server_connection_purge(const pmix_nspace_t nspace)

--- a/test/unit/prted/test_prted.c
+++ b/test/unit/prted/test_prted.c
@@ -68,6 +68,7 @@
 #include "src/util/proc_info.h"
 #include "src/util/pmix_environ.h"
 
+#include "src/mca/plm/plm.h"
 #include "src/mca/rmaps/base/base.h"
 #include "src/mca/rmaps/rmaps_types.h"
 #include "src/mca/schizo/base/base.h"
@@ -2342,6 +2343,164 @@ static int test_connections(void)
 }
 
 /*
+ * Fate sharing is transitive.
+ *
+ * A spawn connects the child to the parent PROCESS, so a parent that spawns
+ * two children sits in two assemblages that do not name each other.  When one
+ * child fails, terminating the parent is only the first step: the parent is
+ * now gone too, so the assemblage it shares with its OTHER child has lost a
+ * member as well, and that child - which by then has nothing left to talk to -
+ * has to come down with it.  Stopping after one step leaves it running, and
+ * the DVM never exits because it is still waiting on a job that is alive.
+ */
+static char **fate_killed = NULL;
+
+static int fate_terminate_procs(pmix_pointer_array_t *procs)
+{
+    prte_proc_t *pobj;
+    int i;
+
+    for (i = 0; i < procs->size; i++) {
+        pobj = (prte_proc_t *) pmix_pointer_array_get_item(procs, i);
+        if (NULL != pobj) {
+            PMIx_Argv_append_nosize(&fate_killed, pobj->name.nspace);
+        }
+    }
+    return PRTE_SUCCESS;
+}
+
+static bool fate_was_killed(const char *nspace)
+{
+    int i;
+
+    for (i = 0; NULL != fate_killed && NULL != fate_killed[i]; i++) {
+        if (0 == strcmp(fate_killed[i], nspace)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static prte_job_t *fate_job(const char *nspace)
+{
+    prte_job_t *jdata;
+
+    jdata = PMIX_NEW(prte_job_t);
+    PMIX_LOAD_NSPACE(jdata->nspace, nspace);
+    if (PRTE_SUCCESS != prte_set_job_data_object(jdata)) {
+        PMIX_RELEASE(jdata);
+        return NULL;
+    }
+    return jdata;
+}
+
+static int test_connection_fate_sharing(void)
+{
+    int failures = 0;
+    pmix_proc_t members[2];
+    prte_job_t *parent, *victim, *middle, *grandchild;
+    prte_pmix_server_connection_t *cptr;
+    prte_plm_base_module_t saved_plm;
+    bool made_array = false;
+    int nterminating = 0;
+
+    PMIX_CONSTRUCT(&prte_pmix_server_globals.connections, pmix_list_t);
+    prte_pmix_server_globals.initialized = true;
+    prte_pmix_server_globals.terminate_connected = true;
+    if (NULL == prte_job_data) {
+        prte_job_data = PMIX_NEW(pmix_pointer_array_t);
+        pmix_pointer_array_init(prte_job_data, 8, INT32_MAX, 8);
+        made_array = true;
+    }
+
+    /* the kills are what this is about, so catch them rather than sending
+     * them - the real module would put them on the wire */
+    saved_plm = prte_plm;
+    memset(&prte_plm, 0, sizeof(prte_plm));
+    prte_plm.terminate_procs = fate_terminate_procs;
+
+    parent = fate_job("unit-test-fate@1");
+    victim = fate_job("unit-test-fate@2");
+    middle = fate_job("unit-test-fate@3");
+    grandchild = fate_job("unit-test-fate@4");
+    CHECK("the fate-sharing jobs register",
+          NULL != parent && NULL != victim && NULL != middle && NULL != grandchild);
+    if (NULL == parent || NULL == victim || NULL == middle || NULL == grandchild) {
+        goto cleanup;
+    }
+
+    /* parent rank 0 spawned the victim, parent rank 1 spawned the middle
+     * job, and the middle job spawned a child of its own.  No two of these
+     * three assemblages name each other's far end. */
+    PMIX_LOAD_PROCID(&members[0], parent->nspace, 0);
+    PMIX_LOAD_PROCID(&members[1], victim->nspace, PMIX_RANK_WILDCARD);
+    prte_pmix_server_connection_record(members, 2);
+
+    PMIX_LOAD_PROCID(&members[0], parent->nspace, 1);
+    PMIX_LOAD_PROCID(&members[1], middle->nspace, PMIX_RANK_WILDCARD);
+    prte_pmix_server_connection_record(members, 2);
+
+    PMIX_LOAD_PROCID(&members[0], middle->nspace, 0);
+    PMIX_LOAD_PROCID(&members[1], grandchild->nspace, PMIX_RANK_WILDCARD);
+    prte_pmix_server_connection_record(members, 2);
+
+    CHECK("three assemblages recorded",
+          3 == pmix_list_get_size(&prte_pmix_server_globals.connections));
+
+    prte_pmix_server_connection_job_failed(victim->nspace);
+
+    CHECK("the parent of the failed job is terminated",
+          fate_was_killed(parent->nspace));
+    CHECK("so is the parent's other child",
+          fate_was_killed(middle->nspace));
+    CHECK("and so is that child's own child",
+          fate_was_killed(grandchild->nspace));
+    CHECK("the job that failed is not killed again",
+          !fate_was_killed(victim->nspace));
+
+    PMIX_LIST_FOREACH(cptr, &prte_pmix_server_globals.connections,
+                      prte_pmix_server_connection_t) {
+        if (cptr->terminating) {
+            nterminating++;
+        }
+    }
+    CHECK("every assemblage in the closure is marked terminating",
+          3 == nterminating);
+
+cleanup:
+    prte_plm = saved_plm;
+    PMIx_Argv_free(fate_killed);
+    fate_killed = NULL;
+    if (NULL != parent) {
+        pmix_pointer_array_set_item(prte_job_data, parent->index, NULL);
+        PMIX_RELEASE(parent);
+    }
+    if (NULL != victim) {
+        pmix_pointer_array_set_item(prte_job_data, victim->index, NULL);
+        PMIX_RELEASE(victim);
+    }
+    if (NULL != middle) {
+        pmix_pointer_array_set_item(prte_job_data, middle->index, NULL);
+        PMIX_RELEASE(middle);
+    }
+    if (NULL != grandchild) {
+        pmix_pointer_array_set_item(prte_job_data, grandchild->index, NULL);
+        PMIX_RELEASE(grandchild);
+    }
+    prte_pmix_server_globals.initialized = false;
+    PMIX_LIST_DESTRUCT(&prte_pmix_server_globals.connections);
+    if (made_array) {
+        PMIX_RELEASE(prte_job_data);
+        prte_job_data = NULL;
+    }
+
+    if (0 == failures) {
+        fprintf(stdout, "PASSED test_connection_fate_sharing\n");
+    }
+    return failures;
+}
+
+/*
  * prte_parse_uint_option(): the numeric option values.
  *
  * strtoul() reports success and zero for a string with no digits in it, and
@@ -2567,6 +2726,7 @@ int main(void)
     failures += test_departed_jobs();
     failures += test_monitor_accounting();
     failures += test_connections();
+    failures += test_connection_fate_sharing();
     failures += test_tool_registration();
     failures += test_query_qualifiers();
     failures += test_group_left();


### PR DESCRIPTION
The `plm/slurm` component guide named `--external-launcher` only as a version-gated flag, which leaves the next reader to guess why we pass it and — worse — to reach for the `srun` command line first when something goes wrong in this component.

SLURM added the option for integrations like ours. SLURM wants to keep changing `srun`'s command line at will (adding options, removing them, changing what a flag means), and any of that can break a project that execs `srun` the way we do. Passing the flag declares that we are such a project, and in exchange SLURM undertakes that the command line we see will not move under us. That makes our argv an unlikely culprit for a failure here, which is worth saying so nobody spends a day auditing it.

What the guarantee does **not** cover is `srun`'s *behavior*, and that does change — how the procs `srun` starts get bound is the standing example, and a change there can require a matching change in what the `prted` does or in the `prted` command line we hand it.

Both halves are now recorded in `src/mca/plm/slurm/AGENTS.md`, so triage starts by asking what `srun` did to the daemons rather than what we typed. Documentation only; no code change.