### PR TITLE
Check the three sub-list conversions in register_nspace()

### DIFF
--- a/docs/todo.rst
+++ b/docs/todo.rst
@@ -107,21 +107,6 @@ which nodes, and the daemon-launch path would have to fan out through more
 than one.  At minimum it needs a launcher affinity recorded per node and
 honored by ``prte_plm_base_setup_virtual_machine``.
 
-**``register_nspace()`` checks the list it is building, not the entries it
-puts in it.**  ``prte_pmix_server_register_nspace``
-(``src/prted/pmix/pmix_server_register_fns.c``) makes roughly forty
-``PMIX_INFO_LIST_ADD`` calls and reads the status of three of them.  The
-review checked the two that decide whether the registration is coherent at
-all — that the list handle exists, and that the final conversion into the
-array handed to ``PMIx_server_register_nspace`` succeeded — and left the
-rest, on the argument that ``PMIx_Info_list_add`` fails only on a NULL list
-or out of memory, and that forty checks would treble the length of an
-already very long function to report a condition under which the daemon is
-failing everywhere at once.  The consequence if that argument is wrong is a
-job registered with a key silently missing.  What would settle it properly
-is not forty checks but an accumulator — one status the adds fold into,
-tested once — which is a change to the macro, not to this file.
-
 **A session control addressed to every session answers with no session id.**
 ``apply_to_all`` (``src/prted/pmix/pmix_server_session.c``) applies the
 operation to each session the requestor controls and then builds one answer

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -585,6 +585,20 @@ are load bearing:
   daemon, and `pmix_server_dmdx_recv()` arms the timer. That is why the
   attribute table registers `PMIX_TIMEOUT` under `PMIx_Get`.
 
+**The adds are answerable at the conversions, not one by one.**
+`register_nspace()` makes sixty-eight `PMIX_INFO_LIST_ADD` calls and tests
+three of them, and that is deliberate. An info list carries the first
+failure any add onto it hit, and `PMIX_INFO_LIST_CONVERT` reports it — so
+the four conversions in this function are where all sixty-eight are
+checked, and they are all checked. Adding a per-add test buys nothing;
+**leaving a conversion untested loses an entire array**, because the
+converter initializes the caller's `pmix_data_array_t` before anything can
+fail, so what an unchecked failure puts in the payload is an empty
+`PMIX_NODE_INFO_ARRAY` / `PMIX_APP_INFO_ARRAY` / `PMIX_PROC_INFO_ARRAY`
+under a registration that reports success. The three sub-list
+`PMIX_INFO_LIST_START` handles are screened for the same reason: a NULL one
+makes every add onto it fail, and the conversion is what says so.
+
 **`register_nspace()` is not called once per job.** The wildcard arm of
 `dmodex_req()` calls it again whenever a client asks a daemon that hosts none
 of the job's procs for job-level data the local server does not hold — once

--- a/src/prted/pmix/pmix_server_register_fns.c
+++ b/src/prted/pmix/pmix_server_register_fns.c
@@ -335,6 +335,15 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
             }
             /* construct the node info array */
             PMIX_INFO_LIST_START(iarray);
+            if (NULL == iarray) {
+                PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+                if (NULL != tmp) {
+                    free(tmp);
+                }
+                PMIX_INFO_LIST_RELEASE(info);
+                rc = PRTE_ERR_OUT_OF_RESOURCE;
+                goto errout;
+            }
             /* start with the hostname */
             PMIX_INFO_LIST_ADD(ret, iarray, PMIX_HOSTNAME, node->name, PMIX_STRING);
             /* add any aliases */
@@ -367,8 +376,21 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
             if (PRTE_FLAG_TEST(node, PRTE_NODE_FLAG_OVERSUBSCRIBED)) {
                 PMIX_INFO_LIST_ADD(ret, iarray, PMIX_NODE_OVERSUBSCRIBED, NULL, PMIX_BOOL);
             }
-            /* add to the overall payload */
+            /* Add to the overall payload.  The conversion is the one place
+             * the adds above are answerable: an info list carries the first
+             * failure any add onto it hit, and reports it here.  Without this
+             * test the whole array goes in empty - not one key missing but
+             * every key of every node - under a registration that reports
+             * success. */
             PMIX_INFO_LIST_CONVERT(ret, iarray, &darray);
+            if (PMIX_SUCCESS != ret) {
+                PMIX_ERROR_LOG(ret);
+                PMIX_DATA_ARRAY_DESTRUCT(&darray);
+                PMIX_INFO_LIST_RELEASE(iarray);
+                PMIX_INFO_LIST_RELEASE(info);
+                rc = prte_pmix_convert_status(ret);
+                goto errout;
+            }
             PMIX_INFO_LIST_ADD(ret, info, PMIX_NODE_INFO_ARRAY, &darray, PMIX_DATA_ARRAY);
             PMIX_DATA_ARRAY_DESTRUCT(&darray);
             PMIX_INFO_LIST_RELEASE(iarray);
@@ -558,6 +580,12 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
             continue;
         }
         PMIX_INFO_LIST_START(iarray);
+        if (NULL == iarray) {
+            PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+            PMIX_INFO_LIST_RELEASE(info);
+            rc = PRTE_ERR_OUT_OF_RESOURCE;
+            goto errout;
+        }
         /* start with the app number */
         PMIX_INFO_LIST_ADD(ret, iarray, PMIX_APPNUM, &app->idx, PMIX_UINT32);
         /* add the app size */
@@ -642,8 +670,17 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
             }
             PMIX_LIST_DESTRUCT(&members);
         }
-        /* add to the main payload */
+        /* add to the main payload - see the node array above for why the
+         * conversion is checked */
         PMIX_INFO_LIST_CONVERT(ret, iarray, &darray);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            PMIX_DATA_ARRAY_DESTRUCT(&darray);
+            PMIX_INFO_LIST_RELEASE(iarray);
+            PMIX_INFO_LIST_RELEASE(info);
+            rc = prte_pmix_convert_status(ret);
+            goto errout;
+        }
         PMIX_INFO_LIST_ADD(ret, info, PMIX_APP_INFO_ARRAY, &darray, PMIX_DATA_ARRAY);
         PMIX_DATA_ARRAY_DESTRUCT(&darray);
         PMIX_INFO_LIST_RELEASE(iarray);
@@ -710,6 +747,12 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
             }
             /* setup the proc map object */
             PMIX_INFO_LIST_START(pmap);
+            if (NULL == pmap) {
+                PRTE_ERROR_LOG(PRTE_ERR_OUT_OF_RESOURCE);
+                PMIX_INFO_LIST_RELEASE(info);
+                rc = PRTE_ERR_OUT_OF_RESOURCE;
+                goto errout;
+            }
 
             /* must start with rank */
             PMIX_INFO_LIST_ADD(ret, pmap, PMIX_RANK, &pptr->name.rank, PMIX_PROC_RANK);
@@ -859,7 +902,16 @@ int prte_pmix_server_register_nspace(prte_job_t *jdata,
                 PMIX_INFO_LIST_ADD(ret, pmap, PMIX_DEVICE_ID, devarray, PMIX_DATA_ARRAY);
                 PMIX_DATA_ARRAY_FREE(devarray);
             }
+            /* see the node array above for why the conversion is checked */
             PMIX_INFO_LIST_CONVERT(ret, pmap, &darray);
+            if (PMIX_SUCCESS != ret) {
+                PMIX_ERROR_LOG(ret);
+                PMIX_DATA_ARRAY_DESTRUCT(&darray);
+                PMIX_INFO_LIST_RELEASE(pmap);
+                PMIX_INFO_LIST_RELEASE(info);
+                rc = prte_pmix_convert_status(ret);
+                goto errout;
+            }
             PMIX_INFO_LIST_ADD(ret, info, PMIX_PROC_INFO_ARRAY, &darray, PMIX_DATA_ARRAY);
             PMIX_DATA_ARRAY_DESTRUCT(&darray);
             PMIX_INFO_LIST_RELEASE(pmap);


### PR DESCRIPTION
## The problem

`prte_pmix_server_register_nspace()` makes sixty-eight
`PMIX_INFO_LIST_ADD` calls and reads the status of three of them. That was
deliberate, and `docs/todo.rst` recorded it: `PMIx_Info_list_add()` fails
only on a NULL list or out of memory, and sixty-eight checks would treble
the length of an already very long function to report a condition under
which the daemon is failing everywhere at once. The entry said what would
settle it — an accumulator, one status the adds fold into, tested once,
which is a change to PMIx rather than to this file.

PMIx now has it (**depends on openpmix/openpmix#4238**): an info list
carries the first failure any add onto it hit, and
`PMIX_INFO_LIST_CONVERT` reports it. The four conversions in this function
are therefore where all sixty-eight adds are answerable.

Which is why the three that were **not** checked matter more than the adds
ever did. `PMIx_Info_list_convert()` initializes the caller's
`pmix_data_array_t` before anything can fail, so an unchecked failure does
not leave a stale array — it adds an *empty* one. Not one key missing from
a node but every key of every node: `PMIX_NODE_INFO_ARRAY`,
`PMIX_APP_INFO_ARRAY` or `PMIX_PROC_INFO_ARRAY` going into the payload
with nothing in it, under a registration that then reports success. The
final conversion — the one that produces the array handed to
`PMIx_server_register_nspace` — was already checked for exactly this
reason. The three that build the sub-arrays were not.

Their `PMIX_INFO_LIST_START` handles were not screened either. A NULL
sub-list makes every add onto it fail, and nothing said so: the conversion
returned an initialized, empty array and the code carried on.

## What this does

Six lines of checking, in the three places that can lose an entire array,
and the todo entry deleted since this closes it. No per-add checks are
added — with the accumulator they would buy nothing, and `AGENTS.md` now
records that so the next reader does not add them.

## Testing

- Clean `--enable-debug` build against the PMIx branch above; `make check`
  green.
- Live DVM: `prun -n 4 hostname`, `--display map` (node and proc arrays,
  with cpusets and locality strings), MPMD with two app contexts (two
  `PMIX_APP_INFO_ARRAY` conversions), and `--pset` (`PMIX_PSET_MEMBERS`) —
  every conversion site in the function is exercised.

The failure paths themselves are allocation failures, which
`test/unit/prted` cannot stage: it initializes no PMIx server, and
everything past the early returns of this file ends in
`PMIx_server_register_nspace`. The behaviour that the accumulator makes
these checks meaningful is covered by unit tests on the PMIx side.
