### PR TITLE
ras/slurm: match the HNP's node by locality when releasing

### DIFF
--- a/src/mca/ras/slurm/AGENTS.md
+++ b/src/mca/ras/slurm/AGENTS.md
@@ -88,8 +88,8 @@ deviation* and the framework guide.
   phases — see below.
 - **`PMIX_ALLOC_NEW`** → the same request; see below.
 - **`PMIX_ALLOC_RELEASE`** → `serve_release_req`: shrinks the SLURM job
-  with `scontrol update job`, removing nodes by count while protecting
-  the launching node (`SLURMD_NODENAME`).
+  with `scontrol update job`, removing nodes by count or by name while
+  protecting the node the HNP is running on.
 - **`PMIX_ALLOC_REQ_CANCEL`** → `serve_cancel_req`: cancels a pending
   extend by request id, and answers it (see below).
 

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -18,6 +18,7 @@
 #include "ras_slurm_modify_release_tracker.h"
 #include "src/mca/preg/preg.h"
 #include "src/mca/ras/base/base.h"
+#include "src/runtime/prte_globals.h"
 
 /* Local functions */
 static bool prte_ras_slurm_session_contains_invoker(prte_session_t *session, const char *launching_jobid);
@@ -30,7 +31,7 @@ static int prte_ras_slurm_remove_allocation_by_id(prte_pmix_server_req_t *req, c
 static int prte_ras_slurm_remove_nodes_by_count(prte_pmix_server_req_t *req, uint64_t node_count);
 static int prte_ras_slurm_append_session_targets(prte_session_t *session, char ***target_nodes);
 static int prte_ras_slurm_append_release_targets(prte_session_t *session, char **requested_nodes, char ***target_nodes);
-static int prte_ras_slurm_append_count_session_targets(prte_session_t *session, const char *protected_node, int nodes_to_remove, char ***target_nodes);
+static int prte_ras_slurm_append_count_session_targets(prte_session_t *session, int nodes_to_remove, char ***target_nodes);
 static int prte_ras_slurm_attach_shrink_tracker(prte_shrink_campaign_t *campaign, prte_ras_slurm_shrink_tracker_t *tracker);
 static int prte_ras_slurm_start_shrink(prte_pmix_server_req_t *req, prte_ras_slurm_shrink_tracker_t *tracker, char **target_nodes);
 static int prte_ras_slurm_complete_release_request(prte_pmix_server_req_t *req);
@@ -296,13 +297,13 @@ static int prte_ras_slurm_append_release_targets(prte_session_t *session,
 /**
  * @brief Append count-selected nodes from a session.
  *
+ * Skips the node the HNP runs on.
+ *
  * @param[in] session Session to inspect.
- * @param[in] protected_node Node that must not be selected.
  * @param[in] nodes_to_remove Number of nodes to append.
  * @param[in,out] target_nodes Target node argv.
  */
 static int prte_ras_slurm_append_count_session_targets(prte_session_t *session,
-                                                       const char *protected_node,
                                                        int nodes_to_remove,
                                                        char ***target_nodes)
 {
@@ -320,7 +321,10 @@ static int prte_ras_slurm_append_count_session_targets(prte_session_t *session,
         if (NULL == node || NULL == node->name) {
             continue;
         }
-        if (NULL != protected_node && 0 == strcmp(node->name, protected_node)) {
+        /* Releasing the HNP's node kills the DVM. quickmatch also checks
+         * node->aliases, where node_insert leaves the fully qualified
+         * domain name when it shortens a node name. */
+        if (prte_quickmatch(node, prte_process_info.nodename)) {
             continue;
         }
 
@@ -912,7 +916,6 @@ static int prte_ras_slurm_remove_nodes_by_name(prte_pmix_server_req_t *req, char
     int err = PRTE_SUCCESS;
     int node_count;
     char *launching_jobid;
-    char *protected_node = NULL;
     char **target_nodes = NULL;
     char **processed_jobs = NULL;
     prte_ras_slurm_shrink_tracker_t *tracker = NULL;
@@ -933,6 +936,7 @@ static int prte_ras_slurm_remove_nodes_by_name(prte_pmix_server_req_t *req, char
 
     for (int i = 0; NULL != nodes[i]; i++) {
         prte_session_stack_item_t *session_item;
+        prte_node_t *nd;
 
         err = prte_ras_slurm_validate_hostname(nodes[i]);
         if (PRTE_SUCCESS != err) {
@@ -955,19 +959,13 @@ static int prte_ras_slurm_remove_nodes_by_name(prte_pmix_server_req_t *req, char
             return PRTE_ERR_RESOURCE_BUSY;
         }
 
-        if (prte_ras_slurm_session_contains_invoker(session_item->session, launching_jobid)) {
-            if (NULL == protected_node) {
-                protected_node = getenv("SLURMD_NODENAME");
-                if (NULL == protected_node) {
-                    return PRTE_ERR_BAD_PARAM;
-                }
-            }
-
-            if (0 == strcmp(nodes[i], protected_node)) {
-                pmix_output(0, "ras:slurm:remove_nodes_by_name: refusing to remove current node %s",
-                            protected_node);
-                return PRTE_ERR_BAD_PARAM;
-            }
+        /* Releasing the HNP's node kills the DVM. */
+        nd = prte_node_match(NULL, nodes[i]);
+        if (NULL != nd && NULL != nd->name &&
+            prte_quickmatch(nd, prte_process_info.nodename)) {
+            pmix_output(0, "ras:slurm:remove_nodes_by_name: refusing to remove %s, "
+                           "the node this DVM's HNP is running on", nodes[i]);
+            return PRTE_ERR_BAD_PARAM;
         }
     }
 
@@ -1282,27 +1280,14 @@ static int prte_ras_slurm_remove_nodes_by_count(prte_pmix_server_req_t *req, uin
             }
 
             /* Case 2: keep the Slurm job alive and shrink it to its survivors. */
-            char *protected_node = NULL;
-
-            if(contains_invoker) {
-                protected_node = getenv("SLURMD_NODENAME");
-
-                if (NULL == protected_node) {
-                    pmix_output(0,
-                                "ras:slurm:remove_nodes_by_count: SLURMD_NODENAME is not set. "
-                                "Refusing to shrink job %s because the current node cannot be "
-                                "excluded from the resize operation.",
-                                session->alloc_refid);
-                    err = PRTE_ERR_BAD_PARAM;
-                    PRTE_ERROR_LOG(err);
-                    goto cleanup; 
-                }
-            }
-
-            err = prte_ras_slurm_append_count_session_targets(session, protected_node,
-                                                             nodes_to_rem_from_session,
-                                                             &session_targets);
+            err = prte_ras_slurm_append_count_session_targets(session,
+                                                              nodes_to_rem_from_session,
+                                                              &session_targets);
             if (PRTE_SUCCESS != err) {
+                pmix_output(0, "ras:slurm:remove_nodes_by_count: could not select %d "
+                               "releasable nodes from job %s",
+                            nodes_to_rem_from_session, session->alloc_refid);
+                PRTE_ERROR_LOG(err);
                 PMIx_Argv_free(session_targets);
                 goto cleanup;
             }

--- a/test/unit/ras/test_ras.c
+++ b/test/unit/ras/test_ras.c
@@ -1780,6 +1780,52 @@ static int test_spawn_alloc(void)
 }
 
 
+/*
+ * ras/slurm's release path skips the HNP's node via prte_quickmatch().
+ * node_insert() truncates a fully qualified domain name to the short name
+ * and keeps the full one as an alias, so a strcmp on the pool entry's name
+ * would miss it and the guard would silently stop protecting anything.
+ */
+static int test_hnp_locality_match(void)
+{
+    int failures = 0;
+    prte_node_t *nd;
+    char *save;
+    char *fqdn;
+
+    save = prte_process_info.nodename;
+    prte_process_info.nodename = strdup("prte-unit-test-hnp");
+
+    /* the short name the pool would hold */
+    nd = PMIX_NEW(prte_node_t);
+    nd->name = strdup("prte-unit-test-hnp");
+    CHECK("hnp match: short name",
+          prte_quickmatch(nd, prte_process_info.nodename));
+    PMIX_RELEASE(nd);
+
+    /* the shape normalize_node() leaves behind: the case a strcmp misses */
+    nd = PMIX_NEW(prte_node_t);
+    nd->name = strdup("prte-unit-test-hnp");
+    fqdn = strdup("prte-unit-test-hnp.unit.test");
+    nd->rawname = strdup(fqdn);
+    PMIx_Argv_append_nosize(&nd->aliases, fqdn);
+    free(prte_process_info.nodename);
+    prte_process_info.nodename = fqdn;
+    CHECK("hnp match: qualified name resolves through the alias",
+          prte_quickmatch(nd, prte_process_info.nodename));
+    PMIX_RELEASE(nd);
+
+    nd = PMIX_NEW(prte_node_t);
+    nd->name = strdup("prte-unit-test-other");
+    CHECK("hnp match: unrelated node does not match",
+          !prte_quickmatch(nd, prte_process_info.nodename));
+    PMIX_RELEASE(nd);
+
+    free(prte_process_info.nodename);
+    prte_process_info.nodename = save;
+    return failures;
+}
+
 /* A reservation torn down while a job is still running in it.
  *
  * Teardown deregisters the session, which puts it beyond every later sweep
@@ -1910,6 +1956,7 @@ int main(void)
     failures += test_activate_nodes();
     failures += test_spawn_alloc();
     failures += test_teardown_reservation();
+    failures += test_hnp_locality_match();
     /* after test_select(), which opens the framework and latches a
      * selection made with no SLURM allocation in the environment -- so
      * nothing has called slurm's init() before this does */


### PR DESCRIPTION

## The problem

`ras/slurm`'s release path must not hand the node the HNP runs on back to
Slurm — doing so kills the DVM. It identified that node by reading
`getenv("SLURMD_NODENAME")` and comparing it to `node->name` with `strcmp`.
That fails in two ways.

**Releases that should succeed are refused.** `slurmstepd` exports
`SLURMD_NODENAME` only to step tasks, so it is present for an HNP started by
`sbatch` or `srun` and absent for one started on a login node against
`salloc --no-shell` with an exported `SLURM_JOB_ID`, for an interactive
`salloc` shell, and for a persistent DVM started by hand and later handed a
jobid. In each of those the HNP is not on an allocated node, so there is
nothing to protect, yet every Slurm-served release returns
`PMIX_ERR_BAD_PARAM`. In the by-name path the refusal is silent — no
`pmix_output`, no `PRTE_ERROR_LOG`, nothing at `ras_base_verbose 10` — so the
request appears to have been rejected by Slurm when Slurm was never asked.

**The HNP's node can be released anyway.** `strcmp` is exact. If
`SLURMD_NODENAME` matches no entry in `session->nodes`, the skip never fires
and `append_count_session_targets()` takes whatever it meets walking the array
backwards, the HNP's node included. The `nodes_in_session - 1` reserve in
`session_removable_count()` does not cover this: it guarantees that *a* node
survives, not that *the HNP's* node does. Two ways the names diverge in
practice — `prte_ras_base_node_insert()` renames the HNP's pool entry to the
literal `"prte"` under `launch_orted_on_hn`, and the HNP runs `ess/hnp` rather
than `ess/slurm`, so it never receives the `SLURMD_NODENAME` correction
daemons get and can hold a differently qualified name.

## The change

Ask `prte_quickmatch(node, prte_process_info.nodename)` instead. That is the
predicate the rest of the tree already uses for this question:
`prte_ras_base_node_insert()` normalizes every node to its short name while
keeping the fully qualified form as an alias *so that* `prte_quickmatch`
resolves both, and the same locality test decides whether a Slurm-reported
node is the HNP's when the allocation is first ingested.

The check no longer depends on the target session being the invoker's. The
HNP does not move, so its node is only ever in the invoker's session or in no
session at all; dropping the condition removes a redundant term rather than
changing behaviour.

`session_removable_count()` is untouched. Its `-1` reserve keeps a shrink
resizing a Slurm job rather than emptying it, and where the HNP's node is in
the session that reserve is that node, so the budget and the skip agree
without being coupled.

One related fix: the counted path's node-selection failure now logs. It
previously returned `PRTE_ERR_NOT_FOUND` with nothing printed, indistinguishable
at the console from "no releasable session found".

## Testing

- `make check` — 25/25 unit tests pass, including the three source-scan gates.
- New `test_hnp_locality_match()` in `test/unit/ras/test_ras.c` pins the
  predicate the fix rests on: a short name, a fully qualified name resolving
  through the node's alias list (the case `strcmp` missed), and a negative.
  Mutation-checked — inverting the alias assertion fails the suite.
- `contrib/slurmswarm` against a real `slurmctld`: **142 passed, 0 failed, 1
  skipped**. This covers all three release paths — by name, by count, and by
  allocation id.

Credits: AccelCom @ Barcelona Supercomputing Center