### PR TITLE
Answer a proc table from state the answering daemon actually has

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -55,7 +55,7 @@ It is **not** a Docker Swarm in the orchestration sense — just ten plain
 | *(no file here)* | `build.sh` also compiles [`examples/dynamic.c`](../../examples/dynamic.c) from the main tree as `dynamic` — the only client in this harness that calls `PMIx_Spawn`, and so the only way to get a **parent/child job pair**. See §11. |
 | `dataserver.c` | A bare PMIx client for the publish/lookup service (`dataserver` in the install): publish/lookup/lookupwait/lookup2/unpublish. Drives `src/runtime/data_server`. See §13. |
 | `jobinfo.c` | A bare PMIx client for the **direct-modex** paths (`jobinfo` in the install): `publish`/`fetch`/`fetchkey`. Drives `src/prted/pmix/pmix_server_fence.c` from a daemon that hosts none of the target job's procs. |
-| `proctable.c` | A bare PMIx client for the **proc-table and server-URI queries** (`proctable` in the install): `procs`/`localprocs`/`serveruri`. Those are the only callers of `prte_pmix_convert_state()`, and the local-vs-global proc-table split has no meaning on one host. Drives `src/pmix`. |
+| `proctable.c` | A bare PMIx client for the **proc-table and server-URI queries** (`proctable` in the install): `procs`/`localprocs`/`departed`/`serveruri`. Those are the only callers of `prte_pmix_convert_state()`, and the local-vs-global proc-table split has no meaning on one host. `departed` lets half the job exit first, which is what tells a table that is *current* from one that is merely the launch message read back. Drives `src/pmix`. |
 | `peerinfo.c` | A bare PMIx client in which every rank asks **every other rank of its own job** where it is (`peerinfo` in the install): rank, app rank, local/node rank, node id, hostname, cpuset, locality string — and device distances, the one key an off-node peer must be *refused*. The only client here that reads a *peer's* reserved keys, and so the only one that reaches the daemon's derive-on-demand path — everything else either reads back what it put itself or asks about the job. Drives `derive_proc_data()` in `src/prted/pmix/pmix_server_fence.c`. See §20. |
 | `groupcon.c` | A bare PMIx client that drives a **group construct/destruct** (`groupcon` in the install): every rank contributes a local cid, asks for a context id, constructs, reads every peer's contribution back, destructs. Drives grpcomm's `grp_release` on daemons that merely *received* the broadcast. See §15. |
 | `groupinv.c` | A bare PMIx client that forms a group by **invitation** and asks for a context id (`groupinv` in the install). The highest rank leads, so mapped by node the leader is never the HNP - which is the point: that method runs no collective, so its leader asks for the id through job control and only the HNP holds the pool, so the request has to be relayed. Drives `PRTE_PMIX_GROUP_CTXID` in `src/prted/pmix`. See §15. |
@@ -639,6 +639,24 @@ is `proctable`, and it asserts:
 - `PMIX_QUERY_LOCAL_PROC_TABLE` returns *some but not all* of a job's procs.
   On one host "local" and "all" are the same set, so this case cannot exist
   there.
+- a proc that has **departed** is reported as departed. A daemon advances
+  `pid`, `state` and `exit_code` for its own local children and for nothing
+  else — proc states travel *up* to the master and never back down, because
+  no daemon needs a peer's — so the global table answered locally reported
+  every off-node rank with the state the launch message shipped, forever.
+  A rank that had exited seconds ago came back `LAUNCH_UNDERWAY`, and that
+  table is the only signal PRRTE offers for "has this proc gone away".
+  Neither case above catches it: a freshly launched job is one whose stale
+  entries happen to be right.
+
+  The probe is `proctable departed` — ranks 1 and 3 leave, rank 0 asks six
+  seconds later — and it runs **twice**, with the querier once on a
+  non-master node and once on the master. The master's own answer was
+  correct all along, so a case that asks only a non-master cannot tell a
+  fix from a daemon that stopped answering at all; the assertion worth
+  making is that the two placements agree. It also requires the two
+  survivors to still read as alive, since a table that called everything
+  terminated would satisfy the first half.
 - **every daemon serves every node's `PMIX_SERVER_URI`**. The consumer here
   is a **tool**, not a daemon — daemons reach each other over the RML and
   never form PMIx connections to one another; see `examples/tool.c --uri

--- a/contrib/dockerswarm/proctable.c
+++ b/contrib/dockerswarm/proctable.c
@@ -20,6 +20,15 @@
  *       Same, but PMIX_QUERY_LOCAL_PROC_TABLE -- only the procs the
  *       answering daemon hosts.
  *
+ *   proctable departed [seconds]
+ *       The whole job fences, then every ODD rank finalizes and exits.
+ *       Rank 0 waits [seconds] (default 5) and then queries
+ *       PMIX_QUERY_PROC_TABLE for its own namespace, printing the table the
+ *       same way "procs" does. Every other rank just waits and exits.
+ *       Mapped by node, the ranks that leave are on a different node from
+ *       rank 0, so the answering daemon hosts none of them -- which is the
+ *       whole point. See the second block comment below.
+ *
  *   proctable serveruri [hostname] [seconds]
  *       PMIx_Query(PMIX_SERVER_URI), optionally qualified by PMIX_HOSTNAME so
  *       the answer must come from ANOTHER node's daemon record. Prints
@@ -50,6 +59,16 @@
  * on this path was reported to the tool as a bare PMIX_ERROR. On one host
  * the hostname qualifier resolves to the local daemon and the interesting
  * branch is never taken.
+ *
+ * "departed" is the same query asked after some of the job has left. A
+ * daemon's copy of a job's proc array is the snapshot the launch message
+ * carried, and it advances the state of its OWN local children and nothing
+ * else -- no message carries a peer daemon's proc states back down the tree,
+ * because no daemon needs them. So an entry for a proc hosted elsewhere kept
+ * the state it was launched with for the life of the DVM, and a client whose
+ * daemon is not the master was told that a rank which exited long ago was
+ * still starting up. The master's table was correct all along, which is why
+ * this cannot be seen on one host: there the only daemon IS the master.
  *
  * Note that PMIX_SERVER_URI is the rendezvous address of a node's PMIx
  * SERVER -- how a client or tool connects to it. It is not how daemons reach
@@ -182,6 +201,34 @@ static int do_proc_table(const char *key, int seconds)
     return 0;
 }
 
+/* Fence the job, let the odd ranks go, then ask for the whole table.  Rank 0
+ * is the only one that queries; mapped by node it sits on a different node
+ * from every rank that left, so its daemon hosts none of them. */
+static int do_departed(int seconds)
+{
+    pmix_status_t rc;
+
+    /* nobody leaves until everybody has arrived, so the table rank 0 asks
+     * for is one whose entries all reached RUNNING first */
+    rc = PMIx_Fence(NULL, 0, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        printf("ERR %d %s\n", (int) rc, PMIx_Error_string(rc));
+        return 1;
+    }
+    if (0 != myproc.rank % 2) {
+        printf("LEAVING %u\n", myproc.rank);
+        fflush(stdout);
+        return 0;
+    }
+    if (0 != myproc.rank) {
+        /* an even rank that is not the querier just has to outlive it */
+        sleep(seconds + 5);
+        return 0;
+    }
+    sleep(seconds);
+    return do_proc_table(PMIX_QUERY_PROC_TABLE, 0);
+}
+
 static int do_server_uri(const char *hostname, int seconds)
 {
     pmix_query_t query;
@@ -225,7 +272,7 @@ int main(int argc, char **argv)
     int ret = 1;
 
     if (2 > argc) {
-        fprintf(stderr, "usage: %s procs|localprocs|serveruri [args]\n", argv[0]);
+        fprintf(stderr, "usage: %s procs|localprocs|departed|serveruri [args]\n", argv[0]);
         return 2;
     }
 
@@ -239,6 +286,8 @@ int main(int argc, char **argv)
         ret = do_proc_table(PMIX_QUERY_PROC_TABLE, (3 <= argc) ? atoi(argv[2]) : 0);
     } else if (0 == strcmp(argv[1], "localprocs")) {
         ret = do_proc_table(PMIX_QUERY_LOCAL_PROC_TABLE, (3 <= argc) ? atoi(argv[2]) : 0);
+    } else if (0 == strcmp(argv[1], "departed")) {
+        ret = do_departed((3 <= argc) ? atoi(argv[2]) : 5);
     } else if (0 == strcmp(argv[1], "serveruri")) {
         const char *host = (3 <= argc && 0 != strcmp(argv[2], "-")) ? argv[2] : NULL;
         ret = do_server_uri(host, (4 <= argc) ? atoi(argv[3]) : 0);

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -2645,6 +2645,48 @@ test_pmix() {
         && ok "...and no local proc reported UNDEF" \
         || bad "$undef local procs reported UNDEF"
 
+    banner "pmix: the proc table reports a departed proc as departed"
+    # A daemon's copy of a job is the launch message's snapshot, and it
+    # advances pid/state/exit_code for its OWN local children and nothing
+    # else -- no message carries a peer daemon's proc states back down the
+    # tree, because no daemon needs them.  Only the master is told.  So
+    # PMIX_QUERY_PROC_TABLE answered locally reported every off-node rank
+    # with the state the launch message shipped, for the life of the DVM: a
+    # rank that exited seconds ago came back as LAUNCH_UNDERWAY.  The whole
+    # key now goes to the master when the table reaches a proc this daemon
+    # does not host.
+    #
+    # This cannot be seen on one host -- there the only daemon IS the master
+    # -- and it does not show up in the two cases above either, because a
+    # freshly launched job is one whose stale entries happen to be right.
+    # Ranks 1 and 3 leave; rank 0 asks six seconds later.
+    #
+    # Run it BOTH ways.  The master's own answer was correct all along, so a
+    # case that only asks a non-master cannot tell a fix from a daemon that
+    # stopped answering at all -- and the point of the fix is that the two
+    # placements agree.
+    for site in node2:2,node3:2 node1:2,node2:2; do
+        case "$site" in
+            node1:*) who="the master" ;;
+            *)       who="a non-master daemon" ;;
+        esac
+        out=$(PRUN "--host $site -n 4 --map-by node $PT departed 6" 2>&1)
+        gone=$(echo "$out" | awk '$1=="PROC" && ($2==1 || $2==3) {print $5}')
+        n=$(echo "$gone" | grep -c 'TERMINATED' | tr -d ' ')
+        if [ "$n" = 2 ]; then
+            ok "$who reported both departed ranks as TERMINATED"
+        else
+            bad "$who reported the departed ranks as [$(echo "$gone" | tr '\n' ' ')]: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        fi
+        # the survivors must still read as alive -- a table that called
+        # everything terminated would pass the assertion above
+        n=$(echo "$out" | awk '$1=="PROC" && ($2==0 || $2==2) {print $4}' \
+            | awk '$1 < 15' | grep -c . | tr -d ' ')
+        [ "$n" = 2 ] \
+            && ok "...and both surviving ranks as still running" \
+            || bad "$who reported $n of 2 survivors as alive: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    done
+
     banner "pmix: every daemon serves every node's PMIX_SERVER_URI"
     # The consumer of this query is a TOOL, not a daemon -- daemons reach
     # each other over the RML and never form PMIx connections to one another.

--- a/src/mca/state/prted/AGENTS.md
+++ b/src/mca/state/prted/AGENTS.md
@@ -93,6 +93,20 @@ Keyed on `caddy->name` / `caddy->proc_state`. Per incoming proc state:
   the map), optionally run the fd-leak check, notify a data server, and
   release the job object.
 
+  **The batch is the point — do not report each proc as it exits.** One
+  message per node per job, sent once every one of that job's local procs
+  has finished, is a deliberate choice: reporting each termination as it
+  happened would put one message on the wire per terminated proc, and at
+  the scales PRRTE runs at that storm costs far more than the earlier
+  notice is worth. A consequence is that a rank which exits early reads
+  as still alive, on the master as much as anywhere, until its node-mates
+  finish. That is not a fidelity gap to be closed; the batch boundary is
+  also exactly the moment every proc on the node is gone, which is the
+  question anything waiting on this is really asking. Abnormal
+  terminations are a different path ([`errmgr/prted`](../../errmgr/prted/))
+  and *are* reported individually, because they are rare and the HNP has
+  to act on them at once.
+
 ### `track_jobs`
 Handles the two job states above. It walks `prte_local_children`, and for
 each child in the target job packs vpid + pid (+ state/exit-code for

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -830,6 +830,12 @@ flagged `PRTE_PROC_FLAG_LOCAL` — which is exactly the condition under
 which the accessor succeeds. It must not defer: relaying it would answer
 about the *master's* local procs.
 
+That arm also defers when it has never heard of the job at all. A launch
+message goes only to the daemons that host part of the job, so "no such
+job" from a prted is a statement about that daemon, not about the DVM —
+the master has heard of all of them. The local arm keeps answering
+`PMIX_ERR_NOT_FOUND` there, because for it that is the truth.
+
 **The decision is made by the read, never by a list of keys.** Which keys
 need the master is not knowable in advance, and a written-down list goes
 stale the first time someone adds one — silently, because the stale case

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -794,26 +794,55 @@ as `PMIX_SUCCESS`** — a wrong answer no caller can tell from a right one.
 The rank that happens to land on the master gets the truth; every other
 rank gets nothing, silently.
 
+The **job** table is stale in the same way, in one place. A daemon does
+hold a `prte_proc_t` for every proc of every job it hosts part of — the
+launch message ships the whole array — but it advances `pid`, `state` and
+`exit_code` for its own local children and for nothing else. No message
+carries a peer daemon's proc states back down the tree, because no daemon
+needs them: the hosting daemon reports them *up*, to the master, in
+`PRTE_PLM_UPDATE_PROC_STATE`. So an entry for a proc on another node
+keeps the state the launch message shipped for the life of the DVM.
+`PMIX_QUERY_PROC_TABLE` answered locally therefore reported every
+off-node rank as `PMIX_PROC_STATE_LAUNCH_UNDERWAY` — the conversion of
+`PRTE_PROC_STATE_INIT` — including ranks that had exited long ago, and
+that is the only signal PRRTE offers for "has this proc gone away"
+(`PMIX_EVENT_PROC_TERMINATED` is not implemented). A client co-located
+with the master saw the truth; every other client did not.
+
 So such an arm does not read that state directly. It goes through
-`prte_get_allocated_nodes()`, `prte_get_allocation_session()` or
-`prte_get_allocation_sessions()`
+`prte_get_allocated_nodes()`, `prte_get_allocation_session()`,
+`prte_get_allocation_sessions()` or `prte_get_proc_runtime_state()`
 ([`src/runtime/prte_globals.c`](../../runtime/prte_globals.c)), which
-succeed on the master and return `PRTE_ERR_NOT_AUTHORITATIVE` anywhere
-else. An arm that gets that back jumps to the `defer:` label at the foot
+succeed where the answer is authoritative — on the master, and for
+`prte_get_proc_runtime_state()` also on the daemon hosting that
+particular proc — and return `PRTE_ERR_NOT_AUTHORITATIVE` where it is
+not. An arm that gets that back jumps to the `defer:` label at the foot
 of the key loop; at `done:` the deferred keys go to the master on
 `PRTE_RML_TAG_QUERY`, and its reply is merged into the results gathered
 locally, so the client sees one answer covering every key it asked for.
+
+The proc-table arm defers on the *first* proc it does not host, having
+destructed the array it had begun to fill: the table is one answer, and
+half of it from here and half from the master would be a table whose
+entries disagree about what "now" means. `PMIX_QUERY_LOCAL_PROC_TABLE`
+reads the same fields and never defers, because it visits only procs
+flagged `PRTE_PROC_FLAG_LOCAL` — which is exactly the condition under
+which the accessor succeeds. It must not defer: relaying it would answer
+about the *master's* local procs.
 
 **The decision is made by the read, never by a list of keys.** Which keys
 need the master is not knowable in advance, and a written-down list goes
 stale the first time someone adds one — silently, because the stale case
 returns a plausible zero rather than failing. Which *reads* cannot be
-satisfied locally is exactly the three accessors above, and that is
-enforced where it is used. A key added tomorrow that reads capacity is
-relayed with no edit here; one that reads only what the nidmap and the
-launch message already deliver stays local with no edit either.
+satisfied locally is exactly the four accessors above, and that is
+enforced where it is used. A key added tomorrow that reads capacity, or
+that reports whether a proc is still alive, is relayed with no edit here;
+one that reads only what the nidmap and the launch message already
+deliver stays local with no edit either.
 [`test/unit/check_query_authority.py`](../../../test/unit/check_query_authority.py)
-fails `make check` if this file reaches that state any other way.
+fails `make check` if this file reaches that state any other way — it
+keys off `->pid`, `->exit_code` and `prte_pmix_convert_state()` for the
+proc half, because `->state` alone cannot be told from a node's.
 
 Deferral is per **key**, not per query and not per request, because the
 things a daemon must answer for *itself* can arrive in the same
@@ -830,7 +859,11 @@ locally. The relay uses the tracker pattern described under
 requestor so the master defaults the query to the right job rather than to
 the asking daemon. `contrib/dockerswarm`'s `slotinfo` client is the
 regression test: on one node every rank is on the master, and the bug
-cannot be seen at all.
+cannot be seen at all. Its `proctable departed` mode is the same test for
+the proc half — some of the job leaves, and the querier is placed once on
+a non-master node and once on the master, because the master's answer was
+right all along and a case that asks only one of them cannot tell a fix
+from a daemon that stopped answering.
 
 
 Several relays add an entry (usually `PMIX_REQUESTOR`) to an info array

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -85,16 +85,26 @@ static void qrel(void *cbdata)
  * default one.  A key whose answer comes out of either therefore has to
  * be asked of the DVM master.
  *
+ * A daemon's copy of a job is stale in the same way, in one place: it
+ * holds a prte_proc_t for every proc of the job, but it advances pid,
+ * state and exit_code for the procs it hosts and for nothing else.  No
+ * message carries a peer daemon's proc states back down the tree,
+ * because no daemon needs them - only the master is told.  So an entry
+ * for a proc on another node reports the state the launch message
+ * shipped, forever.
+ *
  * Which keys those are is deliberately not written down anywhere.  Such
  * a list is a point-in-time snapshot that goes stale the first time
  * someone adds a key, and a stale entry does not fail loudly: it returns
  * a default-constructed zero that reads exactly like a real answer.  So
  * the decision is made by the *read* instead.  A branch reaches
  * allocation state only through prte_get_allocated_nodes() and its two
- * companions, which succeed on the master and return
- * PRTE_ERR_NOT_AUTHORITATIVE anywhere else; a branch that gets that back
- * jumps to the "defer" label and its key is forwarded.  A key added
- * tomorrow that reads capacity is relayed with no edit here, and one
+ * companions, and a proc's runtime fields only through
+ * prte_get_proc_runtime_state(); all of them succeed where the answer is
+ * authoritative and return PRTE_ERR_NOT_AUTHORITATIVE where it is not.
+ * A branch that gets that back jumps to the "defer" label and its key is
+ * forwarded.  A key added tomorrow that reads capacity, or that reports
+ * whether a proc is still alive, is relayed with no edit here, and one
  * that reads only what the nidmap and the launch message already deliver
  * stays local with no edit either.
  *
@@ -269,6 +279,9 @@ static void _query(int sd, short args, void *cbdata)
     prte_session_t *session;
     int matched;
     pmix_proc_info_t *procinfo;
+    prte_proc_state_t pstate;
+    pid_t ppid;
+    prte_exit_code_t pexit;
     /* PMIx initializes this before anything in PMIx_Info_list_convert() can
      * fail, but every path to the done: label depends on that and the early
      * ones reach it having never touched this - so initialize it here rather
@@ -780,6 +793,21 @@ static void _query(int sd, short args, void *cbdata)
                     if (NULL == proct) {
                         continue;
                     }
+                    /* this table spans the whole job, so off the master it
+                     * reaches procs this daemon does not host - and their
+                     * pid, state and exit code are the launch message's
+                     * snapshot, which never changes again.  The first one
+                     * ends the branch and the key goes to the master. */
+                    prc = prte_get_proc_runtime_state(proct, &pstate, &ppid, &pexit);
+                    if (PRTE_ERR_NOT_AUTHORITATIVE == prc) {
+                        PMIX_DATA_ARRAY_DESTRUCT(&dry);
+                        goto defer;
+                    }
+                    if (PRTE_SUCCESS != prc) {
+                        PMIX_DATA_ARRAY_DESTRUCT(&dry);
+                        ret = prte_pmix_convert_rc(prc);
+                        goto done;
+                    }
                     PMIX_LOAD_PROCID(&procinfo[p].proc, proct->name.nspace, proct->name.rank);
                     if (NULL != proct->node && NULL != proct->node->name) {
                         procinfo[p].hostname = strdup(proct->node->name);
@@ -793,9 +821,9 @@ static void _query(int sd, short args, void *cbdata)
                             procinfo[p].executable_name = pmix_os_path(false, app->cwd, app->app, NULL);
                         }
                     }
-                    procinfo[p].pid = proct->pid;
-                    procinfo[p].exit_code = proct->exit_code;
-                    procinfo[p].state = prte_pmix_convert_state(proct->state);
+                    procinfo[p].pid = ppid;
+                    procinfo[p].exit_code = pexit;
+                    procinfo[p].state = prte_pmix_convert_state(pstate);
                     ++p;
                 }
                 PMIX_INFO_LIST_ADD(rc, results, PMIX_QUERY_PROC_TABLE, &dry, PMIX_DATA_ARRAY);
@@ -828,6 +856,16 @@ static void _query(int sd, short args, void *cbdata)
                         continue;
                     }
                     if (PRTE_FLAG_TEST(proct, PRTE_PROC_FLAG_LOCAL)) {
+                        /* every entry here is a proc this daemon hosts, so
+                         * the accessor cannot refuse - but it is still how
+                         * the read is spelled, because "local" is exactly
+                         * the condition under which it succeeds */
+                        prc = prte_get_proc_runtime_state(proct, &pstate, &ppid, &pexit);
+                        if (PRTE_SUCCESS != prc) {
+                            PMIX_DATA_ARRAY_DESTRUCT(&dry);
+                            ret = prte_pmix_convert_rc(prc);
+                            goto done;
+                        }
                         PMIX_LOAD_PROCID(&procinfo[p].proc, proct->name.nspace, proct->name.rank);
                         if (NULL != proct->node && NULL != proct->node->name) {
                             procinfo[p].hostname = strdup(proct->node->name);
@@ -841,9 +879,9 @@ static void _query(int sd, short args, void *cbdata)
                                 procinfo[p].executable_name = pmix_os_path(false, app->cwd, app->app, NULL);
                             }
                         }
-                        procinfo[p].pid = proct->pid;
-                        procinfo[p].exit_code = proct->exit_code;
-                        procinfo[p].state = prte_pmix_convert_state(proct->state);
+                        procinfo[p].pid = ppid;
+                        procinfo[p].exit_code = pexit;
+                        procinfo[p].state = prte_pmix_convert_state(pstate);
                         ++p;
                     }
                 }

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -775,12 +775,14 @@ static void _query(int sd, short args, void *cbdata)
                 /* construct a list of values with prte_proc_info_t
                  * entries for each proc in the indicated job */
                 jdata = prte_get_job_data_object(jobid);
-                if (NULL == jdata) {
-                    ret = PMIX_ERR_NOT_FOUND;
-                    goto done;
-                }
-                /* Check if there are any entries in global proctable */
-                if (0 == jdata->num_procs) {
+                if (NULL == jdata || 0 == jdata->num_procs) {
+                    /* a job's launch message goes only to the daemons that
+                     * host some of it, so "I have never heard of this job"
+                     * is a statement about this daemon, not about the DVM.
+                     * The master has heard of all of them. */
+                    if (!PRTE_PROC_IS_MASTER) {
+                        goto defer;
+                    }
                     ret = PMIX_ERR_NOT_FOUND;
                     goto done;
                 }

--- a/src/runtime/AGENTS.md
+++ b/src/runtime/AGENTS.md
@@ -143,6 +143,41 @@ you were handed can be handed to somebody else later.
 The lookups are linear scans over the whole array. That is fine at DVM
 scale, but do not put one inside a per-proc loop on a launch path.
 
+### What a registry holds is not what it is authoritative for
+
+A `prted` has all three registries, and parts of all three are stale on it
+by design. Its node pool carries a node's *identity* — the nidmap ships
+names, aliases, daemon vpids and pool slots and nothing else — so `slots`,
+`slots_max`, `slots_inuse` and node `state` read back default-constructed.
+Its `prte_sessions` holds the default session and no other. And its copy
+of a job carries a `prte_proc_t` for every proc, but it advances `pid`,
+`state` and `exit_code` only for the procs it hosts: proc states travel
+*up* to the master in `PRTE_PLM_UPDATE_PROC_STATE` and are never sent back
+down, because no daemon needs a peer's. So an entry for a proc on another
+node reports what the launch message shipped, for the life of the DVM.
+
+None of that fails loudly. A stale read hands back a plausible zero — a
+node with no slots, a rank still `PRTE_PROC_STATE_INIT` — that no caller
+can tell from a real answer, and the rank that happens to land on the
+master gets the truth while every other rank silently does not. So the
+four reads that cannot be satisfied everywhere are behind accessors that
+say so:
+
+| Accessor | Authoritative on |
+|----------|------------------|
+| `prte_get_allocated_nodes()` | the master |
+| `prte_get_allocation_session()` | the master |
+| `prte_get_allocation_sessions()` | the master |
+| `prte_get_proc_runtime_state()` | the master, and the daemon hosting that proc |
+
+Anywhere else each returns `PRTE_ERR_NOT_AUTHORITATIVE` having touched
+nothing — the caller's cue to ask the master instead, which is what
+[`src/prted/pmix/pmix_server_queries.c`](../prted/pmix/pmix_server_queries.c)
+does with its `defer:` label. Reach past them for that state and the bug
+you write is invisible at the point of failure;
+[`test/unit/check_query_authority.py`](../../test/unit/check_query_authority.py)
+fails `make check` if the query file does.
+
 ---
 
 ## Sessions (reservations)

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -418,6 +418,31 @@ int prte_get_allocation_sessions(pmix_pointer_array_t **sessions)
     return PRTE_SUCCESS;
 }
 
+/* See the block comment in prte_globals.h.  This is the same gate in a
+ * second dimension: what only the daemon hosting a proc, and the master it
+ * reports to, actually know about it. */
+int prte_get_proc_runtime_state(const prte_proc_t *proc, prte_proc_state_t *state,
+                                pid_t *pid, prte_exit_code_t *exit_code)
+{
+    if (NULL == proc) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+    /* the master is told about every proc; a daemon knows only its own */
+    if (!PRTE_PROC_IS_MASTER && !PRTE_FLAG_TEST(proc, PRTE_PROC_FLAG_LOCAL)) {
+        return PRTE_ERR_NOT_AUTHORITATIVE;
+    }
+    if (NULL != state) {
+        *state = proc->state;
+    }
+    if (NULL != pid) {
+        *pid = proc->pid;
+    }
+    if (NULL != exit_code) {
+        *exit_code = proc->exit_code;
+    }
+    return PRTE_SUCCESS;
+}
+
 prte_session_t *prte_get_session_object_from_refid(const char *refid)
 {
     prte_session_t *session;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -610,6 +610,28 @@ PRTE_EXPORT int prte_get_allocation_session(const char *allocid,
                                             prte_session_t **session);
 PRTE_EXPORT int prte_get_allocation_sessions(pmix_pointer_array_t **sessions);
 
+/* Reach a proc's runtime state - the fields nobody but the daemon hosting
+ * that proc ever writes.
+ *
+ * A daemon's copy of a job's proc array is the snapshot the launch message
+ * carried: pid, state and exit_code as the master packed them.  From then on
+ * a daemon advances those fields for its own local children and for nothing
+ * else, and no message carries a peer daemon's updates back down the tree -
+ * no daemon needs them.  So an entry for a proc hosted elsewhere still reads
+ * PRTE_PROC_STATE_INIT and pid 0 for the life of the DVM, which is
+ * indistinguishable from a real answer: a rank that exited long ago reports
+ * itself as one that has not started yet.
+ *
+ * The hosting daemon does tell the master (PRTE_PLM_UPDATE_PROC_STATE), so
+ * this succeeds on the master for every proc, and on a daemon only for a
+ * proc that daemon hosts.  Anywhere else it returns
+ * PRTE_ERR_NOT_AUTHORITATIVE having touched nothing, which is the caller's
+ * cue to ask the master instead.  Any out parameter may be NULL. */
+PRTE_EXPORT int prte_get_proc_runtime_state(const prte_proc_t *proc,
+                                            prte_proc_state_t *state,
+                                            pid_t *pid,
+                                            prte_exit_code_t *exit_code);
+
 /* Point a job at the session it runs in, maintaining the reference count on
  * both the outgoing and the incoming session.  Every assignment to
  * prte_job_t::session must go through this. */

--- a/test/unit/check_query_authority.py
+++ b/test/unit/check_query_authority.py
@@ -19,16 +19,25 @@
 # default-constructed zero, which is indistinguishable from a real answer
 # and is returned to the client as one.
 #
+# A daemon's copy of a job is stale in the same way, in one place: it
+# holds a prte_proc_t for every proc of the job, but it advances pid,
+# state and exit_code only for the procs it hosts.  Nothing carries a peer
+# daemon's proc states back down the tree - only the master is told - so
+# an entry for a proc on another node reports what the launch message
+# shipped for the life of the DVM.  That is how PMIX_QUERY_PROC_TABLE came
+# to report a rank that had exited long ago as one that had not started.
+#
 # pmix_server_queries.c therefore reaches that state only through the
 # accessors in src/runtime/prte_globals.c, which return
-# PRTE_ERR_NOT_AUTHORITATIVE off the master so the key can be relayed to
-# it.  This checks that it still does.  The rule cannot be enforced by
-# the compiler - the fields are ordinary members of a struct the file
-# legitimately uses for node *identity* - so it is enforced here.
+# PRTE_ERR_NOT_AUTHORITATIVE where the answer is not authoritative so the
+# key can be relayed to the master.  This checks that it still does.  The
+# rule cannot be enforced by the compiler - the fields are ordinary
+# members of structs the file legitimately uses for node and proc
+# *identity* - so it is enforced here.
 #
 # Deliberately not a list of query keys.  Which keys need the master is
 # not knowable in advance and goes stale the moment someone adds one;
-# which *reads* cannot be satisfied locally is exactly the set below.
+# which *reads* cannot be satisfied locally is exactly the sets below.
 
 import os
 import re
@@ -42,6 +51,16 @@ SESSIONS = "prte_sessions"
 ACCESSORS = ("prte_get_allocated_nodes",
              "prte_get_allocation_session",
              "prte_get_allocation_sessions")
+
+# The proc half.  ->state is no good as a marker here because prte_node_t
+# has one too and this file reads it legitimately (inside a branch the
+# rule above already gates).  ->pid and ->exit_code belong to no other
+# struct the file touches, and prte_pmix_convert_state() takes a PRRTE
+# PROC state and nothing else - so those three name a proc's runtime
+# state unambiguously, which is what the checker needs.
+PROC_RUNTIME = (r"->\s*pid\b", r"->\s*exit_code\b",
+                r"\bprte_pmix_convert_state\s*\(")
+PROC_ACCESSOR = "prte_get_proc_runtime_state"
 
 TARGET = os.path.join("src", "prted", "pmix", "pmix_server_queries.c")
 
@@ -101,6 +120,23 @@ def main():
                       "PRTE_ERR_NOT_AUTHORITATIVE"
                       % (TARGET, n, hit.group(1), ", ".join(ACCESSORS)))
 
+    # The same rule for a proc's runtime fields, in the same per-branch
+    # shape: a branch that reports whether a proc is alive, what its pid
+    # is, or how it exited has to have settled authority first.
+    runtime = re.compile("|".join(PROC_RUNTIME))
+    for offset, chunk in chunks:
+        text = "".join(chunk)
+        hit = runtime.search(text)
+        if hit is None:
+            continue
+        if PROC_ACCESSOR in text:
+            continue
+        n = offset + text[:hit.start()].count("\n") + 1
+        errors.append("%s:%d: reports a proc's runtime state without first "
+                      "establishing authority; read it through %s() and "
+                      "defer on PRTE_ERR_NOT_AUTHORITATIVE"
+                      % (TARGET, n, PROC_ACCESSOR))
+
     if errors:
         for e in errors:
             print(e)
@@ -108,7 +144,7 @@ def main():
               "query_complete() in %s." % (len(errors), TARGET))
         return 1
 
-    print("check_query_authority: %s reaches master-only state only "
+    print("check_query_authority: %s reaches state it may not hold only "
           "through the accessors" % TARGET)
     return 0
 

--- a/test/unit/runtime/test_runtime.c
+++ b/test/unit/runtime/test_runtime.c
@@ -470,6 +470,89 @@ static int test_proc_lookups(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* proc runtime-state authority                                       */
+/* ------------------------------------------------------------------ */
+
+/* A daemon's copy of a job carries a prte_proc_t for every proc, but it
+ * only ever advances pid, state and exit_code for the procs it hosts:
+ * nothing sends a peer daemon's updates back down the tree, because no
+ * daemon needs them.  So the entry for a proc on another node keeps the
+ * launch message's snapshot for the life of the DVM, and reading it
+ * yields a plausible-looking lie - PMIX_QUERY_PROC_TABLE reported a rank
+ * that had exited long ago as one that had not started yet.
+ *
+ * prte_get_proc_runtime_state() is the gate: the master hears about every
+ * proc, a daemon only about its own. */
+static int test_proc_runtime_authority(void)
+{
+    int failures = 0;
+    prte_proc_t *local, *remote;
+    prte_proc_state_t state;
+    prte_exit_code_t code;
+    pid_t pid;
+    prte_proc_type_t saved;
+
+    reset_globals();
+
+    local = PMIX_NEW(prte_proc_t);
+    PMIX_LOAD_PROCID(&local->name, "app.job", 0);
+    local->state = PRTE_PROC_STATE_TERMINATED;
+    local->pid = 4242;
+    local->exit_code = 7;
+    PRTE_FLAG_SET(local, PRTE_PROC_FLAG_LOCAL);
+
+    remote = PMIX_NEW(prte_proc_t);
+    PMIX_LOAD_PROCID(&remote->name, "app.job", 1);
+    remote->state = PRTE_PROC_STATE_INIT;
+    remote->pid = 0;
+    remote->exit_code = 0;
+
+    /* main() initialized this process as the master */
+    saved = prte_process_info.proc_type;
+    CHECK("runtime: the harness starts out as the master", PRTE_PROC_IS_MASTER);
+
+    state = PRTE_PROC_STATE_UNDEF;
+    pid = -1;
+    code = -1;
+    CHECK("runtime: the master answers for a proc it hosts",
+          PRTE_SUCCESS == prte_get_proc_runtime_state(local, &state, &pid, &code));
+    CHECK("runtime: ...with that proc's state", PRTE_PROC_STATE_TERMINATED == state);
+    CHECK("runtime: ...its pid", 4242 == pid);
+    CHECK("runtime: ...and its exit code", 7 == code);
+
+    CHECK("runtime: the master answers for a proc it does not host",
+          PRTE_SUCCESS == prte_get_proc_runtime_state(remote, &state, &pid, &code));
+
+    /* now stand where a prted stands */
+    prte_process_info.proc_type = PRTE_PROC_DAEMON;
+    CHECK("runtime: a daemon answers for its own child",
+          PRTE_SUCCESS == prte_get_proc_runtime_state(local, &state, &pid, &code));
+    CHECK("runtime: ...with the state it recorded", PRTE_PROC_STATE_TERMINATED == state);
+
+    state = PRTE_PROC_STATE_UNDEF;
+    pid = -1;
+    code = -1;
+    CHECK("runtime: a daemon refuses a proc it does not host",
+          PRTE_ERR_NOT_AUTHORITATIVE
+              == prte_get_proc_runtime_state(remote, &state, &pid, &code));
+    /* a refusal that had written the stale values first would leave the
+     * caller with exactly the plausible lie the gate exists to stop */
+    CHECK("runtime: ...having touched nothing",
+          PRTE_PROC_STATE_UNDEF == state && -1 == pid && -1 == code);
+
+    CHECK("runtime: every out parameter is optional",
+          PRTE_SUCCESS == prte_get_proc_runtime_state(local, NULL, NULL, NULL));
+    CHECK("runtime: a NULL proc is rejected",
+          PRTE_ERR_BAD_PARAM == prte_get_proc_runtime_state(NULL, &state, &pid, &code));
+
+    prte_process_info.proc_type = saved;
+    PMIX_RELEASE(local);
+    PMIX_RELEASE(remote);
+    reset_globals();
+    return failures;
+}
+
+/* ------------------------------------------------------------------ */
 /* node matching                                                      */
 /* ------------------------------------------------------------------ */
 
@@ -2015,6 +2098,7 @@ int main(void)
     failures += test_session_ownership();
     failures += test_session_job_backref();
     failures += test_proc_lookups();
+    failures += test_proc_runtime_authority();
     failures += test_node_matching();
     failures += test_node_copy();
     failures += test_app_copy();


### PR DESCRIPTION
Fixes #2771.

## The problem

`PMIX_QUERY_PROC_TABLE` answered by a non-master `prted` reports every off-node rank of the job as still starting up, forever — including ranks that exited long ago.

A daemon holds a `prte_proc_t` for every proc of a job it hosts part of: the launch message ships the whole array, `pid`, `state` and `exit_code` included. From then on it advances those three fields for its own local children and for nothing else. Proc states travel *up* to the master in `PRTE_PLM_UPDATE_PROC_STATE` and are never sent back down, because no daemon needs a peer's. So the entry for a proc on another node keeps the state the launch message shipped, which converts to `PMIX_PROC_STATE_LAUNCH_UNDERWAY` (2), for the life of the DVM.

The master's table was correct all along and updates within milliseconds of an exit, so whether a client got the truth depended on where it happened to land. Reproduced on the `contrib/dockerswarm` harness — same job, same nodes, only the querier moves:

```
querier on a NON-master node, ranks 1 and 3 exited 6s earlier:
  PROC 0 node2  6 CONNECTED
  PROC 1 node3  2 LAUNCH_UNDERWAY     <- gone
  PROC 2 node2  6 CONNECTED
  PROC 3 node3  2 LAUNCH_UNDERWAY     <- gone

querier on the MASTER's node:
  PROC 1 node2 20 TERMINATED
  PROC 3 node2 20 TERMINATED
```

This matters because the proc table is the only signal PRRTE offers for "has this proc gone away" — `PMIX_EVENT_PROC_TERMINATED` is not implemented — so an application that must know whether the procs on a node have finished, before asking the DVM to release that node from an elastic allocation say, had no correct answer unless it was co-located with the master.

## The fix

`pmix_server_queries.c` already decides what it may answer by the **read** rather than by a list of keys, precisely because such a list goes stale silently. What was missing was a read to decide on: `jdata->procs` is present on every daemon and merely stale, which is exactly the failure its block comment warns about — a default-constructed value that reads like a real answer.

So these three fields get the same gate the allocation state has. `prte_get_proc_runtime_state()` joins `prte_get_allocated_nodes()` and its two companions: it succeeds on the master, and on a daemon only for a proc that daemon hosts; anywhere else it returns `PRTE_ERR_NOT_AUTHORITATIVE` having touched nothing.

- The proc-table arm reads through it and jumps to the existing `defer:` label on the first proc it does not host, so the whole key goes to the master and its reply is merged back. It defers on the first such proc rather than filling in what it can — half a table from here and half from the master would be one answer whose entries disagree about what "now" means.
- `PMIX_QUERY_LOCAL_PROC_TABLE` reads the same fields through the same accessor and never defers: it visits only procs flagged `PRTE_PROC_FLAG_LOCAL`, which is exactly when the accessor succeeds. It must not defer — relaying it would answer about the *master's* local procs.

The second commit is a drive-by in the same arm: a job's launch message goes only to the daemons hosting part of it, so a prted asked about a job that landed entirely elsewhere was answering `PMIX_ERR_NOT_FOUND`. That is the same defect in a different dress — an answer that depends on which daemon the client is attached to. Off the master it now defers instead. The local arm keeps answering `NOT_FOUND`, because for it that genuinely is the answer.

## Testing

- `test/unit/check_query_authority.py` grows the matching rule, keyed off `->pid`, `->exit_code` and `prte_pmix_convert_state()` — `->state` alone cannot be told from a node's. Run against the pre-fix file it flags both arms.
- New `test_proc_runtime_authority()` in `test/unit/runtime` pins down that a refusal writes nothing: a refusal that filled in the stale values first would hand the caller the exact lie the gate exists to stop.
- New multi-node case in `contrib/dockerswarm`, driven by a new `proctable departed` mode — half the job exits, then the table is asked for. It runs **twice**, querier on a non-master node and on the master. The master was right before this change, so a case that asks only one placement cannot tell a fix from a daemon that stopped answering; the assertion worth making is that the two agree. It also requires the survivors to still read as alive, since a table that called everything terminated would satisfy the first half.
- Warning-free `--enable-debug` builds on macOS and in the swarm builder; `make check` clean; the `pmix` phase of the multi-node suite passes 41/41.
- Full `run-tests.sh linux`: **809 passed, 1 failed, 3 skipped**. The three skips are the network-device cases these topologies cannot exercise. The one failure is `connect: the termination that failure causes is transitive`, which asserts on a `show_help` diagnostic; PMIx's `show_help` suppresses a given (file, topic) pair after its first appearance for the life of the process, so on a persistent DVM that message is emitted once ever and later jobs hitting the same condition get nothing. Reproduced on a fresh DVM (message appears every time) vs. a reused one (first run only), independent of this branch. Filed separately -- it is in `pmix_show_help.c` and this PR does not touch that path.

## What this does not change, by design

A daemon reports a job's normal terminations to the master in one message, once every one of that job's procs on that node has finished -- `state_prted.c` gates the report on `num_terminated == num_local_procs`. So a single early-exiting rank whose node-mates are still running reads as alive until they finish, from the master as much as from anywhere else. That is deliberate: reporting each proc as it exits would put one message per terminated proc on the wire, and at scale that storm costs far more than it is worth. This change does not touch it, and should not -- the batch boundary is also exactly the point at which a node's procs are all gone, which is the question an elastic release actually asks.

The third commit writes that reason into `src/mca/state/prted/AGENTS.md`, which described the report-once machinery in full without ever saying why the report waits for the whole node. The silence read as an oversight and invited exactly the "fix" that must not be made.
