### PR TITLE
Multiple commits

### DIFF
--- a/contrib/dockerswarm/AGENTS.md
+++ b/contrib/dockerswarm/AGENTS.md
@@ -55,7 +55,7 @@ It is **not** a Docker Swarm in the orchestration sense — just ten plain
 | *(no file here)* | `build.sh` also compiles [`examples/dynamic.c`](../../examples/dynamic.c) from the main tree as `dynamic` — the only client in this harness that calls `PMIx_Spawn`, and so the only way to get a **parent/child job pair**. See §11. |
 | `dataserver.c` | A bare PMIx client for the publish/lookup service (`dataserver` in the install): publish/lookup/lookupwait/lookup2/unpublish. Drives `src/runtime/data_server`. See §13. |
 | `jobinfo.c` | A bare PMIx client for the **direct-modex** paths (`jobinfo` in the install): `publish`/`fetch`/`fetchkey`. Drives `src/prted/pmix/pmix_server_fence.c` from a daemon that hosts none of the target job's procs. |
-| `proctable.c` | A bare PMIx client for the **proc-table and server-URI queries** (`proctable` in the install): `procs`/`localprocs`/`serveruri`. Those are the only callers of `prte_pmix_convert_state()`, and the local-vs-global proc-table split has no meaning on one host. Drives `src/pmix`. |
+| `proctable.c` | A bare PMIx client for the **proc-table and server-URI queries** (`proctable` in the install): `procs`/`localprocs`/`departed`/`serveruri`. Those are the only callers of `prte_pmix_convert_state()`, and the local-vs-global proc-table split has no meaning on one host. `departed` lets half the job exit first, which is what tells a table that is *current* from one that is merely the launch message read back. Drives `src/pmix`. |
 | `peerinfo.c` | A bare PMIx client in which every rank asks **every other rank of its own job** where it is (`peerinfo` in the install): rank, app rank, local/node rank, node id, hostname, cpuset, locality string — and device distances, the one key an off-node peer must be *refused*. The only client here that reads a *peer's* reserved keys, and so the only one that reaches the daemon's derive-on-demand path — everything else either reads back what it put itself or asks about the job. Drives `derive_proc_data()` in `src/prted/pmix/pmix_server_fence.c`. See §20. |
 | `groupcon.c` | A bare PMIx client that drives a **group construct/destruct** (`groupcon` in the install): every rank contributes a local cid, asks for a context id, constructs, reads every peer's contribution back, destructs. Drives grpcomm's `grp_release` on daemons that merely *received* the broadcast. See §15. |
 | `groupinv.c` | A bare PMIx client that forms a group by **invitation** and asks for a context id (`groupinv` in the install). The highest rank leads, so mapped by node the leader is never the HNP - which is the point: that method runs no collective, so its leader asks for the id through job control and only the HNP holds the pool, so the request has to be relayed. Drives `PRTE_PMIX_GROUP_CTXID` in `src/prted/pmix`. See §15. |
@@ -639,6 +639,24 @@ is `proctable`, and it asserts:
 - `PMIX_QUERY_LOCAL_PROC_TABLE` returns *some but not all* of a job's procs.
   On one host "local" and "all" are the same set, so this case cannot exist
   there.
+- a proc that has **departed** is reported as departed. A daemon advances
+  `pid`, `state` and `exit_code` for its own local children and for nothing
+  else — proc states travel *up* to the master and never back down, because
+  no daemon needs a peer's — so the global table answered locally reported
+  every off-node rank with the state the launch message shipped, forever.
+  A rank that had exited seconds ago came back `LAUNCH_UNDERWAY`, and that
+  table is the only signal PRRTE offers for "has this proc gone away".
+  Neither case above catches it: a freshly launched job is one whose stale
+  entries happen to be right.
+
+  The probe is `proctable departed` — ranks 1 and 3 leave, rank 0 asks six
+  seconds later — and it runs **twice**, with the querier once on a
+  non-master node and once on the master. The master's own answer was
+  correct all along, so a case that asks only a non-master cannot tell a
+  fix from a daemon that stopped answering at all; the assertion worth
+  making is that the two placements agree. It also requires the two
+  survivors to still read as alive, since a table that called everything
+  terminated would satisfy the first half.
 - **every daemon serves every node's `PMIX_SERVER_URI`**. The consumer here
   is a **tool**, not a daemon — daemons reach each other over the RML and
   never form PMIx connections to one another; see `examples/tool.c --uri

--- a/contrib/dockerswarm/proctable.c
+++ b/contrib/dockerswarm/proctable.c
@@ -20,6 +20,15 @@
  *       Same, but PMIX_QUERY_LOCAL_PROC_TABLE -- only the procs the
  *       answering daemon hosts.
  *
+ *   proctable departed [seconds]
+ *       The whole job fences, then every ODD rank finalizes and exits.
+ *       Rank 0 waits [seconds] (default 5) and then queries
+ *       PMIX_QUERY_PROC_TABLE for its own namespace, printing the table the
+ *       same way "procs" does. Every other rank just waits and exits.
+ *       Mapped by node, the ranks that leave are on a different node from
+ *       rank 0, so the answering daemon hosts none of them -- which is the
+ *       whole point. See the second block comment below.
+ *
  *   proctable serveruri [hostname] [seconds]
  *       PMIx_Query(PMIX_SERVER_URI), optionally qualified by PMIX_HOSTNAME so
  *       the answer must come from ANOTHER node's daemon record. Prints
@@ -50,6 +59,16 @@
  * on this path was reported to the tool as a bare PMIX_ERROR. On one host
  * the hostname qualifier resolves to the local daemon and the interesting
  * branch is never taken.
+ *
+ * "departed" is the same query asked after some of the job has left. A
+ * daemon's copy of a job's proc array is the snapshot the launch message
+ * carried, and it advances the state of its OWN local children and nothing
+ * else -- no message carries a peer daemon's proc states back down the tree,
+ * because no daemon needs them. So an entry for a proc hosted elsewhere kept
+ * the state it was launched with for the life of the DVM, and a client whose
+ * daemon is not the master was told that a rank which exited long ago was
+ * still starting up. The master's table was correct all along, which is why
+ * this cannot be seen on one host: there the only daemon IS the master.
  *
  * Note that PMIX_SERVER_URI is the rendezvous address of a node's PMIx
  * SERVER -- how a client or tool connects to it. It is not how daemons reach
@@ -182,6 +201,34 @@ static int do_proc_table(const char *key, int seconds)
     return 0;
 }
 
+/* Fence the job, let the odd ranks go, then ask for the whole table.  Rank 0
+ * is the only one that queries; mapped by node it sits on a different node
+ * from every rank that left, so its daemon hosts none of them. */
+static int do_departed(int seconds)
+{
+    pmix_status_t rc;
+
+    /* nobody leaves until everybody has arrived, so the table rank 0 asks
+     * for is one whose entries all reached RUNNING first */
+    rc = PMIx_Fence(NULL, 0, NULL, 0);
+    if (PMIX_SUCCESS != rc) {
+        printf("ERR %d %s\n", (int) rc, PMIx_Error_string(rc));
+        return 1;
+    }
+    if (0 != myproc.rank % 2) {
+        printf("LEAVING %u\n", myproc.rank);
+        fflush(stdout);
+        return 0;
+    }
+    if (0 != myproc.rank) {
+        /* an even rank that is not the querier just has to outlive it */
+        sleep(seconds + 5);
+        return 0;
+    }
+    sleep(seconds);
+    return do_proc_table(PMIX_QUERY_PROC_TABLE, 0);
+}
+
 static int do_server_uri(const char *hostname, int seconds)
 {
     pmix_query_t query;
@@ -225,7 +272,7 @@ int main(int argc, char **argv)
     int ret = 1;
 
     if (2 > argc) {
-        fprintf(stderr, "usage: %s procs|localprocs|serveruri [args]\n", argv[0]);
+        fprintf(stderr, "usage: %s procs|localprocs|departed|serveruri [args]\n", argv[0]);
         return 2;
     }
 
@@ -239,6 +286,8 @@ int main(int argc, char **argv)
         ret = do_proc_table(PMIX_QUERY_PROC_TABLE, (3 <= argc) ? atoi(argv[2]) : 0);
     } else if (0 == strcmp(argv[1], "localprocs")) {
         ret = do_proc_table(PMIX_QUERY_LOCAL_PROC_TABLE, (3 <= argc) ? atoi(argv[2]) : 0);
+    } else if (0 == strcmp(argv[1], "departed")) {
+        ret = do_departed((3 <= argc) ? atoi(argv[2]) : 5);
     } else if (0 == strcmp(argv[1], "serveruri")) {
         const char *host = (3 <= argc && 0 != strcmp(argv[2], "-")) ? argv[2] : NULL;
         ret = do_server_uri(host, (4 <= argc) ? atoi(argv[3]) : 0);

--- a/contrib/dockerswarm/run-tests.sh
+++ b/contrib/dockerswarm/run-tests.sh
@@ -2645,6 +2645,48 @@ test_pmix() {
         && ok "...and no local proc reported UNDEF" \
         || bad "$undef local procs reported UNDEF"
 
+    banner "pmix: the proc table reports a departed proc as departed"
+    # A daemon's copy of a job is the launch message's snapshot, and it
+    # advances pid/state/exit_code for its OWN local children and nothing
+    # else -- no message carries a peer daemon's proc states back down the
+    # tree, because no daemon needs them.  Only the master is told.  So
+    # PMIX_QUERY_PROC_TABLE answered locally reported every off-node rank
+    # with the state the launch message shipped, for the life of the DVM: a
+    # rank that exited seconds ago came back as LAUNCH_UNDERWAY.  The whole
+    # key now goes to the master when the table reaches a proc this daemon
+    # does not host.
+    #
+    # This cannot be seen on one host -- there the only daemon IS the master
+    # -- and it does not show up in the two cases above either, because a
+    # freshly launched job is one whose stale entries happen to be right.
+    # Ranks 1 and 3 leave; rank 0 asks six seconds later.
+    #
+    # Run it BOTH ways.  The master's own answer was correct all along, so a
+    # case that only asks a non-master cannot tell a fix from a daemon that
+    # stopped answering at all -- and the point of the fix is that the two
+    # placements agree.
+    for site in node2:2,node3:2 node1:2,node2:2; do
+        case "$site" in
+            node1:*) who="the master" ;;
+            *)       who="a non-master daemon" ;;
+        esac
+        out=$(PRUN "--host $site -n 4 --map-by node $PT departed 6" 2>&1)
+        gone=$(echo "$out" | awk '$1=="PROC" && ($2==1 || $2==3) {print $5}')
+        n=$(echo "$gone" | grep -c 'TERMINATED' | tr -d ' ')
+        if [ "$n" = 2 ]; then
+            ok "$who reported both departed ranks as TERMINATED"
+        else
+            bad "$who reported the departed ranks as [$(echo "$gone" | tr '\n' ' ')]: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+        fi
+        # the survivors must still read as alive -- a table that called
+        # everything terminated would pass the assertion above
+        n=$(echo "$out" | awk '$1=="PROC" && ($2==0 || $2==2) {print $4}' \
+            | awk '$1 < 15' | grep -c . | tr -d ' ')
+        [ "$n" = 2 ] \
+            && ok "...and both surviving ranks as still running" \
+            || bad "$who reported $n of 2 survivors as alive: $(echo "$out" | tr '\n' ' ' | tail -c 300)"
+    done
+
     banner "pmix: every daemon serves every node's PMIX_SERVER_URI"
     # The consumer of this query is a TOOL, not a daemon -- daemons reach
     # each other over the RML and never form PMIx connections to one another.

--- a/src/grpcomm/grpcomm.c
+++ b/src/grpcomm/grpcomm.c
@@ -215,7 +215,7 @@ int prte_grpcomm_init(void)
      * and would otherwise say it once each. */
     if (PRTE_PROC_IS_MASTER && prte_grpcomm_globals.low_radix_release
         && prte_rml_base.radix2 == prte_rml_base.radix) {
-        prte_show_help("help-prte-grpcomm.txt", "release-radix-noop", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-grpcomm.txt", "release-radix-noop", true,
                        prte_rml_base.radix, prte_rml_base.radix2);
     }
 

--- a/src/grpcomm/grpcomm_fence.c
+++ b/src/grpcomm/grpcomm_fence.c
@@ -716,7 +716,7 @@ static void fence(int sd, short args, void *cbdata)
      * reach a tracker its answer has to agree with the first. */
     if (!prte_grpcomm_fence_op_merge(coll,
                                      prte_grpcomm_fence_op_from_info(cd->info, cd->ninfo))) {
-        prte_show_help("help-prte-grpcomm.txt", "fence-op-mismatch", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-grpcomm.txt", "fence-op-mismatch", true,
                        prte_process_info.nodename);
         if (PMIX_SUCCESS == coll->status) {
             coll->status = PMIX_ERR_INVALID_ARG;
@@ -1027,7 +1027,7 @@ void prte_grpcomm_fence_recv(int status, pmix_proc_t *sender,
          * same treatment a non-success PMIX_LOCAL_COLLECTIVE_STATUS gets, and
          * the status is deliberately the one PMIx answers for the local form
          * of the same disagreement. */
-        prte_show_help("help-prte-grpcomm.txt", "fence-op-mismatch", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-grpcomm.txt", "fence-op-mismatch", true,
                        prte_process_info.nodename);
         if (PMIX_SUCCESS == coll->status) {
             coll->status = PMIX_ERR_INVALID_ARG;

--- a/src/grpcomm/grpcomm_group.c
+++ b/src/grpcomm/grpcomm_group.c
@@ -1305,7 +1305,7 @@ static void check_complete(prte_grpcomm_group_t *coll)
                 }
                 // did we lose anyone?
                 if (nfinal != pmix_list_get_size(&nmlist)) {
-                    prte_show_help("help-prte-runtime.txt", "bad-final-order", true);
+                    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "bad-final-order", true);
                     coll->status = PMIX_ERR_BAD_PARAM;
                     PMIX_LIST_DESTRUCT(&nmlist);
                     goto answer;

--- a/src/grpcomm/grpcomm_xcast.c
+++ b/src/grpcomm/grpcomm_xcast.c
@@ -1817,7 +1817,7 @@ static void process_msg(op_t* op){
             (uint8_t**) &decomp_msg.bytes, &decomp_msg.size
         );
         if(!success){
-            prte_show_help("help-prte-runtime.txt", "failed-to-uncompress",
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "failed-to-uncompress",
                            true, prte_process_info.nodename);
             PMIX_BYTE_OBJECT_DESTRUCT(&decomp_msg);
             PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_FORCED_EXIT);

--- a/src/hwloc/hwloc.c
+++ b/src/hwloc/hwloc.c
@@ -111,7 +111,7 @@ int prte_hwloc_base_register(void)
         } else if (0 == strcasecmp(mem_alloc_policy, "local_only")) {
             prte_hwloc_base_map = PRTE_HWLOC_BASE_MAP_LOCAL_ONLY;
         } else {
-            prte_show_help("help-prte-hwloc-base.txt", "invalid binding_policy", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-hwloc-base.txt", "invalid binding_policy", true,
                            "memory allocation", mem_alloc_policy);
             return PRTE_ERR_SILENT;
         }
@@ -140,7 +140,7 @@ int prte_hwloc_base_register(void)
         } else if (0 == strcasecmp(mem_bind_failure_action, "error")) {
             prte_hwloc_base_mbfa = PRTE_HWLOC_BASE_MBFA_ERROR;
         } else {
-            prte_show_help("help-prte-hwloc-base.txt", "invalid binding_policy", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-hwloc-base.txt", "invalid binding_policy", true,
                            "memory bind failure action", mem_bind_failure_action);
             return PRTE_ERR_SILENT;
         }
@@ -230,7 +230,7 @@ int prte_hwloc_base_register(void)
             } else if (0 == strcasecmp(ptr, "CORECPUS")) {
                 prte_hwloc_default_use_hwthread_cpus = false;
             } else {
-                prte_show_help("help-prte-hwloc-base.txt", "bad-processor-type", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-hwloc-base.txt", "bad-processor-type", true,
                                default_cpu_list, ptr);
                 free(prte_hwloc_default_cpu_list);
                 prte_hwloc_default_cpu_list = NULL;
@@ -609,7 +609,7 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
             PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_PACKAGE);
 
         } else {
-            prte_show_help("help-prte-hwloc-base.txt", "invalid binding_policy", true, "binding",
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-hwloc-base.txt", "invalid binding_policy", true, "binding",
                            spec);
             free(myspec);
             return PRTE_ERR_BAD_PARAM;
@@ -631,7 +631,7 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
 
             } else if (PMIX_CHECK_CLI_OPTION(quals[i], PRTE_CLI_REPORT)) {
                 if (NULL == jdata) {
-                    prte_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
                                    "binding policy", quals[i]);
                     PMIx_Argv_free(quals);
                     free(myspec);
@@ -642,7 +642,7 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
 
             } else if (PMIX_CHECK_CLI_OPTION(quals[i], PRTE_CLI_LIMIT)) {
                 if (NULL == jdata) {
-                    prte_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
                                    "binding policy", quals[i]);
                     PMIx_Argv_free(quals);
                     free(myspec);
@@ -654,7 +654,7 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
                 p2 = pmix_cli_qualifier_value(quals[i]);
                 if (NULL == p2) {
                     /* missing the value */
-                    prte_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "invalid-value", true,
                                    "binding limit", "LIMIT", quals[i]);
                     PMIx_Argv_free(quals);
                     free(myspec);
@@ -669,7 +669,7 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
                     0 >= lval || UINT16_MAX < lval) {
                     /* value is not a number, has trailing garbage, or is out
                      * of range (a limit of zero is meaningless) */
-                    prte_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "invalid-value", true,
                                    "binding limit", "LIMIT", quals[i]);
                     PMIx_Argv_free(quals);
                     free(myspec);
@@ -681,7 +681,7 @@ int prte_hwloc_base_set_binding_policy(void *jdat, char *spec)
 
             } else {
                 /* unknown option */
-                prte_show_help("help-prte-hwloc-base.txt", "unrecognized-modifier", true, spec);
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-hwloc-base.txt", "unrecognized-modifier", true, spec);
                 PMIx_Argv_free(quals);
                 free(myspec);
                 return PRTE_ERR_BAD_PARAM;

--- a/src/hwloc/hwloc_base_util.c
+++ b/src/hwloc/hwloc_base_util.c
@@ -223,7 +223,7 @@ hwloc_cpuset_t prte_hwloc_base_generate_cpuset(hwloc_topology_t topo,
             break;
         }
         if (bad) {
-            prte_show_help("help-prte-hwloc-base.txt", "unfound-cpu", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-hwloc-base.txt", "unfound-cpu", true,
                            *cpulist, ranges[idx],
                            use_hwthread_cpus ? "hwthread" : "core");
             PMIx_Argv_free(ranges);
@@ -1174,7 +1174,7 @@ static int collect_sites(hwloc_topology_t topo, hwloc_const_cpuset_t bitmap,
             obj = obj->parent;
         }
         if (NULL == obj) {
-            prte_show_help("help-prte-hwloc-base.txt", "pu-not-found", true, (unsigned) id);
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-hwloc-base.txt", "pu-not-found", true, (unsigned) id);
             free(indices);
             return -1;
         }

--- a/src/mca/errmgr/dvm/errmgr_dvm.c
+++ b/src/mca/errmgr/dvm/errmgr_dvm.c
@@ -239,7 +239,7 @@ static void job_errors(int fd, short args, void *cbdata)
              * daemons fail to start would only bury it. */
             if (PRTE_JOB_STATE_FAILED_TO_START == jdata->state
                 || PRTE_JOB_STATE_FAILED_TO_LAUNCH == jdata->state) {
-                prte_show_help("help-errmgr-base.txt", "failed-daemon-launch",
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-errmgr-base.txt", "failed-daemon-launch",
                                true, prte_tool_basename);
             }
             prte_routing_is_enabled = false;
@@ -254,7 +254,7 @@ static void job_errors(int fd, short args, void *cbdata)
          * likely already output an error message */
         if (PRTE_JOB_STATE_ABORTED == jobstate && jdata->num_procs != jdata->num_reported) {
             prte_routing_is_enabled = false;
-            prte_show_help("help-errmgr-base.txt", "failed-daemon", true);
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-errmgr-base.txt", "failed-daemon", true);
         }
         /* there really isn't much else we can do since the problem
          * is in the DVM itself, so best just to terminate */
@@ -520,7 +520,7 @@ static void proc_errors(int fd, short args, void *cbdata)
                      * A daemon we have never placed has no node, and this
                      * message is the last thing that should turn a lost
                      * daemon into a segfault in the HNP */
-                    prte_show_help("help-errmgr-base.txt", "node-died", true,
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-errmgr-base.txt", "node-died", true,
                                    PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), prte_process_info.nodename,
                                    PRTE_NAME_PRINT(proc),
                                    NULL == pptr->node ? "unknown" : pptr->node->name);

--- a/src/mca/errmgr/prted/errmgr_prted.c
+++ b/src/mca/errmgr/prted/errmgr_prted.c
@@ -155,7 +155,7 @@ static void prted_abort(int error_code, char *fmt, ...)
     /* use the show-help system to get the message out.  Callers are not
      * required to supply a message, and the help topic has a %s in it, so
      * substitute something printable rather than handing show_help a NULL */
-    prte_show_help("help-errmgr-base.txt", "simple-message", true,
+    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-errmgr-base.txt", "simple-message", true,
                    NULL == outmsg ? "(no further information available)" : outmsg);
     if (NULL != outmsg) {
         free(outmsg);

--- a/src/mca/ess/base/ess_base_bootstrap.c
+++ b/src/mca/ess/base/ess_base_bootstrap.c
@@ -136,7 +136,7 @@ static int pick_host_address(prte_bootstrap_config_t *cfg, const char *host,
     hints.ai_family = family;
     hints.ai_socktype = SOCK_STREAM;
     if (0 != getaddrinfo(host, NULL, &hints, &res) || NULL == res) {
-        prte_show_help("help-prte-runtime.txt", "bootstrap-unresolved-host", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "bootstrap-unresolved-host", true,
                        prte_process_info.nodename, host);
         return PRTE_ERR_NOT_FOUND;
     }
@@ -195,12 +195,12 @@ static int pick_host_address(prte_bootstrap_config_t *cfg, const char *host,
             }
         }
         if (0 == nmatch) {
-            prte_show_help("help-prte-runtime.txt", "bootstrap-no-matching-address", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "bootstrap-no-matching-address", true,
                            prte_process_info.nodename, host, cfg->dvm_networks);
             return PRTE_ERR_NOT_FOUND;
         }
         if (1 < nmatch) {
-            prte_show_help("help-prte-runtime.txt", "bootstrap-ambiguous-address", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "bootstrap-ambiguous-address", true,
                            prte_process_info.nodename, host, cfg->dvm_networks);
             return PRTE_ERR_BAD_PARAM;
         }
@@ -213,7 +213,7 @@ static int pick_host_address(prte_bootstrap_config_t *cfg, const char *host,
         *chosen_prefix = -1;
         return PRTE_SUCCESS;
     }
-    prte_show_help("help-prte-runtime.txt", "bootstrap-ambiguous-address", true,
+    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "bootstrap-ambiguous-address", true,
                    prte_process_info.nodename, host,
                    (NULL != cfg->dvm_networks) ? cfg->dvm_networks : "(none)");
     return PRTE_ERR_BAD_PARAM;
@@ -322,7 +322,7 @@ int prte_ess_base_bootstrap_params(void)
         PMIx_Setenv("PRTE_MCA_prte_disable_ipv6_family", "0", true, &environ);
         PMIx_Setenv("PRTE_MCA_prte_disable_ipv4_family", "1", true, &environ);
 #else
-        prte_show_help("help-prte-runtime.txt", "bootstrap-ipv6-unavailable", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "bootstrap-ipv6-unavailable", true,
                        prte_process_info.nodename);
         /* we are refusing this configuration, so do not leave it behind
          * looking valid to the phases that reuse it */
@@ -414,7 +414,7 @@ int prte_ess_base_bootstrap(bool *is_controller)
     /* determine our role and rank from the configuration */
     rc = prte_bootstrap_my_identity(&bootstrap_cfg, &ctrl, &rank);
     if (PRTE_SUCCESS != rc) {
-        prte_show_help("help-prte-runtime.txt", "bootstrap-node-not-member", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "bootstrap-node-not-member", true,
                        prte_process_info.nodename, bootstrap_cfg.ctrlhost);
         rc = PRTE_ERR_SILENT;
         goto cleanup;

--- a/src/mca/ess/base/ess_base_frame.c
+++ b/src/mca/ess/base/ess_base_frame.c
@@ -151,7 +151,7 @@ static int get_env_index(const char *envar, unsigned long *val)
     errno = 0;
     *val = strtoul(str, &endp, 10);
     if (0 != errno || endp == str || '\0' != *endp || '-' == str[0]) {
-        prte_show_help("help-ess-base.txt", "ess-base:bad-identity", true, envar, str);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ess-base.txt", "ess-base:bad-identity", true, envar, str);
         return PRTE_ERR_SILENT;
     }
     return PRTE_SUCCESS;
@@ -178,7 +178,7 @@ int prte_ess_base_set_identity(const char *offset_envar, int offset_adjust)
     vpid = strtoul(prte_ess_base_vpid, &endp, 10);
     if (0 != errno || endp == prte_ess_base_vpid || '\0' != *endp
         || '-' == prte_ess_base_vpid[0]) {
-        prte_show_help("help-ess-base.txt", "ess-base:bad-identity", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ess-base.txt", "ess-base:bad-identity", true,
                        "ess_base_vpid", prte_ess_base_vpid);
         return PRTE_ERR_SILENT;
     }
@@ -207,7 +207,7 @@ int prte_ess_base_set_identity(const char *offset_envar, int offset_adjust)
     /* compare the sum as a long: PMIX_RANK_IS_VALID would take a pmix_rank_t
      * and the narrowing conversion is what we are trying to catch */
     if (0 > rank || (long) PMIX_RANK_VALID <= rank) {
-        prte_show_help("help-ess-base.txt", "ess-base:rank-out-of-range", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ess-base.txt", "ess-base:rank-out-of-range", true,
                        prte_ess_base_vpid,
                        (NULL == offset_envar) ? "none" : offset_envar,
                        offset, offset_adjust);
@@ -351,7 +351,7 @@ pmix_status_t prte_ess_base_setup_signals(char *input)
             errno = 0;
             sval = strtoul(signals[i], &tmp, 10);
             if (0 != errno || '\0' != *tmp) {
-                prte_show_help("help-ess-base.txt", "ess-base:unknown-signal", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ess-base.txt", "ess-base:unknown-signal", true,
                                signals[i], mysignals);
                 PMIx_Argv_free(signals);
                 return PMIX_ERR_SILENT;
@@ -362,7 +362,7 @@ pmix_status_t prte_ess_base_setup_signals(char *input)
              * follows fails silently on both - so the user's signal is never
              * forwarded and nothing ever says why. */
             if (0 >= sval || _NSIG <= sval) {
-                prte_show_help("help-ess-base.txt", "ess-base:unknown-signal", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ess-base.txt", "ess-base:unknown-signal", true,
                                signals[i], mysignals);
                 PMIx_Argv_free(signals);
                 return PMIX_ERR_SILENT;
@@ -375,7 +375,7 @@ pmix_status_t prte_ess_base_setup_signals(char *input)
                      * branch - a non-forwardable signal must be rejected
                      * whether it was given by name or by number */
                     if (!known_signals[j].can_forward) {
-                        prte_show_help("help-ess-base.txt", "ess-base:cannot-forward", true,
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ess-base.txt", "ess-base:cannot-forward", true,
                                        known_signals[j].signame, mysignals);
                         PMIx_Argv_free(signals);
                         return PMIX_ERR_SILENT;
@@ -396,7 +396,7 @@ pmix_status_t prte_ess_base_setup_signals(char *input)
                  * anything (no signal is 0) */
                 if (0 == strcasecmp(signals[i], known_signals[j].signame)) {
                     if (!known_signals[j].can_forward) {
-                        prte_show_help("help-ess-base.txt", "ess-base:cannot-forward", true,
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ess-base.txt", "ess-base:cannot-forward", true,
                                        known_signals[j].signame, mysignals);
                         PMIx_Argv_free(signals);
                         return PMIX_ERR_SILENT;
@@ -408,7 +408,7 @@ pmix_status_t prte_ess_base_setup_signals(char *input)
                 }
             }
             if (!found) {
-                prte_show_help("help-ess-base.txt", "ess-base:unknown-signal", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ess-base.txt", "ess-base:unknown-signal", true,
                                signals[i], mysignals);
                 PMIx_Argv_free(signals);
                 return PMIX_ERR_SILENT;

--- a/src/mca/ess/base/ess_base_std_prolog.c
+++ b/src/mca/ess/base/ess_base_std_prolog.c
@@ -61,7 +61,7 @@ int prte_ess_base_std_prolog(void)
     return PRTE_SUCCESS;
 
 error:
-    prte_show_help("help-prte-runtime.txt",
+    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt",
                    "prte_init:startup:internal-failure", true,
                    error, PRTE_ERROR_NAME(ret), ret);
 

--- a/src/mca/ess/base/ess_base_std_prted.c
+++ b/src/mca/ess/base/ess_base_std_prted.c
@@ -187,7 +187,7 @@ int prte_ess_base_prted_setup(void)
     /* set the schizo personality to "prte" by default */
     jdata->schizo = (struct prte_schizo_base_module_t*)prte_schizo_base_detect_proxy("prte");
     if (NULL == jdata->schizo) {
-        prte_show_help("help-schizo-base.txt", "no-proxy", true, prte_tool_basename, "prte");
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "no-proxy", true, prte_tool_basename, "prte");
         error = "select personality";
         ret = PRTE_ERR_SILENT;
         goto error;
@@ -412,7 +412,7 @@ error:
      * that here rather than following it with this generic one, the same way
      * every ess module's error path does. */
     if (PRTE_ERR_SILENT != ret && !prte_report_silent_errors) {
-        prte_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
                        error, PRTE_ERROR_NAME(ret), ret);
     }
     if (NULL != jdata) {

--- a/src/mca/ess/env/ess_env_module.c
+++ b/src/mca/ess/env/ess_env_module.c
@@ -107,7 +107,7 @@ static int rte_init(int argc, char **argv)
 
 error:
     if (PRTE_ERR_SILENT != ret && !prte_report_silent_errors) {
-        prte_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true, error,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "prte_init:startup:internal-failure", true, error,
                        PRTE_ERROR_NAME(ret), ret);
     }
 

--- a/src/mca/ess/hnp/ess_hnp_module.c
+++ b/src/mca/ess/hnp/ess_hnp_module.c
@@ -176,7 +176,7 @@ static int rte_init(int argc, char **argv)
     /* set the schizo personality to "prte" by default */
     jdata->schizo = (struct prte_schizo_base_module_t*)prte_schizo_base_detect_proxy("prte");
     if (NULL == jdata->schizo) {
-        prte_show_help("help-schizo-base.txt", "no-proxy", true, prte_tool_basename, "prte");
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "no-proxy", true, prte_tool_basename, "prte");
         error = "select personality";
         ret = PRTE_ERR_SILENT;
         goto error;
@@ -422,7 +422,7 @@ static int rte_init(int argc, char **argv)
 
 error:
     if (PRTE_ERR_SILENT != ret && !prte_report_silent_errors) {
-        prte_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true, error,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "prte_init:startup:internal-failure", true, error,
                        PRTE_ERROR_NAME(ret), ret);
     }
     if (NULL != jdata) {

--- a/src/mca/ess/lsf/ess_lsf_module.c
+++ b/src/mca/ess/lsf/ess_lsf_module.c
@@ -83,7 +83,7 @@ static int rte_init(int argc, char **argv)
 
 error:
     if (PRTE_ERR_SILENT != ret && !prte_report_silent_errors) {
-        prte_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true, error,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "prte_init:startup:internal-failure", true, error,
                        PRTE_ERROR_NAME(ret), ret);
     }
 

--- a/src/mca/ess/pals/ess_pals_module.c
+++ b/src/mca/ess/pals/ess_pals_module.c
@@ -88,7 +88,7 @@ static int rte_init(int argc, char **argv)
 
 error:
     if (PRTE_ERR_SILENT != ret && !prte_report_silent_errors) {
-        prte_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true, error,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "prte_init:startup:internal-failure", true, error,
                        PRTE_ERROR_NAME(ret), ret);
     }
 

--- a/src/mca/ess/slurm/ess_slurm_module.c
+++ b/src/mca/ess/slurm/ess_slurm_module.c
@@ -86,7 +86,7 @@ static int rte_init(int argc, char **argv)
 
 error:
     if (PRTE_ERR_SILENT != ret && !prte_report_silent_errors) {
-        prte_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true, error,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "prte_init:startup:internal-failure", true, error,
                        PRTE_ERROR_NAME(ret), ret);
     }
 

--- a/src/mca/filem/raw/filem_raw_module.c
+++ b/src/mca/filem/raw/filem_raw_module.c
@@ -652,7 +652,7 @@ static int raw_preposition_files(prte_job_t *jdata,
         if (NULL == fs->remote_target || '\0' == fs->remote_target[0] ||
             0 == strcmp(fs->remote_target, ".") ||
             prte_filem_base_has_dotdot(fs->remote_target)) {
-            prte_show_help("help-prte-filem-raw.txt", "preload-bad-path", true,
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-filem-raw.txt", "preload-bad-path", true,
                            fs->local_target);
             PMIX_LIST_DESTRUCT(&fsets);
             if (NULL != cbfunc) {
@@ -677,7 +677,7 @@ static int raw_preposition_files(prte_job_t *jdata,
             prte_filem_base_file_set_t *fs2 = (prte_filem_base_file_set_t *) itm;
             if (0 == strcmp(fs->remote_target, fs2->remote_target) &&
                 !same_source(fs->local_target, fs2->local_target)) {
-                prte_show_help("help-prte-filem-raw.txt", "preload-name-clash", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-filem-raw.txt", "preload-name-clash", true,
                                fs->local_target, fs2->local_target, fs->remote_target);
                 PMIX_LIST_DESTRUCT(&fsets);
                 if (NULL != cbfunc) {
@@ -1039,7 +1039,7 @@ static int place_file(char *my_dir, char *wdir, char *fname)
                                  PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), fname, dest));
             goto cleanup;
         }
-        prte_show_help("help-prte-filem-raw.txt", "preload-collision", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-filem-raw.txt", "preload-collision", true,
                        fname, wdir, prte_process_info.nodename);
         rc = PRTE_ERR_PRELOAD_CONFLICT;
         goto cleanup;
@@ -1348,7 +1348,7 @@ static int raw_link_local_files(prte_job_t *jdata, prte_app_context_t *app)
             }
         }
         if (!staged) {
-            prte_show_help("help-prte-filem-raw.txt", "preload-not-staged", true,
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-filem-raw.txt", "preload-not-staged", true,
                            files[j], prte_process_info.nodename);
             PMIx_Argv_free(files);
             return PRTE_ERR_FILE_OPEN_FAILURE;

--- a/src/mca/odls/base/odls_base_bind.c
+++ b/src/mca/odls/base/odls_base_bind.c
@@ -303,7 +303,7 @@ void prte_odls_base_prepare_binding(prte_odls_spawn_caddy_t *cd)
                available processors */
             root = hwloc_get_root_obj(prte_hwloc_topology);
             if (NULL == root->userdata) {
-                prte_show_help("help-prte-odls-default.txt", "incorrectly bound", true,
+                prte_show_help(PRTE_JOB_NSPACE(jobdat), "help-prte-odls-default.txt", "incorrectly bound", true,
                                prte_process_info.nodename, context->app);
             }
             cd->bind_cpuset = hwloc_bitmap_dup(
@@ -333,7 +333,7 @@ void prte_odls_base_prepare_binding(prte_odls_spawn_caddy_t *cd)
                 && PRTE_BINDING_POLICY_IS_SET(jobdat->map->binding)) {
                 cd->bind_fatal = true;
             } else if (PRTE_BINDING_POLICY_IS_SET(jobdat->map->binding)) {
-                prte_show_help("help-prte-odls-default.txt", "not bound", true,
+                prte_show_help(PRTE_JOB_NSPACE(jobdat), "help-prte-odls-default.txt", "not bound", true,
                                prte_process_info.nodename, context->app,
                                "unable to apply the requested binding");
             }

--- a/src/mca/odls/base/odls_base_default_fns.c
+++ b/src/mca/odls/base/odls_base_default_fns.c
@@ -969,7 +969,7 @@ int prte_odls_base_default_construct_child_list(pmix_data_buffer_t *buffer, pmix
             goto REPORT_ERROR;
         }
         if (NULL == jdata->schizo) {
-            prte_show_help("help-schizo-base.txt", "no-proxy", true,
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-schizo-base.txt", "no-proxy", true,
                            prte_tool_basename, "NULL");
             rc = PRTE_ERR_NOT_FOUND;
             goto REPORT_ERROR;
@@ -989,7 +989,7 @@ int prte_odls_base_default_construct_child_list(pmix_data_buffer_t *buffer, pmix
         }
         jdata->schizo = (struct prte_schizo_base_module_t*)prte_schizo_base_detect_proxy(tmp);
         if (NULL == jdata->schizo) {
-            prte_show_help("help-schizo-base.txt", "no-proxy", true,
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-schizo-base.txt", "no-proxy", true,
                            prte_tool_basename, (NULL == tmp) ? "NULL" : tmp);
             if (NULL != tmp) {
                 free(tmp);
@@ -1438,7 +1438,7 @@ void prte_odls_base_spawn_proc(int fd, short sd, void *cbdata)
                 break;
             } else if (jobdat->num_procs <= nm->name.rank) { /* check for bozo case */
                 /* can't be done! */
-                prte_show_help("help-prte-odls-base.txt", "prte-odls-base:xterm-rank-out-of-bounds",
+                prte_show_help(PRTE_JOB_NSPACE(jobdat), "help-prte-odls-base.txt", "prte-odls-base:xterm-rank-out-of-bounds",
                                true, prte_process_info.nodename, nm->name.rank, jobdat->num_procs);
                 rc = PRTE_ERR_BAD_PARAM;
                 state = PRTE_PROC_STATE_FAILED_TO_LAUNCH;
@@ -1458,7 +1458,7 @@ void prte_odls_base_spawn_proc(int fd, short sd, void *cbdata)
         }
         cd->cmd = pmix_path_findv(cd->argv[0], X_OK, prte_launch_environ, NULL);
         if (NULL == cd->cmd) {
-            prte_show_help("help-prte-odls-base.txt", "prte-odls-base:fork-agent-not-found", true,
+            prte_show_help(PRTE_JOB_NSPACE(jobdat), "help-prte-odls-base.txt", "prte-odls-base:fork-agent-not-found", true,
                            prte_process_info.nodename, ptr);
             rc = PRTE_ERR_NOT_FOUND;
             state = PRTE_PROC_STATE_FAILED_TO_LAUNCH;
@@ -1475,7 +1475,7 @@ void prte_odls_base_spawn_proc(int fd, short sd, void *cbdata)
         }
         cd->cmd = pmix_path_findv(cd->argv[0], X_OK, prte_launch_environ, NULL);
         if (NULL == cd->cmd) {
-            prte_show_help("help-prte-odls-base.txt", "prte-odls-base:fork-agent-not-found", true,
+            prte_show_help(PRTE_JOB_NSPACE(jobdat), "help-prte-odls-base.txt", "prte-odls-base:fork-agent-not-found", true,
                            prte_process_info.nodename, cd->argv[0]);
             rc = PRTE_ERR_NOT_FOUND;
             state = PRTE_PROC_STATE_FAILED_TO_LAUNCH;
@@ -1966,7 +1966,7 @@ void prte_odls_base_default_launch_local(int fd, short sd, void *cbdata)
         if (PRTE_SUCCESS != (rc = prte_util_init_sys_limits(&msg))) {
             /* the "Application name" field is a %s - pass the app's
              * executable, not the app_context object itself */
-            prte_show_help("help-prte-odls-default.txt", "set limit", true,
+            prte_show_help(PRTE_JOB_NSPACE(jobdat), "help-prte-odls-default.txt", "set limit", true,
                            prte_process_info.nodename, app->app, __FILE__, __LINE__, msg);
             /* flag this app's procs and abort the whole job (see setup_fork) */
             PRTE_ODLS_SET_ERROR(job, rc, j);

--- a/src/mca/odls/base/odls_base_frame.c
+++ b/src/mca/odls/base/odls_base_frame.c
@@ -205,7 +205,7 @@ static int prte_odls_base_open(pmix_mca_base_open_flag_t flags)
                 nm->name.rank = PMIX_RANK_WILDCARD;
             } else if (rank < 0) {
                 /* error out on bozo case */
-                prte_show_help("help-prte-odls-base.txt", "prte-odls-base:xterm-neg-rank", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-odls-base.txt", "prte-odls-base:xterm-neg-rank", true,
                                rank);
                 /* nm was never put on the list, and we still own the parsed
                  * range - do not walk out holding either */
@@ -226,7 +226,7 @@ static int prte_odls_base_open(pmix_mca_base_open_flag_t flags)
         prte_odls_globals.xtermcmd = NULL;
         tmp = pmix_find_absolute_path("xterm");
         if (NULL == tmp) {
-            prte_show_help("help-prte-odls-base.txt", "prte-odls-base:xterm-not-found", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-odls-base.txt", "prte-odls-base:xterm-not-found", true,
                            prte_process_info.nodename);
             return PRTE_ERROR;
         }

--- a/src/mca/odls/pdefault/odls_pdefault_module.c
+++ b/src/mca/odls/pdefault/odls_pdefault_module.c
@@ -455,40 +455,40 @@ static void render_child_msg(prte_odls_spawn_caddy_t *cd, prte_odls_pipe_err_msg
 
     switch (msg->which) {
     case PRTE_ODLS_CHILD_ERR_IOF_SETUP:
-        prte_show_help("help-prte-odls-default.txt", "iof setup failed", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-odls-default.txt", "iof setup failed", true,
                        prte_process_info.nodename, cd->app->app);
         break;
     case PRTE_ODLS_CHILD_ERR_NEG_FD:
-        prte_show_help("help-prte-odls-default.txt", "neg-fd", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-odls-default.txt", "neg-fd", true,
                        prte_process_info.nodename, "/dev/null");
         break;
     case PRTE_ODLS_CHILD_ERR_WDIR:
-        prte_show_help("help-prun.txt", "prun:wdir-not-found", true, "prted",
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "prun:wdir-not-found", true, "prted",
                        (NULL == cd->wdir) ? "<none>" : cd->wdir,
                        prte_process_info.nodename, rank);
         break;
     case PRTE_ODLS_CHILD_ERR_STOP_ON_EXEC:
-        prte_show_help("help-prun.txt", "prun:stop-on-exec", true, "prted",
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "prun:stop-on-exec", true, "prted",
                        strerror(msg->errnum), prte_process_info.nodename, rank);
         break;
     case PRTE_ODLS_CHILD_ERR_BIND:
-        prte_show_help("help-prte-odls-default.txt", "binding generic error", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-odls-default.txt", "binding generic error", true,
                        prte_process_info.nodename, cd->app->app, bind_errmsg(msg->errnum));
         break;
     case PRTE_ODLS_CHILD_ERR_BIND_MEM:
-        prte_show_help("help-prte-odls-default.txt", "memory binding error", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-odls-default.txt", "memory binding error", true,
                        prte_process_info.nodename, cd->app->app, bind_errmsg(msg->errnum));
         break;
     case PRTE_ODLS_CHILD_WARN_NOT_BOUND:
-        prte_show_help("help-prte-odls-default.txt", "not bound", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-odls-default.txt", "not bound", true,
                        prte_process_info.nodename, cd->app->app, bind_errmsg(msg->errnum));
         break;
     case PRTE_ODLS_CHILD_WARN_MEM_NOT_BOUND:
-        prte_show_help("help-prte-odls-default.txt", "memory not bound", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-odls-default.txt", "memory not bound", true,
                        prte_process_info.nodename, cd->app->app, bind_errmsg(msg->errnum));
         break;
     case PRTE_ODLS_CHILD_WARN_INCORRECT:
-        prte_show_help("help-prte-odls-default.txt", "incorrectly bound", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-odls-default.txt", "incorrectly bound", true,
                        prte_process_info.nodename, cd->app->app);
         break;
     case PRTE_ODLS_CHILD_ERR_EXEC:
@@ -525,7 +525,7 @@ static void render_child_msg(prte_odls_spawn_caddy_t *cd, prte_odls_pipe_err_msg
         } else {
             errmsg = strerror(msg->errnum);
         }
-        prte_show_help("help-prte-odls-default.txt", "execve error", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-odls-default.txt", "execve error", true,
                        prte_process_info.nodename, wdir, cd->app->app, errmsg);
         break;
     }

--- a/src/mca/plm/base/plm_base_frame.c
+++ b/src/mca/plm/base/plm_base_frame.c
@@ -291,7 +291,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
     }
 
     // otherwise, this is an error
-    prte_show_help("help-plm-base.txt", "no-available-pls", true);
+    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-base.txt", "no-available-pls", true);
     PRTE_ACTIVATE_JOB_STATE(state->jdata, PRTE_JOB_STATE_FAILED_TO_START);
     PMIX_RELEASE(state);
 }

--- a/src/mca/plm/base/plm_base_launch_support.c
+++ b/src/mca/plm/base/plm_base_launch_support.c
@@ -1906,7 +1906,7 @@ void prte_plm_base_daemon_callback(int status, pmix_proc_t *sender, pmix_data_bu
                         goto CLEANUP;
                     }
                 } else {
-                    prte_show_help("help-prte-runtime.txt", "failed-to-uncompress",
+                    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "failed-to-uncompress",
                                    true, prte_process_info.nodename);
                     prted_failed_launch = true;
                     PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
@@ -3110,7 +3110,7 @@ process:
         }
         if (PMIX_RANK_VALID - 1 <= vpid) {
             /* no more daemons available */
-            prte_show_help("help-prte-rmaps-base.txt", "out-of-vpids", true);
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "out-of-vpids", true);
             PMIX_RELEASE(proc);
             PMIX_LIST_DESTRUCT(&nodes);
             return PRTE_ERR_OUT_OF_RESOURCE;

--- a/src/mca/plm/base/plm_base_receive.c
+++ b/src/mca/plm/base/plm_base_receive.c
@@ -717,7 +717,7 @@ void prte_plm_base_recv(int status, pmix_proc_t *sender,
         tmp = PMIx_Argv_join(jdata->personality, ',');
         jdata->schizo = (struct prte_schizo_base_module_t*)prte_schizo_base_detect_proxy(tmp);
         if (NULL == jdata->schizo) {
-            prte_show_help("help-schizo-base.txt", "no-proxy", true, prte_tool_basename, tmp);
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-schizo-base.txt", "no-proxy", true, prte_tool_basename, tmp);
             free(tmp);
             rc = PRTE_ERR_NOT_FOUND;
             goto ANSWER_LAUNCH;

--- a/src/mca/plm/lsf/plm_lsf_module.c
+++ b/src/mca/plm/lsf/plm_lsf_module.c
@@ -265,7 +265,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
         /* every node in the map already has a daemon - there is nothing
          * for lsb_launch to do, and handing it an empty host list is not
          * something we should ask of it */
-        prte_show_help("help-plm-lsf.txt", "no-hosts-in-list", true);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-lsf.txt", "no-hosts-in-list", true);
         rc = PRTE_ERR_FAILED_TO_START;
         goto cleanup;
     }
@@ -401,7 +401,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
         PRTE_ERROR_LOG(PRTE_ERR_FAILED_TO_START);
         char *flattened_nodelist = NULL;
         flattened_nodelist = PMIx_Argv_join(nodelist_argv, '\n');
-        prte_show_help("help-plm-lsf.txt", "lsb_launch-failed", true, rc, lsberrno, lsb_sysmsg(),
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-lsf.txt", "lsb_launch-failed", true, rc, lsberrno, lsb_sysmsg(),
                        PMIx_Argv_count(nodelist_argv), flattened_nodelist);
         free(flattened_nodelist);
         rc = PRTE_ERR_FAILED_TO_START;

--- a/src/mca/plm/pals/plm_pals_module.c
+++ b/src/mca/plm/pals/plm_pals_module.c
@@ -306,7 +306,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
             pmix_argv_append(&nodelist_argc, &nodelist_argv, node->name);
         }
         if (0 == PMIx_Argv_count(nodelist_argv)) {
-            prte_show_help("help-plm-pals.txt", "no-hosts-in-list", true);
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-pals.txt", "no-hosts-in-list", true);
             rc = PRTE_ERR_FAILED_TO_START;
             goto cleanup;
         }

--- a/src/mca/plm/slurm/plm_slurm_module.c
+++ b/src/mca/plm/slurm/plm_slurm_module.c
@@ -406,7 +406,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
         PMIx_Argv_append_nosize(&nodelist_argv, node->name);
     }
     if (0 == PMIx_Argv_count(nodelist_argv)) {
-        prte_show_help("help-plm-slurm.txt", "no-hosts-in-list", true);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-slurm.txt", "no-hosts-in-list", true);
         rc = PRTE_ERR_FAILED_TO_START;
         goto cleanup;
     }
@@ -642,7 +642,7 @@ static void srun_wait_cb(int sd, short fd, void *cbdata)
     /* need to check that we are at least version 17.11 */
     slurm = prte_common_slurm_version();
     if (slurm->ancient) {
-        prte_show_help("help-plm-slurm.txt", "ancient-version", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-slurm.txt", "ancient-version", true,
                        slurm->major, slurm->minor);
         PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_DAEMONS_TERMINATED);
         free(job_id);
@@ -689,7 +689,7 @@ static void srun_wait_cb(int sd, short fd, void *cbdata)
         /* an orted must have died unexpectedly - report
          * that the daemon has failed so we exit
          */
-        prte_show_help("help-plm-slurm.txt", "srun-failed", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-slurm.txt", "srun-failed", true,
                        proc->exit_code);
         PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_DAEMONS_TERMINATED);
     } else {
@@ -748,7 +748,7 @@ static int plm_slurm_start_proc(int argc, char **argv,
     PRTE_HIDE_UNUSED_PARAMS(argc);
 
     if (NULL == exec_argv) {
-        prte_show_help("help-plm-slurm.txt", "no-srun", true);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-slurm.txt", "no-srun", true);
         return PRTE_ERR_SILENT;
     }
 

--- a/src/mca/plm/ssh/plm_ssh_component.c
+++ b/src/mca/plm/ssh/plm_ssh_component.c
@@ -207,7 +207,7 @@ static int ssh_component_open(void)
 
     /* lookup parameters */
     if (prte_mca_plm_ssh_component.num_concurrent <= 0) {
-        prte_show_help("help-plm-ssh.txt", "concurrency-less-than-zero", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-ssh.txt", "concurrency-less-than-zero", true,
                        prte_mca_plm_ssh_component.num_concurrent);
         prte_mca_plm_ssh_component.num_concurrent = 1;
     }
@@ -298,7 +298,7 @@ lookup:
          * then we want to error out and not continue */
         if (NULL != prte_mca_plm_ssh_component.agent &&
             0 != strcmp(prte_mca_plm_ssh_component.agent, "ssh : rsh")) {
-            prte_show_help("help-plm-ssh.txt", "agent-not-found", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-ssh.txt", "agent-not-found", true,
                            prte_mca_plm_ssh_component.agent);
             PRTE_ACTIVATE_JOB_STATE(NULL, PRTE_JOB_STATE_NEVER_LAUNCHED);
             return PRTE_ERR_FATAL;

--- a/src/mca/plm/ssh/plm_ssh_module.c
+++ b/src/mca/plm/ssh/plm_ssh_module.c
@@ -702,7 +702,7 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
         /* prte_launch_agent named nothing to run - an empty
          * --prtemca prte_launch_agent "" gets here. There is no command to
          * ssh, so say so rather than strdup(NULL) */
-        prte_show_help("help-plm-ssh.txt", "no-launch-agent", true);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-ssh.txt", "no-launch-agent", true);
         free(orted_prefix);
         PMIx_Argv_free(final_argv);
         PMIx_Argv_free(argv);
@@ -770,7 +770,7 @@ static int setup_launch(int *argcptr, char ***argvptr, char *nodename, int *node
 
     value = PMIx_Argv_join(argv, ' ');
     if (sysconf(_SC_ARG_MAX) < (int) strlen(value)) {
-        prte_show_help("help-plm-ssh.txt", "cmd-line-too-long", true, strlen(value),
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-ssh.txt", "cmd-line-too-long", true, strlen(value),
                        sysconf(_SC_ARG_MAX));
         free(value);
         PMIx_Argv_free(argv);
@@ -1193,7 +1193,7 @@ static void launch_daemons(int fd, short args, void *cbdata)
          * As we cannot run in this situation, pretty print the error
          * and return an error code.
          */
-        prte_show_help("help-plm-ssh.txt", "deadlock-params", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-ssh.txt", "deadlock-params", true,
                        prte_mca_plm_ssh_component.num_concurrent, map->num_new_daemons);
         PRTE_ERROR_LOG(PRTE_ERR_FATAL);
         rc = PRTE_ERR_SILENT;

--- a/src/mca/ras/base/ras_base_allocate.c
+++ b/src/mca/ras/base/ras_base_allocate.c
@@ -410,7 +410,7 @@ void prte_ras_base_allocate(int fd, short args, void *cbdata)
         if (prte_allocation_required) {
             /* an allocation is required, so this is fatal */
             PMIX_LIST_DESTRUCT(&nodes);
-            prte_show_help("help-ras-base.txt", "ras-base:no-allocation", true);
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-ras-base.txt", "ras-base:no-allocation", true);
             PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_ALLOC_FAILED);
             PMIX_RELEASE(caddy);
             return;
@@ -764,7 +764,7 @@ static void ras_base_activate_request(prte_pmix_server_req_t *req)
 
     if ((NULL == hosts || '\0' == *hosts) &&
         (NULL == hostfile || '\0' == *hostfile)) {
-        prte_show_help("help-ras-base.txt", "ras-base:activate-nothing-named", true);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ras-base.txt", "ras-base:activate-nothing-named", true);
         req->pstatus = PMIX_ERR_BAD_PARAM;
         return;
     }
@@ -2245,7 +2245,7 @@ static int ras_base_add_hosts_allowed(void)
     prte_ras_base_selected_module_t *mod;
 
     if (prte_ras_base.scheduler_owned) {
-        prte_show_help("help-ras-base.txt", "ras-base:add-host-managed", true);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ras-base.txt", "ras-base:add-host-managed", true);
         return PRTE_ERR_NOT_SUPPORTED;
     }
 
@@ -2255,7 +2255,7 @@ static int ras_base_add_hosts_allowed(void)
         }
     }
 
-    prte_show_help("help-ras-base.txt", "ras-base:add-host-unsupported", true);
+    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ras-base.txt", "ras-base:add-host-unsupported", true);
     return PRTE_ERR_NOT_SUPPORTED;
 }
 
@@ -2481,7 +2481,7 @@ int prte_ras_base_spawn_alloc(prte_job_t *jdata, bool *posted)
     if (!have_directive) {
         /* the one element that cannot be defaulted: a request whose directive
          * we had to guess would ask for something nobody asked for */
-        prte_show_help("help-ras-base.txt", "ras-base:spawn-alloc-nodirective", true);
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-ras-base.txt", "ras-base:spawn-alloc-nodirective", true);
         PMIX_INFO_FREE(info, nalloc);
         return PRTE_ERR_BAD_PARAM;
     }
@@ -2706,7 +2706,7 @@ static int ras_base_activate_select(pmix_pointer_array_t *sel, prte_node_t *node
         return PRTE_SUCCESS;
     }
     if (!ras_base_activatable(node)) {
-        prte_show_help("help-ras-base.txt", "ras-base:activate-unavailable", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ras-base.txt", "ras-base:activate-unavailable", true,
                        node->name, prte_node_state_to_str(node->state), token);
         return PRTE_ERR_SILENT;
     }
@@ -2729,7 +2729,7 @@ static int ras_base_activate_hostfile(const char *hostfile, pmix_pointer_array_t
     int rc;
 
     if ('\0' == *hostfile) {
-        prte_show_help("help-ras-base.txt", "ras-base:activate-nofile", true);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ras-base.txt", "ras-base:activate-nofile", true);
         return PRTE_ERR_SILENT;
     }
 
@@ -2745,7 +2745,7 @@ static int ras_base_activate_hostfile(const char *hostfile, pmix_pointer_array_t
     PMIX_LIST_FOREACH(nd, &nodes, prte_node_t) {
         node = prte_node_match(NULL, nd->name);
         if (NULL == node) {
-            prte_show_help("help-ras-base.txt", "ras-base:activate-unknown-in-file", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ras-base.txt", "ras-base:activate-unknown-in-file", true,
                            nd->name, hostfile);
             PMIX_LIST_DESTRUCT(&nodes);
             return PRTE_ERR_SILENT;
@@ -2812,13 +2812,13 @@ static int ras_base_activate_spec(const char *spec, pmix_pointer_array_t *sel)
              * --add-host where PRRTE owns the allocation and the slot count
              * really is PRRTE's to change. */
             if (NULL != strchr(tokens[k], ':')) {
-                prte_show_help("help-ras-base.txt", "ras-base:activate-slots", true, tokens[k]);
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ras-base.txt", "ras-base:activate-slots", true, tokens[k]);
                 rc = PRTE_ERR_SILENT;
                 goto done;
             }
             node = prte_node_match(NULL, tokens[k]);
             if (NULL == node) {
-                prte_show_help("help-ras-base.txt", "ras-base:activate-unknown", true, tokens[k]);
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ras-base.txt", "ras-base:activate-unknown", true, tokens[k]);
                 rc = PRTE_ERR_SILENT;
                 goto done;
             }
@@ -2845,7 +2845,7 @@ static int ras_base_activate_spec(const char *spec, pmix_pointer_array_t *sel)
         } else if ('n' == tokens[k][1] || 'N' == tokens[k][1]) {
             /* a specific node of the allocation, by index */
             if (!ras_base_read_count(&tokens[k][2], &nodeidx)) {
-                prte_show_help("help-dash-host.txt", "dash-host:invalid-relative-node-syntax",
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-dash-host.txt", "dash-host:invalid-relative-node-syntax",
                                true, tokens[k]);
                 rc = PRTE_ERR_SILENT;
                 goto done;
@@ -2857,14 +2857,14 @@ static int ras_base_activate_spec(const char *spec, pmix_pointer_array_t *sel)
                 ++nodeidx;
             }
             if (nodeidx >= prte_node_pool->size) {
-                prte_show_help("help-dash-host.txt", "dash-host:relative-node-out-of-bounds",
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-dash-host.txt", "dash-host:relative-node-out-of-bounds",
                                true, nodeidx, tokens[k]);
                 rc = PRTE_ERR_SILENT;
                 goto done;
             }
             node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, nodeidx);
             if (NULL == node) {
-                prte_show_help("help-dash-host.txt", "dash-host:relative-node-not-found",
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-dash-host.txt", "dash-host:relative-node-not-found",
                                true, nodeidx, tokens[k]);
                 rc = PRTE_ERR_SILENT;
                 goto done;
@@ -2881,12 +2881,12 @@ static int ras_base_activate_spec(const char *spec, pmix_pointer_array_t *sel)
              * not a question about DVM membership at all: the nodes it picks
              * are mostly ones the DVM is already on, so honoring it here
              * would launch nothing and report success. */
-            prte_show_help("help-ras-base.txt", "ras-base:activate-empty", true, tokens[k]);
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ras-base.txt", "ras-base:activate-empty", true, tokens[k]);
             rc = PRTE_ERR_SILENT;
             goto done;
 
         } else {
-            prte_show_help("help-dash-host.txt", "dash-host:invalid-relative-node-syntax",
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-dash-host.txt", "dash-host:invalid-relative-node-syntax",
                            true, tokens[k]);
             rc = PRTE_ERR_SILENT;
             goto done;

--- a/src/mca/ras/flux/ras_flux_module.c
+++ b/src/mca/ras/flux/ras_flux_module.c
@@ -375,7 +375,7 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
 
     h = flux_open_ex(NULL, 0, &flux_error);
     if(NULL == h) {
-        prte_show_help("help-ras-flux.txt", "flux-broker-not-found", 1, flux_error.text);
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-ras-flux.txt", "flux-broker-not-found", 1, flux_error.text);
         ret = PRTE_ERR_NOT_FOUND;
         goto err;
     }
@@ -411,14 +411,14 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
     f = flux_kvs_lookup(h, NULL, 0, "resource.R");
     if (NULL == f) {
         int errno_l = errno;
-        prte_show_help("help-ras-flux.txt", "flux-kvs-lookup-failure", 1, strerror(errno_l));
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-ras-flux.txt", "flux-kvs-lookup-failure", 1, strerror(errno_l));
         ret = PRTE_ERR_NOT_FOUND;
         goto err;
     }
 
     if(flux_kvs_lookup_get (f, (const char **)&return_str) < 0){
         int errno_l = errno;
-        prte_show_help("help-ras-flux.txt", "flux-kvs-lookup-get-failure", 1, strerror(errno_l));
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-ras-flux.txt", "flux-kvs-lookup-get-failure", 1, strerror(errno_l));
         ret = PRTE_ERR_NOT_FOUND;
         goto err;
     }
@@ -431,7 +431,7 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
      */
     root = json_loads(return_str, JSON_DECODE_ANY, &json_err);
     if (NULL == root) {
-        prte_show_help("help-ras-flux.txt", "flux-json-parse-failure", 1, json_err.text);
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-ras-flux.txt", "flux-json-parse-failure", 1, json_err.text);
         ret = PRTE_ERR_UNPACK_FAILURE;
         goto err;
     }

--- a/src/mca/ras/gridengine/ras_gridengine_module.c
+++ b/src/mca/ras/gridengine/ras_gridengine_module.c
@@ -92,7 +92,7 @@ static int prte_ras_gridengine_allocate(prte_job_t *jdata, pmix_list_t *nodelist
     /* check the PE_HOSTFILE before continuing on */
     fp = fopen(pe_hostfile, "r");
     if (NULL == fp) {
-        prte_show_help("help-ras-gridengine.txt", "cannot-read-pe-hostfile", true, pe_hostfile,
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-ras-gridengine.txt", "cannot-read-pe-hostfile", true, pe_hostfile,
                        strerror(errno));
         rc = PRTE_ERROR;
         PRTE_ERROR_LOG(rc);
@@ -160,7 +160,7 @@ static int prte_ras_gridengine_allocate(prte_job_t *jdata, pmix_list_t *nodelist
      * is considered an unrecoverable error and we need to report it
      */
     if (pmix_list_is_empty(nodelist)) {
-        prte_show_help("help-ras-gridengine.txt", "no-nodes-found", true);
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-ras-gridengine.txt", "no-nodes-found", true);
         return PRTE_ERR_NOT_FOUND;
     }
 

--- a/src/mca/ras/hosts/ras_hosts.c
+++ b/src/mca/ras/hosts/ras_hosts.c
@@ -173,7 +173,7 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
                  * here with one.)  The user asked for specific hosts and named
                  * none, so say so rather than carrying on with an allocation
                  * they did not ask for. */
-                prte_show_help("help-hostfile.txt", "no-hostfile", true, hosts);
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-hostfile.txt", "no-hostfile", true, hosts);
                 free(hosts);
                 return PRTE_ERR_SILENT;
             }
@@ -307,7 +307,7 @@ static pmix_status_t process_hostfile(char *hostfile, pmix_list_t *nodes)
      * syntax here */
     fp = fopen(hostfile, "r");
     if (NULL == fp) {
-        prte_show_help("help-ras-base.txt", "ras-base:addhost-not-found", true, hostfile);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ras-base.txt", "ras-base:addhost-not-found", true, hostfile);
         return PMIX_ERR_SILENT;
     }
 
@@ -370,7 +370,7 @@ static pmix_status_t process_hostfile(char *hostfile, pmix_list_t *nodes)
             addslots = true;
         }
         if (!parse_slots(ptr, &slots)) {
-            prte_show_help("help-ras-base.txt", "ras-base:bad-slots", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ras-base.txt", "ras-base:bad-slots", true,
                            cptr, hostfile, ptr);
             fclose(fp);
             free(line);
@@ -408,7 +408,7 @@ process:
             } else if (0 > slots && -1 != slots) {
                 // cannot have a new node with negative slots - the -1
                 // is a marker for a node without slots being specified
-                prte_show_help("help-ras-base.txt", "negative-slots", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ras-base.txt", "negative-slots", true,
                                hostfile, cptr);
                 PMIX_RELEASE(node);
                 free(line);

--- a/src/mca/ras/lsf/ras_lsf_module.c
+++ b/src/mca/ras/lsf/ras_lsf_module.c
@@ -74,7 +74,7 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
 
     /* get the list of allocated nodes */
     if ((num_nodes = lsb_getalloc(&nodelist)) < 0) {
-        prte_show_help("help-ras-lsf.txt", "nodelist-failed", true);
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-ras-lsf.txt", "nodelist-failed", true);
         return PRTE_ERR_NOT_AVAILABLE;
     }
     node = NULL;

--- a/src/mca/ras/pbs/ras_pbs_module.c
+++ b/src/mca/ras/pbs/ras_pbs_module.c
@@ -100,7 +100,7 @@ static int allocate(prte_job_t *jdata, pmix_list_t *nodes)
      * is an unrecoverable error - report it
      */
     if (pmix_list_is_empty(nodes)) {
-        prte_show_help("help-ras-pbs.txt", "no-nodes-found", true, filename);
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-ras-pbs.txt", "no-nodes-found", true, filename);
         return PRTE_ERR_NOT_FOUND;
     }
 
@@ -156,7 +156,7 @@ static int discover(pmix_list_t *nodelist, char *pbs_jobid)
      */
     if (prte_mca_ras_pbs_component.smp_mode) {
         if (NULL == (cppn = getenv("PBS_PPN"))) {
-            prte_show_help("help-ras-pbs.txt", "smp-error", true);
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ras-pbs.txt", "smp-error", true);
             return PRTE_ERR_NOT_FOUND;
         }
         ppn = strtol(cppn, NULL, 10);
@@ -170,7 +170,7 @@ static int discover(pmix_list_t *nodelist, char *pbs_jobid)
         /* try the Cobalt variant */
         filename = getenv("COBALT_NODEFILE");
         if (NULL == filename) {
-            prte_show_help("help-ras-pbs.txt", "no-nodefile", true);
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ras-pbs.txt", "no-nodefile", true);
             return PRTE_ERR_NOT_FOUND;
         }
     }
@@ -199,7 +199,7 @@ static int discover(pmix_list_t *nodelist, char *pbs_jobid)
             if (0 == strcmp(node->name, hostname)) {
                 if (prte_mca_ras_pbs_component.smp_mode) {
                     /* this cannot happen in smp mode */
-                    prte_show_help("help-ras-pbs.txt", "smp-multi", true);
+                    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ras-pbs.txt", "smp-multi", true);
                     fclose(fp);
                     free(hostname);
                     return PRTE_ERR_BAD_PARAM;

--- a/src/mca/ras/slurm/AGENTS.md
+++ b/src/mca/ras/slurm/AGENTS.md
@@ -88,8 +88,8 @@ deviation* and the framework guide.
   phases — see below.
 - **`PMIX_ALLOC_NEW`** → the same request; see below.
 - **`PMIX_ALLOC_RELEASE`** → `serve_release_req`: shrinks the SLURM job
-  with `scontrol update job`, removing nodes by count while protecting
-  the launching node (`SLURMD_NODENAME`).
+  with `scontrol update job`, removing nodes by count or by name while
+  protecting the node the HNP is running on.
 - **`PMIX_ALLOC_REQ_CANCEL`** → `serve_cancel_req`: cancels a pending
   extend by request id, and answers it (see below).
 

--- a/src/mca/ras/slurm/ras_slurm_modify_release.c
+++ b/src/mca/ras/slurm/ras_slurm_modify_release.c
@@ -18,6 +18,7 @@
 #include "ras_slurm_modify_release_tracker.h"
 #include "src/mca/preg/preg.h"
 #include "src/mca/ras/base/base.h"
+#include "src/runtime/prte_globals.h"
 
 /* Local functions */
 static bool prte_ras_slurm_session_contains_invoker(prte_session_t *session, const char *launching_jobid);
@@ -30,7 +31,7 @@ static int prte_ras_slurm_remove_allocation_by_id(prte_pmix_server_req_t *req, c
 static int prte_ras_slurm_remove_nodes_by_count(prte_pmix_server_req_t *req, uint64_t node_count);
 static int prte_ras_slurm_append_session_targets(prte_session_t *session, char ***target_nodes);
 static int prte_ras_slurm_append_release_targets(prte_session_t *session, char **requested_nodes, char ***target_nodes);
-static int prte_ras_slurm_append_count_session_targets(prte_session_t *session, const char *protected_node, int nodes_to_remove, char ***target_nodes);
+static int prte_ras_slurm_append_count_session_targets(prte_session_t *session, int nodes_to_remove, char ***target_nodes);
 static int prte_ras_slurm_attach_shrink_tracker(prte_shrink_campaign_t *campaign, prte_ras_slurm_shrink_tracker_t *tracker);
 static int prte_ras_slurm_start_shrink(prte_pmix_server_req_t *req, prte_ras_slurm_shrink_tracker_t *tracker, char **target_nodes);
 static int prte_ras_slurm_complete_release_request(prte_pmix_server_req_t *req);
@@ -296,13 +297,13 @@ static int prte_ras_slurm_append_release_targets(prte_session_t *session,
 /**
  * @brief Append count-selected nodes from a session.
  *
+ * Skips the node the HNP runs on.
+ *
  * @param[in] session Session to inspect.
- * @param[in] protected_node Node that must not be selected.
  * @param[in] nodes_to_remove Number of nodes to append.
  * @param[in,out] target_nodes Target node argv.
  */
 static int prte_ras_slurm_append_count_session_targets(prte_session_t *session,
-                                                       const char *protected_node,
                                                        int nodes_to_remove,
                                                        char ***target_nodes)
 {
@@ -320,7 +321,10 @@ static int prte_ras_slurm_append_count_session_targets(prte_session_t *session,
         if (NULL == node || NULL == node->name) {
             continue;
         }
-        if (NULL != protected_node && 0 == strcmp(node->name, protected_node)) {
+        /* Releasing the HNP's node kills the DVM. quickmatch also checks
+         * node->aliases, where node_insert leaves the fully qualified
+         * domain name when it shortens a node name. */
+        if (prte_quickmatch(node, prte_process_info.nodename)) {
             continue;
         }
 
@@ -912,7 +916,6 @@ static int prte_ras_slurm_remove_nodes_by_name(prte_pmix_server_req_t *req, char
     int err = PRTE_SUCCESS;
     int node_count;
     char *launching_jobid;
-    char *protected_node = NULL;
     char **target_nodes = NULL;
     char **processed_jobs = NULL;
     prte_ras_slurm_shrink_tracker_t *tracker = NULL;
@@ -933,6 +936,7 @@ static int prte_ras_slurm_remove_nodes_by_name(prte_pmix_server_req_t *req, char
 
     for (int i = 0; NULL != nodes[i]; i++) {
         prte_session_stack_item_t *session_item;
+        prte_node_t *nd;
 
         err = prte_ras_slurm_validate_hostname(nodes[i]);
         if (PRTE_SUCCESS != err) {
@@ -955,19 +959,13 @@ static int prte_ras_slurm_remove_nodes_by_name(prte_pmix_server_req_t *req, char
             return PRTE_ERR_RESOURCE_BUSY;
         }
 
-        if (prte_ras_slurm_session_contains_invoker(session_item->session, launching_jobid)) {
-            if (NULL == protected_node) {
-                protected_node = getenv("SLURMD_NODENAME");
-                if (NULL == protected_node) {
-                    return PRTE_ERR_BAD_PARAM;
-                }
-            }
-
-            if (0 == strcmp(nodes[i], protected_node)) {
-                pmix_output(0, "ras:slurm:remove_nodes_by_name: refusing to remove current node %s",
-                            protected_node);
-                return PRTE_ERR_BAD_PARAM;
-            }
+        /* Releasing the HNP's node kills the DVM. */
+        nd = prte_node_match(NULL, nodes[i]);
+        if (NULL != nd && NULL != nd->name &&
+            prte_quickmatch(nd, prte_process_info.nodename)) {
+            pmix_output(0, "ras:slurm:remove_nodes_by_name: refusing to remove %s, "
+                           "the node this DVM's HNP is running on", nodes[i]);
+            return PRTE_ERR_BAD_PARAM;
         }
     }
 
@@ -1282,27 +1280,14 @@ static int prte_ras_slurm_remove_nodes_by_count(prte_pmix_server_req_t *req, uin
             }
 
             /* Case 2: keep the Slurm job alive and shrink it to its survivors. */
-            char *protected_node = NULL;
-
-            if(contains_invoker) {
-                protected_node = getenv("SLURMD_NODENAME");
-
-                if (NULL == protected_node) {
-                    pmix_output(0,
-                                "ras:slurm:remove_nodes_by_count: SLURMD_NODENAME is not set. "
-                                "Refusing to shrink job %s because the current node cannot be "
-                                "excluded from the resize operation.",
-                                session->alloc_refid);
-                    err = PRTE_ERR_BAD_PARAM;
-                    PRTE_ERROR_LOG(err);
-                    goto cleanup; 
-                }
-            }
-
-            err = prte_ras_slurm_append_count_session_targets(session, protected_node,
-                                                             nodes_to_rem_from_session,
-                                                             &session_targets);
+            err = prte_ras_slurm_append_count_session_targets(session,
+                                                              nodes_to_rem_from_session,
+                                                              &session_targets);
             if (PRTE_SUCCESS != err) {
+                pmix_output(0, "ras:slurm:remove_nodes_by_count: could not select %d "
+                               "releasable nodes from job %s",
+                            nodes_to_rem_from_session, session->alloc_refid);
+                PRTE_ERROR_LOG(err);
                 PMIx_Argv_free(session_targets);
                 goto cleanup;
             }

--- a/src/mca/ras/slurm/ras_slurm_module.c
+++ b/src/mca/ras/slurm/ras_slurm_module.c
@@ -113,7 +113,7 @@ static bool check_taint(char *name, char *evar)
         }
     }
 
-    prte_show_help("help-ras-slurm.txt", "tainted-envar", true,
+    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ras-slurm.txt", "tainted-envar", true,
                    name, prte_mca_ras_slurm_component.max_length);
     return true;
 }
@@ -191,7 +191,7 @@ static int prte_ras_slurm_allocate(prte_job_t *jdata, pmix_list_t *nodes)
 
     regexp = getenv("SLURM_NODELIST");
     if (NULL == regexp) {
-        prte_show_help("help-ras-slurm.txt", "slurm-env-var-not-found", 1, "SLURM_NODELIST");
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-ras-slurm.txt", "slurm-env-var-not-found", 1, "SLURM_NODELIST");
         return PRTE_ERR_NOT_FOUND;
     }
     // check for length violation - untaint the envar value
@@ -209,7 +209,7 @@ static int prte_ras_slurm_allocate(prte_job_t *jdata, pmix_list_t *nodes)
         tasks_per_node = getenv("SLURM_JOB_CPUS_PER_NODE");
         if (NULL == tasks_per_node) {
             /* couldn't find any version - abort */
-            prte_show_help("help-ras-slurm.txt", "slurm-env-var-not-found", 1,
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-ras-slurm.txt", "slurm-env-var-not-found", 1,
                            "SLURM_JOB_CPUS_PER_NODE");
             return PRTE_ERR_NOT_FOUND;
         }
@@ -229,7 +229,7 @@ static int prte_ras_slurm_allocate(prte_job_t *jdata, pmix_list_t *nodes)
         tasks_per_node = getenv("SLURM_TASKS_PER_NODE");
         if (NULL == tasks_per_node) {
             /* couldn't find any version - abort */
-            prte_show_help("help-ras-slurm.txt", "slurm-env-var-not-found", 1,
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-ras-slurm.txt", "slurm-env-var-not-found", 1,
                            "SLURM_TASKS_PER_NODE");
             return PRTE_ERR_NOT_FOUND;
         }
@@ -417,7 +417,7 @@ static int prte_ras_slurm_discover(char *regexp, char *tasks_per_node, pmix_list
         }
         if (i == 0) {
             /* we found a special character at the beginning of the string */
-            prte_show_help("help-ras-slurm.txt", "slurm-env-var-bad-value", 1, regexp,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ras-slurm.txt", "slurm-env-var-bad-value", 1, regexp,
                            tasks_per_node, "SLURM_NODELIST");
             PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
             free(orig);
@@ -434,7 +434,7 @@ static int prte_ras_slurm_discover(char *regexp, char *tasks_per_node, pmix_list
             }
             if (j >= len) {
                 /* we didn't find the end of the range */
-                prte_show_help("help-ras-slurm.txt", "slurm-env-var-bad-value", 1, regexp,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ras-slurm.txt", "slurm-env-var-bad-value", 1, regexp,
                                tasks_per_node, "SLURM_NODELIST");
                 PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
                 free(orig);
@@ -443,7 +443,7 @@ static int prte_ras_slurm_discover(char *regexp, char *tasks_per_node, pmix_list
 
             ret = prte_ras_slurm_parse_ranges(base, base + i + 1, &names);
             if (PRTE_SUCCESS != ret) {
-                prte_show_help("help-ras-slurm.txt", "slurm-env-var-bad-value", 1, regexp,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ras-slurm.txt", "slurm-env-var-bad-value", 1, regexp,
                                tasks_per_node, "SLURM_NODELIST");
                 PRTE_ERROR_LOG(ret);
                 free(orig);
@@ -527,7 +527,7 @@ static int prte_ras_slurm_discover(char *regexp, char *tasks_per_node, pmix_list
         } else if (*endptr == '\0' || j >= num_nodes) {
             break;
         } else {
-            prte_show_help("help-ras-slurm.txt", "slurm-env-var-bad-value", 1, regexp,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-ras-slurm.txt", "slurm-env-var-bad-value", 1, regexp,
                            tasks_per_node, "SLURM_TASKS_PER_NODE");
             PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
             free(slots);

--- a/src/mca/rmaps/base/rmaps_base_binding.c
+++ b/src/mca/rmaps/base/rmaps_base_binding.c
@@ -127,7 +127,7 @@ static int bind_generic(prte_job_t *jdata, prte_proc_t *proc,
     if (0 == nobjs) {
         // if this is not a default binding policy, then error out
         if (PRTE_BINDING_POLICY_IS_SET(jdata->map->binding)) {
-            prte_show_help("help-prte-rmaps-base.txt", "rmaps:binding-target-not-found",
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "rmaps:binding-target-not-found",
                            true, prte_hwloc_base_print_binding(jdata->map->binding), node->name);
             return PRTE_ERR_SILENT;
         }
@@ -226,7 +226,7 @@ static int bind_generic(prte_job_t *jdata, prte_proc_t *proc,
         }
         /* there aren't any appropriate targets under this object */
         if (PRTE_BINDING_REQUIRED(jdata->map->binding)) {
-            prte_show_help("help-prte-rmaps-base.txt", "rmaps:no-available-cpus", true, node->name);
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "rmaps:no-available-cpus", true, node->name);
             return PRTE_ERR_SILENT;
         } else {
             return PRTE_SUCCESS;
@@ -278,7 +278,7 @@ static int bind_generic(prte_job_t *jdata, prte_proc_t *proc,
     if (NULL == tmp_obj) {
         PRTE_ERROR_LOG(PRTE_ERR_NOT_FOUND);
         if (PRTE_BINDING_REQUIRED(jdata->map->binding)) {
-            prte_show_help("help-prte-rmaps-base.txt", "rmaps:no-available-cpus", true, node->name);
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "rmaps:no-available-cpus", true, node->name);
             return PRTE_ERR_SILENT;
         } else {
             return PRTE_SUCCESS;
@@ -363,7 +363,7 @@ static int bind_to_cpuset(prte_job_t *jdata,
         }
     }
     if (!included) {
-        prte_show_help("help-prte-rmaps-base.txt", "span-packages-cpuset", true,
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "span-packages-cpuset", true,
                        prte_rmaps_base_print_mapping(jdata->map->mapping),
                        prte_hwloc_base_print_binding(jdata->map->binding),
                        options->cpuset);
@@ -452,7 +452,7 @@ static int bind_multiple(prte_job_t *jdata, prte_proc_t *proc,
             /* if we get here, then there are no packages that can completely
              * cover the request - so return an error */
             hwloc_bitmap_free(result);
-            prte_show_help("help-prte-rmaps-base.txt", "span-packages-multiple", true,
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "span-packages-multiple", true,
                            prte_rmaps_base_print_mapping(jdata->map->mapping),
                            prte_hwloc_base_print_binding(jdata->map->binding),
                            options->cpus_per_rank,
@@ -475,7 +475,7 @@ static int bind_multiple(prte_job_t *jdata, prte_proc_t *proc,
     hwloc_bitmap_list_asprintf(&proc->cpuset, result);
     hwloc_bitmap_free(result);
     if (NULL == proc->cpuset || 0 == strlen(proc->cpuset)) {
-        prte_show_help("help-prte-rmaps-base.txt", "not-enough-cpus", true,
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "not-enough-cpus", true,
                        options->pprn, hwloc_obj_type_string(options->maptype),
                        options->cpus_per_rank);
         return PRTE_ERR_SILENT;

--- a/src/mca/rmaps/base/rmaps_base_devices.c
+++ b/src/mca/rmaps/base/rmaps_base_devices.c
@@ -327,7 +327,7 @@ int prte_rmaps_base_devices_begin(prte_node_t *node, prte_rmaps_options_t *opts,
     if (0 != (type & (PMIX_DEVTYPE_GPU | PMIX_DEVTYPE_COPROC))) {
         for (n = 0; n < dc->ndevs; n++) {
             if (NULL == dc->devs[n].vendor_id) {
-                prte_show_help("help-prte-rmaps-base.txt", "rmaps:device-not-nameable",
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "rmaps:device-not-nameable",
                                true, opts->map_device, node->name,
                                dc->devs[n].dev.osname);
                 pmix_hwloc_release_devices(dc->devs, dc->ndevs);
@@ -383,7 +383,7 @@ int prte_rmaps_base_devices_begin(prte_node_t *node, prte_rmaps_options_t *opts,
      * binding matching it is then legitimate. */
     for (n = 0; n < dc->ngroups; n++) {
         if (!binding_fits(node, dc->grouploc[n], opts)) {
-            prte_show_help("help-prte-rmaps-base.txt", "rmaps:bind-above-device", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "rmaps:bind-above-device", true,
                            prte_hwloc_base_print_binding(opts->bind),
                            opts->map_device, node->name);
             pmix_hwloc_release_devices(dc->devs, dc->ndevs);
@@ -402,7 +402,7 @@ int prte_rmaps_base_devices_begin(prte_node_t *node, prte_rmaps_options_t *opts,
         }
     }
     if (degenerate && 1 < dc->ngroups) {
-        prte_show_help("help-prte-rmaps-base.txt", "rmaps:degenerate-device-locality",
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "rmaps:degenerate-device-locality",
                        true, opts->map_device, node->name, (int) dc->ngroups);
     }
 

--- a/src/mca/rmaps/base/rmaps_base_frame.c
+++ b/src/mca/rmaps/base/rmaps_base_frame.c
@@ -281,7 +281,7 @@ static int check_pe_list(const char *spec)
 
     entries = PMIx_Argv_split(spec, ',');
     if (NULL == entries) {
-        prte_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "invalid-value", true,
                        "mapping", "PE-LIST", spec);
         return PRTE_ERR_SILENT;
     }
@@ -303,7 +303,7 @@ static int check_pe_list(const char *spec)
     }
     PMIx_Argv_free(entries);
     if (PRTE_SUCCESS != rc) {
-        prte_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "invalid-value", true,
                        "mapping", "PE-LIST", spec);
     }
     return rc;
@@ -353,7 +353,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
         } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_OVERSUB)) {
             if (nooversubscribe_given) {
                 /* conflicting directives */
-                prte_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "conflicting-directives", true,
                                "OVERSUBSCRIBE", "NOOVERSUBSCRIBE");
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
@@ -365,7 +365,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
         } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_NOOVER)) {
             if (oversubscribe_given) {
                 /* conflicting directives */
-                prte_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "conflicting-directives", true,
                                "OVERSUBSCRIBE", "NOOVERSUBSCRIBE");
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
@@ -379,7 +379,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
 
         } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_ORDERED)) {
             if (NULL == attrs) {
-                prte_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "unsupported-default-modifier", true,
                                "mapping policy", ck2[i]);
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
@@ -390,7 +390,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
             /* Numeric value must immediately follow '=' (PE=2) */
             val = pmix_cli_qualifier_value(ck2[i]);
             if (NULL == val) {
-                prte_show_help("help-prte-rmaps-base.txt", "invalid-value", true, "mapping policy",
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "invalid-value", true, "mapping policy",
                                "PE", ck2[i]);
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
@@ -398,7 +398,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
             u16 = strtol(val, &ptr, 10);
             if ('\0' != *ptr) {
                 /* value is invalid */
-                prte_show_help("help-prte-rmaps-base.txt", "invalid-value", true, "mapping policy",
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "invalid-value", true, "mapping policy",
                                "PE", ck2[i]);
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
@@ -414,7 +414,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
         } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_INHERIT)) {
             if (noinherit_given) {
                 /* conflicting directives */
-                prte_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "conflicting-directives", true,
                                "INHERIT", "NOINHERIT");
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
@@ -435,7 +435,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
         } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_NOINHERIT)) {
             if (inherit_given) {
                 /* conflicting directives */
-                prte_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "conflicting-directives", true,
                                "INHERIT", "NOINHERIT");
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
@@ -450,7 +450,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
 
         } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_HWTCPUS)) {
             if (core_cpus_given) {
-                prte_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "conflicting-directives", true,
                                "HWTCPUS", "CORECPUS");
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
@@ -465,7 +465,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
 
         } else if (PMIX_CHECK_CLI_OPTION(ck2[i], PRTE_CLI_CORECPUS)) {
             if (hwthread_cpus_given) {
-                prte_show_help("help-prte-rmaps-base.txt", "conflicting-directives", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "conflicting-directives", true,
                                "HWTCPUS", "CORECPUS");
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
@@ -496,7 +496,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
             val = pmix_cli_qualifier_value(ck2[i]);
             if (NULL == val) {
                 /* missing the value */
-                prte_show_help("help-prte-rmaps-base.txt", "missing-value", true, "mapping policy",
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "missing-value", true, "mapping policy",
                                "FILE", ck2[i]);
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
@@ -504,7 +504,7 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
             if (NULL == attrs) {
                 if (NULL != prte_rmaps_base.file) {
                     // cannot specify it twice
-                    prte_show_help("help-prte-rmaps-base.txt", "multiply-defined", true, "mapping policy",
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "multiply-defined", true, "mapping policy",
                                    "FILE", prte_rmaps_base.file, ck2[i]);
                     PMIx_Argv_free(ck2);
                     return PRTE_ERR_SILENT;
@@ -530,13 +530,13 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
                 val = "package";
             }
             if (!prte_rmaps_base_interleave_level(val, NULL)) {
-                prte_show_help("help-prte-rmaps-base.txt", "rmaps:bad-interleave-level",
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "rmaps:bad-interleave-level",
                                true, val);
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
             }
             if (NULL == attrs) {
-                prte_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier",
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "unsupported-default-modifier",
                                true, "mapping policy", PRTE_CLI_INTERLEAVE);
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
@@ -551,20 +551,20 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
              * the reason given below. */
             val = pmix_cli_qualifier_value(ck2[i]);
             if (NULL == val) {
-                prte_show_help("help-prte-rmaps-base.txt", "missing-value", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "missing-value", true,
                                "mapping policy", "NDEV", ck2[i]);
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
             }
             ndev = strtol(val, &eptr, 10);
             if ('\0' != *eptr || 0 >= ndev || UINT16_MAX < ndev) {
-                prte_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "invalid-value", true,
                                "mapping policy", "NDEV", ck2[i]);
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
             }
             if (NULL == attrs) {
-                prte_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier",
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "unsupported-default-modifier",
                                true, "mapping policy", PRTE_CLI_NDEV);
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
@@ -592,13 +592,13 @@ static int check_modifiers(char *ck, prte_job_t *jdata,
                        || 0 == strcasecmp(val, "no")) {
                 shared = false;
             } else {
-                prte_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "invalid-value", true,
                                "mapping policy", "SHARED", ck2[i]);
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
             }
             if (NULL == attrs) {
-                prte_show_help("help-prte-rmaps-base.txt", "unsupported-default-modifier",
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "unsupported-default-modifier",
                                true, "mapping policy", PRTE_CLI_SHARED);
                 PMIx_Argv_free(ck2);
                 return PRTE_ERR_SILENT;
@@ -681,7 +681,7 @@ int prte_rmaps_base_hoist_job_directives(prte_job_t *jdata,
             if (PRTE_MAPPING_SUBSCRIBE_GIVEN & PRTE_GET_MAPPING_DIRECTIVE(apppol)) {
                 appover = !(PRTE_MAPPING_NO_OVERSUBSCRIBE & PRTE_GET_MAPPING_DIRECTIVE(apppol));
                 if (given && over != appover) {
-                    prte_show_help("help-prte-rmaps-base.txt", "conflicting-job-qualifiers",
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "conflicting-job-qualifiers",
                                    true, appover ? "OVERSUBSCRIBE" : "NOOVERSUBSCRIBE",
                                    app->app, over ? "OVERSUBSCRIBE" : "NOOVERSUBSCRIBE");
                     return PRTE_ERR_SILENT;
@@ -707,7 +707,7 @@ int prte_rmaps_base_hoist_job_directives(prte_job_t *jdata,
         /***   INHERIT / NOINHERIT   ***/
         if (prte_get_attribute(&app->attributes, PRTE_JOB_INHERIT, NULL, PMIX_BOOL)) {
             if (prte_get_attribute(&jdata->attributes, PRTE_JOB_NOINHERIT, NULL, PMIX_BOOL)) {
-                prte_show_help("help-prte-rmaps-base.txt", "conflicting-job-qualifiers",
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "conflicting-job-qualifiers",
                                true, "INHERIT", app->app, "NOINHERIT");
                 return PRTE_ERR_SILENT;
             }
@@ -717,7 +717,7 @@ int prte_rmaps_base_hoist_job_directives(prte_job_t *jdata,
         }
         if (prte_get_attribute(&app->attributes, PRTE_JOB_NOINHERIT, NULL, PMIX_BOOL)) {
             if (prte_get_attribute(&jdata->attributes, PRTE_JOB_INHERIT, NULL, PMIX_BOOL)) {
-                prte_show_help("help-prte-rmaps-base.txt", "conflicting-job-qualifiers",
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "conflicting-job-qualifiers",
                                true, "NOINHERIT", app->app, "INHERIT");
                 return PRTE_ERR_SILENT;
             }
@@ -859,7 +859,7 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
                 /* this is an error - there had to be at least one
                  * colon to delimit the number from the object type
                  */
-                prte_show_help("help-prte-rmaps-base.txt", "invalid-pattern", true, inspec);
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "invalid-pattern", true, inspec);
                 PMIx_Argv_free(ck);
                 return PRTE_ERR_SILENT;
             }
@@ -894,7 +894,7 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
         if (PRTE_SUCCESS != (rc = check_modifiers(cptr, jdata, NULL, &tmp)) &&
             PRTE_ERR_TAKE_NEXT_OPTION != rc) {
             if (PRTE_ERR_BAD_PARAM == rc) {
-                prte_show_help("help-prte-rmaps-base.txt", "unrecognized-modifier", true, inspec);
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "unrecognized-modifier", true, inspec);
                 rc = PRTE_ERR_SILENT;
             }
             PMIx_Argv_free(ck);
@@ -921,7 +921,7 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
         if (PRTE_SUCCESS != (rc = check_modifiers(&inspec[1], jdata, NULL, &tmp)) &&
             PRTE_ERR_TAKE_NEXT_OPTION != rc) {
             if (PRTE_ERR_BAD_PARAM == rc) {
-                prte_show_help("help-prte-rmaps-base.txt", "unrecognized-modifier", true, inspec);
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "unrecognized-modifier", true, inspec);
                 rc = PRTE_ERR_SILENT;
             }
             PMIx_Argv_free(ck);
@@ -940,7 +940,7 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
         ++ptr;
         if ('\0' == *ptr) {
             /* malformed option */
-            prte_show_help("help-prte-rmaps-base.txt", "unrecognized-policy",
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "unrecognized-policy",
                            true, "mapping", ck[0]);
             PMIx_Argv_free(ck);
             free(cptr);
@@ -992,7 +992,7 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
         /* check that the file was given */
         if ((NULL == jdata && NULL == prte_rmaps_base.file) ||
             (NULL != jdata && !prte_get_attribute(&jdata->attributes, PRTE_JOB_FILE, NULL, PMIX_STRING))) {
-            prte_show_help("help-prte-rmaps-base.txt", "rankfile-no-filename", true);
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "rankfile-no-filename", true);
             PMIx_Argv_free(ck);
             free(cptr);
             if (NULL != val) {
@@ -1006,7 +1006,7 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
             if (!prte_get_attribute(&jdata->attributes, PRTE_JOB_FILE, NULL, PMIX_STRING)) {
                 if (NULL == prte_rmaps_base.file) {
                     /* also not allowed */
-                    prte_show_help("help-prte-rmaps-base.txt", "rankfile-no-filename", true);
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "rankfile-no-filename", true);
                     PMIx_Argv_free(ck);
                     free(cptr);
                     if (NULL != val) {
@@ -1034,7 +1034,7 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
 
     } else if (PMIX_CHECK_CLI_OPTION(cptr, PRTE_CLI_PELIST)) {
         if (NULL == jdata) {
-            prte_show_help("help-prte-rmaps-base.txt", "unsupported-default-policy", true,
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "unsupported-default-policy", true,
                            "mapping", cptr);
             PMIx_Argv_free(ck);
             free(cptr);
@@ -1045,7 +1045,7 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
         }
         if (NULL == val) {
             /* malformed option */
-            prte_show_help("help-prte-rmaps-base.txt", "unrecognized-policy",
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "unrecognized-policy",
                            true, "mapping", ck[0]);
             PMIx_Argv_free(ck);
             free(cptr);
@@ -1073,7 +1073,7 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
          * directive's value, which is what lets a new class be supported by
          * adding a value rather than a directive. */
         if (NULL == jdata) {
-            prte_show_help("help-prte-rmaps-base.txt", "unsupported-default-policy", true,
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "unsupported-default-policy", true,
                            "mapping", cptr);
             PMIx_Argv_free(ck);
             free(cptr);
@@ -1084,7 +1084,7 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
         }
         if (NULL == val || 0 == strlen(val)) {
             /* "device" with nothing after the "=" names no device at all */
-            prte_show_help("help-prte-rmaps-base.txt", "missing-value",
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "missing-value",
                            true, "mapping", ck[0]);
             PMIx_Argv_free(ck);
             free(cptr);
@@ -1099,7 +1099,7 @@ int prte_rmaps_base_set_mapping_policy(prte_job_t *jdata, char *inspec)
         PRTE_SET_MAPPING_DIRECTIVE(tmp, PRTE_MAPPING_GIVEN);
 
     } else {
-        prte_show_help("help-prte-rmaps-base.txt", "unrecognized-policy",
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "unrecognized-policy",
                        true, "mapping", cptr);
         PMIx_Argv_free(ck);
         free(cptr);
@@ -1123,7 +1123,7 @@ setpolicy:
     if (NULL != jdata
         && prte_get_attribute(&jdata->attributes, PRTE_JOB_MAP_INTERLEAVE, NULL, PMIX_STRING)
         && PRTE_MAPPING_BYDEVICE != PRTE_GET_MAPPING_POLICY(tmp)) {
-        prte_show_help("help-prte-rmaps-base.txt", "rmaps:interleave-needs-device", true,
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "rmaps:interleave-needs-device", true,
                        prte_rmaps_base_print_mapping(tmp));
         return PRTE_ERR_SILENT;
     }
@@ -1133,14 +1133,14 @@ setpolicy:
     if (NULL != jdata
         && prte_get_attribute(&jdata->attributes, PRTE_JOB_MAP_SHARED, NULL, PMIX_BOOL)
         && PRTE_MAPPING_BYDEVICE != PRTE_GET_MAPPING_POLICY(tmp)) {
-        prte_show_help("help-prte-rmaps-base.txt", "rmaps:shared-needs-device", true,
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "rmaps:shared-needs-device", true,
                        prte_rmaps_base_print_mapping(tmp));
         return PRTE_ERR_SILENT;
     }
     if (NULL != jdata
         && prte_get_attribute(&jdata->attributes, PRTE_JOB_MAP_NDEV, NULL, PMIX_UINT16)
         && PRTE_MAPPING_BYDEVICE != PRTE_GET_MAPPING_POLICY(tmp)) {
-        prte_show_help("help-prte-rmaps-base.txt", "rmaps:ndev-needs-device", true,
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "rmaps:ndev-needs-device", true,
                        prte_rmaps_base_print_mapping(tmp));
         return PRTE_ERR_SILENT;
     }
@@ -1225,7 +1225,7 @@ int prte_rmaps_base_set_ranking_policy(prte_job_t *jdata, char *spec)
         PRTE_SET_RANKING_POLICY(tmp, PRTE_RANK_BY_SPAN);
 
     } else {
-        prte_show_help("help-prte-rmaps-base.txt", "unrecognized-policy", true,
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "unrecognized-policy", true,
                        "ranking", spec);
         return PRTE_ERR_SILENT;
     }
@@ -1267,7 +1267,7 @@ int prte_rmaps_base_set_app_mapping_policy(prte_app_context_t *app, char *inspec
     if (1 < PMIx_Argv_count(ck)) {
         if (0 == strcasecmp(ck[0], "ppr")) {
             if (3 > PMIx_Argv_count(ck)) {
-                prte_show_help("help-prte-rmaps-base.txt", "invalid-pattern", true, inspec);
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "invalid-pattern", true, inspec);
                 PMIx_Argv_free(ck);
                 return PRTE_ERR_SILENT;
             }
@@ -1297,7 +1297,7 @@ int prte_rmaps_base_set_app_mapping_policy(prte_app_context_t *app, char *inspec
         rc = check_modifiers(cptr, NULL, app, &tmp);
         if (PRTE_SUCCESS != rc) {
             if (PRTE_ERR_BAD_PARAM == rc) {
-                prte_show_help("help-prte-rmaps-base.txt", "unrecognized-modifier",
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "unrecognized-modifier",
                                true, cptr);
                 rc = PRTE_ERR_SILENT;
             }
@@ -1319,7 +1319,7 @@ int prte_rmaps_base_set_app_mapping_policy(prte_app_context_t *app, char *inspec
         rc = check_modifiers(&inspec[1], NULL, app, &tmp);
         if (PRTE_SUCCESS != rc) {
             if (PRTE_ERR_BAD_PARAM == rc) {
-                prte_show_help("help-prte-rmaps-base.txt", "unrecognized-modifier",
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "unrecognized-modifier",
                                true, inspec);
                 rc = PRTE_ERR_SILENT;
             }
@@ -1337,7 +1337,7 @@ int prte_rmaps_base_set_app_mapping_policy(prte_app_context_t *app, char *inspec
         *ptr = '=';
         ++ptr;
         if ('\0' == *ptr) {
-            prte_show_help("help-prte-rmaps-base.txt", "unrecognized-policy",
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "unrecognized-policy",
                            true, "mapping", ck[0]);
             PMIx_Argv_free(ck);
             free(cptr);
@@ -1384,7 +1384,7 @@ int prte_rmaps_base_set_app_mapping_policy(prte_app_context_t *app, char *inspec
          * by, and a multi-app command line has nowhere else to say it */
         if (NULL == val) {
             /* malformed option */
-            prte_show_help("help-prte-rmaps-base.txt", "unrecognized-policy",
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "unrecognized-policy",
                            true, "mapping", ck[0]);
             PMIx_Argv_free(ck);
             free(cptr);
@@ -1406,7 +1406,7 @@ int prte_rmaps_base_set_app_mapping_policy(prte_app_context_t *app, char *inspec
          * job-level arm above: a directive accepted at one level and refused
          * at the other is the recurring bug in this file */
         if (NULL == val || 0 == strlen(val)) {
-            prte_show_help("help-prte-rmaps-base.txt", "missing-value",
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "missing-value",
                            true, "mapping", ck[0]);
             PMIx_Argv_free(ck);
             free(cptr);
@@ -1426,7 +1426,7 @@ int prte_rmaps_base_set_app_mapping_policy(prte_app_context_t *app, char *inspec
          * checked by the rank_file mapper itself when the app named none */
         if (!prte_get_attribute(&app->attributes, PRTE_APP_MAP_FILE, NULL, PMIX_STRING)) {
             if (NULL == prte_rmaps_base.file) {
-                prte_show_help("help-prte-rmaps-base.txt", "rankfile-no-filename", true);
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "rankfile-no-filename", true);
                 PMIx_Argv_free(ck);
                 free(cptr);
                 if (NULL != val) {
@@ -1441,7 +1441,7 @@ int prte_rmaps_base_set_app_mapping_policy(prte_app_context_t *app, char *inspec
     } else if (PMIX_CHECK_CLI_OPTION(cptr, PRTE_CLI_NOLOCAL)) {
         PRTE_SET_MAPPING_DIRECTIVE(tmp, PRTE_MAPPING_NO_USE_LOCAL);
     } else {
-        prte_show_help("help-prte-rmaps-base.txt", "unrecognized-policy",
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "unrecognized-policy",
                        true, "mapping", cptr);
         PMIx_Argv_free(ck);
         free(cptr);
@@ -1462,19 +1462,19 @@ setpolicy:
      * see the job-level parser, which refuses it the same way */
     if (prte_get_attribute(&app->attributes, PRTE_APP_MAP_INTERLEAVE, NULL, PMIX_STRING)
         && PRTE_MAPPING_BYDEVICE != PRTE_GET_MAPPING_POLICY(tmp)) {
-        prte_show_help("help-prte-rmaps-base.txt", "rmaps:interleave-needs-device", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "rmaps:interleave-needs-device", true,
                        prte_rmaps_base_print_mapping(tmp));
         return PRTE_ERR_SILENT;
     }
     if (prte_get_attribute(&app->attributes, PRTE_APP_MAP_SHARED, NULL, PMIX_BOOL)
         && PRTE_MAPPING_BYDEVICE != PRTE_GET_MAPPING_POLICY(tmp)) {
-        prte_show_help("help-prte-rmaps-base.txt", "rmaps:shared-needs-device", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "rmaps:shared-needs-device", true,
                        prte_rmaps_base_print_mapping(tmp));
         return PRTE_ERR_SILENT;
     }
     if (prte_get_attribute(&app->attributes, PRTE_APP_MAP_NDEV, NULL, PMIX_UINT16)
         && PRTE_MAPPING_BYDEVICE != PRTE_GET_MAPPING_POLICY(tmp)) {
-        prte_show_help("help-prte-rmaps-base.txt", "rmaps:ndev-needs-device", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "rmaps:ndev-needs-device", true,
                        prte_rmaps_base_print_mapping(tmp));
         return PRTE_ERR_SILENT;
     }
@@ -1499,7 +1499,7 @@ int prte_rmaps_base_set_app_ranking_policy(prte_app_context_t *app, char *spec)
     } else if (PMIX_CHECK_CLI_OPTION(spec, PRTE_CLI_SPAN)) {
         PRTE_SET_RANKING_POLICY(tmp, PRTE_RANK_BY_SPAN);
     } else {
-        prte_show_help("help-prte-rmaps-base.txt", "unrecognized-policy", true, "ranking", spec);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "unrecognized-policy", true, "ranking", spec);
         return PRTE_ERR_SILENT;
     }
     PRTE_SET_RANKING_DIRECTIVE(tmp, PRTE_RANKING_GIVEN);
@@ -1542,7 +1542,7 @@ int prte_rmaps_base_set_app_binding_policy(prte_app_context_t *app, char *spec)
                  * generic "unrecognized qualifier" below, which would be
                  * baffling now that the schizo whitelist lets the same
                  * spelling through on the job. */
-                prte_show_help("help-prte-rmaps-base.txt", "job-only-modifier", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "job-only-modifier", true,
                                "binding", quals[i]);
                 PMIx_Argv_free(quals);
                 free(myspec);
@@ -1550,7 +1550,7 @@ int prte_rmaps_base_set_app_binding_policy(prte_app_context_t *app, char *spec)
             } else if (PMIX_CHECK_CLI_OPTION(quals[i], PRTE_CLI_LIMIT)) {
                 p2 = pmix_cli_qualifier_value(quals[i]);
                 if (NULL == p2) {
-                    prte_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
+                    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "invalid-value", true,
                                    "binding limit", "LIMIT", quals[i]);
                     PMIx_Argv_free(quals);
                     free(myspec);
@@ -1566,7 +1566,7 @@ int prte_rmaps_base_set_app_binding_policy(prte_app_context_t *app, char *spec)
                 lval = strtol(p2, &endp, 10);
                 if (endp == p2 || '\0' != *endp || 0 != errno ||
                     0 >= lval || UINT16_MAX < lval) {
-                    prte_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
+                    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "invalid-value", true,
                                    "binding limit", "LIMIT", quals[i]);
                     PMIx_Argv_free(quals);
                     free(myspec);
@@ -1576,7 +1576,7 @@ int prte_rmaps_base_set_app_binding_policy(prte_app_context_t *app, char *spec)
                 prte_set_attribute(&app->attributes, PRTE_APP_BINDING_LIMIT,
                                    PRTE_ATTR_GLOBAL, &u16, PMIX_UINT16);
             } else {
-                prte_show_help("help-prte-hwloc-base.txt", "unrecognized-modifier", true, spec);
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-hwloc-base.txt", "unrecognized-modifier", true, spec);
                 PMIx_Argv_free(quals);
                 free(myspec);
                 return PRTE_ERR_BAD_PARAM;
@@ -1608,7 +1608,7 @@ int prte_rmaps_base_set_app_binding_policy(prte_app_context_t *app, char *spec)
     } else if (PMIX_CHECK_CLI_OPTION(myspec, PRTE_CLI_PACKAGE)) {
         PRTE_SET_BINDING_POLICY(tmp, PRTE_BIND_TO_PACKAGE);
     } else {
-        prte_show_help("help-prte-hwloc-base.txt", "invalid binding_policy", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-hwloc-base.txt", "invalid binding_policy", true,
                        "binding", spec);
         free(myspec);
         return PRTE_ERR_BAD_PARAM;

--- a/src/mca/rmaps/base/rmaps_base_map_job.c
+++ b/src/mca/rmaps/base/rmaps_base_map_job.c
@@ -313,7 +313,7 @@ int prte_rmaps_base_resolve_app_options(prte_job_t *jdata,
             char **pk = PMIx_Argv_split(str, ':');
             if (2 != PMIx_Argv_count(pk) ||
                 !ppr_object(pk[1], &opts->maptype, &opts->mapdepth, &opts->map_device)) {
-                prte_show_help("help-prte-rmaps-ppr.txt", "invalid-ppr", true, str);
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-ppr.txt", "invalid-ppr", true, str);
                 PMIx_Argv_free(pk);
                 free(str);
                 return PRTE_ERR_SILENT;
@@ -562,7 +562,7 @@ static void report_no_mapper(prte_job_t *jdata, prte_app_context_t *app,
     if (1 < pmix_list_get_size(&prte_rmaps_base.selected_modules)) {
         /* the full set is loaded, so the request is simply not one any of
          * them implements */
-        prte_show_help("help-prte-rmaps-base.txt", "failed-map", true,
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "failed-map", true,
                        PRTE_ERROR_NAME(rc),
                        (NULL == app) ? "N/A" : app->app, nprocs,
                        prte_rmaps_base_print_mapping(opts->map),
@@ -575,7 +575,7 @@ static void report_no_mapper(prte_job_t *jdata, prte_app_context_t *app,
         PMIx_Argv_append_nosize(&names, mod->component->pmix_mca_component_name);
     }
     loaded = (NULL == names) ? strdup("none") : PMIx_Argv_join(names, ',');
-    prte_show_help("help-prte-rmaps-base.txt", "mapper-restricted", true,
+    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "mapper-restricted", true,
                    prte_rmaps_base_print_mapping(opts->map),
                    prte_hwloc_base_print_binding(opts->bind),
                    (NULL == app) ? "N/A" : app->app, loaded);
@@ -632,7 +632,7 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
     jdata = caddy->jdata;
     schizo = (prte_schizo_base_module_t*)jdata->schizo;
     if (NULL == schizo) {
-        prte_show_help("help-prte-rmaps-base.txt", "missing-personality", true,
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "missing-personality", true,
                        PRTE_JOBID_PRINT(jdata->nspace));
         PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_FAILED);
         goto cleanup;
@@ -1135,7 +1135,7 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
         ck = PMIx_Argv_split(tmp, ':');
         if (2 != PMIx_Argv_count(ck)) {
             /* must provide a specification */
-            prte_show_help("help-prte-rmaps-ppr.txt", "invalid-ppr", true, tmp);
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-ppr.txt", "invalid-ppr", true, tmp);
             PMIx_Argv_free(ck);
             free(tmp);
             jdata->exit_code = PRTE_ERR_BAD_PARAM;
@@ -1146,7 +1146,7 @@ void prte_rmaps_base_map_job(int fd, short args, void *cbdata)
         options.pprn = strtoul(ck[0], NULL, 10);
         if (!ppr_object(ck[1], &options.maptype, &options.mapdepth, &options.map_device)) {
             /* unknown spec */
-            prte_show_help("help-prte-rmaps-ppr.txt", "unrecognized-ppr-option", true,
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-ppr.txt", "unrecognized-ppr-option", true,
                            ck[1], tmp);
             free(tmp);
             PMIx_Argv_free(ck);
@@ -1311,7 +1311,7 @@ ranking:
                 !options.use_hwthreads) {
                 /* we cannot support this operation as there is only one
                  * cpu in a core */
-                prte_show_help("help-prte-rmaps-base.txt", "mapping-too-low", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "mapping-too-low", true,
                                options.cpus_per_rank, 1,
                                prte_rmaps_base_print_mapping(options.map));
                 jdata->exit_code = PRTE_ERR_SILENT;
@@ -1325,7 +1325,7 @@ ranking:
             if (1 < options.cpus_per_rank) {
                 /* we cannot support this operation as there is only one
                  * cpu in a core */
-                prte_show_help("help-prte-rmaps-base.txt", "mapping-too-low", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "mapping-too-low", true,
                                options.cpus_per_rank, 1,
                                prte_rmaps_base_print_mapping(options.map));
                 jdata->exit_code = PRTE_ERR_SILENT;
@@ -1385,7 +1385,7 @@ ranking:
         PRTE_MAPPING_PPR != options.map) {
         if (options.map < PRTE_MAPPING_BYNUMA ||
             options.map > PRTE_MAPPING_BYHWTHREAD) {
-            prte_show_help("help-prte-rmaps-base.txt", "must-map-by-obj",
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "must-map-by-obj",
                            true, prte_rmaps_base_print_mapping(options.map),
                            prte_rmaps_base_print_ranking(options.rank));
             jdata->exit_code = PRTE_ERR_SILENT;
@@ -1432,7 +1432,7 @@ ranking:
         PRTE_BIND_TO_NONE != options.bind) {
         /* we cannot bind to objects higher in the
          * topology than where we mapped */
-        prte_show_help("help-prte-hwloc-base.txt", "bind-upwards", true,
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-hwloc-base.txt", "bind-upwards", true,
                        prte_rmaps_base_print_mapping(options.map),
                        prte_hwloc_base_print_binding(options.bind));
         /* the message is out - rc still holds the SUCCESS of the last call
@@ -1478,7 +1478,7 @@ ranking:
         if (PRTE_BINDING_POLICY_IS_SET(jdata->map->binding)) {
             if (PRTE_BIND_TO_CORE != options.bind &&
                 PRTE_BIND_TO_HWTHREAD != options.bind) {
-                prte_show_help("help-prte-rmaps-base.txt", "unsupported-combination", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "unsupported-combination", true,
                                "binding", prte_hwloc_base_print_binding(options.bind));
                 PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
                 jdata->exit_code = PRTE_ERR_BAD_PARAM;
@@ -1694,7 +1694,7 @@ ranking:
         /* the map was done but nothing could be mapped
          * for launch as all the resources were busy
          */
-        prte_show_help("help-prte-rmaps-base.txt", "cannot-launch", true);
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "cannot-launch", true);
         jdata->exit_code = rc;
         PRTE_ACTIVATE_JOB_STATE(jdata, PRTE_JOB_STATE_MAP_FAILED);
         goto cleanup;
@@ -1704,7 +1704,7 @@ ranking:
      * the map, then that's an error
      */
     if (!did_map || 0 == jdata->num_procs || 0 == jdata->map->num_nodes) {
-        prte_show_help("help-prte-rmaps-base.txt", "failed-map", true,
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "failed-map", true,
                        PRTE_ERROR_NAME(rc),
                        "N/A",
                        jdata->num_procs,
@@ -1957,7 +1957,7 @@ static int map_colocate(prte_job_t *jdata,
                     if (nptr->slots < cnt) {
                         // oversubscribed - we can still fit if they allow oversubscription
                         if (PRTE_MAPPING_NO_OVERSUBSCRIBE & PRTE_GET_MAPPING_DIRECTIVE(map->mapping)) {
-                            prte_show_help("help-prte-rmaps-base.txt", "prte-rmaps-base:alloc-error", true,
+                            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "prte-rmaps-base:alloc-error", true,
                                            app->num_procs, app->app, prte_process_info.nodename);
                             PRTE_UPDATE_EXIT_STATUS(PRTE_ERROR_DEFAULT_EXIT_CODE);
                             ret = PRTE_ERR_SILENT;
@@ -2042,7 +2042,7 @@ static int map_colocate(prte_job_t *jdata,
                 if (nptr->slots < cnt) {
                     // oversubscribed - we can still fit if they allow oversubscription
                     if (PRTE_MAPPING_NO_OVERSUBSCRIBE & PRTE_GET_MAPPING_DIRECTIVE(map->mapping)) {
-                        prte_show_help("help-prte-rmaps-base.txt", "prte-rmaps-base:alloc-error", true,
+                        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "prte-rmaps-base:alloc-error", true,
                                        app->num_procs, app->app, prte_process_info.nodename);
                         PRTE_UPDATE_EXIT_STATUS(PRTE_ERROR_DEFAULT_EXIT_CODE);
                         ret = PRTE_ERR_SILENT;

--- a/src/mca/rmaps/base/rmaps_base_support_fns.c
+++ b/src/mca/rmaps/base/rmaps_base_support_fns.c
@@ -74,7 +74,7 @@ int prte_rmaps_base_filter_nodes(prte_app_context_t *app, pmix_list_t *nodes, bo
         }
         /** check that anything is here */
         if (0 == pmix_list_get_size(nodes)) {
-            prte_show_help("help-prte-rmaps-base.txt", "prte-rmaps-base:no-mapped-node", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "prte-rmaps-base:no-mapped-node", true,
                            app->app, "-hostfile", hosts);
             free(hosts);
             return PRTE_ERR_SILENT;
@@ -92,7 +92,7 @@ int prte_rmaps_base_filter_nodes(prte_app_context_t *app, pmix_list_t *nodes, bo
         }
         /** check that anything is left! */
         if (0 == pmix_list_get_size(nodes)) {
-            prte_show_help("help-prte-rmaps-base.txt", "prte-rmaps-base:no-mapped-node", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "prte-rmaps-base:no-mapped-node", true,
                            app->app, "-host", hosts);
             free(hosts);
             return PRTE_ERR_SILENT;
@@ -327,7 +327,7 @@ int prte_rmaps_base_get_target_nodes(pmix_list_t *allocated_nodes,
     /** check that anything is here */
     if (0 == pmix_list_get_size(allocated_nodes)) {
         if (!silent) {
-            prte_show_help("help-prte-rmaps-base.txt", "prte-rmaps-base:no-available-resources",
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "prte-rmaps-base:no-available-resources",
                            true);
         }
         return PRTE_ERR_SILENT;
@@ -441,7 +441,7 @@ int prte_rmaps_base_get_target_nodes(pmix_list_t *allocated_nodes,
                         (PRTE_MAPPING_NO_OVERSUBSCRIBE &
                          PRTE_GET_MAPPING_DIRECTIVE(policy))) {
                         if (prte_ras_base.scheduler_owned) {
-                            prte_show_help("help-dash-host.txt",
+                            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-dash-host.txt",
                                            "dash-host:slots-exceed-allocation", true,
                                            node->name, s,
                                            node->slots - node->slots_inuse);
@@ -449,7 +449,7 @@ int prte_rmaps_base_get_target_nodes(pmix_list_t *allocated_nodes,
                         }
                         if (0 != node->slots_max &&
                             node->slots_inuse + s > node->slots_max) {
-                            prte_show_help("help-dash-host.txt",
+                            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-dash-host.txt",
                                            "dash-host:slots-exceed-max", true,
                                            node->name, s,
                                            node->slots_max - node->slots_inuse,
@@ -517,7 +517,7 @@ int prte_rmaps_base_get_target_nodes(pmix_list_t *allocated_nodes,
              */
             return PRTE_ERR_RESOURCE_BUSY;
         } else {
-            prte_show_help("help-prte-rmaps-base.txt",
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt",
                            "prte-rmaps-base:all-available-resources-used", true);
             return PRTE_ERR_SILENT;
         }
@@ -901,7 +901,7 @@ int prte_rmaps_base_check_support(prte_job_t *jdata,
         if (PRTE_BINDING_REQUIRED(jdata->map->binding) &&
             PRTE_BINDING_POLICY_IS_SET(jdata->map->binding)) {
             /* we are required to bind but cannot */
-            prte_show_help("help-prte-rmaps-base.txt", "rmaps:cpubind-not-supported",
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "rmaps:cpubind-not-supported",
                            true, node->name);
             return PRTE_ERR_SILENT;
         }
@@ -918,11 +918,11 @@ int prte_rmaps_base_check_support(prte_job_t *jdata,
         !support->membind->set_thisthread_membind &&
         PRTE_BINDING_POLICY_IS_SET(jdata->map->binding)) {
         if (PRTE_HWLOC_BASE_MBFA_WARN == prte_hwloc_base_mbfa && !options->membind_warned) {
-            prte_show_help("help-prte-rmaps-base.txt", "rmaps:membind-not-supported", true,
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "rmaps:membind-not-supported", true,
                            node->name);
             options->membind_warned = true;
         } else if (PRTE_HWLOC_BASE_MBFA_ERROR == prte_hwloc_base_mbfa) {
-            prte_show_help("help-prte-rmaps-base.txt", "rmaps:membind-not-supported-fatal",
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "rmaps:membind-not-supported-fatal",
                            true, node->name);
             return PRTE_ERR_SILENT;
         }
@@ -963,13 +963,13 @@ int prte_rmaps_base_check_oversubscribed(prte_job_t *jdata,
              * via hostfile/dash-host */
             if (!(PRTE_MAPPING_SUBSCRIBE_GIVEN &
                   PRTE_GET_MAPPING_DIRECTIVE(jdata->map->mapping))) {
-                prte_show_help("help-prte-rmaps-base.txt", "prte-rmaps-base:alloc-error",
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "prte-rmaps-base:alloc-error",
                                true, app->num_procs, app->app, prte_process_info.nodename);
                 PRTE_UPDATE_EXIT_STATUS(PRTE_ERROR_DEFAULT_EXIT_CODE);
                 return PRTE_ERR_SILENT;
             } else if (!options->oversubscribe) {
                 /* if we were explicitly told not to oversubscribe, then don't */
-                prte_show_help("help-prte-rmaps-base.txt", "prte-rmaps-base:alloc-error",
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "prte-rmaps-base:alloc-error",
                                true, app->num_procs, app->app, prte_process_info.nodename);
                 PRTE_UPDATE_EXIT_STATUS(PRTE_ERROR_DEFAULT_EXIT_CODE);
                 return PRTE_ERR_SILENT;

--- a/src/mca/rmaps/lsf/rmaps_lsf.c
+++ b/src/mca/rmaps/lsf/rmaps_lsf.c
@@ -221,7 +221,7 @@ static int lsf_map(prte_job_t *jdata,
         if (PRTE_FLAG_TEST(app, PRTE_APP_FLAG_COMPUTED)) {
             app->num_procs = num_ranks;
             if (0 == app->num_procs) {
-                prte_show_help("help-rmaps_lsf.txt", "bad-syntax", true, affinity_file);
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-rmaps_lsf.txt", "bad-syntax", true, affinity_file);
                 rc = PRTE_ERR_SILENT;
                 goto error;
             }
@@ -242,7 +242,7 @@ static int lsf_map(prte_job_t *jdata,
                     slots = prte_hwloc_default_cpu_list;
                 } else {
                     /* all ranks must be specified */
-                    prte_show_help("help-rmaps_lsf.txt", "missing-rank", true, entry,
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-rmaps_lsf.txt", "missing-rank", true, entry,
                                    affinity_file);
                     rc = PRTE_ERR_SILENT;
                     goto error;
@@ -303,7 +303,7 @@ static int lsf_map(prte_job_t *jdata,
                         relative_index = atoi(strtok(rfmap->node_name, "+n"));
                         if (relative_index >= (int) pmix_list_get_size(&node_list)
                             || (0 > relative_index)) {
-                            prte_show_help("help-rmaps_lsf.txt", "bad-index", true,
+                            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-rmaps_lsf.txt", "bad-index", true,
                                            rfmap->node_name);
                             PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
                             rc = PRTE_ERR_BAD_PARAM;
@@ -321,7 +321,7 @@ static int lsf_map(prte_job_t *jdata,
             if (NULL == node) {
                 /* rfmap is NULL for a rank the file did not list, which the
                  * fallback above placed on a node of its own choosing */
-                prte_show_help("help-rmaps_lsf.txt", "resource-not-found", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-rmaps_lsf.txt", "resource-not-found", true,
                                (NULL == rfmap) ? "N/A" : rfmap->node_name);
                 rc = PRTE_ERR_SILENT;
                 goto error;
@@ -339,7 +339,7 @@ static int lsf_map(prte_job_t *jdata,
                 goto error;
             }
             if (!prte_rmaps_base_check_avail(jdata, app, node, &node_list, NULL, options)) {
-                prte_show_help("help-rmaps_lsf.txt", "bad-host", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-rmaps_lsf.txt", "bad-host", true,
                                (NULL == rfmap) ? "N/A" : rfmap->node_name);
                 rc = PRTE_ERR_SILENT;
                 goto error;
@@ -370,7 +370,7 @@ static int lsf_map(prte_job_t *jdata,
                 (PRTE_BIND_TO_NONE != PRTE_GET_BINDING_POLICY(jdata->map->binding) || options->overload) ) {
                 if (NULL == node->topology || NULL == node->topology->topo) {
                     // Not allowed - for rank-file, we must have the topology
-                    prte_show_help("help-prte-rmaps-base.txt", "rmaps:no-topology", true,
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "rmaps:no-topology", true,
                                    node->name);
                     rc = PRTE_ERR_SILENT;
                     goto error;
@@ -382,14 +382,14 @@ static int lsf_map(prte_job_t *jdata,
                 if (PRTE_ERR_NOT_FOUND == rc) {
                     char *tmp = prte_hwloc_base_cset2str(hwloc_topology_get_allowed_cpuset(node->topology->topo),
                                                          false, physical, node->topology->topo);
-                    prte_show_help("help-rmaps_lsf.txt", "missing-cpu", true,
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-rmaps_lsf.txt", "missing-cpu", true,
                                    prte_tool_basename, slots, tmp);
                     free(tmp);
                     rc = PRTE_ERR_SILENT;
                     hwloc_bitmap_free(proc_bitmap);
                     goto error;
                 } else if (PRTE_ERROR == rc) {
-                    prte_show_help("help-rmaps_lsf.txt", "bad-syntax", true, affinity_file);
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-rmaps_lsf.txt", "bad-syntax", true, affinity_file);
                     rc = PRTE_ERR_SILENT;
                     hwloc_bitmap_free(proc_bitmap);
                     goto error;
@@ -430,7 +430,7 @@ static int lsf_map(prte_job_t *jdata,
                     overlap_bitmap = prte_hwloc_base_cpuset2ranges(node->topology->topo, bitmap,
                                                                    options->use_hwthreads, false);
 
-                    prte_show_help("help-rmaps_lsf.txt", "rmaps:proc-slots-overloaded", true,
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-rmaps_lsf.txt", "rmaps:proc-slots-overloaded", true,
                                    PRTE_NAME_PRINT(&proc->name),
                                    node->name,
                                    (NULL == req_bitmap) ? "NONE" : req_bitmap,
@@ -523,7 +523,7 @@ static int file_parse(const char *affinity_file)
     /* check to see if the file is empty - if it is,
      * then affinity wasn't actually set for this job */
     if (0 != stat(affinity_file, &buf)) {
-        prte_show_help("help-rmaps_lsf.txt", "lsf-affinity-file-not-found", true, affinity_file);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-rmaps_lsf.txt", "lsf-affinity-file-not-found", true, affinity_file);
         return PRTE_ERR_SILENT;
     }
     if (0 == buf.st_size) {
@@ -611,7 +611,7 @@ static int file_parse(const char *affinity_file)
         }
         if (NULL == nptr) {
             /* wasn't found - that is an error */
-            prte_show_help("help-rmaps_lsf.txt",
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-rmaps_lsf.txt",
                            "resource-not-found", true,
                            hstname);
             fclose(fp);

--- a/src/mca/rmaps/ppr/rmaps_ppr.c
+++ b/src/mca/rmaps/ppr/rmaps_ppr.c
@@ -157,7 +157,7 @@ static int ppr_mapper(prte_job_t *jdata,
         PRTE_RANK_BY_FILL == options->rank) {
         if (options->map < PRTE_MAPPING_BYNUMA ||
             options->map > PRTE_MAPPING_BYHWTHREAD) {
-            prte_show_help("help-prte-rmaps-base.txt", "must-map-by-obj",
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "must-map-by-obj",
                            true, prte_rmaps_base_print_mapping(options->map),
                            prte_rmaps_base_print_ranking(options->rank));
             free(jobppr);
@@ -258,7 +258,7 @@ static int ppr_mapper(prte_job_t *jdata,
         if (!PRTE_FLAG_TEST(app, PRTE_APP_FLAG_TOOL) &&
             num_slots < (int) app->num_procs) {
             if (!options->oversubscribe) {
-                prte_show_help("help-prte-rmaps-base.txt", "prte-rmaps-base:alloc-error", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "prte-rmaps-base:alloc-error", true,
                                app->num_procs, app->app, prte_process_info.nodename);
                 rc = PRTE_ERR_SILENT;
                 goto error;
@@ -358,7 +358,7 @@ static int ppr_mapper(prte_job_t *jdata,
                      * the pattern means: "2 per L3cache" over nodes that
                      * have no L3cache placed nothing there while reporting
                      * success. Same rule as round_robin's object mapper. */
-                    prte_show_help("help-prte-rmaps-base.txt", "rmaps:mapping-target-not-found",
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "rmaps:mapping-target-not-found",
                                    true,
                                    bydev ? options->map_device
                                          : hwloc_obj_type_string(options->maptype),
@@ -448,7 +448,7 @@ static int ppr_mapper(prte_job_t *jdata,
         }
         if (nprocs_mapped < app->num_procs) {
             /* couldn't map them all */
-            prte_show_help("help-prte-rmaps-ppr.txt", "ppr-too-many-procs", true, app->app,
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-ppr.txt", "ppr-too-many-procs", true, app->app,
                            app->num_procs, nprocs_mapped, options->nprocs, jobppr);
             rc = PRTE_ERR_SILENT;
             goto error;

--- a/src/mca/rmaps/rank_file/rmaps_rank_file.c
+++ b/src/mca/rmaps/rank_file/rmaps_rank_file.c
@@ -236,7 +236,7 @@ static int prte_rmaps_rf_map(prte_job_t *jdata,
         if (PRTE_FLAG_TEST(app, PRTE_APP_FLAG_COMPUTED)) {
             app->num_procs = num_ranks;
             if (0 == app->num_procs) {
-                prte_show_help("help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
                 rc = PRTE_ERR_SILENT;
                 goto error;
             }
@@ -256,7 +256,7 @@ static int prte_rmaps_rf_map(prte_job_t *jdata,
                     slots = prte_hwloc_default_cpu_list;
                 } else {
                     /* all ranks must be specified */
-                    prte_show_help("help-rmaps_rank_file.txt", "missing-rank", true, entry,
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-rmaps_rank_file.txt", "missing-rank", true, entry,
                                    rankfile);
                     rc = PRTE_ERR_SILENT;
                     goto error;
@@ -317,7 +317,7 @@ static int prte_rmaps_rf_map(prte_job_t *jdata,
                         relative_index = atoi(strtok(rfmap->node_name, "+n"));
                         if (relative_index >= (int) pmix_list_get_size(&node_list)
                             || (0 > relative_index)) {
-                            prte_show_help("help-rmaps_rank_file.txt", "bad-index", true,
+                            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-rmaps_rank_file.txt", "bad-index", true,
                                            rfmap->node_name);
                             PRTE_ERROR_LOG(PRTE_ERR_BAD_PARAM);
                             rc = PRTE_ERR_BAD_PARAM;
@@ -335,7 +335,7 @@ static int prte_rmaps_rf_map(prte_job_t *jdata,
             if (NULL == node) {
                 /* rfmap is NULL for a rank the file did not list, which the
                  * fallback above placed on a node of its own choosing */
-                prte_show_help("help-rmaps_rank_file.txt", "bad-host", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-rmaps_rank_file.txt", "bad-host", true,
                                (NULL == rfmap) ? "N/A" : rfmap->node_name);
                 rc = PRTE_ERR_SILENT;
                 goto error;
@@ -355,7 +355,7 @@ static int prte_rmaps_rf_map(prte_job_t *jdata,
             if (!prte_rmaps_base_check_avail(jdata, app, node, &node_list, NULL, options)) {
                 /* rfmap is NULL for a rank the file did not list, which the
                  * fallback above placed on a node of its own choosing */
-                prte_show_help("help-rmaps_rank_file.txt", "bad-host", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-rmaps_rank_file.txt", "bad-host", true,
                                (NULL == rfmap) ? "N/A" : rfmap->node_name);
                 rc = PRTE_ERR_SILENT;
                 goto error;
@@ -397,7 +397,7 @@ static int prte_rmaps_rf_map(prte_job_t *jdata,
                 (PRTE_BIND_TO_NONE != PRTE_GET_BINDING_POLICY(jdata->map->binding) || options->overload) ) {
                 if (NULL == node->topology || NULL == node->topology->topo) {
                     // Not allowed - for rank-file, we must have the topology
-                    prte_show_help("help-prte-rmaps-base.txt", "rmaps:no-topology", true,
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "rmaps:no-topology", true,
                                    node->name);
                     rc = PRTE_ERR_SILENT;
                     goto error;
@@ -409,14 +409,14 @@ static int prte_rmaps_rf_map(prte_job_t *jdata,
                 if (PRTE_ERR_NOT_FOUND == rc) {
                     char *tmp = prte_hwloc_base_cset2str(hwloc_topology_get_allowed_cpuset(node->topology->topo),
                                                          false, physical, node->topology->topo);
-                    prte_show_help("help-rmaps_rank_file.txt", "missing-cpu", true,
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-rmaps_rank_file.txt", "missing-cpu", true,
                                    prte_tool_basename, slots, tmp);
                     free(tmp);
                     rc = PRTE_ERR_SILENT;
                     hwloc_bitmap_free(proc_bitmap);
                     goto error;
                 } else if (PRTE_ERROR == rc) {
-                    prte_show_help("help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
                     rc = PRTE_ERR_SILENT;
                     hwloc_bitmap_free(proc_bitmap);
                     goto error;
@@ -457,7 +457,7 @@ static int prte_rmaps_rf_map(prte_job_t *jdata,
                     overlap_bitmap = prte_hwloc_base_cpuset2ranges(node->topology->topo, bitmap,
                                                                    options->use_hwthreads, false);
 
-                    prte_show_help("help-rmaps_rank_file.txt", "rmaps:proc-slots-overloaded", true,
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-rmaps_rank_file.txt", "rmaps:proc-slots-overloaded", true,
                                    PRTE_NAME_PRINT(&proc->name),
                                    node->name,
                                    (NULL == req_bitmap) ? "NONE" : req_bitmap,
@@ -567,7 +567,7 @@ static int prte_rmaps_rank_file_parse(const char *rankfile)
     prte_rmaps_rank_file_in = fopen(rankfile, "r");
 
     if (NULL == prte_rmaps_rank_file_in) {
-        prte_show_help("help-rmaps_rank_file.txt", "no-rankfile", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-rmaps_rank_file.txt", "no-rankfile", true,
                        prte_tool_basename, rankfile, prte_tool_basename);
         rc = PRTE_ERR_NOT_FOUND;
         goto unlock;
@@ -578,12 +578,12 @@ static int prte_rmaps_rank_file_parse(const char *rankfile)
 
         switch (token) {
         case PRTE_RANKFILE_ERROR:
-            prte_show_help("help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
             rc = PRTE_ERR_BAD_PARAM;
             PRTE_ERROR_LOG(rc);
             goto unlock;
         case PRTE_RANKFILE_QUOTED_STRING:
-            prte_show_help("help-rmaps_rank_file.txt", "not-supported-rankfile", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-rmaps_rank_file.txt", "not-supported-rankfile", true,
                            "QUOTED_STRING", rankfile);
             rc = PRTE_ERR_BAD_PARAM;
             PRTE_ERROR_LOG(rc);
@@ -604,21 +604,21 @@ static int prte_rmaps_rank_file_parse(const char *rankfile)
                 pmix_pointer_array_set_item(&rankmap, rank, rfmap);
                 num_ranks++; // keep track of number of provided ranks
             } else {
-                prte_show_help("help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
                 rc = PRTE_ERR_BAD_PARAM;
                 PRTE_ERROR_LOG(rc);
                 goto unlock;
             }
             break;
         case PRTE_RANKFILE_USERNAME:
-            prte_show_help("help-rmaps_rank_file.txt", "not-supported-rankfile", true, "USERNAME",
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-rmaps_rank_file.txt", "not-supported-rankfile", true, "USERNAME",
                            rankfile);
             rc = PRTE_ERR_BAD_PARAM;
             PRTE_ERROR_LOG(rc);
             goto unlock;
         case PRTE_RANKFILE_EQUAL:
             if (rank < 0) {
-                prte_show_help("help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
                 rc = PRTE_ERR_BAD_PARAM;
                 PRTE_ERROR_LOG(rc);
                 goto unlock;
@@ -647,7 +647,7 @@ static int prte_rmaps_rank_file_parse(const char *rankfile)
                 } else if (2 == cnt) {
                     node_name = strdup(argv[1]);
                 } else {
-                    prte_show_help("help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
+                    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
                     rc = PRTE_ERR_BAD_PARAM;
                     PRTE_ERROR_LOG(rc);
                     PMIx_Argv_free(argv);
@@ -666,7 +666,7 @@ static int prte_rmaps_rank_file_parse(const char *rankfile)
 
                 /* check the rank item */
                 if (NULL == rfmap) {
-                    prte_show_help("help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
+                    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
                     rc = PRTE_ERR_BAD_PARAM;
                     PRTE_ERROR_LOG(rc);
                     goto unlock;
@@ -682,7 +682,7 @@ static int prte_rmaps_rank_file_parse(const char *rankfile)
         case PRTE_RANKFILE_SLOT:
             if (NULL == node_name || rank < 0
                 || NULL == (value = prte_rmaps_rank_file_parse_string_or_int())) {
-                prte_show_help("help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
                 rc = PRTE_ERR_BAD_PARAM;
                 PRTE_ERROR_LOG(rc);
                 goto unlock;
@@ -695,7 +695,7 @@ static int prte_rmaps_rank_file_parse(const char *rankfile)
              * any rank but 0 rejected its own rank 0 line as a duplicate, and
              * a genuine duplicate of any other rank went unnoticed */
             if (NULL != pmix_pointer_array_get_item(assigned_ranks_array, rank)) {
-                prte_show_help("help-rmaps_rank_file.txt", "bad-assign", true, rank,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-rmaps_rank_file.txt", "bad-assign", true, rank,
                                pmix_pointer_array_get_item(assigned_ranks_array, rank), rankfile);
                 rc = PRTE_ERR_BAD_PARAM;
                 free(value);
@@ -709,7 +709,7 @@ static int prte_rmaps_rank_file_parse(const char *rankfile)
 
             /* check the rank item */
             if (NULL == rfmap) {
-                prte_show_help("help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-rmaps_rank_file.txt", "bad-syntax", true, rankfile);
                 rc = PRTE_ERR_BAD_PARAM;
                 PRTE_ERROR_LOG(rc);
                 free(value);

--- a/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
+++ b/src/mca/rmaps/round_robin/rmaps_rr_mappers.c
@@ -65,7 +65,7 @@ int prte_rmaps_rr_byslot(prte_job_t *jdata,
     /* check to see if we can map all the procs */
     if (num_slots < (int) app->num_procs) {
         if (!options->oversubscribe) {
-            prte_show_help("help-prte-rmaps-base.txt", "prte-rmaps-base:alloc-error", true,
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "prte-rmaps-base:alloc-error", true,
                            app->num_procs, app->app, prte_process_info.nodename);
             PRTE_UPDATE_EXIT_STATUS(PRTE_ERROR_DEFAULT_EXIT_CODE);
             return PRTE_ERR_SILENT;
@@ -183,7 +183,7 @@ pass:
     if (second_pass) {
     errout:
         if (PRTE_ERR_SILENT != rc) {
-            prte_show_help("help-prte-rmaps-base.txt",
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt",
                            "failed-map", true,
                            PRTE_ERROR_NAME(rc),
                            (NULL == app) ? "N/A" : app->app,
@@ -243,7 +243,7 @@ int prte_rmaps_rr_bynode(prte_job_t *jdata,
     /* quick check to see if we can map all the procs */
     if (num_slots < (int) app->num_procs) {
         if (!options->oversubscribe) {
-            prte_show_help("help-prte-rmaps-base.txt", "prte-rmaps-base:alloc-error", true,
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "prte-rmaps-base:alloc-error", true,
                            app->num_procs, app->app, prte_process_info.nodename);
             PRTE_UPDATE_EXIT_STATUS(PRTE_ERROR_DEFAULT_EXIT_CODE);
             return PRTE_ERR_SILENT;
@@ -350,7 +350,7 @@ pass:
     errout:
         /* unable to do it */
         if (PRTE_ERR_SILENT != rc) {
-            prte_show_help("help-prte-rmaps-base.txt",
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt",
                            "failed-map", true,
                            PRTE_ERROR_NAME(rc),
                            (NULL == app) ? "N/A" : app->app,
@@ -411,7 +411,7 @@ int prte_rmaps_rr_bydevice(prte_job_t *jdata, prte_app_context_t *app,
     if (!options->map_shared) {
         ndevs = prte_rmaps_base_devices_total(node_list, options);
         if (0 < ndevs && ndevs < (size_t) app->num_procs) {
-            prte_show_help("help-prte-rmaps-base.txt", "rmaps:too-few-devices", true,
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "rmaps:too-few-devices", true,
                            (int) app->num_procs, options->map_device, (int) ndevs);
             return PRTE_ERR_SILENT;
         }
@@ -445,7 +445,7 @@ int prte_rmaps_rr_bycpu(prte_job_t *jdata, prte_app_context_t *app,
     /* check to see if we can map all the procs */
     if (num_slots < (int) app->num_procs) {
         if (!options->oversubscribe) {
-            prte_show_help("help-prte-rmaps-base.txt", "prte-rmaps-base:alloc-error", true,
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "prte-rmaps-base:alloc-error", true,
                            app->num_procs, app->app, prte_process_info.nodename);
             PRTE_UPDATE_EXIT_STATUS(PRTE_ERROR_DEFAULT_EXIT_CODE);
             return PRTE_ERR_SILENT;
@@ -614,7 +614,7 @@ pass:
 errout:
     /* if we get here, then we were unable to map all the procs */
     if (PRTE_ERR_SILENT != rc) {
-        prte_show_help("help-prte-rmaps-rr.txt",
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-rr.txt",
                        "prte-rmaps-rr:not-enough-cpus", true,
                        app->app, app->num_procs, savecpuset);
     }
@@ -694,7 +694,7 @@ int prte_rmaps_rr_map_targets(prte_job_t *jdata, prte_app_context_t *app,
     /* quick check to see if we can map all the procs */
     if (num_slots < app->num_procs) {
         if (!options->oversubscribe) {
-            prte_show_help("help-prte-rmaps-base.txt", "prte-rmaps-base:alloc-error", true,
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "prte-rmaps-base:alloc-error", true,
                            app->num_procs, app->app, prte_process_info.nodename);
             PRTE_UPDATE_EXIT_STATUS(PRTE_ERROR_DEFAULT_EXIT_CODE);
             return PRTE_ERR_SILENT;
@@ -813,7 +813,7 @@ int prte_rmaps_rr_map_targets(prte_job_t *jdata, prte_app_context_t *app,
                  * them, and quietly falling back to by-slot (which the
                  * caller used to do) placed the job by a rule they never
                  * asked for. */
-                prte_show_help("help-prte-rmaps-base.txt", "rmaps:mapping-target-not-found",
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "rmaps:mapping-target-not-found",
                                true, tgts->name, node->name);
                 rc = PRTE_ERR_SILENT;
                 goto errout;
@@ -1008,14 +1008,14 @@ errout:
     }
     if (outofcpus) {
         /* ran out of cpus */
-        prte_show_help("help-prte-rmaps-base.txt",
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt",
                        "allocation-overload", true,
                        app->app, app->num_procs,
                        prte_rmaps_base_print_mapping(options->map),
                        prte_hwloc_base_print_binding(options->bind));
         return PRTE_ERR_SILENT;
     }
-    prte_show_help("help-prte-rmaps-base.txt",
+    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt",
                    "failed-map", true,
                    PRTE_ERROR_NAME(rc),
                    app->app, app->num_procs,

--- a/src/mca/rmaps/seq/rmaps_seq.c
+++ b/src/mca/rmaps/seq/rmaps_seq.c
@@ -114,7 +114,7 @@ static int bind_to_entry_cpuset(prte_job_t *jdata, prte_proc_t *proc,
 
     if (NULL == node->topology || NULL == node->topology->topo) {
         /* without a topology there is nothing to resolve the list against */
-        prte_show_help("help-prte-rmaps-base.txt", "rmaps:no-topology", true, node->name);
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "rmaps:no-topology", true, node->name);
         return PRTE_ERR_SILENT;
     }
 
@@ -124,7 +124,7 @@ static int bind_to_entry_cpuset(prte_job_t *jdata, prte_proc_t *proc,
     if (PRTE_SUCCESS != rc) {
         char *tmp = prte_hwloc_base_cset2str(hwloc_topology_get_allowed_cpuset(node->topology->topo),
                                              false, false, node->topology->topo);
-        prte_show_help("help-prte-rmaps-seq.txt", "seq:bad-cpuset", true,
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-seq.txt", "seq:bad-cpuset", true,
                        cpuset, node->name, tmp);
         free(tmp);
         hwloc_bitmap_free(bits);
@@ -146,7 +146,7 @@ static int bind_to_entry_cpuset(prte_job_t *jdata, prte_proc_t *proc,
                                               options->use_hwthreads, false);
         overlap = prte_hwloc_base_cpuset2ranges(node->topology->topo, missing,
                                                 options->use_hwthreads, false);
-        prte_show_help("help-prte-rmaps-seq.txt", "seq:cpuset-not-available", true,
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-seq.txt", "seq:cpuset-not-available", true,
                        PRTE_NAME_PRINT(&proc->name), node->name, cpuset,
                        (NULL == avail) ? "NONE" : avail,
                        (NULL == overlap) ? "NONE" : overlap);
@@ -350,7 +350,7 @@ static int prte_rmaps_seq_map(prte_job_t *jdata,
             seq_list = &default_seq_list;
         } else {
             /* can't do anything - no nodes available! */
-            prte_show_help("help-prte-rmaps-base.txt", "prte-rmaps-base:no-available-resources",
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "prte-rmaps-base:no-available-resources",
                            true);
             rc = PRTE_ERR_SILENT;
             goto error;
@@ -374,7 +374,7 @@ process:
         }
 
         if (NULL == seq_list || 0 == (num_nodes = (int32_t) pmix_list_get_size(seq_list))) {
-            prte_show_help("help-prte-rmaps-base.txt", "prte-rmaps-base:no-available-resources",
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "prte-rmaps-base:no-available-resources",
                            true);
             rc = PRTE_ERR_SILENT;
             goto error;
@@ -387,7 +387,7 @@ process:
                                 "mca:rmaps:seq: setting num procs to %s for app %s",
                                 PRTE_VPID_PRINT(app->num_procs), app->app);
         } else if (num_nodes < app->num_procs) {
-            prte_show_help("help-prte-rmaps-seq.txt", "seq:not-enough-resources", true,
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-seq.txt", "seq:not-enough-resources", true,
                            app->num_procs, num_nodes);
             rc = PRTE_ERR_SILENT;
             goto error;
@@ -414,7 +414,7 @@ process:
             if (NULL == sq || pmix_list_get_end(seq_list) == &sq->super) {
                 /* "n" entries were consumed getting this far, so that is how
                  * many the sequence turned out to be worth to this app */
-                prte_show_help("help-prte-rmaps-seq.txt", "seq:not-enough-resources", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-seq.txt", "seq:not-enough-resources", true,
                                (int) app->num_procs, n);
                 rc = PRTE_ERR_SILENT;
                 goto error;
@@ -436,7 +436,7 @@ process:
             }
             if (!match) {
                 /* wasn't found - that is an error */
-                prte_show_help("help-prte-rmaps-seq.txt", "prte-rmaps-seq:resource-not-found", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-seq.txt", "prte-rmaps-seq:resource-not-found", true,
                                sq->hostname);
                 rc = PRTE_ERR_SILENT;
                 goto error;
@@ -479,7 +479,7 @@ process:
             options->bind = savebind;
             options->cpuset = savecpuset;
             if (NULL == proc) {
-                prte_show_help("help-prte-rmaps-seq.txt", "proc-failed-to-map", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-seq.txt", "proc-failed-to-map", true,
                                sq->hostname, app->app);
                 rc = PRTE_ERR_SILENT;
                 goto error;
@@ -547,7 +547,7 @@ error:
         free(hosts);
     }
     if (PRTE_ERR_SILENT != rc) {
-        prte_show_help("help-prte-rmaps-base.txt",
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt",
                        "failed-map", true,
                        PRTE_ERROR_NAME(rc),
                        (NULL == app) ? "N/A" : app->app,

--- a/src/mca/schizo/base/schizo_base_frame.c
+++ b/src/mca/schizo/base/schizo_base_frame.c
@@ -185,7 +185,7 @@ bool prte_schizo_base_check_qualifiers(char *directive,
         }
     }
     v = PMIx_Argv_join(valid, ',');
-    prte_show_help("help-prte-rmaps-base.txt",
+    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt",
                    "unrecognized-qualifier", true,
                    directive, qual, v);
     free(v);
@@ -257,7 +257,7 @@ bool prte_schizo_base_check_directives(char *directive,
                          * qualifiers given, so the count could be greater
                          * than 3 - but it has to at least contain
                          * those three fields */
-                        prte_show_help("help-prte-rmaps-base.txt",
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt",
                                        "invalid-pattern", true,
                                        dir);
                         PMIx_Argv_free(args);
@@ -268,7 +268,7 @@ bool prte_schizo_base_check_directives(char *directive,
                     if (NULL != v && 0 < strlen(v)) {
                         /* the first entry had to be a pure number */
                         pmix_asprintf(&v, "ppr:[Number of procs/object]:%s", args[2]);
-                        prte_show_help("help-prte-rmaps-base.txt",
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt",
                                        "unrecognized-qualifier", true,
                                        directive, dir, v);
                         free(v);
@@ -298,7 +298,7 @@ bool prte_schizo_base_check_directives(char *directive,
                         v = PMIx_Argv_join(pproptions, ':');
                         pmix_asprintf(&q, "ppr:%s:[%s]", args[1], v);
                         free(v);
-                        prte_show_help("help-prte-rmaps-base.txt",
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt",
                                        "unrecognized-qualifier", true,
                                        directive, dir, q);
                         free(q);
@@ -330,7 +330,7 @@ bool prte_schizo_base_check_directives(char *directive,
         }
     }
     v = PMIx_Argv_join(valid, ':');
-    prte_show_help("help-prte-rmaps-base.txt",
+    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt",
                    "unrecognized-directive", true,
                    directive, dir, v);
     PMIx_Argv_free(args);
@@ -388,7 +388,7 @@ static int check_ndirs(pmix_cli_item_t *opt)
             count = PMIx_Argv_count(opt->values);
             if (1 < count) {
                 param = PMIx_Argv_join(opt->values, ' ');
-                prte_show_help("help-schizo-base.txt", "too-many-instances", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "too-many-instances", true,
                                param, opt->key, count, 1);
                 free(param);
                 return PRTE_ERR_SILENT;
@@ -682,7 +682,7 @@ int prte_schizo_base_hoist_job_option(pmix_cli_result_t *results,
             if (hoist_agree(&items[i], &items[j])) {
                 continue;
             }
-            prte_show_help("help-schizo-base.txt", "conflicting-job-directives", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "conflicting-job-directives", true,
                            key, items[i].name, items[i].token, items[j].token);
             rc = PRTE_ERR_SILENT;
             goto cleanup;
@@ -811,23 +811,23 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
     };
 
     if (1 < pmix_cmd_line_get_ninsts(cmd_line, PRTE_CLI_MAPBY)) {
-        prte_show_help("help-schizo-base.txt", "multi-instances", true, PRTE_CLI_MAPBY);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "multi-instances", true, PRTE_CLI_MAPBY);
         return PRTE_ERR_SILENT;
     }
     if (1 < pmix_cmd_line_get_ninsts(cmd_line, PRTE_CLI_RANKBY)) {
-        prte_show_help("help-schizo-base.txt", "multi-instances", true, PRTE_CLI_RANKBY);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "multi-instances", true, PRTE_CLI_RANKBY);
         return PRTE_ERR_SILENT;
     }
     if (1 < pmix_cmd_line_get_ninsts(cmd_line, PRTE_CLI_BINDTO)) {
-        prte_show_help("help-schizo-base.txt", "multi-instances", true, PRTE_CLI_BINDTO);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "multi-instances", true, PRTE_CLI_BINDTO);
         return PRTE_ERR_SILENT;
     }
     if (1 < pmix_cmd_line_get_ninsts(cmd_line, PRTE_CLI_DISPLAY)) {
-        prte_show_help("help-schizo-base.txt", "multi-instances", true, PRTE_CLI_DISPLAY);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "multi-instances", true, PRTE_CLI_DISPLAY);
         return PRTE_ERR_SILENT;
     }
     if (1 < pmix_cmd_line_get_ninsts(cmd_line, PRTE_CLI_RTOS)) {
-        prte_show_help("help-schizo-base.txt", "multi-instances", true, PRTE_CLI_RTOS);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "multi-instances", true, PRTE_CLI_RTOS);
         return PRTE_ERR_SILENT;
     }
 
@@ -949,7 +949,7 @@ int prte_schizo_base_sanity(pmix_cli_result_t *cmd_line)
                 NULL != strcasestr(newopt->values[0], "hwt")) {
                 return PRTE_SUCCESS;
             }
-            prte_show_help("help-schizo-base.txt", "binding-pe-conflict", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "binding-pe-conflict", true,
                            opt->values[0], newopt->values[0]);
             return PRTE_ERR_SILENT;
         }
@@ -1001,7 +1001,7 @@ static bool set_bool_directive(prte_bool_directive_t *tbl, const char *option,
             continue;
         }
         if (PRTE_SUCCESS != prte_cli_bool_value(value, &flag)) {
-            prte_show_help("help-schizo-base.txt", "non-boolean-value", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "non-boolean-value", true,
                            option, tbl[n].directive, value);
             *rc = PRTE_ERR_SILENT;
             return true;
@@ -1085,7 +1085,7 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
                 for (m=0; NULL != quals[m]; m++) {
                     if (!set_bool_directive(qualtbl, PRTE_CLI_DISPLAY, quals[m],
                                             PMIX_CLI_QUALIFIER_VALUE(quals[m]), &rc)) {
-                        prte_show_help("help-prte-rmaps-base.txt", "unrecognized-qualifier", true,
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "unrecognized-qualifier", true,
                                        "display", cptr, "PARSEABLE,PARSABLE,PHYSICAL");
                         rc = PRTE_ERR_FATAL;
                         goto cleanup;
@@ -1114,7 +1114,7 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
                     ++ptr;
                     if ('\0' == *ptr) {
                         /* missing the value or value is invalid */
-                        prte_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "invalid-value", true,
                                        "display", "TOPO", targv[idx]);
                         rc = PRTE_ERR_FATAL;
                         goto cleanup;
@@ -1135,7 +1135,7 @@ int prte_schizo_base_parse_display(pmix_cli_item_t *opt, void *jinfo)
                     ++ptr;
                     if ('\0' == *ptr) {
                         /* missing the value or value is invalid */
-                        prte_show_help("help-prte-rmaps-base.txt", "invalid-value", true,
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt", "invalid-value", true,
                                        "display", "PROCESSORS", targv[idx]);
                         rc = PRTE_ERR_FATAL;
                         goto cleanup;
@@ -1246,13 +1246,13 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                     if (PMIX_CHECK_CLI_OPTION(options[m], PRTE_CLI_NOCOPY)) {
                         if (copyqualgiven) {
                             // cannot give both copy and nocopy
-                            prte_show_help("help-schizo-output.txt", "copy-nocopy", true, cptr);
+                            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-output.txt", "copy-nocopy", true, cptr);
                             rc = PRTE_ERR_SILENT;
                             goto cleanup;
                         }
                         if (PRTE_SUCCESS != prte_cli_bool_value(PMIX_CLI_QUALIFIER_VALUE(options[m]),
                                                                 &flag)) {
-                            prte_show_help("help-schizo-base.txt", "non-boolean-value", true,
+                            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "non-boolean-value", true,
                                            PRTE_CLI_OUTPUT, PRTE_CLI_NOCOPY,
                                            PMIX_CLI_QUALIFIER_VALUE(options[m]));
                             rc = PRTE_ERR_SILENT;
@@ -1264,13 +1264,13 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                     } else if (PMIX_CHECK_CLI_OPTION(options[m], PRTE_CLI_COPY)) {
                         if (copyqualgiven) {
                             // cannot give both copy and nocopy
-                            prte_show_help("help-schizo-output.txt", "copy-nocopy", true, cptr);
+                            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-output.txt", "copy-nocopy", true, cptr);
                             rc = PRTE_ERR_SILENT;
                             goto cleanup;
                         }
                         if (PRTE_SUCCESS != prte_cli_bool_value(PMIX_CLI_QUALIFIER_VALUE(options[m]),
                                                                 &flag)) {
-                            prte_show_help("help-schizo-base.txt", "non-boolean-value", true,
+                            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "non-boolean-value", true,
                                            PRTE_CLI_OUTPUT, PRTE_CLI_COPY,
                                            PMIX_CLI_QUALIFIER_VALUE(options[m]));
                             rc = PRTE_ERR_SILENT;
@@ -1282,7 +1282,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                     } else if (PMIX_CHECK_CLI_OPTION(options[m], PRTE_CLI_PATTERN)) {
                         if (PRTE_SUCCESS != prte_cli_bool_value(PMIX_CLI_QUALIFIER_VALUE(options[m]),
                                                                 &flag)) {
-                            prte_show_help("help-schizo-base.txt", "non-boolean-value", true,
+                            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "non-boolean-value", true,
                                            PRTE_CLI_OUTPUT, PRTE_CLI_PATTERN,
                                            PMIX_CLI_QUALIFIER_VALUE(options[m]));
                             rc = PRTE_ERR_SILENT;
@@ -1298,7 +1298,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
                          * cannot do it - say so rather than accept a
                          * qualifier that would be silently ignored */
                         if (flag) {
-                            prte_show_help("help-schizo-output.txt", "pattern-unsupported", true);
+                            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-output.txt", "pattern-unsupported", true);
                             rc = PRTE_ERR_SILENT;
                             goto cleanup;
                         }
@@ -1330,14 +1330,14 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
 
             } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_DIR)) {
                 if (NULL == ptr || '\0' == *ptr) {
-                    prte_show_help("help-prte-rmaps-base.txt",
+                    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt",
                                    "missing-qualifier", true,
                                    "output", "directory", "directory");
                     rc = PRTE_ERR_FATAL;
                     goto cleanup;
                 }
                 if (NULL != outfile) {
-                    prte_show_help("help-prted.txt", "both-file-and-dir-set", true, outfile, ptr);
+                    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prted.txt", "both-file-and-dir-set", true, outfile, ptr);
                     rc = PRTE_ERR_FATAL;
                     goto cleanup;
                 }
@@ -1362,14 +1362,14 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
 
             } else if (PMIX_CHECK_CLI_OPTION(targv[idx], PRTE_CLI_FILE)) {
                 if (NULL == ptr || '\0' == *ptr) {
-                    prte_show_help("help-prte-rmaps-base.txt",
+                    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-rmaps-base.txt",
                                    "missing-qualifier", true,
                                    "output", "filename", "filename");
                     rc = PRTE_ERR_FATAL;
                     goto cleanup;
                 }
                 if (NULL != outdir) {
-                    prte_show_help("help-prted.txt", "both-file-and-dir-set", true, ptr, outdir);
+                    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prted.txt", "both-file-and-dir-set", true, ptr, outdir);
                     rc = PRTE_ERR_FATAL;
                     goto cleanup;
                 }
@@ -1402,7 +1402,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
         /* "pattern" says how to name an output FILE.  Given without one it
          * has nothing to qualify, and silently ignoring it would leave the
          * user believing they had asked for something */
-        prte_show_help("help-schizo-output.txt", "pattern-needs-file", true);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-output.txt", "pattern-needs-file", true);
         rc = PRTE_ERR_SILENT;
         goto cleanup;
     }
@@ -1438,7 +1438,7 @@ int prte_schizo_base_parse_output(pmix_cli_item_t *opt, void *jinfo)
             char *badconv = NULL;
             ret = pmix_iof_check_pattern(outfile, &badconv);
             if (PMIX_SUCCESS != ret) {
-                prte_show_help("help-schizo-output.txt", "bad-pattern", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-output.txt", "bad-pattern", true,
                                outfileraw, (NULL == badconv) ? "(none)" : badconv);
                 if (NULL != badconv) {
                     free(badconv);

--- a/src/mca/schizo/base/schizo_base_stubs.c
+++ b/src/mca/schizo/base/schizo_base_stubs.c
@@ -361,7 +361,7 @@ int prte_schizo_base_parse_prte(int argc, int start, char **argv, char ***target
         if (0 == strcmp("--prtemca", argv[i])) {
             if (NULL == argv[i + 1] || NULL == argv[i + 2]) {
                 /* this is an error */
-                prte_show_help("help-schizo-base.txt", "missing-values", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "missing-values", true,
                                "--prtemca");
                 return PRTE_ERR_SILENT;
             }
@@ -388,7 +388,7 @@ int prte_schizo_base_parse_prte(int argc, int start, char **argv, char ***target
         if (0 == strcmp("--mca", argv[i])) {
             if (NULL == argv[i + 1] || NULL == argv[i + 2]) {
                 /* this is an error */
-                prte_show_help("help-schizo-base.txt", "missing-values", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "missing-values", true,
                                "--mca");
                 return PRTE_ERR_SILENT;
             }
@@ -456,7 +456,7 @@ int prte_schizo_base_parse_pmix(int argc, int start, char **argv, char ***target
         if (0 == strcmp("--pmixmca", argv[i]) || 0 == strcmp("--gpmixmca", argv[i])) {
             if (NULL == argv[i + 1] || NULL == argv[i + 2]) {
                 /* this is an error */
-                prte_show_help("help-schizo-base.txt", "missing-values", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "missing-values", true,
                                "--pmixmca");
                 return PRTE_ERR_SILENT;
             }

--- a/src/mca/schizo/ompi/schizo_ompi.c
+++ b/src/mca/schizo/ompi/schizo_ompi.c
@@ -427,7 +427,7 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
             }
         }
         if(orig_args && corrected_args) {
-            prte_show_help("help-schizo-base.txt", "single-dash-error", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "single-dash-error", true,
                             orig_args, corrected_args);
             free(orig_args);
             free(corrected_args);
@@ -664,7 +664,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
         else if (0 == strcmp(option, "ppr")) {
             /* if they didn't specify a complete pattern, then this is an error */
             if (NULL == strchr(opt->values[0], ':')) {
-                prte_show_help("help-schizo-base.txt", "bad-ppr", true, opt->values[0], true);
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "bad-ppr", true, opt->values[0], true);
                 return PRTE_ERR_SILENT;
             }
             pmix_asprintf(&p2, "ppr:%s", opt->values[0]);
@@ -836,7 +836,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
          */
         else if (0 == strcmp(option, "debug")) {
             if (warn) {
-                prte_show_help("help-schizo-base.txt", "deprecated-inform", true, option,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "deprecated-inform", true, option,
                                "This CLI option will be deprecated starting in Open MPI v5");
             }
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
@@ -988,7 +988,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
                     free(tmp);
                 }
                 else {
-                    prte_show_help("help-schizo-ompi.txt", "with-ft-bad-option", true, p1);
+                    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-ompi.txt", "with-ft-bad-option", true, p1);
                     return PRTE_ERR_SILENT;
                 }
             }
@@ -1021,7 +1021,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
             }
         } else if (0 == strcmp(option, "hetero-nodes")) {
             if (warn) {
-                prte_show_help("help-schizo-base.txt", "deprecated-hetero-nodes", true);
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "deprecated-hetero-nodes", true);
             }
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }
@@ -1051,7 +1051,7 @@ static int check_cache_noadd(char ***c1, char ***c2, char *p1, char *p2)
                 /* we do have it - check for same value */
                 if (0 != strcmp(cachevals[k], p2)) {
                     /* this is an error */
-                    prte_show_help("help-schizo-base.txt", "duplicate-mca-value", true, p1, p2,
+                    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "duplicate-mca-value", true, p1, p2,
                                    cachevals[k]);
                     return PRTE_ERR_BAD_PARAM;
                 }
@@ -1130,7 +1130,7 @@ static int process_envar(const char *p, char ***cache, char ***cachevals)
                     }
                 }
                 if (!found) {
-                    prte_show_help("help-schizo-base.txt", "env-not-found", true, p1);
+                    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "env-not-found", true, p1);
                     rc = PRTE_ERR_NOT_FOUND;
                 }
             }
@@ -1189,7 +1189,7 @@ static int process_env_list(const char *env_list, char ***xparams, char ***xvals
         rc = process_token(tokens[i], xparams, xvals);
         if (PRTE_SUCCESS != rc) {
             if (PRTE_ERR_NOT_FOUND == rc) {
-                prte_show_help("help-schizo-base.txt", "incorrect-env-list-param", true, tokens[i],
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "incorrect-env-list-param", true, tokens[i],
                                env_list);
             }
             break;
@@ -1224,7 +1224,7 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                 p1 = pmix_os_path(false, DEFAULT_PARAM_FILE_PATH, tmp[i], NULL);
                 fp = fopen(p1, "r");
                 if (NULL == fp) {
-                    prte_show_help("help-schizo-base.txt", "missing-param-file-def", true, tmp[i], p1);;
+                    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "missing-param-file-def", true, tmp[i], p1);;
                     PMIx_Argv_free(tmp);
                     PMIx_Argv_free(cache);
                     PMIx_Argv_free(cachevals);
@@ -1235,7 +1235,7 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                 }
                 free(p1);
             } else {
-                prte_show_help("help-schizo-base.txt", "missing-param-file", true, tmp[i]);;
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "missing-param-file", true, tmp[i]);;
                 PMIx_Argv_free(tmp);
                 PMIx_Argv_free(cache);
                 PMIx_Argv_free(cachevals);
@@ -1251,7 +1251,7 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
             }
             opts = PMIx_Argv_split_with_empty(line, ' ');
             if (NULL == opts) {
-                prte_show_help("help-schizo-base.txt", "bad-param-line", true, tmp[i], line);
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "bad-param-line", true, tmp[i], line);
                 free(line);
                 PMIx_Argv_free(tmp);
                 PMIx_Argv_free(cache);
@@ -1269,7 +1269,7 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                 if (0 == strcmp(opts[n], "-x")) {
                     /* the next value must be the envar */
                     if (NULL == opts[n + 1]) {
-                        prte_show_help("help-schizo-base.txt", "bad-param-line", true, tmp[i],
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "bad-param-line", true, tmp[i],
                                        line);
                         free(line);
                         PMIx_Argv_free(tmp);
@@ -1287,7 +1287,7 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                      * the battle to correct their error, try to accommodate it here */
                     if (NULL != opts[n + 2] && 0 == strcmp(opts[n + 2], "=")) {
                         if (NULL == opts[n + 3]) {
-                            prte_show_help("help-schizo-base.txt", "bad-param-line", true, tmp[i],
+                            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "bad-param-line", true, tmp[i],
                                            line);
                             free(line);
                             free(p1);
@@ -1323,7 +1323,7 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                     ++n; // skip over the envar option
                 } else if (0 == strcmp(opts[n], "--mca")) {
                     if (NULL == opts[n + 1] || NULL == opts[n + 2]) {
-                        prte_show_help("help-schizo-base.txt", "bad-param-line", true, tmp[i],
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "bad-param-line", true, tmp[i],
                                        line);
                         free(line);
                         PMIx_Argv_free(tmp);
@@ -1362,7 +1362,7 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                     /* find the equal sign */
                     p1 = strchr(opts[n], '=');
                     if (NULL == p1) {
-                        prte_show_help("help-schizo-base.txt", "bad-param-line", true, tmp[i],
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "bad-param-line", true, tmp[i],
                                        line);
                         free(line);
                         PMIx_Argv_free(tmp);
@@ -1390,7 +1390,7 @@ static int process_tune_files(char *filename, char ***dstenv, char sep)
                 } else {
                     rc = process_token(opts[n], &cache, &cachevals);
                     if (PRTE_SUCCESS != rc) {
-                        prte_show_help("help-schizo-base.txt", "bad-param-line", true, tmp[i],
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "bad-param-line", true, tmp[i],
                                        line);
                         fclose(fp);
                         PMIx_Argv_free(tmp);
@@ -1612,14 +1612,14 @@ static int parse_env(char **srcenv, char ***dstenv,
     if (NULL != (opt = pmix_cmd_line_get_param(results, "stream-buffering"))) {
         uint16_t u16;
         if (prte_mca_schizo_ompi_component.warn_deprecations) {
-            prte_show_help("help-schizo-base.txt", "deprecated-inform", true, "stream-buffering",
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "deprecated-inform", true, "stream-buffering",
                            "This CLI option will be deprecated starting in Open MPI v5. "
                            "If you need this functionality use the Open MPI MCA option: ompi_stream_buffering");
         }
         u16 = strtol(opt->values[0], NULL, 10);
         if (0 != u16 && 1 != u16 && 2 != u16) {
             /* bad value */
-            prte_show_help("help-schizo-base.txt", "bad-stream-buffering-value", true, u16);
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "bad-stream-buffering-value", true, u16);
         }
         PMIx_Setenv("OMPI_MCA_ompi_stream_buffering", opt->values[0], true, dstenv);
     }

--- a/src/mca/schizo/prte/schizo_prte.c
+++ b/src/mca/schizo/prte/schizo_prte.c
@@ -558,7 +558,7 @@ static int parse_cli(char **argv, pmix_cli_result_t *results,
          * above, so this is unreachable today - but handing
          * pmix_cmd_line_parse a NULL option table is a crash, not a
          * diagnosable error, so refuse rather than continue */
-        prte_show_help("help-schizo-base.txt", "no-proxy", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "no-proxy", true,
                        prte_tool_basename, prte_tool_actual);
         return PRTE_ERR_NOT_FOUND;
     }
@@ -774,7 +774,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
         else if (0 == strcmp(option, "ppr")) {
             /* if they didn't specify a complete pattern, then this is an error */
             if (NULL == strchr(opt->values[0], ':')) {
-                prte_show_help("help-schizo-base.txt", "bad-ppr", true, opt->values[0], true);
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "bad-ppr", true, opt->values[0], true);
                 return PRTE_ERR_SILENT;
             }
             pmix_asprintf(&p2, "ppr:%s", opt->values[0]);
@@ -967,7 +967,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
          */
         else if (0 == strcmp(option, "debug")) {
             if (warn) {
-                prte_show_help("help-schizo-base.txt", "deprecated-inform", true, option,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "deprecated-inform", true, option,
                                "This CLI option will be deprecated starting in Open MPI v5");
             }
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
@@ -1173,7 +1173,7 @@ static int convert_deprecated_cli(pmix_cli_result_t *results,
         // --hetero-nodes
         else if (0 == strcmp(option, "hetero-nodes")) {
             if (warn) {
-                prte_show_help("help-schizo-base.txt", "deprecated-hetero-nodes", true);
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "deprecated-hetero-nodes", true);
             }
             PMIX_CLI_REMOVE_DEPRECATED(results, opt);
         }

--- a/src/mca/state/base/state_base_fns.c
+++ b/src/mca/state/base/state_base_fns.c
@@ -571,7 +571,10 @@ void prte_state_base_orphaned_proc(pmix_proc_t *proc, prte_proc_state_t state)
         return;
     }
 
-    prte_show_help("help-state-base.txt", "orphaned-proc", true,
+    /* the proc's own nspace, not a job object: this path exists precisely
+     * because the job object is gone, and the report is still about that
+     * job - which is what has to scope its duplicate suppression */
+    prte_show_help(proc->nspace, "help-state-base.txt", "orphaned-proc", true,
                    PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), PRTE_NAME_PRINT(proc));
 
     /* Retire the proc ourselves.  Clearing PRTE_PROC_FLAG_ALIVE and dropping

--- a/src/mca/state/base/state_base_log.c
+++ b/src/mca/state/base/state_base_log.c
@@ -164,14 +164,14 @@ void prte_state_base_log_open(void)
     rc = prte_state_base_log_resolve_dir(prte_state_base.log_path,
                                          prte_process_info.tmpdir_base, &dir);
     if (PRTE_SUCCESS != rc) {
-        prte_show_help("help-state-base.txt", "state-log-no-path", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-state-base.txt", "state-log-no-path", true,
                        prte_process_info.nodename,
                        (NULL == prte_state_base.log_path) ? "(none)" : prte_state_base.log_path);
         goto disable;
     }
     rc = pmix_os_dirpath_create(dir, S_IRWXU);
     if (PMIX_SUCCESS != rc && PMIX_ERR_EXISTS != rc) {
-        prte_show_help("help-state-base.txt", "state-log-open-failed", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-state-base.txt", "state-log-open-failed", true,
                        prte_process_info.nodename, dir, PMIx_Error_string(rc));
         goto disable;
     }
@@ -191,7 +191,7 @@ void prte_state_base_log_open(void)
      * erase the record of the first.  The banner below separates the runs. */
     prte_state_base.log_fp = fopen(prte_state_base.log_file, "a");
     if (NULL == prte_state_base.log_fp) {
-        prte_show_help("help-state-base.txt", "state-log-open-failed", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-state-base.txt", "state-log-open-failed", true,
                        prte_process_info.nodename, prte_state_base.log_file, strerror(errno));
         goto disable;
     }

--- a/src/mca/state/base/state_base_options.c
+++ b/src/mca/state/base/state_base_options.c
@@ -279,7 +279,7 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
                 ++ptr;
                 if ('\0' == *ptr) {
                     /* missing the value */
-                    prte_show_help("help-prte-rmaps-base.txt", "missing-value", true,
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "missing-value", true,
                                    "runtime options", options[n], "empty");
                     PMIx_Argv_free(options);
                     return PRTE_ERR_BAD_PARAM;
@@ -295,7 +295,7 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
             if (NULL != ptr && !prte_schizo_base_directive_is_valued(options[n]) &&
                 !PMIX_CHECK_CLI_OPTION(options[n], PRTE_CLI_STOP_IN_APP) &&
                 PRTE_SUCCESS != prte_cli_bool_value(ptr, &flag)) {
-                prte_show_help("help-schizo-base.txt", "non-boolean-value", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-schizo-base.txt", "non-boolean-value", true,
                                PRTE_CLI_RTOS, options[n], ptr);
                 PMIX_VALUE_DESTRUCT(&value);
                 PMIx_Argv_free(options);
@@ -353,7 +353,7 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
             } else if (PMIX_CHECK_CLI_OPTION(options[n], PRTE_CLI_MAX_RESTARTS)) {
                 if (NULL == ptr || '\0' == *ptr) {
                     /* missing the value */
-                    prte_show_help("help-prte-rmaps-base.txt", "missing-value", true,
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "missing-value", true,
                                    "runtime options", options[n], "empty");
                     PMIX_VALUE_DESTRUCT(&value);
                     PMIx_Argv_free(options);
@@ -501,7 +501,7 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
                                    &flag, PMIX_BOOL);
 
             } else {
-                prte_show_help("help-prte-rmaps-base.txt", "unrecognized-policy", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "unrecognized-policy", true,
                                "runtime options", spec);
                 PMIX_VALUE_DESTRUCT(&value);
                 PMIx_Argv_free(options);
@@ -520,7 +520,7 @@ int prte_state_base_set_runtime_options(prte_job_t *jdata, char *spec)
     if (prte_get_attribute(&jdata->attributes, PRTE_JOB_NOTIFY_ERRORS, NULL, PMIX_BOOL) &&
         !prte_get_attribute(&jdata->attributes, PRTE_JOB_RECOVERABLE, NULL, PMIX_BOOL) &&
         !prte_get_attribute(&jdata->attributes, PRTE_JOB_CONTINUOUS, NULL, PMIX_BOOL)) {
-        prte_show_help("help-state-base.txt", "bad-combination", true);
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-state-base.txt", "bad-combination", true);
         return PRTE_ERR_SILENT;
     }
     return PRTE_SUCCESS;

--- a/src/mca/state/dvm/state_dvm.c
+++ b/src/mca/state/dvm/state_dvm.c
@@ -854,7 +854,7 @@ static void check_complete_resume(int fd, short args, void *cbdata)
          * spawned by it. */
         if (report_child_jobs_separately() && 1 != PRTE_LOCAL_JOBID(jdata->nspace)) {
             if (0 != jdata->exit_code) {
-                prte_show_help("help-state-base.txt", "child-job-status", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-state-base.txt", "child-job-status", true,
                                PRTE_LOCAL_JOBID_PRINT(jdata->nspace), jdata->exit_code);
             }
         } else {
@@ -1087,7 +1087,7 @@ release:
                 ++nprocs;
                 if (1 == nprocs) {
                     // output a warning message that at least one child is being terminated
-                    prte_show_help("help-state-base.txt", "child-term", true,
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-state-base.txt", "child-term", true,
                                    jdata->nspace, jptr->nspace);
                 }
             }

--- a/src/mca/state/prted/AGENTS.md
+++ b/src/mca/state/prted/AGENTS.md
@@ -93,6 +93,20 @@ Keyed on `caddy->name` / `caddy->proc_state`. Per incoming proc state:
   the map), optionally run the fd-leak check, notify a data server, and
   release the job object.
 
+  **The batch is the point — do not report each proc as it exits.** One
+  message per node per job, sent once every one of that job's local procs
+  has finished, is a deliberate choice: reporting each termination as it
+  happened would put one message on the wire per terminated proc, and at
+  the scales PRRTE runs at that storm costs far more than the earlier
+  notice is worth. A consequence is that a rank which exits early reads
+  as still alive, on the master as much as anywhere, until its node-mates
+  finish. That is not a fidelity gap to be closed; the batch boundary is
+  also exactly the moment every proc on the node is gone, which is the
+  question anything waiting on this is really asking. Abnormal
+  terminations are a different path ([`errmgr/prted`](../../errmgr/prted/))
+  and *are* reported individually, because they are rare and the HNP has
+  to act on them at once.
+
 ### `track_jobs`
 Handles the two job states above. It walks `prte_local_children`, and for
 each child in the target job packs vpid + pid (+ state/exit-code for

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -830,6 +830,12 @@ flagged `PRTE_PROC_FLAG_LOCAL` — which is exactly the condition under
 which the accessor succeeds. It must not defer: relaying it would answer
 about the *master's* local procs.
 
+That arm also defers when it has never heard of the job at all. A launch
+message goes only to the daemons that host part of the job, so "no such
+job" from a prted is a statement about that daemon, not about the DVM —
+the master has heard of all of them. The local arm keeps answering
+`PMIX_ERR_NOT_FOUND` there, because for it that is the truth.
+
 **The decision is made by the read, never by a list of keys.** Which keys
 need the master is not knowable in advance, and a written-down list goes
 stale the first time someone adds one — silently, because the stale case

--- a/src/prted/pmix/AGENTS.md
+++ b/src/prted/pmix/AGENTS.md
@@ -794,26 +794,55 @@ as `PMIX_SUCCESS`** — a wrong answer no caller can tell from a right one.
 The rank that happens to land on the master gets the truth; every other
 rank gets nothing, silently.
 
+The **job** table is stale in the same way, in one place. A daemon does
+hold a `prte_proc_t` for every proc of every job it hosts part of — the
+launch message ships the whole array — but it advances `pid`, `state` and
+`exit_code` for its own local children and for nothing else. No message
+carries a peer daemon's proc states back down the tree, because no daemon
+needs them: the hosting daemon reports them *up*, to the master, in
+`PRTE_PLM_UPDATE_PROC_STATE`. So an entry for a proc on another node
+keeps the state the launch message shipped for the life of the DVM.
+`PMIX_QUERY_PROC_TABLE` answered locally therefore reported every
+off-node rank as `PMIX_PROC_STATE_LAUNCH_UNDERWAY` — the conversion of
+`PRTE_PROC_STATE_INIT` — including ranks that had exited long ago, and
+that is the only signal PRRTE offers for "has this proc gone away"
+(`PMIX_EVENT_PROC_TERMINATED` is not implemented). A client co-located
+with the master saw the truth; every other client did not.
+
 So such an arm does not read that state directly. It goes through
-`prte_get_allocated_nodes()`, `prte_get_allocation_session()` or
-`prte_get_allocation_sessions()`
+`prte_get_allocated_nodes()`, `prte_get_allocation_session()`,
+`prte_get_allocation_sessions()` or `prte_get_proc_runtime_state()`
 ([`src/runtime/prte_globals.c`](../../runtime/prte_globals.c)), which
-succeed on the master and return `PRTE_ERR_NOT_AUTHORITATIVE` anywhere
-else. An arm that gets that back jumps to the `defer:` label at the foot
+succeed where the answer is authoritative — on the master, and for
+`prte_get_proc_runtime_state()` also on the daemon hosting that
+particular proc — and return `PRTE_ERR_NOT_AUTHORITATIVE` where it is
+not. An arm that gets that back jumps to the `defer:` label at the foot
 of the key loop; at `done:` the deferred keys go to the master on
 `PRTE_RML_TAG_QUERY`, and its reply is merged into the results gathered
 locally, so the client sees one answer covering every key it asked for.
+
+The proc-table arm defers on the *first* proc it does not host, having
+destructed the array it had begun to fill: the table is one answer, and
+half of it from here and half from the master would be a table whose
+entries disagree about what "now" means. `PMIX_QUERY_LOCAL_PROC_TABLE`
+reads the same fields and never defers, because it visits only procs
+flagged `PRTE_PROC_FLAG_LOCAL` — which is exactly the condition under
+which the accessor succeeds. It must not defer: relaying it would answer
+about the *master's* local procs.
 
 **The decision is made by the read, never by a list of keys.** Which keys
 need the master is not knowable in advance, and a written-down list goes
 stale the first time someone adds one — silently, because the stale case
 returns a plausible zero rather than failing. Which *reads* cannot be
-satisfied locally is exactly the three accessors above, and that is
-enforced where it is used. A key added tomorrow that reads capacity is
-relayed with no edit here; one that reads only what the nidmap and the
-launch message already deliver stays local with no edit either.
+satisfied locally is exactly the four accessors above, and that is
+enforced where it is used. A key added tomorrow that reads capacity, or
+that reports whether a proc is still alive, is relayed with no edit here;
+one that reads only what the nidmap and the launch message already
+deliver stays local with no edit either.
 [`test/unit/check_query_authority.py`](../../../test/unit/check_query_authority.py)
-fails `make check` if this file reaches that state any other way.
+fails `make check` if this file reaches that state any other way — it
+keys off `->pid`, `->exit_code` and `prte_pmix_convert_state()` for the
+proc half, because `->state` alone cannot be told from a node's.
 
 Deferral is per **key**, not per query and not per request, because the
 things a daemon must answer for *itself* can arrive in the same
@@ -830,7 +859,11 @@ locally. The relay uses the tracker pattern described under
 requestor so the master defaults the query to the right job rather than to
 the asking daemon. `contrib/dockerswarm`'s `slotinfo` client is the
 regression test: on one node every rank is on the master, and the bug
-cannot be seen at all.
+cannot be seen at all. Its `proctable departed` mode is the same test for
+the proc half — some of the job leaves, and the querier is placed once on
+a non-master node and once on the master, because the master's answer was
+right all along and a case that asks only one of them cannot tell a fix
+from a daemon that stopped answering.
 
 
 Several relays add an entry (usually `PMIX_REQUESTOR`) to an info array

--- a/src/prted/pmix/pmix_server.c
+++ b/src/prted/pmix/pmix_server.c
@@ -1199,7 +1199,7 @@ int pmix_server_init(void)
     if (PMIX_SUCCESS == prc) {
         // check the version
         if (val->data.uint32 < PRTE_PMIX_MINIMUM_VERSION) {
-            prte_show_help("help-prted.txt", "min-pmix-violation", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prted.txt", "min-pmix-violation", true,
                            PRTE_PMIX_MINIMUM_VERSION, val->data.uint32);
             PMIX_VALUE_RELEASE(val);
             return PRTE_ERR_SILENT;

--- a/src/prted/pmix/pmix_server_connect.c
+++ b/src/prted/pmix/pmix_server_connect.c
@@ -547,7 +547,7 @@ void prte_pmix_server_connection_job_failed(const pmix_nspace_t nspace)
 
                 /* the user is about to lose a job they did not ask about, so say
                  * why - "connected" is not a property they can see in ps */
-                prte_show_help("help-prted.txt", "connected-term", true,
+                prte_show_help(PRTE_JOB_NSPACE(jptr), "help-prted.txt", "connected-term", true,
                                cause, jptr->nspace);
 
                 PMIX_LOAD_PROCID(&target, jptr->nspace, PMIX_RANK_WILDCARD);

--- a/src/prted/pmix/pmix_server_dyn.c
+++ b/src/prted/pmix/pmix_server_dyn.c
@@ -269,7 +269,7 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
              * that could be right. Refuse it rather than silently ignore
              * it: a caller asking for a specific mapper is asking for
              * something we cannot promise. */
-            prte_show_help("help-prte-rmaps-base.txt", "mapper-not-supported", true,
+            prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "mapper-not-supported", true,
                            (NULL == info->value.data.string) ? "NULL"
                                                              : info->value.data.string);
             return PRTE_ERR_NOT_SUPPORTED;
@@ -394,7 +394,7 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
         } else if (PMIX_CHECK_KEY(info, PMIX_PPR)) {
             if (PRTE_MAPPING_POLICY_IS_SET(jdata->map->mapping)) {
                 /* not allowed to provide multiple mapping policies */
-                prte_show_help("help-prte-rmaps-base.txt", "redefining-policy", true, "mapping",
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "redefining-policy", true, "mapping",
                                info->value.data.string,
                                prte_rmaps_base_print_mapping(prte_rmaps_base.mapping));
                 return PRTE_ERR_BAD_PARAM;
@@ -407,7 +407,7 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
         } else if (PMIX_CHECK_KEY(info, PMIX_MAPBY)) {
             if (PRTE_MAPPING_POLICY_IS_SET(jdata->map->mapping)) {
                 /* not allowed to provide multiple mapping policies */
-                prte_show_help("help-prte-rmaps-base.txt", "redefining-policy", true, "mapping",
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "redefining-policy", true, "mapping",
                                info->value.data.string,
                                prte_rmaps_base_print_mapping(jdata->map->mapping));
                 return PRTE_ERR_BAD_PARAM;
@@ -445,7 +445,7 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
         } else if (PMIX_CHECK_KEY(info, PMIX_RANKBY)) {
             if (PRTE_RANKING_POLICY_IS_SET(jdata->map->ranking)) {
                 /* not allowed to provide multiple mapping policies */
-                prte_show_help("help-prte-rmaps-base.txt", "redefining-policy", true, "ranking",
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "redefining-policy", true, "ranking",
                                info->value.data.string,
                                prte_rmaps_base_print_ranking(jdata->map->ranking));
                 return PRTE_ERR_BAD_PARAM;
@@ -459,7 +459,7 @@ int prte_pmix_xfer_job_info(prte_job_t *jdata,
         } else if (PMIX_CHECK_KEY(info, PMIX_BINDTO)) {
             if (PRTE_BINDING_POLICY_IS_SET(jdata->map->binding)) {
                 /* not allowed to provide multiple mapping policies */
-                prte_show_help("help-prte-rmaps-base.txt", "redefining-policy", true, "binding",
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "redefining-policy", true, "binding",
                                info->value.data.string,
                                prte_hwloc_base_print_binding(jdata->map->binding));
                 return PRTE_ERR_BAD_PARAM;
@@ -944,7 +944,7 @@ int prte_pmix_xfer_app(prte_job_t *jdata, pmix_app_t *papp)
                     prc = pmix_getcwd(cwd, sizeof(cwd));
                     if (PMIX_SUCCESS != prc) {
                         rc = prte_pmix_convert_status(prc);
-                        prte_show_help("help-prted.txt", "cwd", true, "spawn", rc);
+                        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prted.txt", "cwd", true, "spawn", rc);
                         /* jdata belongs to our caller - it constructed it and
                          * will dispose of it on our error return.  Releasing
                          * it here would leave the caller with a dangling
@@ -984,7 +984,7 @@ int prte_pmix_xfer_app(prte_job_t *jdata, pmix_app_t *papp)
                 if (prte_get_attribute(&app->attributes, PRTE_APP_MAPBY,
                                        (void **) &u16ptr, PMIX_UINT16) &&
                     PRTE_MAPPING_POLICY_IS_SET(appmap)) {
-                    prte_show_help("help-prte-rmaps-base.txt", "redefining-policy", true,
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "redefining-policy", true,
                                    "mapping", info->value.data.string,
                                    prte_rmaps_base_print_mapping(appmap));
                     return PRTE_ERR_BAD_PARAM;
@@ -1033,7 +1033,7 @@ int prte_pmix_xfer_app(prte_job_t *jdata, pmix_app_t *papp)
                 /* see prte_pmix_xfer_job_info(): the mapping policy is the
                  * choice of mapper, so naming a component is not something
                  * PRRTE can act on - per app any more than per job */
-                prte_show_help("help-prte-rmaps-base.txt", "mapper-not-supported", true,
+                prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "mapper-not-supported", true,
                                (NULL == info->value.data.string) ? "NULL"
                                                                  : info->value.data.string);
                 return PRTE_ERR_NOT_SUPPORTED;
@@ -1046,7 +1046,7 @@ int prte_pmix_xfer_app(prte_job_t *jdata, pmix_app_t *papp)
                 if (prte_get_attribute(&app->attributes, PRTE_APP_MAPBY,
                                        (void **) &u16ptr, PMIX_UINT16) &&
                     PRTE_MAPPING_POLICY_IS_SET(appmap)) {
-                    prte_show_help("help-prte-rmaps-base.txt", "redefining-policy", true,
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prte-rmaps-base.txt", "redefining-policy", true,
                                    "mapping", info->value.data.string,
                                    prte_rmaps_base_print_mapping(appmap));
                     return PRTE_ERR_BAD_PARAM;
@@ -1141,7 +1141,7 @@ int prte_pmix_xfer_app(prte_job_t *jdata, pmix_app_t *papp)
             } else {
                 /* unrecognized key */
                 if (9 < pmix_output_get_verbosity(prte_pmix_server_globals.output)) {
-                    prte_show_help("help-prted.txt", "bad-key", true, "spawn", "application",
+                    prte_show_help(PRTE_JOB_NSPACE(jdata), "help-prted.txt", "bad-key", true, "spawn", "application",
                                    info->key);
                 }
             }
@@ -1195,7 +1195,7 @@ static void interim(int sd, short args, void *cbdata)
          * personality string in a spawn request must not take down the DVM */
         char *prsn = (NULL == jdata->personality)
                      ? NULL : PMIx_Argv_join(jdata->personality, ',');
-        prte_show_help("help-schizo-base.txt", "no-proxy", true, prte_tool_basename,
+        prte_show_help(PRTE_JOB_NSPACE(jdata), "help-schizo-base.txt", "no-proxy", true, prte_tool_basename,
                        (NULL == prsn) ? "NULL" : prsn);
         if (NULL != prsn) {
             free(prsn);

--- a/src/prted/pmix/pmix_server_pub.c
+++ b/src/prted/pmix/pmix_server_pub.c
@@ -95,7 +95,7 @@ int prte_pmix_server_init_pubsub(void)
     }
     server_init_rc = init_server();
     if (PRTE_SUCCESS != server_init_rc) {
-        prte_show_help("help-prted.txt", "noserver", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prted.txt", "noserver", true,
                        (NULL == prte_data_server_uri) ? "NULL" : prte_data_server_uri);
     }
     return server_init_rc;
@@ -128,7 +128,7 @@ static int init_server(void)
             filename = strchr(prte_data_server_uri, ':');
             if (NULL == filename) {
                 /* filename is not correctly formatted */
-                prte_show_help("help-prun.txt", "prun:ompi-server-filename-bad", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "prun:ompi-server-filename-bad", true,
                                prte_tool_basename, prte_data_server_uri);
                 return PRTE_ERR_BAD_PARAM;
             }
@@ -136,7 +136,7 @@ static int init_server(void)
 
             if (0 >= strlen(filename)) {
                 /* they forgot to give us the name! */
-                prte_show_help("help-prun.txt", "prun:ompi-server-filename-missing", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "prun:ompi-server-filename-missing", true,
                                prte_tool_basename, prte_data_server_uri);
                 return PRTE_ERR_BAD_PARAM;
             }
@@ -144,14 +144,14 @@ static int init_server(void)
             /* open the file and extract the uri */
             fp = fopen(filename, "r");
             if (NULL == fp) { /* can't find or read file! */
-                prte_show_help("help-prun.txt", "prun:ompi-server-filename-access", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "prun:ompi-server-filename-access", true,
                                prte_tool_basename, prte_data_server_uri);
                 return PRTE_ERR_BAD_PARAM;
             }
             if (NULL == fgets(input, 1024, fp)) {
                 /* something malformed about file */
                 fclose(fp);
-                prte_show_help("help-prun.txt", "prun:ompi-server-file-bad", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "prun:ompi-server-file-bad", true,
                                prte_tool_basename, prte_data_server_uri, prte_tool_basename);
                 return PRTE_ERR_BAD_PARAM;
             }

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -85,16 +85,26 @@ static void qrel(void *cbdata)
  * default one.  A key whose answer comes out of either therefore has to
  * be asked of the DVM master.
  *
+ * A daemon's copy of a job is stale in the same way, in one place: it
+ * holds a prte_proc_t for every proc of the job, but it advances pid,
+ * state and exit_code for the procs it hosts and for nothing else.  No
+ * message carries a peer daemon's proc states back down the tree,
+ * because no daemon needs them - only the master is told.  So an entry
+ * for a proc on another node reports the state the launch message
+ * shipped, forever.
+ *
  * Which keys those are is deliberately not written down anywhere.  Such
  * a list is a point-in-time snapshot that goes stale the first time
  * someone adds a key, and a stale entry does not fail loudly: it returns
  * a default-constructed zero that reads exactly like a real answer.  So
  * the decision is made by the *read* instead.  A branch reaches
  * allocation state only through prte_get_allocated_nodes() and its two
- * companions, which succeed on the master and return
- * PRTE_ERR_NOT_AUTHORITATIVE anywhere else; a branch that gets that back
- * jumps to the "defer" label and its key is forwarded.  A key added
- * tomorrow that reads capacity is relayed with no edit here, and one
+ * companions, and a proc's runtime fields only through
+ * prte_get_proc_runtime_state(); all of them succeed where the answer is
+ * authoritative and return PRTE_ERR_NOT_AUTHORITATIVE where it is not.
+ * A branch that gets that back jumps to the "defer" label and its key is
+ * forwarded.  A key added tomorrow that reads capacity, or that reports
+ * whether a proc is still alive, is relayed with no edit here, and one
  * that reads only what the nidmap and the launch message already deliver
  * stays local with no edit either.
  *
@@ -269,6 +279,9 @@ static void _query(int sd, short args, void *cbdata)
     prte_session_t *session;
     int matched;
     pmix_proc_info_t *procinfo;
+    prte_proc_state_t pstate;
+    pid_t ppid;
+    prte_exit_code_t pexit;
     /* PMIx initializes this before anything in PMIx_Info_list_convert() can
      * fail, but every path to the done: label depends on that and the early
      * ones reach it having never touched this - so initialize it here rather
@@ -780,6 +793,21 @@ static void _query(int sd, short args, void *cbdata)
                     if (NULL == proct) {
                         continue;
                     }
+                    /* this table spans the whole job, so off the master it
+                     * reaches procs this daemon does not host - and their
+                     * pid, state and exit code are the launch message's
+                     * snapshot, which never changes again.  The first one
+                     * ends the branch and the key goes to the master. */
+                    prc = prte_get_proc_runtime_state(proct, &pstate, &ppid, &pexit);
+                    if (PRTE_ERR_NOT_AUTHORITATIVE == prc) {
+                        PMIX_DATA_ARRAY_DESTRUCT(&dry);
+                        goto defer;
+                    }
+                    if (PRTE_SUCCESS != prc) {
+                        PMIX_DATA_ARRAY_DESTRUCT(&dry);
+                        ret = prte_pmix_convert_rc(prc);
+                        goto done;
+                    }
                     PMIX_LOAD_PROCID(&procinfo[p].proc, proct->name.nspace, proct->name.rank);
                     if (NULL != proct->node && NULL != proct->node->name) {
                         procinfo[p].hostname = strdup(proct->node->name);
@@ -793,9 +821,9 @@ static void _query(int sd, short args, void *cbdata)
                             procinfo[p].executable_name = pmix_os_path(false, app->cwd, app->app, NULL);
                         }
                     }
-                    procinfo[p].pid = proct->pid;
-                    procinfo[p].exit_code = proct->exit_code;
-                    procinfo[p].state = prte_pmix_convert_state(proct->state);
+                    procinfo[p].pid = ppid;
+                    procinfo[p].exit_code = pexit;
+                    procinfo[p].state = prte_pmix_convert_state(pstate);
                     ++p;
                 }
                 PMIX_INFO_LIST_ADD(rc, results, PMIX_QUERY_PROC_TABLE, &dry, PMIX_DATA_ARRAY);
@@ -828,6 +856,16 @@ static void _query(int sd, short args, void *cbdata)
                         continue;
                     }
                     if (PRTE_FLAG_TEST(proct, PRTE_PROC_FLAG_LOCAL)) {
+                        /* every entry here is a proc this daemon hosts, so
+                         * the accessor cannot refuse - but it is still how
+                         * the read is spelled, because "local" is exactly
+                         * the condition under which it succeeds */
+                        prc = prte_get_proc_runtime_state(proct, &pstate, &ppid, &pexit);
+                        if (PRTE_SUCCESS != prc) {
+                            PMIX_DATA_ARRAY_DESTRUCT(&dry);
+                            ret = prte_pmix_convert_rc(prc);
+                            goto done;
+                        }
                         PMIX_LOAD_PROCID(&procinfo[p].proc, proct->name.nspace, proct->name.rank);
                         if (NULL != proct->node && NULL != proct->node->name) {
                             procinfo[p].hostname = strdup(proct->node->name);
@@ -841,9 +879,9 @@ static void _query(int sd, short args, void *cbdata)
                                 procinfo[p].executable_name = pmix_os_path(false, app->cwd, app->app, NULL);
                             }
                         }
-                        procinfo[p].pid = proct->pid;
-                        procinfo[p].exit_code = proct->exit_code;
-                        procinfo[p].state = prte_pmix_convert_state(proct->state);
+                        procinfo[p].pid = ppid;
+                        procinfo[p].exit_code = pexit;
+                        procinfo[p].state = prte_pmix_convert_state(pstate);
                         ++p;
                     }
                 }

--- a/src/prted/pmix/pmix_server_queries.c
+++ b/src/prted/pmix/pmix_server_queries.c
@@ -775,12 +775,14 @@ static void _query(int sd, short args, void *cbdata)
                 /* construct a list of values with prte_proc_info_t
                  * entries for each proc in the indicated job */
                 jdata = prte_get_job_data_object(jobid);
-                if (NULL == jdata) {
-                    ret = PMIX_ERR_NOT_FOUND;
-                    goto done;
-                }
-                /* Check if there are any entries in global proctable */
-                if (0 == jdata->num_procs) {
+                if (NULL == jdata || 0 == jdata->num_procs) {
+                    /* a job's launch message goes only to the daemons that
+                     * host some of it, so "I have never heard of this job"
+                     * is a statement about this daemon, not about the DVM.
+                     * The master has heard of all of them. */
+                    if (!PRTE_PROC_IS_MASTER) {
+                        goto defer;
+                    }
                     ret = PMIX_ERR_NOT_FOUND;
                     goto done;
                 }

--- a/src/prted/pmix/pmix_server_session.c
+++ b/src/prted/pmix/pmix_server_session.c
@@ -849,7 +849,7 @@ static prte_job_t *build_session_job(prte_sessctrl_t *ctl, prte_session_t *sessi
         /* no component claims the requested personality. Every later use of
          * jdata->schizo is an unchecked dereference, so refuse here rather
          * than let a bad personality string take down the DVM */
-        prte_show_help("help-schizo-base.txt", "no-proxy", true, prte_tool_basename,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "no-proxy", true, prte_tool_basename,
                        (NULL == ctl->personality) ? "NULL"
                                                   : ctl->personality->value.data.string);
         *status = PMIX_ERR_NOT_FOUND;

--- a/src/prted/prte.c
+++ b/src/prted/prte.c
@@ -523,7 +523,7 @@ PRTE_EXPORT int prte(int argc, char *argv[])
      * schizo module for this tool */
     schizo = prte_schizo_base_detect_proxy(personality);
     if (NULL == schizo) {
-        prte_show_help("help-schizo-base.txt", "no-proxy", true, prte_tool_basename, personality);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "no-proxy", true, prte_tool_basename, personality);
         return 1;
     }
     if (0 != strcmp(schizo->name, "prte")) {
@@ -549,7 +549,7 @@ PRTE_EXPORT int prte(int argc, char *argv[])
     /* Register all global MCA Params */
     if (PRTE_SUCCESS != (rc = prte_register_params())) {
         if (PRTE_ERR_SILENT != rc) {
-            prte_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
                            "prte register params",
                            PRTE_ERROR_NAME(rc), rc);
         }
@@ -579,14 +579,14 @@ PRTE_EXPORT int prte(int argc, char *argv[])
     if (NULL != opt) {
         char cwd[PRTE_PATH_MAX];
         if (PRTE_SUCCESS != (rc = pmix_getcwd(cwd, sizeof(cwd)))) {
-            prte_show_help("help-prun.txt", "prun:init-failure", true, "get the cwd", rc);
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "prun:init-failure", true, "get the cwd", rc);
             return 1;
         }
         // can only be one value
         if (1 < PMIx_Argv_count(opt->values)) {
             // report the error and abort
             param = PMIx_Argv_join(opt->values, ',');
-            prte_show_help("help-prterun.txt", "multiple-default-hostfiles", true, param);
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prterun.txt", "multiple-default-hostfiles", true, param);
             return 1;
          }
         if (NULL != prte_default_hostfile) {
@@ -617,7 +617,7 @@ PRTE_EXPORT int prte(int argc, char *argv[])
         // parse the file and add its context to the argv array
         rc = prte_parse_appfile(opt->values[0], &pargv, &pargc);
         if (PRTE_SUCCESS != rc) {
-            prte_show_help("help-prun.txt", "appfile-failure", true, opt->values[0]);
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "appfile-failure", true, opt->values[0]);
             return 1;
         }
     }
@@ -671,7 +671,7 @@ PRTE_EXPORT int prte(int argc, char *argv[])
                  * However, if this is not "search", then this is an
                  * unknown option and must be reported to the user as
                  * an error */
-                prte_show_help("help-prun.txt", "bad-dvm-option", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "bad-dvm-option", true,
                                opt->values[0], prte_tool_basename);
                 return 1;
             }
@@ -785,7 +785,7 @@ PRTE_EXPORT int prte(int argc, char *argv[])
         pmix_nspace_t sgltn;
         pmix_rank_t sgrank;
         if (PRTE_SUCCESS != prte_parse_singleton_id(opt->values[0], sgltn, &sgrank)) {
-            prte_show_help("help-prte.txt", "bad-singleton", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte.txt", "bad-singleton", true,
                            prte_tool_basename, opt->values[0]);
             return 1;
         }
@@ -808,7 +808,7 @@ PRTE_EXPORT int prte(int argc, char *argv[])
         (void) strtoul(opt->values[0], &endp, 10);
         if (!isdigit((unsigned char) opt->values[0][0]) ||
             NULL == endp || '\0' != *endp || 0 != errno) {
-            prte_show_help("help-prun.txt", "bad-option-input", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "bad-option-input", true,
                            prte_tool_basename, "--" PRTE_CLI_STDIN,
                            opt->values[0], "all, none, or a rank");
             return 1;
@@ -831,7 +831,7 @@ PRTE_EXPORT int prte(int argc, char *argv[])
         /* did they provide an app? */
         if (PRTE_SUCCESS != rc || 0 == pmix_list_get_size(&apps)) {
             if (proxyrun) {
-                prte_show_help("help-prun.txt", "prun:executable-not-specified", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "prun:executable-not-specified", true,
                                prte_tool_basename, prte_tool_basename);
                 PRTE_UPDATE_EXIT_STATUS(rc);
                 goto DONE;
@@ -841,7 +841,7 @@ PRTE_EXPORT int prte(int argc, char *argv[])
             /* they did provide an app - this is only allowed
              * when running as a proxy! */
             if (!proxyrun) {
-                prte_show_help("help-prun.txt", "prun:executable-incorrectly-given", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "prun:executable-incorrectly-given", true,
                                prte_tool_basename, prte_tool_basename);
                 PRTE_UPDATE_EXIT_STATUS(rc);
                 goto DONE;
@@ -963,13 +963,13 @@ PRTE_EXPORT int prte(int argc, char *argv[])
 
     /* get the daemon job object - was created by ess/hnp component */
     if (NULL == (jdata = prte_get_job_data_object(PRTE_PROC_MY_NAME->nspace))) {
-        prte_show_help("help-prun.txt", "bad-job-object", true, prte_tool_basename);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "bad-job-object", true, prte_tool_basename);
         PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
         goto DONE;
     }
     /* ess/hnp also should have created a daemon "app" */
     if (NULL == (dapp = (prte_app_context_t *) pmix_pointer_array_get_item(jdata->apps, 0))) {
-        prte_show_help("help-prun.txt", "bad-app-object", true, prte_tool_basename);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "bad-app-object", true, prte_tool_basename);
         PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
         goto DONE;
     }
@@ -985,7 +985,7 @@ PRTE_EXPORT int prte(int argc, char *argv[])
                 param = strdup(iprteinfo->info.value.data.string);
             } else if (0 != strcmp(param, iprteinfo->info.value.data.string)) {
                 // we have non-matching prefixes
-                prte_show_help("help-plm-base.txt", "multiple-prefixes", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-base.txt", "multiple-prefixes", true,
                                prte_tool_basename, PRTE_CLI_PREFIX,
                                PRTE_CLI_PREFIX, "PRRTE", PRTE_CLI_PREFIX,
                                param, iprteinfo->info.value.data.string);
@@ -1050,7 +1050,7 @@ PRTE_EXPORT int prte(int argc, char *argv[])
         if (prte_get_attribute(&jdata->attributes, PRTE_JOB_PREFIX, (void **) &cptr, PMIX_STRING)) {
             // already have a prefix directory entry - see if they are the same
             if (0 != strcmp(cptr, param)) {
-                prte_show_help("help-plm-base.txt", "multiple-prrte-prefixes", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-base.txt", "multiple-prrte-prefixes", true,
                                prte_tool_basename, prte_tool_basename,
                                prte_tool_basename, param, cptr);
                 free(param);
@@ -1078,7 +1078,7 @@ PRTE_EXPORT int prte(int argc, char *argv[])
                 param = strdup(iprteinfo->info.value.data.string);
             } else if (0 != strcmp(param, iprteinfo->info.value.data.string)) {
                 // we have non-matching prefixes
-                prte_show_help("help-plm-base.txt", "multiple-prefixes", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-base.txt", "multiple-prefixes", true,
                                prte_tool_basename, PRTE_CLI_PMIX_PREFIX,
                                PRTE_CLI_PMIX_PREFIX, "PMIx", PRTE_CLI_PMIX_PREFIX,
                                param, iprteinfo->info.value.data.string);
@@ -1102,7 +1102,7 @@ PRTE_EXPORT int prte(int argc, char *argv[])
         if (prte_get_attribute(&jdata->attributes, PRTE_JOB_PMIX_PREFIX, (void **) &cptr, PMIX_STRING)) {
             // already have a prefix directory entry - see if they are the same
             if (0 != strcmp(cptr, param)) {
-                prte_show_help("help-plm-base.txt", "multiple-pmix-prefixes", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-base.txt", "multiple-pmix-prefixes", true,
                                prte_tool_basename, prte_tool_basename,
                                param, cptr);
                 free(param);
@@ -1693,7 +1693,7 @@ static int prep_singleton(const char *name)
 
     rc = prte_parse_singleton_id(name, nspace, &rank);
     if (PRTE_SUCCESS != rc) {
-        prte_show_help("help-prte.txt", "bad-singleton", true, prte_tool_basename, name);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte.txt", "bad-singleton", true, prte_tool_basename, name);
         return rc;
     }
     jdata = PMIX_NEW(prte_job_t);

--- a/src/prted/prte_app_parse.c
+++ b/src/prted/prte_app_parse.c
@@ -226,7 +226,7 @@ static int add_envar_directives(prte_pmix_app_t *app,
                     // given a unique name
                     value = getenv(param);
                     if (NULL == value) {
-                        prte_show_help("help-schizo-base.txt", "missing-envar-param", true, param);
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "missing-envar-param", true, param);
                         free(param);
                     } else {
                         PMIX_ENVAR_CONSTRUCT(&envt);
@@ -248,7 +248,7 @@ static int add_envar_directives(prte_pmix_app_t *app,
             param = strdup(ordered[k].value);
             if (k + 1 >= nordered || 0 != strcmp(ordered[k + 1].key, key)) {
                 // the value it edits with is missing
-                prte_show_help("help-prun.txt", "malformed-envar", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "malformed-envar", true,
                                prepend ? "prepend" : "append", app->app.cmd, param);
                 rc = PRTE_ERR_SILENT;
                 free(param);
@@ -257,7 +257,7 @@ static int add_envar_directives(prte_pmix_app_t *app,
             // find the [] enclosing the separator
             i = strlen(param);
             if (3 > i || ']' != param[i-1] || '[' != param[i-3]) {
-                prte_show_help("help-prun.txt", "malformed-envar", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "malformed-envar", true,
                                prepend ? "prepend" : "append", app->app.cmd, param);
                 rc = PRTE_ERR_SILENT;
                 free(param);
@@ -281,7 +281,7 @@ static int add_envar_directives(prte_pmix_app_t *app,
             // find the '=' separating name from value
             tval = strchr(param, '=');
             if (NULL == tval) {
-                prte_show_help("help-prun.txt", "malformed-envar", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "malformed-envar", true,
                                "set", app->app.cmd, param);
                 rc = PRTE_ERR_SILENT;
                 free(param);
@@ -371,7 +371,7 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
 
     /* get the cwd - we may need it in several places */
     if (PRTE_SUCCESS != (rc = pmix_getcwd(cwd, sizeof(cwd)))) {
-        prte_show_help("help-prun.txt", "prun:init-failure", true, "get the cwd", rc);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "prun:init-failure", true, "get the cwd", rc);
         goto cleanup;
     }
 
@@ -534,7 +534,7 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
         if (!isdigit((unsigned char) opt->values[0][0]) ||
             NULL == npend || '\0' != *npend || 0 != errno ||
             nprocs > (long) INT_MAX) {
-            prte_show_help("help-prun.txt", "bad-option-input", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "bad-option-input", true,
                            prte_tool_basename, "--" PRTE_CLI_NP,
                            opt->values[0], "a number of processes");
             rc = PRTE_ERR_FATAL;
@@ -545,7 +545,7 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
          * unreachable from the command line - it is kept because the check
          * is what the message names and the two must not drift apart */
         if (0 > count) {
-            prte_show_help("help-prun.txt", "prun:negative-nprocs", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "prun:negative-nprocs", true,
                            prte_tool_basename,
                            app->app.argv[0], count);
             rc = PRTE_ERR_FATAL;
@@ -568,7 +568,7 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
                     if (NULL == param) {
                         param = opt->values[i];
                     } else if (0 != strcmp(param, opt->values[i])) {
-                        prte_show_help("help-plm-base.txt", "multiple-prefixes", true,
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-base.txt", "multiple-prefixes", true,
                                        prte_tool_basename, PRTE_CLI_PREFIX,
                                        PRTE_CLI_PREFIX, "PRRTE", PRTE_CLI_PREFIX,
                                        param, opt->values[i]);
@@ -596,7 +596,7 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
                     if (NULL == param) {
                         param = opt->values[i];
                     } else if (0 != strcmp(param, opt->values[i])) {
-                        prte_show_help("help-plm-base.txt", "multiple-prefixes", true,
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-base.txt", "multiple-prefixes", true,
                                        prte_tool_basename, PRTE_CLI_PMIX_PREFIX,
                                        PRTE_CLI_PMIX_PREFIX, "PMIx", PRTE_CLI_PMIX_PREFIX,
                                        param, opt->values[i]);
@@ -630,7 +630,7 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
 
     app->app.cmd = strdup(app->app.argv[0]);
     if (NULL == app->app.cmd) {
-        prte_show_help("help-prun.txt", "prun:call-failed", true, "prun", "library",
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "prun:call-failed", true, "prun", "library",
                        "strdup returned NULL", errno);
         rc = PRTE_ERR_SILENT;
         goto cleanup;
@@ -669,7 +669,7 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
                 if (NULL == param) {
                     param = opt->values[i];
                 } else if (0 != strcmp(param, opt->values[i])) {
-                    prte_show_help("help-plm-base.txt", "multiple-app-prefixes", true,
+                    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-base.txt", "multiple-app-prefixes", true,
                                    prte_tool_basename, PRTE_CLI_APP_PREFIX,
                                    PRTE_CLI_APP_PREFIX, param, opt->values[i]);
                     rc = PRTE_ERR_FATAL;
@@ -688,7 +688,7 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
     if (NULL != opt) {
         // cannot have a prefix as well as no-prefix
         if (NULL != (opt2 = pmix_cmd_line_get_param(&results, PRTE_CLI_APP_PREFIX))) {
-            prte_show_help("help-plm-base.txt", "prefix-conflict", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-base.txt", "prefix-conflict", true,
                            prte_tool_basename, PRTE_CLI_APP_PREFIX, opt2->values[0],
                            PRTE_CLI_NO_APP_PREFIX);
             rc = PRTE_ERR_FATAL;
@@ -698,7 +698,7 @@ static int create_app(prte_schizo_base_module_t *schizo, char **argv,
     } else if (NULL != getenv("PMIX_APP_NO_PREFIX")) {
         // cannot have a prefix as well as no-prefix
         if (NULL != (opt2 = pmix_cmd_line_get_param(&results, PRTE_CLI_APP_PREFIX))) {
-            prte_show_help("help-plm-base.txt", "prefix-conflict", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-plm-base.txt", "prefix-conflict", true,
                            prte_tool_basename, PRTE_CLI_APP_PREFIX, opt2->values[0],
                            "PMIX_APP_NO_PREFIX");
             rc = PRTE_ERR_FATAL;

--- a/src/prted/prun_common.c
+++ b/src/prted/prun_common.c
@@ -631,7 +631,7 @@ int prun_common(pmix_cli_result_t *results,
     opt = pmix_cmd_line_get_param(results, PRTE_CLI_WAIT_TO_CONNECT);
     if (NULL != opt) {
         if (PRTE_SUCCESS != prte_parse_uint_option(opt->values[0], UINT32_MAX, &ulval)) {
-            prte_show_help("help-prun.txt", "bad-option-input", true, prte_tool_basename,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "bad-option-input", true, prte_tool_basename,
                            "--" PRTE_CLI_WAIT_TO_CONNECT, opt->values[0], "a number of seconds");
             PMIX_INFO_LIST_RELEASE(tinfo);
             return PRTE_ERR_BAD_PARAM;
@@ -643,7 +643,7 @@ int prun_common(pmix_cli_result_t *results,
     opt = pmix_cmd_line_get_param(results, PRTE_CLI_NUM_CONNECT_RETRIES);
     if (NULL != opt) {
         if (PRTE_SUCCESS != prte_parse_uint_option(opt->values[0], UINT32_MAX, &ulval)) {
-            prte_show_help("help-prun.txt", "bad-option-input", true, prte_tool_basename,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "bad-option-input", true, prte_tool_basename,
                            "--" PRTE_CLI_NUM_CONNECT_RETRIES, opt->values[0], "a number of retries");
             PMIX_INFO_LIST_RELEASE(tinfo);
             return PRTE_ERR_BAD_PARAM;
@@ -660,18 +660,18 @@ int prun_common(pmix_cli_result_t *results,
             PMIX_INFO_LIST_ADD(ret, tinfo, PMIX_SERVER_PIDINFO, &pid, PMIX_PID);
             break;
         case PRTE_ERR_FILE_OPEN_FAILURE:
-            prte_show_help("help-prun.txt", "file-open-error", true, prte_tool_basename,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "file-open-error", true, prte_tool_basename,
                            "--" PRTE_CLI_PID, opt->values[0], param);
             PMIX_INFO_LIST_RELEASE(tinfo);
             return PRTE_ERR_BAD_PARAM;
         case PRTE_ERR_FILE_READ_FAILURE:
             /* we could not obtain the single conversion we require */
-            prte_show_help("help-prun.txt", "bad-file", true, prte_tool_basename,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "bad-file", true, prte_tool_basename,
                            "--" PRTE_CLI_PID, opt->values[0], param);
             PMIX_INFO_LIST_RELEASE(tinfo);
             return PRTE_ERR_BAD_PARAM;
         default: /* neither an integer nor a usable 'file:' spec */
-            prte_show_help("help-prun.txt", "bad-option-input", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "bad-option-input", true,
                            prte_tool_basename, "--" PRTE_CLI_PID,
                            opt->values[0], "file:path");
             PMIX_INFO_LIST_RELEASE(tinfo);
@@ -1058,7 +1058,7 @@ int prun_common(pmix_cli_result_t *results,
     while (NULL != child_statuses) {
         child_status_t *cs = child_statuses;
         child_statuses = cs->next;
-        prte_show_help("help-state-base.txt", "child-job-status", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-state-base.txt", "child-job-status", true,
                        PRTE_LOCAL_JOBID_PRINT(cs->nspace), cs->code);
         free(cs);
     }
@@ -1173,7 +1173,7 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
      * in an MPMD line, which we cannot honor - reject it rather than silently
      * applying just one. */
     if (1 < pmix_cmd_line_get_ninsts(results, PRTE_CLI_DISPLAY)) {
-        prte_show_help("help-schizo-base.txt", "multi-instances", true, PRTE_CLI_DISPLAY);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "multi-instances", true, PRTE_CLI_DISPLAY);
         return PRTE_ERR_BAD_PARAM;
     }
 
@@ -1235,7 +1235,7 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
         pmix_rank_t stdintgt;
 
         if (PRTE_SUCCESS != stdin_target_rank(results, &stdintgt)) {
-            prte_show_help("help-prun.txt", "bad-option-input", true, prte_tool_basename,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "bad-option-input", true, prte_tool_basename,
                            "--" PRTE_CLI_STDIN, opt->values[0], "all, none, or a rank");
             PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
             return PRTE_ERR_BAD_PARAM;
@@ -1265,7 +1265,7 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
     opt = pmix_cmd_line_get_param(results, PRTE_CLI_MAX_RESTARTS);
     if (NULL != opt) {
         if (PRTE_SUCCESS != prte_parse_uint_option(opt->values[0], UINT32_MAX, &ulval)) {
-            prte_show_help("help-prun.txt", "bad-option-input", true, prte_tool_basename,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "bad-option-input", true, prte_tool_basename,
                            "--" PRTE_CLI_MAX_RESTARTS, opt->values[0], "a number of restarts");
             PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
             return PRTE_ERR_BAD_PARAM;
@@ -1295,7 +1295,7 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
     opt = pmix_cmd_line_get_param(results, PRTE_CLI_TIMEOUT);
     if (NULL != opt) {
         if (PRTE_SUCCESS != prte_parse_uint_option(opt->values[0], INT_MAX, &ulval)) {
-            prte_show_help("help-prun.txt", "bad-option-input", true, prte_tool_basename,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "bad-option-input", true, prte_tool_basename,
                            "--" PRTE_CLI_TIMEOUT, opt->values[0], "a number of seconds");
             PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
             return PRTE_ERR_BAD_PARAM;
@@ -1303,7 +1303,7 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
         i = (int) ulval;
     } else if (NULL != (param = getenv("MPIEXEC_TIMEOUT"))) {
         if (PRTE_SUCCESS != prte_parse_uint_option(param, INT_MAX, &ulval)) {
-            prte_show_help("help-prun.txt", "bad-option-input", true, prte_tool_basename,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "bad-option-input", true, prte_tool_basename,
                            "MPIEXEC_TIMEOUT", param, "a number of seconds");
             PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
             return PRTE_ERR_BAD_PARAM;
@@ -1329,7 +1329,7 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
     opt = pmix_cmd_line_get_param(results, PRTE_CLI_SPAWN_TIMEOUT);
     if (NULL != opt) {
         if (PRTE_SUCCESS != prte_parse_uint_option(opt->values[0], INT_MAX, &ulval)) {
-            prte_show_help("help-prun.txt", "bad-option-input", true, prte_tool_basename,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "bad-option-input", true, prte_tool_basename,
                            "--" PRTE_CLI_SPAWN_TIMEOUT, opt->values[0], "a number of seconds");
             PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
             return PRTE_ERR_BAD_PARAM;
@@ -1356,7 +1356,7 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
          * value that is neither, the way every other boolean option here
          * does */
         if (PRTE_SUCCESS != prte_cli_bool_value(opt->values[0], &flag)) {
-            prte_show_help("help-prun.txt", "bad-option-input", true, prte_tool_basename,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "bad-option-input", true, prte_tool_basename,
                            "--" PRTE_CLI_GPU_SUPPORT, opt->values[0], "true or false");
             PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
             return PRTE_ERR_BAD_PARAM;
@@ -1378,7 +1378,7 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
     ntargets = 0;
     for (i = 0; NULL != alloc_target_opts[i]; i++) {
         if (1 < pmix_cmd_line_get_ninsts(results, alloc_target_opts[i])) {
-            prte_show_help("help-schizo-base.txt", "multi-instances", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "multi-instances", true,
                            alloc_target_opts[i]);
             PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
             return PRTE_ERR_BAD_PARAM;
@@ -1388,7 +1388,7 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
         }
     }
     if (1 < ntargets) {
-        prte_show_help("help-schizo-base.txt", "alloc-target-conflict", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "alloc-target-conflict", true,
                        PRTE_CLI_SESSION_ID, PRTE_CLI_TARGET_ALLOC, PRTE_CLI_ALLOC_REFID);
         PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
         return PRTE_ERR_BAD_PARAM;
@@ -1406,7 +1406,7 @@ int prte_prun_parse_common_cli(void *jinfo, pmix_cli_result_t *results,
         sid = strtoul(opt->values[0], &endptr, 10);
         if (!isdigit((unsigned char) opt->values[0][0]) || '\0' != *endptr ||
             0 != errno || sid != (unsigned long) (uint32_t) sid) {
-            prte_show_help("help-schizo-base.txt", "bad-session-id", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "bad-session-id", true,
                            PRTE_CLI_SESSION_ID, opt->values[0]);
             PRTE_UPDATE_EXIT_STATUS(PRTE_ERR_FATAL);
             return PRTE_ERR_BAD_PARAM;

--- a/src/rml/oob/oob_tcp.c
+++ b/src/rml/oob/oob_tcp.c
@@ -203,7 +203,7 @@ int prte_oob_open(void)
              * error out as we can't do what was requested
              */
             if (PRTE_ERR_NETWORK_NOT_PARSEABLE == rc) {
-                prte_show_help("help-oob-tcp.txt", "not-parseable", true);
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-oob-tcp.txt", "not-parseable", true);
                 PMIx_Argv_free(interfaces);
                 return PRTE_ERR_BAD_PARAM;
             }
@@ -298,14 +298,14 @@ int prte_oob_open(void)
         /* say so: this is reachable straight from user input (an if_include or
          * if_exclude that leaves nothing), and the caller can only turn the
          * bare error code into an abort */
-        prte_show_help("help-oob-tcp.txt", "no-interfaces", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-oob-tcp.txt", "no-interfaces", true,
                        prte_process_info.nodename);
         return PRTE_ERR_NOT_AVAILABLE;
     }
 
     // start the listeners
     if (PRTE_SUCCESS != (rc = prte_oob_tcp_start_listening())) {
-        prte_show_help("help-oob-tcp.txt", "no-listeners", true);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-oob-tcp.txt", "no-listeners", true);
         PRTE_ERROR_LOG(rc);
     }
     return rc;
@@ -473,7 +473,7 @@ int prte_oob_register(void)
         /* can't have both static and dynamic ports! */
         if (prte_static_ports) {
             char *err = PMIx_Argv_join(prte_oob_base.tcp_static_ports, ',');
-            prte_show_help("help-oob-tcp.txt", "static-and-dynamic", true, err, dyn_port_string);
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-oob-tcp.txt", "static-and-dynamic", true, err, dyn_port_string);
             free(err);
             return PRTE_ERROR;
         }
@@ -503,7 +503,7 @@ int prte_oob_register(void)
             if (NULL != prte_oob_base.tcp6_static_ports) {
                 err6 = PMIx_Argv_join(prte_oob_base.tcp6_static_ports, ',');
             }
-            prte_show_help("help-oob-tcp.txt", "static-and-dynamic-ipv6", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-oob-tcp.txt", "static-and-dynamic-ipv6", true,
                            (NULL == err4) ? "N/A" : err4, (NULL == err6) ? "N/A" : err6,
                            dyn_port_string6);
             if (NULL != err4) {
@@ -800,7 +800,7 @@ void prte_oob_split_and_resolve(char **orig_str, char *name,
         tmp = strdup(argv[i]);
         str = strchr(argv[i], '/');
         if (NULL == str) {
-            prte_show_help("help-oob-tcp.txt", "invalid if_inexclude",
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-oob-tcp.txt", "invalid if_inexclude",
                            true, name, prte_process_info.nodename,
                            tmp, "Invalid specification (missing \"/\")");
             free(tmp);
@@ -815,7 +815,7 @@ void prte_oob_split_and_resolve(char **orig_str, char *name,
                         &((struct sockaddr_in*) &argv_inaddr)->sin_addr);
 
         if (1 != ret) {
-            prte_show_help("help-oob-tcp.txt", "invalid if_inexclude",
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-oob-tcp.txt", "invalid if_inexclude",
                            true, name, prte_process_info.nodename, tmp,
                            "Invalid specification (inet_pton() failed)");
             free(tmp);
@@ -870,7 +870,7 @@ void prte_oob_split_and_resolve(char **orig_str, char *name,
         }
         /* If we didn't find a match, keep trying */
         if (0 == match_count) {
-            prte_show_help("help-oob-tcp.txt", "invalid if_inexclude",
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-oob-tcp.txt", "invalid if_inexclude",
                            true, name, prte_process_info.nodename, tmp,
                            "Did not find interface matching this subnet");
             free(tmp);

--- a/src/rml/oob/oob_tcp_connection.c
+++ b/src/rml/oob/oob_tcp_connection.c
@@ -1189,7 +1189,7 @@ int prte_oob_tcp_peer_recv_connect_ack(prte_oob_tcp_peer_t *pr, int sd, prte_oob
 
     /* get the authentication and version payload */
     if (hdr.nbytes > (uint32_t)(prte_oob_base.max_msg_size * 1024 * 1024)) {
-        prte_show_help("help-oob-tcp.txt", "msg-too-big", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-oob-tcp.txt", "msg-too-big", true,
                         PRTE_NAME_PRINT(&peer->name), PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                         hdr.nbytes, prte_oob_base.max_msg_size);
         abort_handshake(peer, sd);
@@ -1274,7 +1274,7 @@ int prte_oob_tcp_peer_recv_connect_ack(prte_oob_tcp_peer_t *pr, int sd, prte_oob
 
     if (hdr.nbytes == offset) {
         // missing version string
-        prte_show_help("help-oob-tcp.txt", "missing version", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-oob-tcp.txt", "missing version", true,
                        prte_process_info.nodename, PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                        pmix_fd_get_peer_name(sd), PRTE_NAME_PRINT(&(peer->name)));
         abort_handshake(peer, sd);
@@ -1294,7 +1294,7 @@ int prte_oob_tcp_peer_recv_connect_ack(prte_oob_tcp_peer_t *pr, int sd, prte_oob
     }
     offset += cnt + 1;
     if (0 != strcmp(version, prte_version_string)) {
-        prte_show_help("help-oob-tcp.txt", "version mismatch", true, prte_process_info.nodename,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-oob-tcp.txt", "version mismatch", true, prte_process_info.nodename,
                        PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), prte_version_string,
                        pmix_fd_get_peer_name(sd), PRTE_NAME_PRINT(&(peer->name)), version);
 

--- a/src/rml/oob/oob_tcp_listener.c
+++ b/src/rml/oob/oob_tcp_listener.c
@@ -118,13 +118,13 @@ int prte_oob_tcp_start_listening(void)
     rc2 = create_listen6();
     if (PRTE_SUCCESS != rc && PRTE_SUCCESS != rc2) {
         /* we were unable to open any listening sockets */
-        prte_show_help("help-oob-tcp.txt", "no-listeners", true);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-oob-tcp.txt", "no-listeners", true);
         return PRTE_ERR_FATAL;
     }
 #else
     if (PRTE_SUCCESS != rc) {
         /* we were unable to open any listening sockets */
-        prte_show_help("help-oob-tcp.txt", "no-listeners", true);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-oob-tcp.txt", "no-listeners", true);
         return PRTE_ERR_FATAL;
     }
 #endif
@@ -665,7 +665,7 @@ static void *listen_thread(pmix_object_t *obj)
                     else if (EMFILE == prte_socket_errno) {
                         CLOSE_THE_SOCKET(sd);
                         PRTE_ERROR_LOG(PRTE_ERR_SYS_LIMITS_SOCKETS);
-                        prte_show_help("help-oob-tcp.txt", "accept failed", true,
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-oob-tcp.txt", "accept failed", true,
                                        prte_process_info.nodename, prte_socket_errno,
                                        strerror(prte_socket_errno), "Out of file descriptors");
                         goto done;
@@ -674,7 +674,7 @@ static void *listen_thread(pmix_object_t *obj)
                     /* For all other cases, print a
                        warning but try to continue */
                     else {
-                        prte_show_help("help-oob-tcp.txt", "accept failed", true,
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-oob-tcp.txt", "accept failed", true,
                                        prte_process_info.nodename, prte_socket_errno,
                                        strerror(prte_socket_errno),
                                        "Unknown cause; job will try to continue");
@@ -701,7 +701,7 @@ static void *listen_thread(pmix_object_t *obj)
                     if (1024 < inport) {
                         /* someone tried to cross-connect privileges,
                          * say something */
-                        prte_show_help("help-oob-tcp.txt", "privilege failure", true,
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-oob-tcp.txt", "privilege failure", true,
                                        prte_process_info.nodename, listener->port,
                                        pmix_net_get_hostname(
                                            (struct sockaddr *) &pending_connection->addr),
@@ -780,7 +780,7 @@ static void connection_event_handler(int incoming_sd, short flags, void *cbdata)
         else if (EMFILE == prte_socket_errno) {
             CLOSE_THE_SOCKET(incoming_sd);
             PRTE_ERROR_LOG(PRTE_ERR_SYS_LIMITS_SOCKETS);
-            prte_show_help("help-oob-tcp.txt", "accept failed", true, prte_process_info.nodename,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-oob-tcp.txt", "accept failed", true, prte_process_info.nodename,
                            prte_socket_errno, strerror(prte_socket_errno),
                            "Out of file descriptors");
             return;
@@ -790,7 +790,7 @@ static void connection_event_handler(int incoming_sd, short flags, void *cbdata)
            try to continue */
         else {
             CLOSE_THE_SOCKET(incoming_sd);
-            prte_show_help("help-oob-tcp.txt", "accept failed", true, prte_process_info.nodename,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-oob-tcp.txt", "accept failed", true, prte_process_info.nodename,
                            prte_socket_errno, strerror(prte_socket_errno),
                            "Unknown cause; job will try to continue");
             return;

--- a/src/rml/oob/oob_tcp_sendrecv.c
+++ b/src/rml/oob/oob_tcp_sendrecv.c
@@ -559,7 +559,7 @@ void prte_oob_tcp_recv_handler(int sd, short flags, void *cbdata)
                                     PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                                     (unsigned long) peer->recv_msg->hdr.nbytes);
                 if (peer->recv_msg->hdr.nbytes > (uint32_t)(prte_oob_base.max_msg_size * 1024 * 1024)) {
-                    prte_show_help("help-oob-tcp.txt", "msg-too-big", true,
+                    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-oob-tcp.txt", "msg-too-big", true,
                                     PRTE_NAME_PRINT(&peer->name), PRTE_NAME_PRINT(PRTE_PROC_MY_NAME),
                                     peer->recv_msg->hdr.nbytes, prte_oob_base.max_msg_size);
                     peer->state = MCA_OOB_TCP_FAILED;

--- a/src/runtime/AGENTS.md
+++ b/src/runtime/AGENTS.md
@@ -143,6 +143,41 @@ you were handed can be handed to somebody else later.
 The lookups are linear scans over the whole array. That is fine at DVM
 scale, but do not put one inside a per-proc loop on a launch path.
 
+### What a registry holds is not what it is authoritative for
+
+A `prted` has all three registries, and parts of all three are stale on it
+by design. Its node pool carries a node's *identity* — the nidmap ships
+names, aliases, daemon vpids and pool slots and nothing else — so `slots`,
+`slots_max`, `slots_inuse` and node `state` read back default-constructed.
+Its `prte_sessions` holds the default session and no other. And its copy
+of a job carries a `prte_proc_t` for every proc, but it advances `pid`,
+`state` and `exit_code` only for the procs it hosts: proc states travel
+*up* to the master in `PRTE_PLM_UPDATE_PROC_STATE` and are never sent back
+down, because no daemon needs a peer's. So an entry for a proc on another
+node reports what the launch message shipped, for the life of the DVM.
+
+None of that fails loudly. A stale read hands back a plausible zero — a
+node with no slots, a rank still `PRTE_PROC_STATE_INIT` — that no caller
+can tell from a real answer, and the rank that happens to land on the
+master gets the truth while every other rank silently does not. So the
+four reads that cannot be satisfied everywhere are behind accessors that
+say so:
+
+| Accessor | Authoritative on |
+|----------|------------------|
+| `prte_get_allocated_nodes()` | the master |
+| `prte_get_allocation_session()` | the master |
+| `prte_get_allocation_sessions()` | the master |
+| `prte_get_proc_runtime_state()` | the master, and the daemon hosting that proc |
+
+Anywhere else each returns `PRTE_ERR_NOT_AUTHORITATIVE` having touched
+nothing — the caller's cue to ask the master instead, which is what
+[`src/prted/pmix/pmix_server_queries.c`](../prted/pmix/pmix_server_queries.c)
+does with its `defer:` label. Reach past them for that state and the bug
+you write is invisible at the point of failure;
+[`test/unit/check_query_authority.py`](../../test/unit/check_query_authority.py)
+fails `make check` if the query file does.
+
 ---
 
 ## Sessions (reservations)

--- a/src/runtime/data_server/ds_main.c
+++ b/src/runtime/data_server/ds_main.c
@@ -686,7 +686,7 @@ bool prte_ds_make_room(prte_data_object_t *data)
         }
         if (!u->warned) {
             u->warned = true;
-            prte_show_help("help-prte-data-server.txt", "datastore:evicting", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-data-server.txt", "datastore:evicting", true,
                            PRTE_NAME_PRINT(PRTE_PROC_MY_NAME), (unsigned long) data->uid,
                            (unsigned long) prte_data_store.max_size);
         }

--- a/src/runtime/prte_globals.c
+++ b/src/runtime/prte_globals.c
@@ -418,6 +418,31 @@ int prte_get_allocation_sessions(pmix_pointer_array_t **sessions)
     return PRTE_SUCCESS;
 }
 
+/* See the block comment in prte_globals.h.  This is the same gate in a
+ * second dimension: what only the daemon hosting a proc, and the master it
+ * reports to, actually know about it. */
+int prte_get_proc_runtime_state(const prte_proc_t *proc, prte_proc_state_t *state,
+                                pid_t *pid, prte_exit_code_t *exit_code)
+{
+    if (NULL == proc) {
+        return PRTE_ERR_BAD_PARAM;
+    }
+    /* the master is told about every proc; a daemon knows only its own */
+    if (!PRTE_PROC_IS_MASTER && !PRTE_FLAG_TEST(proc, PRTE_PROC_FLAG_LOCAL)) {
+        return PRTE_ERR_NOT_AUTHORITATIVE;
+    }
+    if (NULL != state) {
+        *state = proc->state;
+    }
+    if (NULL != pid) {
+        *pid = proc->pid;
+    }
+    if (NULL != exit_code) {
+        *exit_code = proc->exit_code;
+    }
+    return PRTE_SUCCESS;
+}
+
 prte_session_t *prte_get_session_object_from_refid(const char *refid)
 {
     prte_session_t *session;

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -610,6 +610,28 @@ PRTE_EXPORT int prte_get_allocation_session(const char *allocid,
                                             prte_session_t **session);
 PRTE_EXPORT int prte_get_allocation_sessions(pmix_pointer_array_t **sessions);
 
+/* Reach a proc's runtime state - the fields nobody but the daemon hosting
+ * that proc ever writes.
+ *
+ * A daemon's copy of a job's proc array is the snapshot the launch message
+ * carried: pid, state and exit_code as the master packed them.  From then on
+ * a daemon advances those fields for its own local children and for nothing
+ * else, and no message carries a peer daemon's updates back down the tree -
+ * no daemon needs them.  So an entry for a proc hosted elsewhere still reads
+ * PRTE_PROC_STATE_INIT and pid 0 for the life of the DVM, which is
+ * indistinguishable from a real answer: a rank that exited long ago reports
+ * itself as one that has not started yet.
+ *
+ * The hosting daemon does tell the master (PRTE_PLM_UPDATE_PROC_STATE), so
+ * this succeeds on the master for every proc, and on a daemon only for a
+ * proc that daemon hosts.  Anywhere else it returns
+ * PRTE_ERR_NOT_AUTHORITATIVE having touched nothing, which is the caller's
+ * cue to ask the master instead.  Any out parameter may be NULL. */
+PRTE_EXPORT int prte_get_proc_runtime_state(const prte_proc_t *proc,
+                                            prte_proc_state_t *state,
+                                            pid_t *pid,
+                                            prte_exit_code_t *exit_code);
+
 /* Point a job at the session it runs in, maintaining the reference count on
  * both the outgoing and the incoming session.  Every assignment to
  * prte_job_t::session must go through this. */

--- a/src/runtime/prte_globals.h
+++ b/src/runtime/prte_globals.h
@@ -106,6 +106,19 @@ PRTE_EXPORT extern pmix_nspace_t
 #define PRTE_PROC_MY_NAME   (&prte_process_info.myproc)
 #define PRTE_PROC_MY_PROCID (&prte_process_info.myproc) // backward compatibility synonym
 
+/* The job to attribute a diagnostic to: the one it is about, or our own
+ * when there is no job in hand.
+ *
+ * prte_show_help() scopes duplicate suppression by job, so every call has
+ * to name one.  Many of them sit on paths where the job object may not
+ * exist yet, or where NULL means "set the DVM-wide default rather than
+ * this job's value" - policy parsing takes exactly that form - so a bare
+ * jdata->nspace at those sites is a crash on the error path, which is the
+ * one path nobody exercises.  Evaluates its argument twice; every caller
+ * passes a plain variable. */
+#define PRTE_JOB_NSPACE(j) \
+    ((NULL == (j)) ? PRTE_PROC_MY_NAME->nspace : (j)->nspace)
+
 /* define a special name that point to my parent (aka the process that spawned me) */
 #define PRTE_PROC_MY_PARENT (&prte_process_info.my_parent)
 

--- a/src/runtime/prte_init.c
+++ b/src/runtime/prte_init.c
@@ -322,7 +322,7 @@ int prte_init_minimum(void)
     ret = prte_register_paramfile_params();
     if (PRTE_SUCCESS != ret) {
         if (PRTE_ERR_SILENT != ret) {
-            prte_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
                            "prte register paramfile params", PRTE_ERROR_NAME(ret), ret);
         }
         return 1;
@@ -336,7 +336,7 @@ int prte_init_minimum(void)
     ret = prte_preload_default_mca_params();
     if (PRTE_SUCCESS != ret) {
         if (PRTE_ERR_SILENT != ret) {
-            prte_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
                            "prte preload mca params", PRTE_ERROR_NAME(ret), ret);
         }
         return ret;
@@ -351,7 +351,7 @@ int prte_init_minimum(void)
     if (prte_bootstrap_setup) {
         if (PRTE_SUCCESS != (ret = prte_ess_base_bootstrap_params())) {
             if (PRTE_ERR_SILENT != ret) {
-                prte_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
                                "prte bootstrap params", PRTE_ERROR_NAME(ret), ret);
             }
             return 1;
@@ -361,7 +361,7 @@ int prte_init_minimum(void)
     /* Register all global MCA Params */
     if (PRTE_SUCCESS != (ret = prte_register_params())) {
         if (PRTE_ERR_SILENT != ret) {
-            prte_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
                            "prte register params",
                            PRTE_ERROR_NAME(ret), ret);
         }
@@ -406,7 +406,7 @@ int prte_init_util(prte_proc_type_t flags)
      * doing so twice in cases where the launch agent did it for us
      */
     if (PRTE_SUCCESS != (ret = prte_util_init_sys_limits(&error))) {
-        prte_show_help("help-prte-runtime.txt", "prte_init:syslimit", false, error);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "prte_init:syslimit", false, error);
         return PRTE_ERR_SILENT;
     }
 
@@ -421,7 +421,7 @@ int prte_init_util(prte_proc_type_t flags)
 
 error:
     if (PRTE_ERR_SILENT != ret) {
-        prte_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true, error,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "prte_init:startup:internal-failure", true, error,
                        PRTE_ERROR_NAME(ret), ret);
     }
 
@@ -601,7 +601,7 @@ int prte_init(int *pargc, char ***pargv, prte_proc_type_t flags)
 
 error:
     if (PRTE_ERR_SILENT != ret) {
-        prte_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true, error,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "prte_init:startup:internal-failure", true, error,
                        PRTE_ERROR_NAME(ret), ret);
     }
 
@@ -737,7 +737,7 @@ int prte_preload_default_mca_params(void)
                 PMIX_LIST_FOREACH(fv2, &params, pmix_mca_base_var_file_value_t) {
                     if (0 == strcmp(fv->mbvfv_var, fv2->mbvfv_var)) {
                         if (!prte_suppress_override_warning) {
-                            prte_show_help("help-pmix-mca-var.txt", "overridden-param-set", true, fv->mbvfv_var);
+                            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-pmix-mca-var.txt", "overridden-param-set", true, fv->mbvfv_var);
                         }
                         free(fv->mbvfv_var);
                         fv->mbvfv_var = strdup(fv2->mbvfv_var);
@@ -752,7 +752,7 @@ int prte_preload_default_mca_params(void)
                 if (pmix_pmdl_base_check_pmix_param(fv->mbvfv_var)) {
                     pmix_asprintf(&tmp, "PMIX_MCA_%s", fv->mbvfv_var);
                     if (!prte_suppress_override_warning && NULL != getenv(tmp)) {
-                        prte_show_help("help-pmix-mca-var.txt", "overridden-param-set", true, tmp);
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-pmix-mca-var.txt", "overridden-param-set", true, tmp);
                     }
                     // set it, and overwrite if they already
                     // have a value in our environment
@@ -761,7 +761,7 @@ int prte_preload_default_mca_params(void)
                 } else {
                     pmix_asprintf(&tmp, "PRTE_MCA_%s", fv->mbvfv_var);
                     if (!prte_suppress_override_warning && NULL != getenv(tmp)) {
-                        prte_show_help("help-pmix-mca-var.txt", "overridden-param-set", true, tmp);
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-pmix-mca-var.txt", "overridden-param-set", true, tmp);
                     }
                     // set it, and overwrite if they already
                     // have a value in our environment
@@ -772,7 +772,7 @@ int prte_preload_default_mca_params(void)
                     // the equivalent PMIx value
                     if (check_pmix_overlap(fv->mbvfv_var, fv->mbvfv_value, true) &&
                         !prte_suppress_override_warning) {
-                        prte_show_help("help-pmix-mca-var.txt", "overridden-param-set", true, fv->mbvfv_var);
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-pmix-mca-var.txt", "overridden-param-set", true, fv->mbvfv_var);
                     }
                 }
             }

--- a/src/runtime/prte_mca_params.c
+++ b/src/runtime/prte_mca_params.c
@@ -305,7 +305,7 @@ int prte_register_params(void)
     if (NULL != prte_if_include && NULL != prte_if_exclude) {
         /* Return ERR_NOT_AVAILABLE so that a warning message about
          "open" failing is not printed */
-        prte_show_help("help-oob-tcp.txt", "include-exclude", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-oob-tcp.txt", "include-exclude", true,
                        prte_if_include, prte_if_exclude);
         return PRTE_ERR_SILENT;
     }
@@ -415,7 +415,7 @@ int prte_register_params(void)
     prte_process_info.shared_fs = pmix_path_nfs(prte_process_info.tmpdir_base, &fstype);
     if (prte_process_info.shared_fs && !prte_silence_shared_fs) {
         // this is a shared file system - warn the user
-        prte_show_help("help-prte-runtime.txt", "prte:session:dir:shared", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "prte:session:dir:shared", true,
                        prte_process_info.tmpdir_base, fstype, prte_tool_basename);
     }
     if (NULL != fstype) {

--- a/src/tools/prte_info/prte_info.c
+++ b/src/tools/prte_info/prte_info.c
@@ -71,7 +71,7 @@ static int register_framework_params(pmix_pointer_array_t *component_map)
 
     /* Register mca/base parameters */
     if (PMIX_SUCCESS != pmix_mca_base_open(NULL)) {
-        prte_show_help("help-prte-info.txt", "lib-call-fail", true, "pmix_mca_base_open",
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-info.txt", "lib-call-fail", true, "pmix_mca_base_open",
                        __FILE__, __LINE__);
         return PMIX_ERROR;
     }
@@ -120,7 +120,7 @@ int main(int argc, char *argv[])
 
     /* Initialize the argv parsing stuff */
     if (PRTE_SUCCESS != (ret = prte_init_util(PRTE_PROC_MASTER))) {
-        prte_show_help("help-prte-info.txt", "lib-call-fail", true, "prte_init_util", __FILE__,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-info.txt", "lib-call-fail", true, "prte_init_util", __FILE__,
                        __LINE__, NULL);
         exit(ret);
     }
@@ -145,7 +145,7 @@ int main(int argc, char *argv[])
      * schizo module for this tool */
     schizo = prte_schizo_base_detect_proxy("prte");
     if (NULL == schizo) {
-        prte_show_help("help-schizo-base.txt", "no-proxy", true, prte_tool_basename, "prte");
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "no-proxy", true, prte_tool_basename, "prte");
         return 1;
     }
 
@@ -273,7 +273,7 @@ int main(int argc, char *argv[])
     /* Register all global MCA Params */
     if (PRTE_SUCCESS != (ret = prte_register_params())) {
         if (PRTE_ERR_SILENT != ret) {
-            prte_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
                            "prte register params",
                            PRTE_ERROR_NAME(ret), ret);
         }

--- a/src/tools/prted/prted.c
+++ b/src/tools/prted/prted.c
@@ -283,7 +283,7 @@ int main(int argc, char *argv[])
     /* get our schizo module */
     schizo = prte_schizo_base_detect_proxy(personality);
     if (NULL == schizo) {
-        prte_show_help("help-schizo-base.txt", "no-proxy", true, prte_tool_basename, personality);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "no-proxy", true, prte_tool_basename, personality);
         return 1;
     }
 
@@ -315,7 +315,7 @@ int main(int argc, char *argv[])
     /* Register all global MCA Params */
     if (PRTE_SUCCESS != (ret = prte_register_params())) {
         if (PRTE_ERR_SILENT != ret) {
-            prte_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
                            "prte register params",
                            PRTE_ERROR_NAME(ret), ret);
         }
@@ -444,7 +444,7 @@ int main(int argc, char *argv[])
                 core = strtoul(cores[i], NULL, 10);
                 if (NULL == (pu = prte_hwloc_base_get_pu(prte_hwloc_topology, false, core))) {
                     /* the message will now come out locally */
-                    prte_show_help("help-prted.txt", "orted:cannot-bind", true,
+                    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prted.txt", "orted:cannot-bind", true,
                                    prte_process_info.nodename, prte_daemon_cores);
                     ret = PRTE_ERR_NOT_SUPPORTED;
                     hwloc_bitmap_free(ours);

--- a/src/tools/prun/prun.c
+++ b/src/tools/prun/prun.c
@@ -181,7 +181,7 @@ int prun(int argc, char *argv[])
      * schizo module for this tool */
     schizo = prte_schizo_base_detect_proxy(personality);
     if (NULL == schizo) {
-        prte_show_help("help-schizo-base.txt", "no-proxy", true, prte_tool_basename, personality);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "no-proxy", true, prte_tool_basename, personality);
         return 1;
     }
     if (NULL == personality) {
@@ -285,7 +285,7 @@ int prun(int argc, char *argv[])
         // parse the file and add its context to the argv array
         rc = prte_load_appfile(opt->values[0], &pargv);
         if (PRTE_SUCCESS != rc) {
-            prte_show_help("help-prun.txt", "appfile-failure", true, opt->values[0]);
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "appfile-failure", true, opt->values[0]);
             PRTE_UPDATE_EXIT_STATUS(1);
             goto DONE;
         }

--- a/src/tools/pterm/pterm.c
+++ b/src/tools/pterm/pterm.c
@@ -255,14 +255,14 @@ int main(int argc, char *argv[])
      * schizo module for this tool */
     schizo = prte_schizo_base_detect_proxy(personality);
     if (NULL == schizo) {
-        prte_show_help("help-schizo-base.txt", "no-proxy", true, prte_tool_basename, personality);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-schizo-base.txt", "no-proxy", true, prte_tool_basename, personality);
         return 1;
     }
 
     /* Register all global MCA Params */
     if (PRTE_SUCCESS != (rc = prte_register_params())) {
         if (PRTE_ERR_SILENT != rc) {
-            prte_show_help("help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "prte_init:startup:internal-failure", true,
                            "prte register params",
                            PRTE_ERROR_NAME(rc), rc);
         }
@@ -339,17 +339,17 @@ int main(int argc, char *argv[])
             PMIX_INFO_LIST_ADD(rc, tinfo, PMIX_SERVER_PIDINFO, &pid, PMIX_PID);
             break;
         case PRTE_ERR_FILE_OPEN_FAILURE:
-            prte_show_help("help-prun.txt", "file-open-error", true, prte_tool_basename,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "file-open-error", true, prte_tool_basename,
                            "--" PRTE_CLI_PID, opt->values[0], ptr);
             PMIX_INFO_LIST_RELEASE(tinfo);
             return 1;
         case PRTE_ERR_FILE_READ_FAILURE:
-            prte_show_help("help-prun.txt", "bad-file", true, prte_tool_basename,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "bad-file", true, prte_tool_basename,
                            "--" PRTE_CLI_PID, opt->values[0], ptr);
             PMIX_INFO_LIST_RELEASE(tinfo);
             return 1;
         default:
-            prte_show_help("help-prun.txt", "bad-option-input", true, prte_tool_basename,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prun.txt", "bad-option-input", true, prte_tool_basename,
                            "--" PRTE_CLI_PID, opt->values[0], "file:path");
             PMIX_INFO_LIST_RELEASE(tinfo);
             return 1;

--- a/src/util/AGENTS.md
+++ b/src/util/AGENTS.md
@@ -276,17 +276,49 @@ own output. The message is built and thrown away. The head node looks
 fine only because there the daemon's PMIx server is the one holding the
 tool connection (and under `prterun` it *is* the tool).
 
-`prte_show_help()` has the same signature and the same rendering, and:
+`prte_show_help()` has the same rendering, one extra leading argument
+(below), and:
 
 - on the **HNP**, on a **tool**, or in an **application**, delivers
   locally, exactly as `pmix_show_help()` would;
 - on any **other daemon**, renders locally and ships the text to the HNP
   over `PRTE_RML_TAG_SHOW_HELP`, where `prte_show_help_recv()` delivers
   it. Aggregation and duplicate suppression then happen **once**, on the
-  HNP, keyed by the same filename/topic — which is what you want anyway
-  when 500 nodes hit the same error.
+  HNP — which is what you want anyway when 500 nodes hit the same error.
+  The relayed buffer carries the nspace alongside the filename and topic;
+  a DVM is single-version by rule, so that wire has no format marker and
+  its packer and unpacker change together or not at all.
 - falls back to local delivery if there is no HNP to send to yet (early
   startup, or teardown), so a message is never simply lost.
+
+### The first argument names the job the message is about
+
+PMIx keys duplicate suppression on `(nspace, filename, topic)`, so every
+call has to say which job it is talking about. This is not bookkeeping: a
+DVM is one process that runs many jobs, in parallel and one after another
+for as long as it lives, and suppression that could not tell them apart
+told the first job to trip a diagnostic about it and left every later one
+in silence — for days, on a persistent DVM.
+
+Most messages are about the DVM or the tool rather than any job a user
+submitted — command-line parsing, startup failures, daemon launch — and
+those pass `PRTE_PROC_MY_NAME->nspace`, which *is* that job. It is a
+global reachable from anywhere, so no call site is unable to answer.
+
+A message that stems from a particular job names it, through
+`PRTE_JOB_NSPACE(jdata)`: all of `rmaps`, because a mapping failure is a
+failure to map one job; the binding-policy parsing in `src/hwloc` for the
+same reason; spawn, allocation, file pre-positioning, the `odls` binding
+and launch paths, and the `state`/`errmgr` reports of a job ending.
+
+**Use the macro, not `jdata->nspace`.** Policy parsing takes NULL for
+"set the DVM-wide default rather than this job's value" and branches on
+it, so a bare dereference at those sites is a crash on the error path —
+the one path nobody exercises. `PRTE_JOB_NSPACE()`
+([`src/runtime/prte_globals.h`](../runtime/prte_globals.h)) answers our
+own job for a NULL. Where the job object is *gone* rather than absent —
+`prte_state_base_orphaned_proc()` exists precisely for that case — pass
+the proc's own `nspace`; the report is still about that job.
 
 **The whole tree is converted** — every one of the ~420 call sites that
 used to say `pmix_show_help(` now says `prte_show_help(`, so a plain
@@ -298,8 +330,9 @@ identical outside a daemon, so there is no case where the PMIx spelling
 is the better choice.
 
 (`pmix_show_help_string()` and `pmix_show_help_norender()` are different
-functions with different signatures and are untouched; `prte_show_help()`
-is built on top of them.)
+functions with different signatures; `prte_show_help()` is built on top
+of them. `pmix_show_help_norender()` takes the nspace too — that is how
+the job reaches PMIx's suppression.)
 
 `prte-convert-help.py` recognizes both spellings when it scans for help
 citations, so converting a call site does not remove it from the

--- a/src/util/dash_host/dash_host.c
+++ b/src/util/dash_host/dash_host.c
@@ -434,7 +434,7 @@ static int parse_dash_host(char ***mapped_nodes, char *hosts)
                         ++cptr;
                         if ('\0' == *cptr) {
                             // missing number of nodes being requested
-                            prte_show_help("help-dash-host.txt",
+                            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-dash-host.txt",
                                            "dash-host:invalid-relative-node-syntax", true,
                                            mini_map[k]);
                             rc = PRTE_ERR_SILENT;
@@ -465,7 +465,7 @@ static int parse_dash_host(char ***mapped_nodes, char *hosts)
                         }
                         if (p < nnodes) {
                             // not enough empty nodes
-                            prte_show_help("help-dash-host.txt",
+                            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-dash-host.txt",
                                            "dash-host:not-enough-empty", true,
                                            nnodes-p);
                             rc = PRTE_ERR_SILENT;
@@ -482,7 +482,7 @@ static int parse_dash_host(char ***mapped_nodes, char *hosts)
                     nodeidx = strtol(&mini_map[k][2], NULL, 10);
                     if (nodeidx < 0 || nodeidx >= (int) prte_node_pool->size) {
                         /* this is an error */
-                        prte_show_help("help-dash-host.txt",
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-dash-host.txt",
                                        "dash-host:relative-node-out-of-bounds", true, nodeidx,
                                        mini_map[k]);
                         rc = PRTE_ERR_SILENT;
@@ -499,7 +499,7 @@ static int parse_dash_host(char ***mapped_nodes, char *hosts)
                     node = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, nodeidx);
                     if (NULL == node) {
                         /* this is an error */
-                        prte_show_help("help-dash-host.txt", "dash-host:relative-node-not-found",
+                        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-dash-host.txt", "dash-host:relative-node-not-found",
                                        true, nodeidx, mini_map[k]);
                         rc = PRTE_ERR_SILENT;
                         goto cleanup;
@@ -508,7 +508,7 @@ static int parse_dash_host(char ***mapped_nodes, char *hosts)
                     PMIx_Argv_append_nosize(mapped_nodes, node->name);
                 } else {
                     /* invalid relative node syntax */
-                    prte_show_help("help-dash-host.txt", "dash-host:invalid-relative-node-syntax",
+                    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-dash-host.txt", "dash-host:invalid-relative-node-syntax",
                                    true, mini_map[k]);
                     rc = PRTE_ERR_SILENT;
                     goto cleanup;
@@ -680,7 +680,7 @@ int prte_util_filter_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool remov
     /* was something specified that was -not- found? */
     for (i = 0; i < len_mapped_node; i++) {
         if (NULL != mapped_nodes[i]) {
-            prte_show_help("help-dash-host.txt", "not-all-mapped-alloc", true, mapped_nodes[i]);
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-dash-host.txt", "not-all-mapped-alloc", true, mapped_nodes[i]);
             rc = PRTE_ERR_SILENT;
             goto cleanup;
         }
@@ -704,7 +704,7 @@ int prte_util_filter_dash_host_nodes(pmix_list_t *nodes, char *hosts, bool remov
 
     /* did they ask for more than we could provide */
     if (!want_all_empty && 0 < num_empty) {
-        prte_show_help("help-dash-host.txt", "dash-host:not-enough-empty", true, num_empty);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-dash-host.txt", "dash-host:not-enough-empty", true, num_empty);
         rc = PRTE_ERR_SILENT;
         goto cleanup;
     }

--- a/src/util/hostfile/hostfile.c
+++ b/src/util/hostfile/hostfile.c
@@ -60,17 +60,17 @@ static void hostfile_parse_error(int token)
 {
     switch (token) {
     case PRTE_HOSTFILE_STRING:
-        prte_show_help("help-hostfile.txt", "parse_error_string", true, cur_hostfile_name,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-hostfile.txt", "parse_error_string", true, cur_hostfile_name,
                        prte_util_hostfile_line, token, prte_util_hostfile_value.sval);
         break;
     case PRTE_HOSTFILE_IPV4:
     case PRTE_HOSTFILE_IPV6:
     case PRTE_HOSTFILE_INT:
-        prte_show_help("help-hostfile.txt", "parse_error_int", true, cur_hostfile_name,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-hostfile.txt", "parse_error_int", true, cur_hostfile_name,
                        prte_util_hostfile_line, token, prte_util_hostfile_value.ival);
         break;
     default:
-        prte_show_help("help-hostfile.txt", "parse_error", true, cur_hostfile_name,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-hostfile.txt", "parse_error", true, cur_hostfile_name,
                        prte_util_hostfile_line, token);
         break;
     }
@@ -126,7 +126,7 @@ static int hostfile_parse_username(const char *value, char **username, char **no
         *username = strdup(argv[0]);
         *node_name = strdup(argv[1]);
     } else {
-        prte_show_help("help-hostfile.txt", "user-host", true, cur_hostfile_name,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-hostfile.txt", "user-host", true, cur_hostfile_name,
                        prte_util_hostfile_line, value);
         PMIx_Argv_free(argv);
         return PRTE_ERR_SILENT;
@@ -348,7 +348,7 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
         case PRTE_HOSTFILE_PORT:
             rc = hostfile_parse_int();
             if (rc < 0) {
-                prte_show_help("help-hostfile.txt", "port", true, cur_hostfile_name, rc);
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-hostfile.txt", "port", true, cur_hostfile_name, rc);
                 return PRTE_ERR_SILENT;
             }
             prte_set_attribute(&node->attributes, PRTE_NODE_PORT, PRTE_ATTR_LOCAL, &rc, PMIX_INT);
@@ -359,7 +359,7 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
         case PRTE_HOSTFILE_SLOTS:
             rc = hostfile_parse_int();
             if (rc < 0) {
-                prte_show_help("help-hostfile.txt", "slots", true, cur_hostfile_name, rc);
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-hostfile.txt", "slots", true, cur_hostfile_name, rc);
                 pmix_list_remove_item(updates, &node->super);
                 PMIX_RELEASE(node);
                 return PRTE_ERR_SILENT;
@@ -368,7 +368,7 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
                 /* multiple definitions were given for the
                  * slot count - this is not allowed
                  */
-                prte_show_help("help-hostfile.txt", "slots-given", true, cur_hostfile_name,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-hostfile.txt", "slots-given", true, cur_hostfile_name,
                                node->name);
                 pmix_list_remove_item(updates, &node->super);
                 PMIX_RELEASE(node);
@@ -386,7 +386,7 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
         case PRTE_HOSTFILE_SLOTS_MAX:
             rc = hostfile_parse_int();
             if (rc < 0) {
-                prte_show_help("help-hostfile.txt", "max_slots", true, cur_hostfile_name,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-hostfile.txt", "max_slots", true, cur_hostfile_name,
                                ((size_t) rc));
                 pmix_list_remove_item(updates, &node->super);
                 PMIX_RELEASE(node);
@@ -399,7 +399,7 @@ static int hostfile_parse_line(int token, pmix_list_t *updates,
                     got_max = true;
                 }
             } else {
-                prte_show_help("help-hostfile.txt", "max_slots_lt", true, cur_hostfile_name,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-hostfile.txt", "max_slots_lt", true, cur_hostfile_name,
                                node->slots, rc);
                 pmix_list_remove_item(updates, &node->super);
                 PMIX_RELEASE(node);
@@ -458,7 +458,7 @@ static int hostfile_parse(const char *hostfile, pmix_list_t *updates, pmix_list_
      * below, which is where "no such file" - and the default-hostfile
      * exemption for it - is already handled. */
     if (0 == stat(hostfile, &sbuf) && !S_ISREG(sbuf.st_mode)) {
-        prte_show_help("help-hostfile.txt", "not-a-file", true, hostfile);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-hostfile.txt", "not-a-file", true, hostfile);
         rc = PRTE_ERR_SILENT;
         goto unlock;
     }
@@ -469,7 +469,7 @@ static int hostfile_parse(const char *hostfile, pmix_list_t *updates, pmix_list_
             /* not the default hostfile, so not finding it
              * is an error
              */
-            prte_show_help("help-hostfile.txt", "no-hostfile", true, hostfile);
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-hostfile.txt", "no-hostfile", true, hostfile);
             rc = PRTE_ERR_SILENT;
             goto unlock;
         }
@@ -477,7 +477,7 @@ static int hostfile_parse(const char *hostfile, pmix_list_t *updates, pmix_list_
          * then it's an error
          */
         if (prte_default_hostfile_given) {
-            prte_show_help("help-hostfile.txt", "no-hostfile", true, hostfile);
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-hostfile.txt", "no-hostfile", true, hostfile);
             rc = PRTE_ERR_NOT_FOUND;
             goto unlock;
         }
@@ -565,7 +565,7 @@ int prte_util_add_hostfile_nodes(pmix_list_t *nodes, char *hostfile)
     /* check for any relative node directives */
     PMIX_LIST_FOREACH(node, &adds, prte_node_t) {
         if ('+' == node->name[0]) {
-            prte_show_help("help-hostfile.txt", "hostfile:relative-syntax", true, node->name);
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-hostfile.txt", "hostfile:relative-syntax", true, node->name);
             rc = PRTE_ERR_SILENT;
             goto cleanup;
         }
@@ -737,7 +737,7 @@ int prte_util_filter_hostfile_nodes(pmix_list_t *nodes, char *hostfile, bool rem
                 }
                 /* did they get everything they wanted? */
                 if (!want_all_empty && 0 < num_empty) {
-                    prte_show_help("help-hostfile.txt", "hostfile:not-enough-empty", true,
+                    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-hostfile.txt", "hostfile:not-enough-empty", true,
                                    num_empty);
                     rc = PRTE_ERR_SILENT;
                     goto cleanup;
@@ -761,7 +761,7 @@ int prte_util_filter_hostfile_nodes(pmix_list_t *nodes, char *hostfile, bool rem
                 node_from_pool = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, nodeidx);
                 if (NULL == node_from_pool) {
                     /* this is an error */
-                    prte_show_help("help-hostfile.txt", "hostfile:relative-node-not-found", true,
+                    prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-hostfile.txt", "hostfile:relative-node-not-found", true,
                                    nodeidx, node_from_file->name);
                     rc = PRTE_ERR_SILENT;
                     goto cleanup;
@@ -785,7 +785,7 @@ int prte_util_filter_hostfile_nodes(pmix_list_t *nodes, char *hostfile, bool rem
                 }
             } else {
                 /* invalid relative node syntax */
-                prte_show_help("help-hostfile.txt", "hostfile:invalid-relative-node-syntax", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-hostfile.txt", "hostfile:invalid-relative-node-syntax", true,
                                node_from_file->name);
                 rc = PRTE_ERR_SILENT;
                 goto cleanup;
@@ -852,7 +852,7 @@ int prte_util_filter_hostfile_nodes(pmix_list_t *nodes, char *hostfile, bool rem
              * user and abort
              */
             if (!found) {
-                prte_show_help("help-hostfile.txt", "hostfile:extra-node-not-found", true, hostfile,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-hostfile.txt", "hostfile:extra-node-not-found", true, hostfile,
                                node_from_file->name);
                 rc = PRTE_ERR_SILENT;
                 goto cleanup;
@@ -867,7 +867,7 @@ int prte_util_filter_hostfile_nodes(pmix_list_t *nodes, char *hostfile, bool rem
      * This is an error - report it to the user and return an error
      */
     if (0 != pmix_list_get_size(&newnodes)) {
-        prte_show_help("help-hostfile.txt", "not-all-mapped-alloc", true, hostfile);
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-hostfile.txt", "not-all-mapped-alloc", true, hostfile);
         rc = PRTE_ERR_SILENT;
         goto cleanup;
     }
@@ -988,7 +988,7 @@ int prte_util_get_ordered_host_list(pmix_list_t *nodes, char *hostfile)
             startempty = i;
             /* did they get everything they wanted? */
             if (!want_all_empty && 0 < num_empty) {
-                prte_show_help("help-hostfile.txt", "hostfile:not-enough-empty", true, num_empty);
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-hostfile.txt", "hostfile:not-enough-empty", true, num_empty);
                 rc = PRTE_ERR_SILENT;
                 goto cleanup;
             }
@@ -1013,7 +1013,7 @@ int prte_util_get_ordered_host_list(pmix_list_t *nodes, char *hostfile)
             node_from_pool = (prte_node_t *) pmix_pointer_array_get_item(prte_node_pool, nodeidx);
             if (NULL == node_from_pool) {
                 /* this is an error */
-                prte_show_help("help-hostfile.txt", "hostfile:relative-node-not-found", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-hostfile.txt", "hostfile:relative-node-not-found", true,
                                nodeidx, node->name);
                 rc = PRTE_ERR_SILENT;
                 goto cleanup;
@@ -1044,7 +1044,7 @@ int prte_util_get_ordered_host_list(pmix_list_t *nodes, char *hostfile)
             PMIX_RELEASE(item2);
         } else {
             /* invalid relative node syntax */
-            prte_show_help("help-hostfile.txt", "hostfile:invalid-relative-node-syntax", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-hostfile.txt", "hostfile:invalid-relative-node-syntax", true,
                            node->name);
             rc = PRTE_ERR_SILENT;
             goto cleanup;

--- a/src/util/prte_bootstrap.c
+++ b/src/util/prte_bootstrap.c
@@ -137,7 +137,7 @@ int prte_bootstrap_parse(prte_bootstrap_config_t *cfg)
     path = pmix_os_path(false, prte_install_dirs.sysconfdir, "prte.conf", NULL);
     fp = fopen(path, "r");
     if (NULL == fp) {
-        prte_show_help("help-prte-runtime.txt", "bootstrap-not-found", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "bootstrap-not-found", true,
                        prte_process_info.nodename, path);
         free(path);
         return PRTE_ERR_SILENT;
@@ -151,7 +151,7 @@ int prte_bootstrap_parse(prte_bootstrap_config_t *cfg)
         }
         /* split on the '=' sign */
         if (NULL == (ptr = strchr(line, '='))) {
-            prte_show_help("help-prte-runtime.txt", "bootstrap-bad-entry", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "bootstrap-bad-entry", true,
                            prte_process_info.nodename, path, line);
             free(line);
             fclose(fp);
@@ -160,7 +160,7 @@ int prte_bootstrap_parse(prte_bootstrap_config_t *cfg)
         *ptr = '\0';
         if (0 == strlen(line)) { // missing the field name
             *ptr = '=';
-            prte_show_help("help-prte-runtime.txt", "bootstrap-missing-field-name", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "bootstrap-missing-field-name", true,
                            prte_process_info.nodename, path, ptr);
             free(line);
             fclose(fp);
@@ -168,7 +168,7 @@ int prte_bootstrap_parse(prte_bootstrap_config_t *cfg)
         }
         ++ptr;
         if ('\0' == *ptr) { // missing the value
-            prte_show_help("help-prte-runtime.txt", "bootstrap-missing-value", true,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "bootstrap-missing-value", true,
                            prte_process_info.nodename, path, line);
             free(line);
             fclose(fp);
@@ -248,26 +248,26 @@ int prte_bootstrap_parse(prte_bootstrap_config_t *cfg)
 
     /* we require the node list */
     if (NULL == dvmnodes) {
-        prte_show_help("help-prte-runtime.txt", "bootstrap-missing-entry", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "bootstrap-missing-entry", true,
                        prte_process_info.nodename, path, "DVMNodes");
         goto cleanup;
     }
     /* we must be able to parse that list */
     ret = regex_extract_nodes(dvmnodes, &cfg->nodes);
     if (PMIX_SUCCESS != ret) {
-        prte_show_help("help-prte-runtime.txt", "bootstrap-bad-nodelist", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "bootstrap-bad-nodelist", true,
                        prte_process_info.nodename, path, dvmnodes, PMIx_Error_string(ret));
         goto cleanup;
     }
     /* we must have the controller host so we can find it */
     if (NULL == cfg->ctrlhost) {
-        prte_show_help("help-prte-runtime.txt", "bootstrap-missing-entry", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "bootstrap-missing-entry", true,
                        prte_process_info.nodename, path, "DVMControllerHost");
         goto cleanup;
     }
     /* the IP version must be sane */
     if (4 != cfg->ip_version && 6 != cfg->ip_version) {
-        prte_show_help("help-prte-runtime.txt", "bootstrap-bad-entry", true,
+        prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "bootstrap-bad-entry", true,
                        prte_process_info.nodename, path, "DVMIPVersion");
         goto cleanup;
     }
@@ -287,7 +287,7 @@ int prte_bootstrap_parse(prte_bootstrap_config_t *cfg)
                 /* no nodename here: this runs before the hostname is
                  * established, which is why the sibling messages in this
                  * function report it as "(null)" */
-                prte_show_help("help-prte-runtime.txt", "bootstrap-duplicate-node", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "bootstrap-duplicate-node", true,
                                path, cfg->nodes[i]);
                 goto cleanup;
             }

--- a/src/util/prte_show_help.c
+++ b/src/util/prte_show_help.c
@@ -40,14 +40,15 @@
  * output and has nowhere else to go when no tool is subscribed. Both callers
  * below reached a point where they had concluded the message was theirs to
  * show; without this it was simply dropped. */
-static void deliver_locally(const char *filename, const char *topic,
-                            const char *output, bool emit_directly)
+static void deliver_locally(const char *nspace, const char *filename,
+                            const char *topic, const char *output,
+                            bool emit_directly)
 {
     if (emit_directly) {
         fprintf(stderr, "%s", output);
         fflush(stderr);
     }
-    pmix_show_help_norender(filename, topic, output);
+    pmix_show_help_norender(nspace, filename, topic, output);
 }
 
 /* Carries a rendered message from whatever thread produced it over to the
@@ -61,6 +62,7 @@ static void deliver_locally(const char *filename, const char *topic,
 typedef struct {
     pmix_object_t super;
     prte_event_t ev;
+    pmix_nspace_t nspace;
     char *filename;
     char *topic;
     char *output;
@@ -68,6 +70,7 @@ typedef struct {
 
 static void shcon(prte_show_help_caddy_t *p)
 {
+    PMIX_LOAD_NSPACE(p->nspace, NULL);
     p->filename = NULL;
     p->topic = NULL;
     p->output = NULL;
@@ -100,8 +103,15 @@ static void relay_to_hnp(int sd, short args, void *cbdata)
     PMIX_ACQUIRE_OBJECT(cd);
 
     PMIX_DATA_BUFFER_CREATE(buf);
-    /* the filename and topic travel with the text: the HNP needs them to
-     * key duplicate suppression, and they are what identify the message */
+    /* The job, filename and topic travel with the text: the HNP needs all
+     * three to key duplicate suppression, and the last two are what
+     * identify the message.  A DVM is single-version by rule, so this
+     * wire has no format marker - packer and unpacker change together or
+     * not at all (see prte_show_help_recv). */
+    prc = PMIx_Data_pack(NULL, buf, &cd->nspace, 1, PMIX_PROC_NSPACE);
+    if (PMIX_SUCCESS != prc) {
+        goto fallback;
+    }
     prc = PMIx_Data_pack(NULL, buf, &cd->filename, 1, PMIX_STRING);
     if (PMIX_SUCCESS != prc) {
         goto fallback;
@@ -122,19 +132,19 @@ static void relay_to_hnp(int sd, short args, void *cbdata)
     if (PRTE_SUCCESS != rc) {
         PMIX_DATA_BUFFER_RELEASE(buf);
         /* the relay is what would have shown it, and it did not go */
-        deliver_locally(cd->filename, cd->topic, cd->output, true);
+        deliver_locally(cd->nspace, cd->filename, cd->topic, cd->output, true);
     }
     PMIX_RELEASE(cd);
     return;
 
 fallback:
     PMIX_DATA_BUFFER_RELEASE(buf);
-    deliver_locally(cd->filename, cd->topic, cd->output, true);
+    deliver_locally(cd->nspace, cd->filename, cd->topic, cd->output, true);
     PMIX_RELEASE(cd);
 }
 
-int prte_show_help(const char *filename, const char *topic,
-                   int want_error_header, ...)
+int prte_show_help(const pmix_nspace_t nspace, const char *filename,
+                   const char *topic, int want_error_header, ...)
 {
     va_list arglist;
     char *output;
@@ -163,7 +173,7 @@ int prte_show_help(const char *filename, const char *topic,
          * goes false again on every grow, and a grow is exactly when these
          * messages fire. A tool or an application is its own endpoint and
          * PMIx writes for it. */
-        deliver_locally(filename, topic, output,
+        deliver_locally(nspace, filename, topic, output,
                         prte_persistent && !prte_dvm_started);
         free(output);
         return PRTE_SUCCESS;
@@ -179,7 +189,7 @@ int prte_show_help(const char *filename, const char *topic,
          * PMIX_IOF_LOCAL_OUTPUT=false, so handing this to PMIx is handing it
          * nowhere, and we have just established there is no HNP to relay to
          * either. Our stderr may well still be connected */
-        deliver_locally(filename, topic, output, true);
+        deliver_locally(nspace, filename, topic, output, true);
         free(output);
         return PRTE_SUCCESS;
     }
@@ -188,6 +198,7 @@ int prte_show_help(const char *filename, const char *topic,
      * one of the odls spawn-pool threads - render_child_msg() is called
      * from there - and the RML is progress-thread-only state. */
     cd = PMIX_NEW(prte_show_help_caddy_t);
+    PMIX_LOAD_NSPACE(cd->nspace, nspace);
     cd->filename = (NULL == filename) ? NULL : strdup(filename);
     cd->topic = (NULL == topic) ? NULL : strdup(topic);
     cd->output = output; /* the caddy takes it */
@@ -200,10 +211,19 @@ void prte_show_help_recv(int status, pmix_proc_t *sender,
                          prte_rml_tag_t tag, void *cbdata)
 {
     char *filename = NULL, *topic = NULL, *output = NULL;
+    pmix_nspace_t nspace;
     int32_t cnt;
     pmix_status_t rc;
     PRTE_HIDE_UNUSED_PARAMS(status, tag, cbdata);
 
+    /* see the packer in relay_to_hnp: this wire carries no format
+     * marker, so the two change together */
+    cnt = 1;
+    rc = PMIx_Data_unpack(NULL, buffer, &nspace, &cnt, PMIX_PROC_NSPACE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
     cnt = 1;
     rc = PMIx_Data_unpack(NULL, buffer, &filename, &cnt, PMIX_STRING);
     if (PMIX_SUCCESS != rc) {
@@ -237,7 +257,7 @@ void prte_show_help_recv(int status, pmix_proc_t *sender,
          * one of our own: quiet once a tool is there to receive it, direct
          * while we are still starting and the terminal is all there is - a
          * daemon that fails to launch during DVM startup lands here */
-        deliver_locally(filename, topic, output,
+        deliver_locally(nspace, filename, topic, output,
                         prte_persistent && !prte_dvm_started);
     }
 

--- a/src/util/prte_show_help.h
+++ b/src/util/prte_show_help.h
@@ -38,13 +38,24 @@ BEGIN_C_DECLS
  * So: on the HNP, on a tool, or in an application, deliver locally exactly
  * as pmix_show_help() would.  On any other daemon, ship the rendered text
  * to the HNP over the RML and let it do the delivering.  Aggregation and
- * duplicate suppression still happen once, on the HNP, keyed by the same
- * filename/topic pair - which is better than per-node suppression anyway.
+ * duplicate suppression still happen once, on the HNP - which is better
+ * than per-node suppression anyway.
+ *
+ * The nspace names the job the message is ABOUT, and it is what scopes
+ * that suppression.  It is not optional and it is not decoration: a DVM
+ * runs many jobs, in parallel and one after another for as long as it
+ * lives, and suppression keyed on the message alone told only the first
+ * job to trip a diagnostic about it - every later one got silence, for
+ * days.  Pass the job the message concerns; where the message is about
+ * the DVM itself, a tool, or the command line rather than about any
+ * job - a parse error, a startup failure - pass
+ * PRTE_PROC_MY_NAME->nspace, which is that job.
  *
  * Use this, not pmix_show_help(), for any message that a daemon can
  * produce.  It is safe (and identical) everywhere else.
  */
-PRTE_EXPORT int prte_show_help(const char *filename, const char *topic,
+PRTE_EXPORT int prte_show_help(const pmix_nspace_t nspace,
+                               const char *filename, const char *topic,
                                int want_error_header, ...);
 
 /* HNP-side receiver for the relayed text. Registered by the PMIx server

--- a/src/util/session_dir.c
+++ b/src/util/session_dir.c
@@ -211,7 +211,7 @@ static int setup_base(void)
             /* check if prefix matches */
             if (0 == strncmp(prte_process_info.tmpdir_base, list[i], strlen(list[i]))) {
                 /* this is a prohibited location */
-                prte_show_help("help-prte-runtime.txt", "prte:session:dir:prohibited", true,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-runtime.txt", "prte:session:dir:prohibited", true,
                                prte_process_info.tmpdir_base, prte_prohibited_session_dirs);
                 PMIx_Argv_free(list);
                 return PRTE_ERR_FATAL;

--- a/src/util/stacktrace.c
+++ b/src/util/stacktrace.c
@@ -724,7 +724,7 @@ int prte_util_register_stackhandlers(void)
          *  Similarly for any number which is not in the signal-number range
          */
         if (((0 == sig) && (tmp == next)) || (0 > sig) || (_NSIG <= sig)) {
-            prte_show_help("help-prte-util.txt", "stacktrace bad signal", true, prte_signal_string,
+            prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-util.txt", "stacktrace bad signal", true, prte_signal_string,
                            tmp);
             return PRTE_ERR_SILENT;
         } else if (next == NULL) {
@@ -747,7 +747,7 @@ int prte_util_register_stackhandlers(void)
                 /* JMS This is icky; there is no error message
                    aggregation here so this message may be repeated for
                    every single MPI process... */
-                prte_show_help("help-prte-util.txt", "stacktrace signal override", true, sig, sig,
+                prte_show_help(PRTE_PROC_MY_NAME->nspace, "help-prte-util.txt", "stacktrace signal override", true, sig, sig,
                                sig, prte_signal_string);
                 showed_help = true;
             }

--- a/test/unit/check_query_authority.py
+++ b/test/unit/check_query_authority.py
@@ -19,16 +19,25 @@
 # default-constructed zero, which is indistinguishable from a real answer
 # and is returned to the client as one.
 #
+# A daemon's copy of a job is stale in the same way, in one place: it
+# holds a prte_proc_t for every proc of the job, but it advances pid,
+# state and exit_code only for the procs it hosts.  Nothing carries a peer
+# daemon's proc states back down the tree - only the master is told - so
+# an entry for a proc on another node reports what the launch message
+# shipped for the life of the DVM.  That is how PMIX_QUERY_PROC_TABLE came
+# to report a rank that had exited long ago as one that had not started.
+#
 # pmix_server_queries.c therefore reaches that state only through the
 # accessors in src/runtime/prte_globals.c, which return
-# PRTE_ERR_NOT_AUTHORITATIVE off the master so the key can be relayed to
-# it.  This checks that it still does.  The rule cannot be enforced by
-# the compiler - the fields are ordinary members of a struct the file
-# legitimately uses for node *identity* - so it is enforced here.
+# PRTE_ERR_NOT_AUTHORITATIVE where the answer is not authoritative so the
+# key can be relayed to the master.  This checks that it still does.  The
+# rule cannot be enforced by the compiler - the fields are ordinary
+# members of structs the file legitimately uses for node and proc
+# *identity* - so it is enforced here.
 #
 # Deliberately not a list of query keys.  Which keys need the master is
 # not knowable in advance and goes stale the moment someone adds one;
-# which *reads* cannot be satisfied locally is exactly the set below.
+# which *reads* cannot be satisfied locally is exactly the sets below.
 
 import os
 import re
@@ -42,6 +51,16 @@ SESSIONS = "prte_sessions"
 ACCESSORS = ("prte_get_allocated_nodes",
              "prte_get_allocation_session",
              "prte_get_allocation_sessions")
+
+# The proc half.  ->state is no good as a marker here because prte_node_t
+# has one too and this file reads it legitimately (inside a branch the
+# rule above already gates).  ->pid and ->exit_code belong to no other
+# struct the file touches, and prte_pmix_convert_state() takes a PRRTE
+# PROC state and nothing else - so those three name a proc's runtime
+# state unambiguously, which is what the checker needs.
+PROC_RUNTIME = (r"->\s*pid\b", r"->\s*exit_code\b",
+                r"\bprte_pmix_convert_state\s*\(")
+PROC_ACCESSOR = "prte_get_proc_runtime_state"
 
 TARGET = os.path.join("src", "prted", "pmix", "pmix_server_queries.c")
 
@@ -101,6 +120,23 @@ def main():
                       "PRTE_ERR_NOT_AUTHORITATIVE"
                       % (TARGET, n, hit.group(1), ", ".join(ACCESSORS)))
 
+    # The same rule for a proc's runtime fields, in the same per-branch
+    # shape: a branch that reports whether a proc is alive, what its pid
+    # is, or how it exited has to have settled authority first.
+    runtime = re.compile("|".join(PROC_RUNTIME))
+    for offset, chunk in chunks:
+        text = "".join(chunk)
+        hit = runtime.search(text)
+        if hit is None:
+            continue
+        if PROC_ACCESSOR in text:
+            continue
+        n = offset + text[:hit.start()].count("\n") + 1
+        errors.append("%s:%d: reports a proc's runtime state without first "
+                      "establishing authority; read it through %s() and "
+                      "defer on PRTE_ERR_NOT_AUTHORITATIVE"
+                      % (TARGET, n, PROC_ACCESSOR))
+
     if errors:
         for e in errors:
             print(e)
@@ -108,7 +144,7 @@ def main():
               "query_complete() in %s." % (len(errors), TARGET))
         return 1
 
-    print("check_query_authority: %s reaches master-only state only "
+    print("check_query_authority: %s reaches state it may not hold only "
           "through the accessors" % TARGET)
     return 0
 

--- a/test/unit/ras/test_ras.c
+++ b/test/unit/ras/test_ras.c
@@ -1780,6 +1780,52 @@ static int test_spawn_alloc(void)
 }
 
 
+/*
+ * ras/slurm's release path skips the HNP's node via prte_quickmatch().
+ * node_insert() truncates a fully qualified domain name to the short name
+ * and keeps the full one as an alias, so a strcmp on the pool entry's name
+ * would miss it and the guard would silently stop protecting anything.
+ */
+static int test_hnp_locality_match(void)
+{
+    int failures = 0;
+    prte_node_t *nd;
+    char *save;
+    char *fqdn;
+
+    save = prte_process_info.nodename;
+    prte_process_info.nodename = strdup("prte-unit-test-hnp");
+
+    /* the short name the pool would hold */
+    nd = PMIX_NEW(prte_node_t);
+    nd->name = strdup("prte-unit-test-hnp");
+    CHECK("hnp match: short name",
+          prte_quickmatch(nd, prte_process_info.nodename));
+    PMIX_RELEASE(nd);
+
+    /* the shape normalize_node() leaves behind: the case a strcmp misses */
+    nd = PMIX_NEW(prte_node_t);
+    nd->name = strdup("prte-unit-test-hnp");
+    fqdn = strdup("prte-unit-test-hnp.unit.test");
+    nd->rawname = strdup(fqdn);
+    PMIx_Argv_append_nosize(&nd->aliases, fqdn);
+    free(prte_process_info.nodename);
+    prte_process_info.nodename = fqdn;
+    CHECK("hnp match: qualified name resolves through the alias",
+          prte_quickmatch(nd, prte_process_info.nodename));
+    PMIX_RELEASE(nd);
+
+    nd = PMIX_NEW(prte_node_t);
+    nd->name = strdup("prte-unit-test-other");
+    CHECK("hnp match: unrelated node does not match",
+          !prte_quickmatch(nd, prte_process_info.nodename));
+    PMIX_RELEASE(nd);
+
+    free(prte_process_info.nodename);
+    prte_process_info.nodename = save;
+    return failures;
+}
+
 /* A reservation torn down while a job is still running in it.
  *
  * Teardown deregisters the session, which puts it beyond every later sweep
@@ -1910,6 +1956,7 @@ int main(void)
     failures += test_activate_nodes();
     failures += test_spawn_alloc();
     failures += test_teardown_reservation();
+    failures += test_hnp_locality_match();
     /* after test_select(), which opens the framework and latches a
      * selection made with no SLURM allocation in the environment -- so
      * nothing has called slurm's init() before this does */

--- a/test/unit/runtime/test_runtime.c
+++ b/test/unit/runtime/test_runtime.c
@@ -470,6 +470,89 @@ static int test_proc_lookups(void)
 }
 
 /* ------------------------------------------------------------------ */
+/* proc runtime-state authority                                       */
+/* ------------------------------------------------------------------ */
+
+/* A daemon's copy of a job carries a prte_proc_t for every proc, but it
+ * only ever advances pid, state and exit_code for the procs it hosts:
+ * nothing sends a peer daemon's updates back down the tree, because no
+ * daemon needs them.  So the entry for a proc on another node keeps the
+ * launch message's snapshot for the life of the DVM, and reading it
+ * yields a plausible-looking lie - PMIX_QUERY_PROC_TABLE reported a rank
+ * that had exited long ago as one that had not started yet.
+ *
+ * prte_get_proc_runtime_state() is the gate: the master hears about every
+ * proc, a daemon only about its own. */
+static int test_proc_runtime_authority(void)
+{
+    int failures = 0;
+    prte_proc_t *local, *remote;
+    prte_proc_state_t state;
+    prte_exit_code_t code;
+    pid_t pid;
+    prte_proc_type_t saved;
+
+    reset_globals();
+
+    local = PMIX_NEW(prte_proc_t);
+    PMIX_LOAD_PROCID(&local->name, "app.job", 0);
+    local->state = PRTE_PROC_STATE_TERMINATED;
+    local->pid = 4242;
+    local->exit_code = 7;
+    PRTE_FLAG_SET(local, PRTE_PROC_FLAG_LOCAL);
+
+    remote = PMIX_NEW(prte_proc_t);
+    PMIX_LOAD_PROCID(&remote->name, "app.job", 1);
+    remote->state = PRTE_PROC_STATE_INIT;
+    remote->pid = 0;
+    remote->exit_code = 0;
+
+    /* main() initialized this process as the master */
+    saved = prte_process_info.proc_type;
+    CHECK("runtime: the harness starts out as the master", PRTE_PROC_IS_MASTER);
+
+    state = PRTE_PROC_STATE_UNDEF;
+    pid = -1;
+    code = -1;
+    CHECK("runtime: the master answers for a proc it hosts",
+          PRTE_SUCCESS == prte_get_proc_runtime_state(local, &state, &pid, &code));
+    CHECK("runtime: ...with that proc's state", PRTE_PROC_STATE_TERMINATED == state);
+    CHECK("runtime: ...its pid", 4242 == pid);
+    CHECK("runtime: ...and its exit code", 7 == code);
+
+    CHECK("runtime: the master answers for a proc it does not host",
+          PRTE_SUCCESS == prte_get_proc_runtime_state(remote, &state, &pid, &code));
+
+    /* now stand where a prted stands */
+    prte_process_info.proc_type = PRTE_PROC_DAEMON;
+    CHECK("runtime: a daemon answers for its own child",
+          PRTE_SUCCESS == prte_get_proc_runtime_state(local, &state, &pid, &code));
+    CHECK("runtime: ...with the state it recorded", PRTE_PROC_STATE_TERMINATED == state);
+
+    state = PRTE_PROC_STATE_UNDEF;
+    pid = -1;
+    code = -1;
+    CHECK("runtime: a daemon refuses a proc it does not host",
+          PRTE_ERR_NOT_AUTHORITATIVE
+              == prte_get_proc_runtime_state(remote, &state, &pid, &code));
+    /* a refusal that had written the stale values first would leave the
+     * caller with exactly the plausible lie the gate exists to stop */
+    CHECK("runtime: ...having touched nothing",
+          PRTE_PROC_STATE_UNDEF == state && -1 == pid && -1 == code);
+
+    CHECK("runtime: every out parameter is optional",
+          PRTE_SUCCESS == prte_get_proc_runtime_state(local, NULL, NULL, NULL));
+    CHECK("runtime: a NULL proc is rejected",
+          PRTE_ERR_BAD_PARAM == prte_get_proc_runtime_state(NULL, &state, &pid, &code));
+
+    prte_process_info.proc_type = saved;
+    PMIX_RELEASE(local);
+    PMIX_RELEASE(remote);
+    reset_globals();
+    return failures;
+}
+
+/* ------------------------------------------------------------------ */
 /* node matching                                                      */
 /* ------------------------------------------------------------------ */
 
@@ -2015,6 +2098,7 @@ int main(void)
     failures += test_session_ownership();
     failures += test_session_job_backref();
     failures += test_proc_lookups();
+    failures += test_proc_runtime_authority();
     failures += test_node_matching();
     failures += test_node_copy();
     failures += test_app_copy();


### PR DESCRIPTION
[ras/slurm: match the HNP's node by locality when releasing](https://github.com/openpmix/prrte/commit/1cb81e85a6a00e322e35c24ce24094554390dfd6)

Identify the node hosting the HNP with prte_quickmatch() against
prte_process_info.nodename and skip it in both release paths, whatever
session holds it: handing that node back to Slurm kills the DVM.
Locality is what the question needs, since node_insert() shortens a
fully qualified domain name and keeps the full one as an alias, so a
pool entry can answer to a spelling the request does not use.
session_removable_count() keeps its reserve, which stops a shrink
emptying a Slurm job, and where the HNP's node is in the session that
reserve is that node. Also log the node selection failure in the
counted path, where PRTE_ERR_NOT_FOUND on its own reads at the console
like "no releasable session found".

Credits: AccelCom @ Barcelona Supercomputing Center

Signed-off-by: Petter Sandås <petter.sandas@bsc.es>
(cherry picked from commit https://github.com/openpmix/prrte/commit/e784422b8cd3b22533bed942ec0037dfc23d22b9)

[Answer a proc table from state the answering daemon actually has](https://github.com/openpmix/prrte/commit/863e70f5ebf8c7a1c32e02a84e7220595b6f0275)

A daemon holds a prte_proc_t for every proc of a job it hosts part of --
the launch message ships the whole array, pid, state and exit_code
included -- but from then on it advances those three fields for its own
local children and for nothing else.  Proc states travel up to the
master in PRTE_PLM_UPDATE_PROC_STATE and are never sent back down,
because no daemon needs a peer's.  So an entry for a proc on another
node keeps the state the launch message shipped for the life of the DVM.

PMIX_QUERY_PROC_TABLE was answered out of that array wherever it was
asked, so a client whose local PMIx server is not the DVM master was
told that every off-node rank of its own job was still
PMIX_PROC_STATE_LAUNCH_UNDERWAY -- the conversion of
PRTE_PROC_STATE_INIT -- including ranks that had exited long ago.  The
master's table was correct all along, and updated within milliseconds of
an exit, so whether a client got the truth depended on where it happened
to land.  That table is the only signal PRRTE offers for "has this proc
gone away": PMIX_EVENT_PROC_TERMINATED is not implemented, so an
application that must know whether the procs on a node have finished --
before asking the DVM to release that node from an elastic allocation,
say -- had no correct answer unless it was co-located with the master.

The file already decides what it may answer by the *read* rather than by
a list of keys, precisely because such a list goes stale silently.  What
was missing was a read to decide on: jdata->procs is present on every
daemon and merely stale, which is the failure the block comment warns
about -- a default-constructed value that reads exactly like a real
answer.  So give those three fields the same gate the allocation state
has.  prte_get_proc_runtime_state() succeeds on the master, and on a
daemon only for a proc that daemon hosts; anywhere else it returns
PRTE_ERR_NOT_AUTHORITATIVE having touched nothing.  The proc-table arm
reads through it and jumps to the existing defer: label on the first
proc it does not host, so the whole key goes to the master and its reply
is merged back.  It defers on the first such proc rather than filling in
what it can, because half a table from here and half from the master
would be one answer whose entries disagree about what "now" means.

PMIX_QUERY_LOCAL_PROC_TABLE reads the same fields through the same
accessor and never defers: it visits only procs flagged
PRTE_PROC_FLAG_LOCAL, which is exactly the condition under which the
accessor succeeds.  It must not defer -- relaying it would answer about
the master's local procs.

check_query_authority.py grows the matching rule, keyed off ->pid,
->exit_code and prte_pmix_convert_state() because ->state alone cannot
be told from a node's.  The unit test pins down that a refusal writes
nothing, since a refusal that filled in the stale values first would
hand the caller the exact lie the gate exists to stop.  The multi-node
case runs the querier once on a non-master node and once on the master:
the master was right before this change, so a case that asks only one
placement cannot tell a fix from a daemon that stopped answering.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/3f2df65b53ac6f648a3adfa1e27fc8a87e792708)

[Ask the master about a job a daemon has never heard of](https://github.com/openpmix/prrte/commit/910e5039edf2683b38f97b11d12b5a84bba0b9c0)

A job's launch message goes only to the daemons that host part of it, so
a prted has no job object for a job that landed entirely elsewhere.  The
PMIX_QUERY_PROC_TABLE arm read that as PMIX_ERR_NOT_FOUND and told the
client so, which is the same defect the arm's proc states had: an answer
that depends on which daemon the client happens to be attached to rather
than on anything about the job.  "I have never heard of this job" is a
statement about this daemon; the master has heard of all of them.

So off the master, an unknown or empty job defers the key instead of
refusing it.  PMIX_QUERY_LOCAL_PROC_TABLE keeps answering NOT_FOUND
there, because for it that genuinely is the answer -- it was asked which
of that job's procs this daemon is hosting, and it is hosting none.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/59fc0132390e36810548aaa8d7febd6a0bcf731a)

[Say why a daemon batches its proc-termination report](https://github.com/openpmix/prrte/commit/0f424488fcf0e859140ac77f69708eed7274fbbe)

The component's notes describe the report-once machinery in detail - the
skip_reported flag, PRTE_PROC_FLAG_TERM_REPORTED, the comparison against
num_local_procs - without ever saying why the report waits for the whole
node rather than going out as each proc exits.  That silence reads as an
oversight rather than a decision, and the visible consequence invites
someone to "fix" it: a rank that exits early is reported as alive, from
the master as much as from anywhere, until its node-mates finish.

It is a decision.  Reporting each termination as it happened would put
one message on the wire per terminated proc, and at the scales PRRTE runs
at that storm costs far more than the earlier notice is worth.  Write it
down, along with the reason the coarseness is rarely felt - the batch
boundary coincides with "every proc on this node is gone", which is the
question anything waiting on the report is actually asking - and the
contrast with abnormal terminations, which errmgr/prted does report one
at a time because they are rare and the HNP must act on them at once.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/b5246968557db7afaf272bde7190ff6a52f2694b)

[Give every show_help message the job it is about](https://github.com/openpmix/prrte/commit/63ac3c2aa728ae09ebbdb5834b8666af43617907)

PMIx keys show_help duplicate suppression on the job now, so every
message has to name one.  prte_show_help() takes an nspace as its first
argument and all 484 call sites pass one.

Which one is the whole point.  A DVM is a process that runs many jobs, in
parallel and one after another for as long as it lives, and suppression
that could not tell them apart told the first job to trip a diagnostic
about it and left every later one in silence - for days, on a persistent
DVM.  Naming the job restores each job's own first sighting of each
message.

Most messages are about the DVM or the tool rather than about any job a
user submitted: command-line parsing, startup failures, daemon launch.
Those pass PRTE_PROC_MY_NAME->nspace, which *is* that job - a global
reachable anywhere, so there is no site that cannot answer.  The ones
that stem from a particular job say so: all of rmaps, because a mapping
failure is a failure to map one job; the binding-policy parsing in
src/hwloc for the same reason; spawn requests; allocation; file
pre-positioning; the odls binding and launch paths; the state and errmgr
reports of a job ending; and connected-term, which was the message that
exposed all of this - it names the terminated job in its own text and
now scopes its suppression the same way.

Those sites go through PRTE_JOB_NSPACE(), which answers our own job for a
NULL.  That is not defensive habit: policy parsing takes NULL for "set
the DVM-wide default rather than this job's value" and branches on it, so
a bare jdata->nspace at those sites is a null dereference on the error
path - the one path nobody exercises.  prte_state_base_orphaned_proc()
takes the proc's own nspace instead, since that function exists precisely
because the job object is already gone and the report is still about that
job.

The relay to the HNP carries the nspace alongside the filename and topic.
A DVM is single-version by rule, so that wire has no format marker and
the packer and unpacker change together here.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/e2589f6aa7bd3efb7cbcbc355e39e2d8f2bfb59c)

[Say which job a show_help message must name](https://github.com/openpmix/prrte/commit/c751e4aec559d3f329fc98af33c14d7181697ef8)

The util notes describe prte_show_help() as having the same signature as
pmix_show_help(), which is no longer true, and say suppression is keyed
by filename and topic, which is the thing that changed. Record the new
first argument, what to pass where, and in particular why the job-scoped
sites go through PRTE_JOB_NSPACE() rather than dereferencing jdata: the
NULL those sites can see is a deliberate 'use the DVM-wide default'
rather than an error, so the crash would land on the error path.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit https://github.com/openpmix/prrte/commit/f9ee7c5d57b868d1f563d5edd39ff61e2d59a0ac)
