### PR TITLE
Fix loss of hardening flags (incl. CET) in hostfile/rank_file lexers

### DIFF
--- a/config/prte_setup_cc.m4
+++ b/config/prte_setup_cc.m4
@@ -402,6 +402,14 @@ AC_DEFUN([PRTE_SETUP_CC],[
     PRTE_ENSURE_CONTAINS_OPTFLAGS("$PRTE_CFLAGS_BEFORE_PICKY")
     PRTE_CFLAGS_BEFORE_PICKY="$co_result"
 
+    # PRTE_CFLAGS_BEFORE_PICKY is used by Makefile.am's in directories
+    # that do not want "picky" compiler flags (e.g., because they
+    # contain flex-generated code).  It must be AC_SUBST'ed so that
+    # those Makefiles actually receive a value instead of silently
+    # compiling with an empty CFLAGS (which drops all hardening
+    # flags, such as those for control-flow protection).
+    AC_SUBST([PRTE_CFLAGS_BEFORE_PICKY])
+
     AC_MSG_CHECKING([for C optimization flags])
     PRTE_ENSURE_CONTAINS_OPTFLAGS(["$CFLAGS"])
     AC_MSG_RESULT([$co_result])

--- a/src/mca/rmaps/rank_file/Makefile.am
+++ b/src/mca/rmaps/rank_file/Makefile.am
@@ -31,7 +31,7 @@ AM_LFLAGS = -Pprte_rmaps_rank_file_
 LEX_OUTPUT_ROOT = lex.prte_rmaps_rank_file_
 
 # we do NOT want picky compilers down here due to flex
-CFLAGS = $(PMIX_CFLAGS_BEFORE_PICKY)
+CFLAGS = $(PRTE_CFLAGS_BEFORE_PICKY)
 
 sources = \
         rmaps_rank_file.c \


### PR DESCRIPTION
## Summary

`src/util/hostfile/Makefile.am` and `src/mca/rmaps/rank_file/Makefile.am` each reset `CFLAGS` for their directory to avoid "picky" compiler warnings on flex-generated code, using `$(PRTE_CFLAGS_BEFORE_PICKY)` and `$(PMIX_CFLAGS_BEFORE_PICKY)` respectively. Neither variable is ever `AC_SUBST`'ed (and `PMIX_CFLAGS_BEFORE_PICKY` does not even exist in PRRTE — it looks like it was copied over from PMIx), so `CFLAGS` silently becomes empty for `hostfile.c`, `hostfile_lex.c`, `rmaps_rank_file.c`, `rmaps_rank_file_component.c`, and `rmaps_rank_file_lex.c`.

This drops every hardening flag normally injected by the build environment (`-O2`, `-fstack-protector-strong`, `-D_FORTIFY_SOURCE`, `-fcf-protection`, etc.) for those five files. On a distro that hardens with Intel CET, since those objects end up without a `.note.gnu.property` section, the linker strips CET (IBT/SHSTK) from the *entire* resulting `libprrte.so`, not just those object files — this is how we noticed it, via a Fedora `annocheck` hardening-check failure (`cf-protection`/`property-note` FAIL) on the whole library.

This fixes it by:
- `AC_SUBST`ing `PRTE_CFLAGS_BEFORE_PICKY` in `config/prte_setup_cc.m4`, so it's actually usable as a Makefile variable.
- Having `rank_file`'s `Makefile.am` reference `PRTE_CFLAGS_BEFORE_PICKY` (the correct/existing name) instead of `PMIX_CFLAGS_BEFORE_PICKY`.

## Test plan

- Rebuilt PRRTE 3.0.14 (same bug present on `v3.0` and `master`) in a Fedora rawhide mock chroot with `annocheck` from `annobin`.
- Before the fix: `libprrte.so.3.0.14`'s `.note.gnu.property` was missing the CET (`IBT, SHSTK`) properties entirely; `annocheck` reported `FAIL: cf-protection` and `FAIL: property-note`.
- After the fix: `readelf -n` on the rebuilt `libprrte.so.3.0.14` shows `Properties: x86 feature: IBT, SHSTK`, and `annocheck` no longer reports the `cf-protection`/`property-note` FAILs (only an unrelated pre-existing `lto` MAYB heuristic on `prte_frameworks.c` remains).
- Confirmed the compile command lines for `hostfile.c`/`hostfile_lex.c`/`rmaps_rank_file*.c` now include the full hardened compiler flags, matching every other translation unit in the tree.